### PR TITLE
Update Dataproc WorkflowTemplate, rename REQUIRED_OVERRIDE

### DIFF
--- a/tpgtools/api/dataproc/beta/workflow_template.yaml
+++ b/tpgtools/api/dataproc/beta/workflow_template.yaml
@@ -11,1702 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-components:
-  schemas:
-    ClusterConfig:
-      description: Required. The cluster configuration.
-      properties:
-        autoscalingConfig:
-          description: Optional. Autoscaling config for the policy associated with
-            the cluster. Cluster does not autoscale if this field is unset.
-          properties:
-            policy:
-              description: 'Optional. The autoscaling policy used by the cluster.
-                Only resource names including projectid and location (region) are
-                valid. Examples: * `https://www.googleapis.com/compute/v1/projects/`
-                Note that the policy must be in the same project and Dataproc region.'
-              type: string
-              x-dcl-go-name: Policy
-              x-dcl-references:
-              - field: name
-                resource: Dataproc/AutoscalingPolicy
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: AutoscalingConfig
-          x-dcl-go-type: ClusterClusterConfigAutoscalingConfig
-          x-kubernetes-immutable: true
-        encryptionConfig:
-          description: Optional. Encryption settings for the cluster.
-          properties:
-            gcePdKmsKeyName:
-              description: Optional. The Cloud KMS key name to use for PD disk encryption
-                for all instances in the cluster.
-              type: string
-              x-dcl-go-name: GcePdKmsKeyName
-              x-dcl-references:
-              - field: selfLink
-                resource: Cloudkms/CryptoKey
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: EncryptionConfig
-          x-dcl-go-type: ClusterClusterConfigEncryptionConfig
-          x-kubernetes-immutable: true
-        endpointConfig:
-          description: Optional. Port/endpoint configuration for this cluster
-          properties:
-            enableHttpPortAccess:
-              description: Optional. If true, enable http access to specific ports
-                on the cluster from external sources. Defaults to false.
-              type: boolean
-              x-dcl-go-name: EnableHttpPortAccess
-              x-kubernetes-immutable: true
-            httpPorts:
-              additionalProperties:
-                type: string
-              description: Output only. The map of port descriptions to URLs. Will
-                only be populated if enable_http_port_access is true.
-              readOnly: true
-              type: object
-              x-dcl-go-name: HttpPorts
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: EndpointConfig
-          x-dcl-go-type: ClusterClusterConfigEndpointConfig
-          x-kubernetes-immutable: true
-        gceClusterConfig:
-          description: Optional. The shared Compute Engine config settings for all
-            instances in a cluster.
-          properties:
-            internalIPOnly:
-              description: Optional. If true, all instances in the cluster will only
-                have internal IP addresses. By default, clusters are not restricted
-                to internal IP addresses, and will have ephemeral external IP addresses
-                assigned to each instance. This `internal_ip_only` restriction can
-                only be enabled for subnetwork enabled networks, and all off-cluster
-                dependencies must be configured to be accessible without external
-                IP addresses.
-              type: boolean
-              x-dcl-go-name: InternalIPOnly
-              x-kubernetes-immutable: true
-              x-dcl-server-default: true
-            metadata:
-              additionalProperties:
-                type: string
-              description: The Compute Engine metadata entries to add to all instances
-                (see (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
-              type: object
-              x-dcl-go-name: Metadata
-              x-kubernetes-immutable: true
-            network:
-              description: Optional. The Compute Engine network to be used for machine
-                communications. Cannot be specified with subnetwork_uri. If neither
-                `network_uri` nor `subnetwork_uri` is specified, the "default" network
-                of the project is used, if it exists. Cannot be a "Custom Subnet Network"
-                (see /regions/global/default` * `default`
-              type: string
-              x-dcl-go-name: Network
-              x-dcl-references:
-              - field: selfLink
-                resource: Compute/Network
-              x-kubernetes-immutable: true
-            nodeGroupAffinity:
-              description: Optional. Node Group Affinity for sole-tenant clusters.
-              properties:
-                nodeGroup:
-                  description: Required. The URI of a sole-tenant /zones/us-central1-a/nodeGroups/node-group-1`
-                    * `node-group-1`
-                  type: string
-                  x-dcl-go-name: NodeGroup
-                  x-dcl-references:
-                  - field: selfLink
-                    resource: Compute/NodeGroup
-                  x-kubernetes-immutable: true
-              required:
-              - nodeGroup
-              type: object
-              x-dcl-go-name: NodeGroupAffinity
-              x-dcl-go-type: ClusterClusterConfigGceClusterConfigNodeGroupAffinity
-              x-kubernetes-immutable: true
-            privateIPv6GoogleAccess:
-              description: 'Optional. The type of IPv6 access for a cluster. Possible
-                values: PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED, INHERIT_FROM_SUBNETWORK,
-                OUTBOUND, BIDIRECTIONAL'
-              enum:
-              - PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
-              - INHERIT_FROM_SUBNETWORK
-              - OUTBOUND
-              - BIDIRECTIONAL
-              type: string
-              x-dcl-go-name: PrivateIPv6GoogleAccess
-              x-dcl-go-type: ClusterClusterConfigGceClusterConfigPrivateIPv6GoogleAccessEnum
-              x-kubernetes-immutable: true
-            reservationAffinity:
-              description: Optional. Reservation Affinity for consuming Zonal reservation.
-              properties:
-                consumeReservationType:
-                  description: 'Optional. Type of reservation to consume Possible
-                    values: TYPE_UNSPECIFIED, NO_RESERVATION, ANY_RESERVATION, SPECIFIC_RESERVATION'
-                  enum:
-                  - TYPE_UNSPECIFIED
-                  - NO_RESERVATION
-                  - ANY_RESERVATION
-                  - SPECIFIC_RESERVATION
-                  type: string
-                  x-dcl-go-name: ConsumeReservationType
-                  x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinityConsumeReservationTypeEnum
-                  x-kubernetes-immutable: true
-                key:
-                  description: Optional. Corresponds to the label key of reservation
-                    resource.
-                  type: string
-                  x-dcl-go-name: Key
-                  x-kubernetes-immutable: true
-                values:
-                  description: Optional. Corresponds to the label values of reservation
-                    resource.
-                  items:
-                    type: string
-                    x-dcl-go-type: string
-                  type: array
-                  x-dcl-go-name: Values
-                  x-dcl-list-type: list
-                  x-kubernetes-immutable: true
-              type: object
-              x-dcl-go-name: ReservationAffinity
-              x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinity
-              x-kubernetes-immutable: true
-            serviceAccount:
-              description: Optional. The (https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
-                is used.
-              type: string
-              x-dcl-go-name: ServiceAccount
-              x-dcl-references:
-              - field: email
-                resource: Iam/ServiceAccount
-              x-kubernetes-immutable: true
-            serviceAccountScopes:
-              description: 'Optional. The URIs of service account scopes to be included
-                in Compute Engine instances. The following base set of scopes is always
-                included: * https://www.googleapis.com/auth/cloud.useraccounts.readonly
-                * https://www.googleapis.com/auth/devstorage.read_write * https://www.googleapis.com/auth/logging.write
-                If no scopes are specified, the following defaults are also provided:
-                * https://www.googleapis.com/auth/bigquery * https://www.googleapis.com/auth/bigtable.admin.table
-                * https://www.googleapis.com/auth/bigtable.data * https://www.googleapis.com/auth/devstorage.full_control'
-              items:
-                type: string
-                x-dcl-go-type: string
-              type: array
-              x-dcl-go-name: ServiceAccountScopes
-              x-dcl-list-type: list
-              x-kubernetes-immutable: true
-            subnetwork:
-              description: 'Optional. The Compute Engine subnetwork to be used for
-                machine communications. Cannot be specified with network_uri. A full
-                URL, partial URI, or short name are valid. Examples: * `https://www.googleapis.com/compute/v1/projects//regions/us-east1/subnetworks/sub0`
-                * `sub0`'
-              type: string
-              x-dcl-go-name: Subnetwork
-              x-dcl-references:
-              - field: selfLink
-                resource: Compute/Subnetwork
-              x-kubernetes-immutable: true
-            tags:
-              description: The Compute Engine tags to add to all instances (see (https://cloud.google.com/compute/docs/label-or-tag-resources#tags)).
-              items:
-                type: string
-                x-dcl-go-type: string
-              type: array
-              x-dcl-go-name: Tags
-              x-dcl-list-type: set
-            zone:
-              description: 'Optional. The zone where the Compute Engine cluster will
-                be located. On a create request, it is required in the "global" region.
-                If omitted in a non-global Dataproc region, the service will pick
-                a zone in the corresponding Compute Engine region. On a get request,
-                zone will always be present. A full URL, partial URI, or short name
-                are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/`
-                * `us-central1-f`'
-              type: string
-              x-dcl-go-name: Zone
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: GceClusterConfig
-          x-dcl-go-type: ClusterClusterConfigGceClusterConfig
-          x-kubernetes-immutable: true
-        gkeClusterConfig:
-          description: Optional. The Kubernetes Engine config for Dataproc clusters
-            deployed to Kubernetes. Setting this is considered mutually exclusive
-            with Compute Engine-based options such as `gce_cluster_config`, `master_config`,
-            `worker_config`, `secondary_worker_config`, and `autoscaling_config`.
-          properties:
-            namespacedGkeDeploymentTarget:
-              description: Optional. A target for the deployment.
-              properties:
-                clusterNamespace:
-                  description: Optional. A namespace within the GKE cluster to deploy
-                    into.
-                  type: string
-                  x-dcl-go-name: ClusterNamespace
-                  x-kubernetes-immutable: true
-                targetGkeCluster:
-                  description: 'Optional. The target GKE cluster to deploy to. Format:
-                    ''projects/{project}/locations/{location}/clusters/{cluster_id}'''
-                  type: string
-                  x-dcl-go-name: TargetGkeCluster
-                  x-dcl-references:
-                  - field: name
-                    resource: Container/Cluster
-                  x-kubernetes-immutable: true
-              type: object
-              x-dcl-go-name: NamespacedGkeDeploymentTarget
-              x-dcl-go-type: ClusterClusterConfigGkeClusterConfigNamespacedGkeDeploymentTarget
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: GkeClusterConfig
-          x-dcl-go-type: ClusterClusterConfigGkeClusterConfig
-          x-kubernetes-immutable: true
-        initializationActions:
-          description: 'Optional. Commands to execute on each node after config is
-            completed. By default, executables are run on master and all worker nodes.
-            You can test a node''s `role` metadata to run an executable on a master
-            or worker node, as shown below using `curl` (you can also use `wget`):
-            ROLE=$(curl -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)
-            if ; then ... master specific actions ... else ... worker specific actions
-            ... fi'
-          items:
-            properties:
-              executableFile:
-                description: Required. Cloud Storage URI of executable file.
-                type: string
-                x-dcl-go-name: ExecutableFile
-                x-kubernetes-immutable: true
-              executionTimeout:
-                description: Optional. Amount of time executable has to complete.
-                  Default is 10 minutes (see JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-                  Cluster creation fails with an explanatory error message (the name
-                  of the executable that caused the error and the exceeded timeout
-                  period) if the executable is not completed at end of the timeout
-                  period.
-                type: string
-                x-dcl-go-name: ExecutionTimeout
-                x-kubernetes-immutable: true
-            type: object
-            x-dcl-go-type: ClusterClusterConfigInitializationActions
-          type: array
-          x-dcl-go-name: InitializationActions
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        lifecycleConfig:
-          description: Optional. Lifecycle setting for the cluster.
-          properties:
-            autoDeleteTime:
-              description: Optional. The time when cluster will be auto-deleted (see
-                JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-              format: date-time
-              type: string
-              x-dcl-go-name: AutoDeleteTime
-              x-kubernetes-immutable: true
-            autoDeleteTtl:
-              description: Optional. The lifetime duration of cluster. The cluster
-                will be auto-deleted at the end of this period. Minimum value is 10
-                minutes; maximum value is 14 days (see JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-              type: string
-              x-dcl-go-name: AutoDeleteTtl
-              x-kubernetes-immutable: true
-            idleDeleteTtl:
-              description: Optional. The duration to keep the cluster alive while
-                idling (when no jobs are running). Passing this threshold will cause
-                the cluster to be deleted. Minimum value is 5 minutes; maximum value
-                is 14 days (see JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json).
-              type: string
-              x-dcl-go-name: IdleDeleteTtl
-              x-kubernetes-immutable: true
-            idleStartTime:
-              description: Output only. The time when cluster became idle (most recent
-                job finished) and became eligible for deletion due to idleness (see
-                JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-              format: date-time
-              readOnly: true
-              type: string
-              x-dcl-go-name: IdleStartTime
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: LifecycleConfig
-          x-dcl-go-type: ClusterClusterConfigLifecycleConfig
-          x-kubernetes-immutable: true
-        masterConfig:
-          $ref: '#/components/schemas/InstanceGroupConfig'
-          x-dcl-go-name: MasterConfig
-        metastoreConfig:
-          description: Optional. Metastore configuration.
-          properties:
-            dataprocMetastoreService:
-              description: 'Required. Resource name of an existing Dataproc Metastore
-                service. Example: * `projects/`'
-              type: string
-              x-dcl-go-name: DataprocMetastoreService
-              x-dcl-references:
-              - field: selfLink
-                resource: Metastore/Service
-              x-kubernetes-immutable: true
-          required:
-          - dataprocMetastoreService
-          type: object
-          x-dcl-go-name: MetastoreConfig
-          x-dcl-go-type: ClusterClusterConfigMetastoreConfig
-          x-kubernetes-immutable: true
-        secondaryWorkerConfig:
-          $ref: '#/components/schemas/InstanceGroupConfig'
-          x-dcl-go-name: SecondaryWorkerConfig
-        securityConfig:
-          description: Optional. Security settings for the cluster.
-          properties:
-            kerberosConfig:
-              description: Kerberos related configuration.
-              properties:
-                crossRealmTrustAdminServer:
-                  description: Optional. The admin server (IP or hostname) for the
-                    remote trusted realm in a cross realm trust relationship.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustAdminServer
-                  x-kubernetes-immutable: true
-                crossRealmTrustKdc:
-                  description: Optional. The KDC (IP or hostname) for the remote trusted
-                    realm in a cross realm trust relationship.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustKdc
-                  x-kubernetes-immutable: true
-                crossRealmTrustRealm:
-                  description: Optional. The remote realm the Dataproc on-cluster
-                    KDC will trust, should the user enable cross realm trust.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustRealm
-                  x-kubernetes-immutable: true
-                crossRealmTrustSharedPassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the shared password between the on-cluster Kerberos
-                    realm and the remote trusted realm, in a cross realm trust relationship.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustSharedPassword
-                  x-kubernetes-immutable: true
-                enableKerberos:
-                  description: 'Optional. Flag to indicate whether to Kerberize the
-                    cluster (default: false). Set this field to true to enable Kerberos
-                    on a cluster.'
-                  type: boolean
-                  x-dcl-go-name: EnableKerberos
-                  x-kubernetes-immutable: true
-                kdcDbKey:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the master key of the KDC database.
-                  type: string
-                  x-dcl-go-name: KdcDbKey
-                  x-kubernetes-immutable: true
-                keyPassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the password to the user provided key. For the
-                    self-signed certificate, this password is generated by Dataproc.
-                  type: string
-                  x-dcl-go-name: KeyPassword
-                  x-kubernetes-immutable: true
-                keystore:
-                  description: Optional. The Cloud Storage URI of the keystore file
-                    used for SSL encryption. If not provided, Dataproc will provide
-                    a self-signed certificate.
-                  type: string
-                  x-dcl-go-name: Keystore
-                  x-kubernetes-immutable: true
-                keystorePassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the password to the user provided keystore. For
-                    the self-signed certificate, this password is generated by Dataproc.
-                  type: string
-                  x-dcl-go-name: KeystorePassword
-                  x-kubernetes-immutable: true
-                kmsKey:
-                  description: Optional. The uri of the KMS key used to encrypt various
-                    sensitive files.
-                  type: string
-                  x-dcl-go-name: KmsKey
-                  x-dcl-references:
-                  - field: selfLink
-                    resource: Cloudkms/CryptoKey
-                  x-kubernetes-immutable: true
-                realm:
-                  description: Optional. The name of the on-cluster Kerberos realm.
-                    If not specified, the uppercased domain of hostnames will be the
-                    realm.
-                  type: string
-                  x-dcl-go-name: Realm
-                  x-kubernetes-immutable: true
-                rootPrincipalPassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the root principal password.
-                  type: string
-                  x-dcl-go-name: RootPrincipalPassword
-                  x-kubernetes-immutable: true
-                tgtLifetimeHours:
-                  description: Optional. The lifetime of the ticket granting ticket,
-                    in hours. If not specified, or user specifies 0, then default
-                    value 10 will be used.
-                  format: int64
-                  type: integer
-                  x-dcl-go-name: TgtLifetimeHours
-                  x-kubernetes-immutable: true
-                truststore:
-                  description: Optional. The Cloud Storage URI of the truststore file
-                    used for SSL encryption. If not provided, Dataproc will provide
-                    a self-signed certificate.
-                  type: string
-                  x-dcl-go-name: Truststore
-                  x-kubernetes-immutable: true
-                truststorePassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the password to the user provided truststore.
-                    For the self-signed certificate, this password is generated by
-                    Dataproc.
-                  type: string
-                  x-dcl-go-name: TruststorePassword
-                  x-kubernetes-immutable: true
-              type: object
-              x-dcl-go-name: KerberosConfig
-              x-dcl-go-type: ClusterClusterConfigSecurityConfigKerberosConfig
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: SecurityConfig
-          x-dcl-go-type: ClusterClusterConfigSecurityConfig
-          x-kubernetes-immutable: true
-        softwareConfig:
-          description: Optional. The config settings for software inside the cluster.
-          properties:
-            imageVersion:
-              description: Optional. The version of software inside the cluster. It
-                must be one of the supported (https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
-                If unspecified, it defaults to the latest Debian version.
-              type: string
-              x-dcl-go-name: ImageVersion
-              x-kubernetes-immutable: true
-            properties:
-              additionalProperties:
-                type: string
-              description: 'Optional. The properties to set on daemon config files.
-                Property keys are specified in `prefix:property` format, for example
-                `core:hadoop.tmp.dir`. The following are supported prefixes and their
-                mappings: * capacity-scheduler: `capacity-scheduler.xml` * core: `core-site.xml`
-                * distcp: `distcp-default.xml` * hdfs: `hdfs-site.xml` * hive: `hive-site.xml`
-                * mapred: `mapred-site.xml` * pig: `pig.properties` * spark: `spark-defaults.conf`
-                * yarn: `yarn-site.xml` For more information, see (https://cloud.google.com/dataproc/docs/concepts/cluster-properties).'
-              type: object
-              x-dcl-go-name: Properties
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: SoftwareConfig
-          x-dcl-go-type: ClusterClusterConfigSoftwareConfig
-          x-kubernetes-immutable: true
-        stagingBucket:
-          description: Optional. A Cloud Storage bucket used to stage job dependencies,
-            config files, and job driver console output. If you do not specify a staging
-            bucket, Cloud Dataproc will determine a Cloud Storage location (US, ASIA,
-            or EU) for your cluster's staging bucket according to the Compute Engine
-            zone where your cluster is deployed, and then create and manage this project-level,
-            per-location bucket (see (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
-          type: string
-          x-dcl-go-name: StagingBucket
-          x-dcl-references:
-          - field: name
-            resource: Storage/Bucket
-          x-kubernetes-immutable: true
-        tempBucket:
-          description: Optional. A Cloud Storage bucket used to store ephemeral cluster
-            and jobs data, such as Spark and MapReduce history files. If you do not
-            specify a temp bucket, Dataproc will determine a Cloud Storage location
-            (US, ASIA, or EU) for your cluster's temp bucket according to the Compute
-            Engine zone where your cluster is deployed, and then create and manage
-            this project-level, per-location bucket. The default bucket has a TTL
-            of 90 days, but you can use any TTL (or none) if you specify a bucket.
-          type: string
-          x-dcl-go-name: TempBucket
-          x-dcl-references:
-          - field: name
-            resource: Storage/Bucket
-          x-kubernetes-immutable: true
-        workerConfig:
-          $ref: '#/components/schemas/InstanceGroupConfig'
-          x-dcl-go-name: WorkerConfig
-      type: object
-      x-dcl-go-name: Config
-      x-dcl-go-type: ClusterClusterConfig
-      x-kubernetes-immutable: true
-    InstanceGroupConfig:
-      description: Optional. The Compute Engine config settings for additional worker
-        instances in a cluster.
-      properties:
-        accelerators:
-          description: Optional. The Compute Engine accelerator configuration for
-            these instances.
-          items:
-            properties:
-              acceleratorCount:
-                description: The number of the accelerator cards of this type exposed
-                  to this instance.
-                format: int64
-                type: integer
-                x-dcl-go-name: AcceleratorCount
-                x-kubernetes-immutable: true
-              acceleratorType:
-                description: Full URL, partial URI, or short name of the accelerator
-                  type resource to expose to this instance. See (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
-                  feature, you must use the short name of the accelerator type resource,
-                  for example, `nvidia-tesla-k80`.
-                type: string
-                x-dcl-go-name: AcceleratorType
-                x-kubernetes-immutable: true
-            type: object
-            x-dcl-go-type: ClusterInstanceGroupConfigAccelerators
-          type: array
-          x-dcl-go-name: Accelerators
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        diskConfig:
-          description: Optional. Disk option config settings.
-          properties:
-            bootDiskSizeGb:
-              description: Optional. Size in GB of the boot disk (default is 500GB).
-              format: int64
-              type: integer
-              x-dcl-go-name: BootDiskSizeGb
-              x-kubernetes-immutable: true
-            bootDiskType:
-              description: 'Optional. Type of the boot disk (default is "pd-standard").
-                Valid values: "pd-ssd" (Persistent Disk Solid State Drive) or "pd-standard"
-                (Persistent Disk Hard Disk Drive).'
-              type: string
-              x-dcl-go-name: BootDiskType
-              x-kubernetes-immutable: true
-            numLocalSsds:
-              description: Optional. Number of attached SSDs, from 0 to 4 (default
-                is 0). If SSDs are not attached, the boot disk is used to store runtime
-                logs and (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
-                data. If one or more SSDs are attached, this runtime bulk data is
-                spread across them, and the boot disk contains only basic config and
-                installed binaries.
-              format: int64
-              type: integer
-              x-dcl-go-name: NumLocalSsds
-              x-kubernetes-immutable: true
-              x-dcl-server-default: true
-          type: object
-          x-dcl-go-name: DiskConfig
-          x-dcl-go-type: ClusterInstanceGroupConfigDiskConfig
-          x-kubernetes-immutable: true
-        image:
-          description: 'Optional. The Compute Engine image resource used for cluster
-            instances. The URI can represent an image or image family. Image examples:
-            * `https://www.googleapis.com/compute/beta/projects/` If the URI is unspecified,
-            it will be inferred from `SoftwareConfig.image_version` or the system
-            default.'
-          type: string
-          x-dcl-go-name: Image
-          x-dcl-references:
-          - field: selfLink
-            resource: Compute/Image
-          x-kubernetes-immutable: true
-        instanceNames:
-          description: Output only. The list of instance names. Dataproc derives the
-            names from `cluster_name`, `num_instances`, and the instance group.
-          items:
-            type: string
-            x-dcl-go-type: string
-            x-dcl-references:
-            - field: selfLink
-              resource: Compute/Instance
-          readOnly: true
-          type: array
-          x-dcl-go-name: InstanceNames
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        isPreemptible:
-          description: Output only. Specifies that this instance group contains preemptible
-            instances.
-          readOnly: true
-          type: boolean
-          x-dcl-go-name: IsPreemptible
-          x-kubernetes-immutable: true
-        machineType:
-          description: 'Optional. The Compute Engine machine type used for cluster
-            instances. A full URL, partial URI, or short name are valid. Examples:
-            * `https://www.googleapis.com/compute/v1/projects/(https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
-            feature, you must use the short name of the machine type resource, for
-            example, `n1-standard-2`.'
-          type: string
-          x-dcl-go-name: MachineType
-          x-kubernetes-immutable: true
-        managedGroupConfig:
-          description: Output only. The config for Compute Engine Instance Group Manager
-            that manages this group. This is only used for preemptible instance groups.
-          properties:
-            instanceGroupManagerName:
-              description: Output only. The name of the Instance Group Manager for
-                this group.
-              readOnly: true
-              type: string
-              x-dcl-go-name: InstanceGroupManagerName
-              x-kubernetes-immutable: true
-            instanceTemplateName:
-              description: Output only. The name of the Instance Template used for
-                the Managed Instance Group.
-              readOnly: true
-              type: string
-              x-dcl-go-name: InstanceTemplateName
-              x-kubernetes-immutable: true
-          readOnly: true
-          type: object
-          x-dcl-go-name: ManagedGroupConfig
-          x-dcl-go-type: ClusterInstanceGroupConfigManagedGroupConfig
-          x-kubernetes-immutable: true
-        minCpuPlatform:
-          description: Optional. Specifies the minimum cpu platform for the Instance
-            Group. See (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).
-          type: string
-          x-dcl-go-name: MinCpuPlatform
-          x-kubernetes-immutable: true
-        numInstances:
-          description: Optional. The number of VM instances in the instance group.
-            For master instance groups, must be set to 1.
-          format: int64
-          type: integer
-          x-dcl-go-name: NumInstances
-          x-kubernetes-immutable: true
-        preemptibility:
-          description: 'Optional. Specifies the preemptibility of the instance group.
-            The default value for master and worker groups is `NON_PREEMPTIBLE`. This
-            default cannot be changed. The default value for secondary instances is
-            `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE,
-            PREEMPTIBLE'
-          enum:
-          - PREEMPTIBILITY_UNSPECIFIED
-          - NON_PREEMPTIBLE
-          - PREEMPTIBLE
-          type: string
-          x-dcl-go-name: Preemptibility
-          x-dcl-go-type: ClusterInstanceGroupConfigPreemptibilityEnum
-          x-kubernetes-immutable: true
-      type: object
-      x-dcl-go-name: SecondaryWorkerConfig
-      x-dcl-go-type: ClusterInstanceGroupConfig
-      x-kubernetes-immutable: true
-    WorkflowTemplate:
-      properties:
-        createTime:
-          description: Output only. The time template was created.
-          format: date-time
-          readOnly: true
-          type: string
-          x-dcl-go-name: CreateTime
-          x-kubernetes-immutable: true
-        dagTimeout:
-          description: Optional. Timeout duration for the DAG of jobs. You can use
-            "s", "m", "h", and "d" suffixes for second, minute, hour, and day duration
-            values, respectively. The timeout duration must be from 10 minutes ("10m")
-            to 24 hours ("24h" or "1d"). The timer begins when the first job is submitted.
-            If the workflow is running at the end of the timeout period, any remaining
-            jobs are cancelled, the workflow is ended, and if the workflow was running
-            on a (/dataproc/docs/concepts/workflows/using-workflows#configuring_or_selecting_a_cluster),
-            the cluster is deleted.
-          type: string
-          x-dcl-go-name: DagTimeout
-          x-kubernetes-immutable: true
-        jobs:
-          description: Required. The Directed Acyclic Graph of Jobs to submit.
-          items:
-            properties:
-              hadoopJob:
-                description: Optional. Job is a Hadoop job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      in the working directory of Hadoop drivers and tasks. Supported
-                      file types: .jar, .tar, .tar.gz, .tgz, or .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `-libjars` or `-Dfoo=bar`, that
-                      can be set as job properties, since a collision may occur that
-                      causes an incorrect job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS (Hadoop Compatible Filesystem) URIs
-                      of files to be copied to the working directory of Hadoop drivers
-                      and distributed tasks. Useful for naively parallel tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. Jar file URIs to add to the CLASSPATHs
-                      of the Hadoop driver and tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsHadoopJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainClass:
-                    description: The name of the driver's main class. The jar file
-                      containing the class must be in the default CLASSPATH or specified
-                      in `jar_file_uris`.
-                    type: string
-                    x-dcl-go-name: MainClass
-                    x-kubernetes-immutable: true
-                  mainJarFileUri:
-                    description: 'The HCFS URI of the jar file containing the main
-                      class. Examples: ''gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar''
-                      ''hdfs:/tmp/test-samples/custom-wordcount.jar'' ''file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar'''
-                    type: string
-                    x-dcl-go-name: MainJarFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Hadoop. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/hadoop/conf/*-site and classes in user code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: HadoopJob
-                x-dcl-go-type: WorkflowTemplateJobsHadoopJob
-                x-kubernetes-immutable: true
-              hiveJob:
-                description: Optional. Job is a Hive job.
-                properties:
-                  continueOnFailure:
-                    description: Optional. Whether to continue executing queries if
-                      a query fails. The default value is `false`. Setting to `true`
-                      can be useful when executing independent parallel queries.
-                    type: boolean
-                    x-dcl-go-name: ContinueOnFailure
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
-                      of the Hive server and Hadoop MapReduce (MR) tasks. Can contain
-                      Hive SerDes and UDFs.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names and values,
-                      used to configure Hive. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml,
-                      and classes in user code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains Hive queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsHiveJobQueryList
-                    x-kubernetes-immutable: true
-                  scriptVariables:
-                    additionalProperties:
-                      type: string
-                    description: 'Optional. Mapping of query variable names to values
-                      (equivalent to the Hive command: `SET name="value";`).'
-                    type: object
-                    x-dcl-go-name: ScriptVariables
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: HiveJob
-                x-dcl-go-type: WorkflowTemplateJobsHiveJob
-                x-kubernetes-immutable: true
-              labels:
-                additionalProperties:
-                  type: string
-                description: 'Optional. The labels to associate with this job. Label
-                  keys must be between 1 and 63 characters long, and must conform
-                  to the following regular expression: {0,63} No more than 32 labels
-                  can be associated with a given job.'
-                type: object
-                x-dcl-go-name: Labels
-                x-kubernetes-immutable: true
-              pigJob:
-                description: Optional. Job is a Pig job.
-                properties:
-                  continueOnFailure:
-                    description: Optional. Whether to continue executing queries if
-                      a query fails. The default value is `false`. Setting to `true`
-                      can be useful when executing independent parallel queries.
-                    type: boolean
-                    x-dcl-go-name: ContinueOnFailure
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
-                      of the Pig Client and Hadoop MapReduce (MR) tasks. Can contain
-                      Pig UDFs.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsPigJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Pig. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties,
-                      and classes in user code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains the Pig
-                      queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsPigJobQueryList
-                    x-kubernetes-immutable: true
-                  scriptVariables:
-                    additionalProperties:
-                      type: string
-                    description: 'Optional. Mapping of query variable names to values
-                      (equivalent to the Pig command: `name=`).'
-                    type: object
-                    x-dcl-go-name: ScriptVariables
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: PigJob
-                x-dcl-go-type: WorkflowTemplateJobsPigJob
-                x-kubernetes-immutable: true
-              prerequisiteStepIds:
-                description: Optional. The optional list of prerequisite job step_ids.
-                  If not specified, the job will start at the beginning of workflow.
-                items:
-                  type: string
-                  x-dcl-go-type: string
-                type: array
-                x-dcl-go-name: PrerequisiteStepIds
-                x-dcl-list-type: list
-                x-kubernetes-immutable: true
-              prestoJob:
-                description: Optional. Job is a Presto job.
-                properties:
-                  clientTags:
-                    description: Optional. Presto client tags to attach to this query
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ClientTags
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  continueOnFailure:
-                    description: Optional. Whether to continue executing queries if
-                      a query fails. The default value is `false`. Setting to `true`
-                      can be useful when executing independent parallel queries.
-                    type: boolean
-                    x-dcl-go-name: ContinueOnFailure
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  outputFormat:
-                    description: Optional. The format in which query output will be
-                      displayed. See the Presto documentation for supported output
-                      formats
-                    type: string
-                    x-dcl-go-name: OutputFormat
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values.
-                      Used to set Presto (https://prestodb.io/docs/current/sql/set-session.html)
-                      Equivalent to using the --session flag in the Presto CLI
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains SQL queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobQueryList
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: PrestoJob
-                x-dcl-go-type: WorkflowTemplateJobsPrestoJob
-                x-kubernetes-immutable: true
-              pysparkJob:
-                description: Optional. Job is a PySpark job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      into the working directory of each executor. Supported file
-                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `--conf`, that can be set as
-                      job properties, since a collision may occur that causes an incorrect
-                      job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS URIs of files to be placed in the
-                      working directory of each executor. Useful for naively parallel
-                      tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
-                      of the Python driver and tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsPysparkJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainPythonFileUri:
-                    description: Required. The HCFS URI of the main Python file to
-                      use as the driver. Must be a .py file.
-                    type: string
-                    x-dcl-go-name: MainPythonFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure PySpark. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/spark/conf/spark-defaults.conf and classes in user
-                      code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  pythonFileUris:
-                    description: 'Optional. HCFS file URIs of Python files to pass
-                      to the PySpark framework. Supported file types: .py, .egg, and
-                      .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: PythonFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                required:
-                - mainPythonFileUri
-                type: object
-                x-dcl-go-name: PysparkJob
-                x-dcl-go-type: WorkflowTemplateJobsPysparkJob
-                x-kubernetes-immutable: true
-              scheduling:
-                description: Optional. Job scheduling configuration.
-                properties:
-                  maxFailuresPerHour:
-                    description: Optional. Maximum number of times per hour a driver
-                      may be restarted as a result of driver exiting with non-zero
-                      code before job is reported failed. A job may be reported as
-                      thrashing if driver exits with non-zero code 4 times within
-                      10 minute window. Maximum value is 10.
-                    format: int64
-                    type: integer
-                    x-dcl-go-name: MaxFailuresPerHour
-                    x-kubernetes-immutable: true
-                  maxFailuresTotal:
-                    description: Optional. Maximum number of times in total a driver
-                      may be restarted as a result of driver exiting with non-zero
-                      code before job is reported failed. Maximum value is 240
-                    format: int64
-                    type: integer
-                    x-dcl-go-name: MaxFailuresTotal
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: Scheduling
-                x-dcl-go-type: WorkflowTemplateJobsScheduling
-                x-kubernetes-immutable: true
-              sparkJob:
-                description: Optional. Job is a Spark job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      into the working directory of each executor. Supported file
-                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `--conf`, that can be set as
-                      job properties, since a collision may occur that causes an incorrect
-                      job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS URIs of files to be placed in the
-                      working directory of each executor. Useful for naively parallel
-                      tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
-                      of the Spark driver and tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsSparkJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainClass:
-                    description: The name of the driver's main class. The jar file
-                      that contains the class must be in the default CLASSPATH or
-                      specified in `jar_file_uris`.
-                    type: string
-                    x-dcl-go-name: MainClass
-                    x-kubernetes-immutable: true
-                  mainJarFileUri:
-                    description: The HCFS URI of the jar file that contains the main
-                      class.
-                    type: string
-                    x-dcl-go-name: MainJarFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Spark. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/spark/conf/spark-defaults.conf and classes in user
-                      code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: SparkJob
-                x-dcl-go-type: WorkflowTemplateJobsSparkJob
-                x-kubernetes-immutable: true
-              sparkRJob:
-                description: Optional. Job is a SparkR job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      into the working directory of each executor. Supported file
-                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `--conf`, that can be set as
-                      job properties, since a collision may occur that causes an incorrect
-                      job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS URIs of files to be placed in the
-                      working directory of each executor. Useful for naively parallel
-                      tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsSparkRJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainRFileUri:
-                    description: Required. The HCFS URI of the main R file to use
-                      as the driver. Must be a .R file.
-                    type: string
-                    x-dcl-go-name: MainRFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure SparkR. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/spark/conf/spark-defaults.conf and classes in user
-                      code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                required:
-                - mainRFileUri
-                type: object
-                x-dcl-go-name: SparkRJob
-                x-dcl-go-type: WorkflowTemplateJobsSparkRJob
-                x-kubernetes-immutable: true
-              sparkSqlJob:
-                description: Optional. Job is a SparkSql job.
-                properties:
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to be added to the
-                      Spark CLASSPATH.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Spark SQL's SparkConf. Properties that conflict
-                      with values set by the Dataproc API may be overwritten.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains SQL queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobQueryList
-                    x-kubernetes-immutable: true
-                  scriptVariables:
-                    additionalProperties:
-                      type: string
-                    description: 'Optional. Mapping of query variable names to values
-                      (equivalent to the Spark SQL command: SET `name="value";`).'
-                    type: object
-                    x-dcl-go-name: ScriptVariables
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: SparkSqlJob
-                x-dcl-go-type: WorkflowTemplateJobsSparkSqlJob
-                x-kubernetes-immutable: true
-              stepId:
-                description: Required. The step id. The id must be unique among all
-                  jobs within the template. The step id is used as prefix for job
-                  id, as job `goog-dataproc-workflow-step-id` label, and in field
-                  from other steps. The id must contain only letters (a-z, A-Z), numbers
-                  (0-9), underscores (_), and hyphens (-). Cannot begin or end with
-                  underscore or hyphen. Must consist of between 3 and 50 characters.
-                type: string
-                x-dcl-go-name: StepId
-                x-kubernetes-immutable: true
-            required:
-            - stepId
-            type: object
-            x-dcl-go-type: WorkflowTemplateJobs
-          type: array
-          x-dcl-go-name: Jobs
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        labels:
-          additionalProperties:
-            type: string
-          description: Optional. The labels to associate with this template. These
-            labels will be propagated to all jobs and clusters created by the workflow
-            instance. Label **keys** must contain 1 to 63 characters, and must conform
-            to (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can
-            be associated with a template.
-          type: object
-          x-dcl-go-name: Labels
-          x-kubernetes-immutable: true
-        location:
-          description: The location for the resource
-          type: string
-          x-dcl-go-name: Location
-          x-kubernetes-immutable: true
-        name:
-          description: 'Output only. The resource name of the workflow template, as
-            described in https://cloud.google.com/apis/design/resource_names. * For
-            `projects.regions.workflowTemplates`, the resource name of the template
-            has the following format: `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
-            * For `projects.locations.workflowTemplates`, the resource name of the
-            template has the following format: `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`'
-          type: string
-          x-dcl-go-name: Name
-          x-kubernetes-immutable: true
-        parameters:
-          description: Optional. Template parameters whose values are substituted
-            into the template. Values for parameters must be provided when the template
-            is instantiated.
-          items:
-            properties:
-              description:
-                description: Optional. Brief description of the parameter. Must not
-                  exceed 1024 characters.
-                type: string
-                x-dcl-go-name: Description
-                x-kubernetes-immutable: true
-              fields:
-                description: Required. Paths to all fields that the parameter replaces.
-                  A field is allowed to appear in at most one parameter's list of
-                  field paths. A field path is similar in syntax to a .sparkJob.args
-                items:
-                  type: string
-                  x-dcl-go-type: string
-                type: array
-                x-dcl-go-name: Fields
-                x-dcl-list-type: list
-                x-kubernetes-immutable: true
-              name:
-                description: Required. Parameter name. The parameter name is used
-                  as the key, and paired with the parameter value, which are passed
-                  to the template when the template is instantiated. The name must
-                  contain only capital letters (A-Z), numbers (0-9), and underscores
-                  (_), and must not start with a number. The maximum length is 40
-                  characters.
-                type: string
-                x-dcl-go-name: Name
-                x-kubernetes-immutable: true
-              validation:
-                description: Optional. Validation rules to be applied to this parameter's
-                  value.
-                properties:
-                  regex:
-                    description: Validation based on regular expressions.
-                    properties:
-                      regexes:
-                        description: Required. RE2 regular expressions used to validate
-                          the parameter's value. The value must match the regex in
-                          its entirety (substring matches are not sufficient).
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Regexes
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - regexes
-                    type: object
-                    x-dcl-go-name: Regex
-                    x-dcl-go-type: WorkflowTemplateParametersValidationRegex
-                    x-kubernetes-immutable: true
-                  values:
-                    description: Validation based on a list of allowed values.
-                    properties:
-                      values:
-                        description: Required. List of allowed values for the parameter.
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Values
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - values
-                    type: object
-                    x-dcl-go-name: Values
-                    x-dcl-go-type: WorkflowTemplateParametersValidationValues
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: Validation
-                x-dcl-go-type: WorkflowTemplateParametersValidation
-                x-kubernetes-immutable: true
-            required:
-            - name
-            - fields
-            type: object
-            x-dcl-go-type: WorkflowTemplateParameters
-          type: array
-          x-dcl-go-name: Parameters
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        placement:
-          description: Required. WorkflowTemplate scheduling information.
-          properties:
-            clusterSelector:
-              description: Optional. A selector that chooses target cluster for jobs
-                based on metadata. The selector is evaluated at the time each job
-                is submitted.
-              properties:
-                clusterLabels:
-                  additionalProperties:
-                    type: string
-                  description: Required. The cluster labels. Cluster must have all
-                    labels to match.
-                  type: object
-                  x-dcl-go-name: ClusterLabels
-                  x-kubernetes-immutable: true
-                zone:
-                  description: Optional. The zone where workflow process executes.
-                    This parameter does not affect the selection of the cluster. If
-                    unspecified, the zone of the first cluster matching the selector
-                    is used.
-                  type: string
-                  x-dcl-go-name: Zone
-                  x-kubernetes-immutable: true
-              required:
-              - clusterLabels
-              type: object
-              x-dcl-go-name: ClusterSelector
-              x-dcl-go-type: WorkflowTemplatePlacementClusterSelector
-              x-kubernetes-immutable: true
-            managedCluster:
-              description: A cluster that is managed by the workflow.
-              properties:
-                clusterName:
-                  description: Required. The cluster name prefix. A unique cluster
-                    name will be formed by appending a random suffix. The name must
-                    contain only lower-case letters (a-z), numbers (0-9), and hyphens
-                    (-). Must begin with a letter. Cannot begin or end with hyphen.
-                    Must consist of between 2 and 35 characters.
-                  type: string
-                  x-dcl-go-name: ClusterName
-                  x-kubernetes-immutable: true
-                config:
-                  $ref: '#/components/schemas/ClusterConfig'
-                  x-dcl-go-name: Config
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: 'Optional. The labels to associate with this cluster.
-                    Label keys must be between 1 and 63 characters long, and must
-                    conform to the following PCRE regular expression: {0,63} No more
-                    than 32 labels can be associated with a given cluster.'
-                  type: object
-                  x-dcl-go-name: Labels
-                  x-kubernetes-immutable: true
-              required:
-              - clusterName
-              - config
-              type: object
-              x-dcl-go-name: ManagedCluster
-              x-dcl-go-type: WorkflowTemplatePlacementManagedCluster
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: Placement
-          x-dcl-go-type: WorkflowTemplatePlacement
-          x-kubernetes-immutable: true
-        project:
-          description: The project for the resource
-          type: string
-          x-dcl-go-name: Project
-          x-dcl-references:
-          - field: name
-            parent: true
-            resource: Cloudresourcemanager/Project
-          x-kubernetes-immutable: true
-        updateTime:
-          description: Output only. The time template was last updated.
-          format: date-time
-          readOnly: true
-          type: string
-          x-dcl-go-name: UpdateTime
-          x-kubernetes-immutable: true
-        version:
-          description: Optional. Used to perform a consistent read-modify-write. This
-            field should be left blank for a `CreateWorkflowTemplate` request. It
-            is required for an `UpdateWorkflowTemplate` request, and must match the
-            current server version. A typical update template flow would fetch the
-            current template with a `GetWorkflowTemplate` request, which will return
-            the current template with the `version` field filled in with the current
-            server version. The user updates other fields in the template, then returns
-            it as part of the `UpdateWorkflowTemplate` request.
-          format: int64
-          type: integer
-          x-dcl-go-name: Version
-          x-kubernetes-immutable: true
-          x-dcl-server-default: true
-      required:
-      - name
-      - placement
-      - jobs
-      - project
-      - location
-      title: WorkflowTemplate
-      type: object
-      x-dcl-id: projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}
-      x-dcl-labels: labels
-      x-dcl-locations: []
-      x-dcl-parent-container: project
-      x-dcl-uses-state-hint: false
 info:
-  description: DCL Specification for the Dataproc WorkflowTemplate resource
   title: Dataproc/WorkflowTemplate
+  description: DCL Specification for the Dataproc WorkflowTemplate resource
   x-dcl-has-iam: false
 paths:
+  get:
+    description: The function used to get information about a WorkflowTemplate
+    parameters:
+    - name: WorkflowTemplate
+      required: true
+      description: A full instance of a WorkflowTemplate
   apply:
     description: The function used to apply information about a WorkflowTemplate
     parameters:
-    - description: A full instance of a WorkflowTemplate
-      name: WorkflowTemplate
+    - name: WorkflowTemplate
       required: true
+      description: A full instance of a WorkflowTemplate
   delete:
     description: The function used to delete a WorkflowTemplate
     parameters:
-    - description: A full instance of a WorkflowTemplate
-      name: WorkflowTemplate
+    - name: WorkflowTemplate
       required: true
+      description: A full instance of a WorkflowTemplate
   deleteAll:
     description: The function used to delete all WorkflowTemplate
     parameters:
@@ -1718,12 +45,6 @@ paths:
       required: true
       schema:
         type: string
-  get:
-    description: The function used to get information about a WorkflowTemplate
-    parameters:
-    - description: A full instance of a WorkflowTemplate
-      name: WorkflowTemplate
-      required: true
   list:
     description: The function used to list information about many WorkflowTemplate
     parameters:
@@ -1735,3 +56,1805 @@ paths:
       required: true
       schema:
         type: string
+components:
+  schemas:
+    ClusterConfig:
+      type: object
+      x-dcl-go-name: Config
+      x-dcl-go-type: ClusterClusterConfig
+      description: Required. The cluster configuration.
+      x-kubernetes-immutable: true
+      properties:
+        autoscalingConfig:
+          type: object
+          x-dcl-go-name: AutoscalingConfig
+          x-dcl-go-type: ClusterClusterConfigAutoscalingConfig
+          description: Optional. Autoscaling config for the policy associated with
+            the cluster. Cluster does not autoscale if this field is unset.
+          x-kubernetes-immutable: true
+          properties:
+            policy:
+              type: string
+              x-dcl-go-name: Policy
+              description: 'Optional. The autoscaling policy used by the cluster.
+                Only resource names including projectid and location (region) are
+                valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]`
+                * `projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]`
+                Note that the policy must be in the same project and Dataproc region.'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Dataproc/AutoscalingPolicy
+                field: name
+        encryptionConfig:
+          type: object
+          x-dcl-go-name: EncryptionConfig
+          x-dcl-go-type: ClusterClusterConfigEncryptionConfig
+          description: Optional. Encryption settings for the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            gcePdKmsKeyName:
+              type: string
+              x-dcl-go-name: GcePdKmsKeyName
+              description: Optional. The Cloud KMS key name to use for PD disk encryption
+                for all instances in the cluster.
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Cloudkms/CryptoKey
+                field: selfLink
+        endpointConfig:
+          type: object
+          x-dcl-go-name: EndpointConfig
+          x-dcl-go-type: ClusterClusterConfigEndpointConfig
+          description: Optional. Port/endpoint configuration for this cluster
+          x-kubernetes-immutable: true
+          properties:
+            enableHttpPortAccess:
+              type: boolean
+              x-dcl-go-name: EnableHttpPortAccess
+              description: Optional. If true, enable http access to specific ports
+                on the cluster from external sources. Defaults to false.
+              x-kubernetes-immutable: true
+            httpPorts:
+              type: object
+              additionalProperties:
+                type: string
+              x-dcl-go-name: HttpPorts
+              readOnly: true
+              description: Output only. The map of port descriptions to URLs. Will
+                only be populated if enable_http_port_access is true.
+              x-kubernetes-immutable: true
+        gceClusterConfig:
+          type: object
+          x-dcl-go-name: GceClusterConfig
+          x-dcl-go-type: ClusterClusterConfigGceClusterConfig
+          description: Optional. The shared Compute Engine config settings for all
+            instances in a cluster.
+          x-kubernetes-immutable: true
+          properties:
+            internalIPOnly:
+              type: boolean
+              x-dcl-go-name: InternalIPOnly
+              description: Optional. If true, all instances in the cluster will only
+                have internal IP addresses. By default, clusters are not restricted
+                to internal IP addresses, and will have ephemeral external IP addresses
+                assigned to each instance. This `internal_ip_only` restriction can
+                only be enabled for subnetwork enabled networks, and all off-cluster
+                dependencies must be configured to be accessible without external
+                IP addresses.
+              x-kubernetes-immutable: true
+              x-dcl-server-default: true
+            metadata:
+              type: object
+              additionalProperties:
+                type: string
+              x-dcl-go-name: Metadata
+              description: The Compute Engine metadata entries to add to all instances
+                (see [Project and instance metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
+              x-kubernetes-immutable: true
+            network:
+              type: string
+              x-dcl-go-name: Network
+              description: 'Optional. The Compute Engine network to be used for machine
+                communications. Cannot be specified with subnetwork_uri. If neither
+                `network_uri` nor `subnetwork_uri` is specified, the "default" network
+                of the project is used, if it exists. Cannot be a "Custom Subnet Network"
+                (see [Using Subnetworks](https://cloud.google.com/compute/docs/subnetworks)
+                for more information). A full URL, partial URI, or short name are
+                valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default`
+                * `projects/[project_id]/regions/global/default` * `default`'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Compute/Network
+                field: selfLink
+            nodeGroupAffinity:
+              type: object
+              x-dcl-go-name: NodeGroupAffinity
+              x-dcl-go-type: ClusterClusterConfigGceClusterConfigNodeGroupAffinity
+              description: Optional. Node Group Affinity for sole-tenant clusters.
+              x-kubernetes-immutable: true
+              required:
+              - nodeGroup
+              properties:
+                nodeGroup:
+                  type: string
+                  x-dcl-go-name: NodeGroup
+                  description: 'Required. The URI of a sole-tenant [node group resource](https://cloud.google.com/compute/docs/reference/rest/v1/nodeGroups)
+                    that the cluster will be created on. A full URL, partial URI,
+                    or node group name are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-central1-a/nodeGroups/node-group-1`
+                    * `projects/[project_id]/zones/us-central1-a/nodeGroups/node-group-1`
+                    * `node-group-1`'
+                  x-kubernetes-immutable: true
+                  x-dcl-references:
+                  - resource: Compute/NodeGroup
+                    field: selfLink
+            privateIPv6GoogleAccess:
+              type: string
+              x-dcl-go-name: PrivateIPv6GoogleAccess
+              x-dcl-go-type: ClusterClusterConfigGceClusterConfigPrivateIPv6GoogleAccessEnum
+              description: 'Optional. The type of IPv6 access for a cluster. Possible
+                values: PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED, INHERIT_FROM_SUBNETWORK,
+                OUTBOUND, BIDIRECTIONAL'
+              x-kubernetes-immutable: true
+              enum:
+              - PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
+              - INHERIT_FROM_SUBNETWORK
+              - OUTBOUND
+              - BIDIRECTIONAL
+            reservationAffinity:
+              type: object
+              x-dcl-go-name: ReservationAffinity
+              x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinity
+              description: Optional. Reservation Affinity for consuming Zonal reservation.
+              x-kubernetes-immutable: true
+              properties:
+                consumeReservationType:
+                  type: string
+                  x-dcl-go-name: ConsumeReservationType
+                  x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinityConsumeReservationTypeEnum
+                  description: 'Optional. Type of reservation to consume Possible
+                    values: TYPE_UNSPECIFIED, NO_RESERVATION, ANY_RESERVATION, SPECIFIC_RESERVATION'
+                  x-kubernetes-immutable: true
+                  enum:
+                  - TYPE_UNSPECIFIED
+                  - NO_RESERVATION
+                  - ANY_RESERVATION
+                  - SPECIFIC_RESERVATION
+                key:
+                  type: string
+                  x-dcl-go-name: Key
+                  description: Optional. Corresponds to the label key of reservation
+                    resource.
+                  x-kubernetes-immutable: true
+                values:
+                  type: array
+                  x-dcl-go-name: Values
+                  description: Optional. Corresponds to the label values of reservation
+                    resource.
+                  x-kubernetes-immutable: true
+                  x-dcl-send-empty: true
+                  x-dcl-list-type: list
+                  items:
+                    type: string
+                    x-dcl-go-type: string
+            serviceAccount:
+              type: string
+              x-dcl-go-name: ServiceAccount
+              description: Optional. The [Dataproc service account](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts#service_accounts_in_dataproc)
+                (also see [VM Data Plane identity](https://cloud.google.com/dataproc/docs/concepts/iam/dataproc-principals#vm_service_account_data_plane_identity))
+                used by Dataproc cluster VM instances to access Google Cloud Platform
+                services. If not specified, the [Compute Engine default service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
+                is used.
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Iam/ServiceAccount
+                field: email
+            serviceAccountScopes:
+              type: array
+              x-dcl-go-name: ServiceAccountScopes
+              description: 'Optional. The URIs of service account scopes to be included
+                in Compute Engine instances. The following base set of scopes is always
+                included: * https://www.googleapis.com/auth/cloud.useraccounts.readonly
+                * https://www.googleapis.com/auth/devstorage.read_write * https://www.googleapis.com/auth/logging.write
+                If no scopes are specified, the following defaults are also provided:
+                * https://www.googleapis.com/auth/bigquery * https://www.googleapis.com/auth/bigtable.admin.table
+                * https://www.googleapis.com/auth/bigtable.data * https://www.googleapis.com/auth/devstorage.full_control'
+              x-kubernetes-immutable: true
+              x-dcl-send-empty: true
+              x-dcl-list-type: list
+              items:
+                type: string
+                x-dcl-go-type: string
+            subnetwork:
+              type: string
+              x-dcl-go-name: Subnetwork
+              description: 'Optional. The Compute Engine subnetwork to be used for
+                machine communications. Cannot be specified with network_uri. A full
+                URL, partial URI, or short name are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/subnetworks/sub0`
+                * `projects/[project_id]/regions/us-east1/subnetworks/sub0` * `sub0`'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Compute/Subnetwork
+                field: selfLink
+            tags:
+              type: array
+              x-dcl-go-name: Tags
+              description: The Compute Engine tags to add to all instances (see [Tagging
+                instances](https://cloud.google.com/compute/docs/label-or-tag-resources#tags)).
+              x-kubernetes-immutable: true
+              x-dcl-send-empty: true
+              x-dcl-list-type: set
+              items:
+                type: string
+                x-dcl-go-type: string
+            zone:
+              type: string
+              x-dcl-go-name: Zone
+              description: 'Optional. The zone where the Compute Engine cluster will
+                be located. On a create request, it is required in the "global" region.
+                If omitted in a non-global Dataproc region, the service will pick
+                a zone in the corresponding Compute Engine region. On a get request,
+                zone will always be present. A full URL, partial URI, or short name
+                are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]`
+                * `projects/[project_id]/zones/[zone]` * `us-central1-f`'
+              x-kubernetes-immutable: true
+        gkeClusterConfig:
+          type: object
+          x-dcl-go-name: GkeClusterConfig
+          x-dcl-go-type: ClusterClusterConfigGkeClusterConfig
+          description: Optional. BETA. The Kubernetes Engine config for Dataproc clusters
+            deployed to Kubernetes. Setting this is considered mutually exclusive
+            with Compute Engine-based options such as `gce_cluster_config`, `master_config`,
+            `worker_config`, `secondary_worker_config`, and `autoscaling_config`.
+          x-kubernetes-immutable: true
+          properties:
+            namespacedGkeDeploymentTarget:
+              type: object
+              x-dcl-go-name: NamespacedGkeDeploymentTarget
+              x-dcl-go-type: ClusterClusterConfigGkeClusterConfigNamespacedGkeDeploymentTarget
+              description: Optional. A target for the deployment.
+              x-kubernetes-immutable: true
+              properties:
+                clusterNamespace:
+                  type: string
+                  x-dcl-go-name: ClusterNamespace
+                  description: Optional. A namespace within the GKE cluster to deploy
+                    into.
+                  x-kubernetes-immutable: true
+                targetGkeCluster:
+                  type: string
+                  x-dcl-go-name: TargetGkeCluster
+                  description: 'Optional. The target GKE cluster to deploy to. Format:
+                    ''projects/{project}/locations/{location}/clusters/{cluster_id}'''
+                  x-kubernetes-immutable: true
+                  x-dcl-references:
+                  - resource: Container/Cluster
+                    field: name
+        initializationActions:
+          type: array
+          x-dcl-go-name: InitializationActions
+          description: 'Optional. Commands to execute on each node after config is
+            completed. By default, executables are run on master and all worker nodes.
+            You can test a node''s `role` metadata to run an executable on a master
+            or worker node, as shown below using `curl` (you can also use `wget`):
+            ROLE=$(curl -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)
+            if [[ "${ROLE}" == ''Master'' ]]; then ... master specific actions ...
+            else ... worker specific actions ... fi'
+          x-kubernetes-immutable: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: ClusterClusterConfigInitializationActions
+            properties:
+              executableFile:
+                type: string
+                x-dcl-go-name: ExecutableFile
+                description: Required. Cloud Storage URI of executable file.
+                x-kubernetes-immutable: true
+              executionTimeout:
+                type: string
+                x-dcl-go-name: ExecutionTimeout
+                description: Optional. Amount of time executable has to complete.
+                  Default is 10 minutes (see JSON representation of [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+                  Cluster creation fails with an explanatory error message (the name
+                  of the executable that caused the error and the exceeded timeout
+                  period) if the executable is not completed at end of the timeout
+                  period.
+                x-kubernetes-immutable: true
+        lifecycleConfig:
+          type: object
+          x-dcl-go-name: LifecycleConfig
+          x-dcl-go-type: ClusterClusterConfigLifecycleConfig
+          description: Optional. Lifecycle setting for the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            autoDeleteTime:
+              type: string
+              format: date-time
+              x-dcl-go-name: AutoDeleteTime
+              description: Optional. The time when cluster will be auto-deleted (see
+                JSON representation of [Timestamp](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+            autoDeleteTtl:
+              type: string
+              x-dcl-go-name: AutoDeleteTtl
+              description: Optional. The lifetime duration of cluster. The cluster
+                will be auto-deleted at the end of this period. Minimum value is 10
+                minutes; maximum value is 14 days (see JSON representation of [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+            idleDeleteTtl:
+              type: string
+              x-dcl-go-name: IdleDeleteTtl
+              description: Optional. The duration to keep the cluster alive while
+                idling (when no jobs are running). Passing this threshold will cause
+                the cluster to be deleted. Minimum value is 5 minutes; maximum value
+                is 14 days (see JSON representation of [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+            idleStartTime:
+              type: string
+              format: date-time
+              x-dcl-go-name: IdleStartTime
+              readOnly: true
+              description: Output only. The time when cluster became idle (most recent
+                job finished) and became eligible for deletion due to idleness (see
+                JSON representation of [Timestamp](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+        masterConfig:
+          $ref: '#/components/schemas/InstanceGroupConfig'
+          x-dcl-go-name: MasterConfig
+          x-kubernetes-immutable: true
+        metastoreConfig:
+          type: object
+          x-dcl-go-name: MetastoreConfig
+          x-dcl-go-type: ClusterClusterConfigMetastoreConfig
+          description: Optional. Metastore configuration.
+          x-kubernetes-immutable: true
+          required:
+          - dataprocMetastoreService
+          properties:
+            dataprocMetastoreService:
+              type: string
+              x-dcl-go-name: DataprocMetastoreService
+              description: 'Required. Resource name of an existing Dataproc Metastore
+                service. Example: * `projects/[project_id]/locations/[dataproc_region]/services/[service-name]`'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Metastore/Service
+                field: selfLink
+        secondaryWorkerConfig:
+          $ref: '#/components/schemas/InstanceGroupConfig'
+          x-dcl-go-name: SecondaryWorkerConfig
+          x-kubernetes-immutable: true
+        securityConfig:
+          type: object
+          x-dcl-go-name: SecurityConfig
+          x-dcl-go-type: ClusterClusterConfigSecurityConfig
+          description: Optional. Security settings for the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            kerberosConfig:
+              type: object
+              x-dcl-go-name: KerberosConfig
+              x-dcl-go-type: ClusterClusterConfigSecurityConfigKerberosConfig
+              description: Optional. Kerberos related configuration.
+              x-kubernetes-immutable: true
+              properties:
+                crossRealmTrustAdminServer:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustAdminServer
+                  description: Optional. The admin server (IP or hostname) for the
+                    remote trusted realm in a cross realm trust relationship.
+                  x-kubernetes-immutable: true
+                crossRealmTrustKdc:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustKdc
+                  description: Optional. The KDC (IP or hostname) for the remote trusted
+                    realm in a cross realm trust relationship.
+                  x-kubernetes-immutable: true
+                crossRealmTrustRealm:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustRealm
+                  description: Optional. The remote realm the Dataproc on-cluster
+                    KDC will trust, should the user enable cross realm trust.
+                  x-kubernetes-immutable: true
+                crossRealmTrustSharedPassword:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustSharedPassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the shared password between the on-cluster Kerberos
+                    realm and the remote trusted realm, in a cross realm trust relationship.
+                  x-kubernetes-immutable: true
+                enableKerberos:
+                  type: boolean
+                  x-dcl-go-name: EnableKerberos
+                  description: 'Optional. Flag to indicate whether to Kerberize the
+                    cluster (default: false). Set this field to true to enable Kerberos
+                    on a cluster.'
+                  x-kubernetes-immutable: true
+                kdcDbKey:
+                  type: string
+                  x-dcl-go-name: KdcDbKey
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the master key of the KDC database.
+                  x-kubernetes-immutable: true
+                keyPassword:
+                  type: string
+                  x-dcl-go-name: KeyPassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the password to the user provided key. For the
+                    self-signed certificate, this password is generated by Dataproc.
+                  x-kubernetes-immutable: true
+                keystore:
+                  type: string
+                  x-dcl-go-name: Keystore
+                  description: Optional. The Cloud Storage URI of the keystore file
+                    used for SSL encryption. If not provided, Dataproc will provide
+                    a self-signed certificate.
+                  x-kubernetes-immutable: true
+                keystorePassword:
+                  type: string
+                  x-dcl-go-name: KeystorePassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the password to the user provided keystore. For
+                    the self-signed certificate, this password is generated by Dataproc.
+                  x-kubernetes-immutable: true
+                kmsKey:
+                  type: string
+                  x-dcl-go-name: KmsKey
+                  description: Optional. The uri of the KMS key used to encrypt various
+                    sensitive files.
+                  x-kubernetes-immutable: true
+                  x-dcl-references:
+                  - resource: Cloudkms/CryptoKey
+                    field: selfLink
+                realm:
+                  type: string
+                  x-dcl-go-name: Realm
+                  description: Optional. The name of the on-cluster Kerberos realm.
+                    If not specified, the uppercased domain of hostnames will be the
+                    realm.
+                  x-kubernetes-immutable: true
+                rootPrincipalPassword:
+                  type: string
+                  x-dcl-go-name: RootPrincipalPassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the root principal password.
+                  x-kubernetes-immutable: true
+                tgtLifetimeHours:
+                  type: integer
+                  format: int64
+                  x-dcl-go-name: TgtLifetimeHours
+                  description: Optional. The lifetime of the ticket granting ticket,
+                    in hours. If not specified, or user specifies 0, then default
+                    value 10 will be used.
+                  x-kubernetes-immutable: true
+                truststore:
+                  type: string
+                  x-dcl-go-name: Truststore
+                  description: Optional. The Cloud Storage URI of the truststore file
+                    used for SSL encryption. If not provided, Dataproc will provide
+                    a self-signed certificate.
+                  x-kubernetes-immutable: true
+                truststorePassword:
+                  type: string
+                  x-dcl-go-name: TruststorePassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the password to the user provided truststore.
+                    For the self-signed certificate, this password is generated by
+                    Dataproc.
+                  x-kubernetes-immutable: true
+        softwareConfig:
+          type: object
+          x-dcl-go-name: SoftwareConfig
+          x-dcl-go-type: ClusterClusterConfigSoftwareConfig
+          description: Optional. The config settings for software inside the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            imageVersion:
+              type: string
+              x-dcl-go-name: ImageVersion
+              description: Optional. The version of software inside the cluster. It
+                must be one of the supported [Dataproc Versions](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#supported_dataproc_versions),
+                such as "1.2" (including a subminor version, such as "1.2.29"), or
+                the ["preview" version](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
+                If unspecified, it defaults to the latest Debian version.
+              x-kubernetes-immutable: true
+            optionalComponents:
+              type: array
+              x-dcl-go-name: OptionalComponents
+              description: Optional. The set of components to activate on the cluster.
+              x-kubernetes-immutable: true
+              x-dcl-send-empty: true
+              x-dcl-list-type: list
+              items:
+                type: string
+                x-dcl-go-type: ClusterClusterConfigSoftwareConfigOptionalComponentsEnum
+                enum:
+                - COMPONENT_UNSPECIFIED
+                - ANACONDA
+                - DOCKER
+                - DRUID
+                - FLINK
+                - HBASE
+                - HIVE_WEBHCAT
+                - JUPYTER
+                - KERBEROS
+                - PRESTO
+                - RANGER
+                - SOLR
+                - ZEPPELIN
+                - ZOOKEEPER
+            properties:
+              type: object
+              additionalProperties:
+                type: string
+              x-dcl-go-name: Properties
+              description: 'Optional. The properties to set on daemon config files.
+                Property keys are specified in `prefix:property` format, for example
+                `core:hadoop.tmp.dir`. The following are supported prefixes and their
+                mappings: * capacity-scheduler: `capacity-scheduler.xml` * core: `core-site.xml`
+                * distcp: `distcp-default.xml` * hdfs: `hdfs-site.xml` * hive: `hive-site.xml`
+                * mapred: `mapred-site.xml` * pig: `pig.properties` * spark: `spark-defaults.conf`
+                * yarn: `yarn-site.xml` For more information, see [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties).'
+              x-kubernetes-immutable: true
+        stagingBucket:
+          type: string
+          x-dcl-go-name: StagingBucket
+          description: Optional. A Cloud Storage bucket used to stage job dependencies,
+            config files, and job driver console output. If you do not specify a staging
+            bucket, Cloud Dataproc will determine a Cloud Storage location (US, ASIA,
+            or EU) for your cluster's staging bucket according to the Compute Engine
+            zone where your cluster is deployed, and then create and manage this project-level,
+            per-location bucket (see [Dataproc staging bucket](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
+            **This field requires a Cloud Storage bucket name, not a URI to a Cloud
+            Storage bucket.**
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Storage/Bucket
+            field: name
+        tempBucket:
+          type: string
+          x-dcl-go-name: TempBucket
+          description: Optional. A Cloud Storage bucket used to store ephemeral cluster
+            and jobs data, such as Spark and MapReduce history files. If you do not
+            specify a temp bucket, Dataproc will determine a Cloud Storage location
+            (US, ASIA, or EU) for your cluster's temp bucket according to the Compute
+            Engine zone where your cluster is deployed, and then create and manage
+            this project-level, per-location bucket. The default bucket has a TTL
+            of 90 days, but you can use any TTL (or none) if you specify a bucket.
+            **This field requires a Cloud Storage bucket name, not a URI to a Cloud
+            Storage bucket.**
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Storage/Bucket
+            field: name
+        workerConfig:
+          $ref: '#/components/schemas/InstanceGroupConfig'
+          x-dcl-go-name: WorkerConfig
+          x-kubernetes-immutable: true
+    InstanceGroupConfig:
+      type: object
+      x-dcl-go-name: WorkerConfig
+      x-dcl-go-type: ClusterInstanceGroupConfig
+      description: Optional. The Compute Engine config settings for worker instances
+        in a cluster.
+      x-kubernetes-immutable: true
+      x-dcl-server-default: true
+      properties:
+        accelerators:
+          type: array
+          x-dcl-go-name: Accelerators
+          description: Optional. The Compute Engine accelerator configuration for
+            these instances.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: ClusterInstanceGroupConfigAccelerators
+            properties:
+              acceleratorCount:
+                type: integer
+                format: int64
+                x-dcl-go-name: AcceleratorCount
+                description: The number of the accelerator cards of this type exposed
+                  to this instance.
+                x-kubernetes-immutable: true
+              acceleratorType:
+                type: string
+                x-dcl-go-name: AcceleratorType
+                description: 'Full URL, partial URI, or short name of the accelerator
+                  type resource to expose to this instance. See [Compute Engine AcceleratorTypes](https://cloud.google.com/compute/docs/reference/beta/acceleratorTypes).
+                  Examples: * `https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
+                  * `projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
+                  * `nvidia-tesla-k80` **Auto Zone Exception**: If you are using the
+                  Dataproc [Auto Zone Placement](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                  feature, you must use the short name of the accelerator type resource,
+                  for example, `nvidia-tesla-k80`.'
+                x-kubernetes-immutable: true
+        diskConfig:
+          type: object
+          x-dcl-go-name: DiskConfig
+          x-dcl-go-type: ClusterInstanceGroupConfigDiskConfig
+          description: Optional. Disk option config settings.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          properties:
+            bootDiskSizeGb:
+              type: integer
+              format: int64
+              x-dcl-go-name: BootDiskSizeGb
+              description: Optional. Size in GB of the boot disk (default is 500GB).
+              x-kubernetes-immutable: true
+            bootDiskType:
+              type: string
+              x-dcl-go-name: BootDiskType
+              description: 'Optional. Type of the boot disk (default is "pd-standard").
+                Valid values: "pd-balanced" (Persistent Disk Balanced Solid State
+                Drive), "pd-ssd" (Persistent Disk Solid State Drive), or "pd-standard"
+                (Persistent Disk Hard Disk Drive). See [Disk types](https://cloud.google.com/compute/docs/disks#disk-types).'
+              x-kubernetes-immutable: true
+            numLocalSsds:
+              type: integer
+              format: int64
+              x-dcl-go-name: NumLocalSsds
+              description: Optional. Number of attached SSDs, from 0 to 4 (default
+                is 0). If SSDs are not attached, the boot disk is used to store runtime
+                logs and [HDFS](https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
+                data. If one or more SSDs are attached, this runtime bulk data is
+                spread across them, and the boot disk contains only basic config and
+                installed binaries.
+              x-kubernetes-immutable: true
+              x-dcl-server-default: true
+        image:
+          type: string
+          x-dcl-go-name: Image
+          description: 'Optional. The Compute Engine image resource used for cluster
+            instances. The URI can represent an image or image family. Image examples:
+            * `https://www.googleapis.com/compute/beta/projects/[project_id]/global/images/[image-id]`
+            * `projects/[project_id]/global/images/[image-id]` * `image-id` Image
+            family examples. Dataproc will use the most recent image from the family:
+            * `https://www.googleapis.com/compute/beta/projects/[project_id]/global/images/family/[custom-image-family-name]`
+            * `projects/[project_id]/global/images/family/[custom-image-family-name]`
+            If the URI is unspecified, it will be inferred from `SoftwareConfig.image_version`
+            or the system default.'
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Compute/Image
+            field: selfLink
+        instanceNames:
+          type: array
+          x-dcl-go-name: InstanceNames
+          readOnly: true
+          description: Output only. The list of instance names. Dataproc derives the
+            names from `cluster_name`, `num_instances`, and the instance group.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          x-dcl-list-type: list
+          items:
+            type: string
+            x-dcl-go-type: string
+            x-dcl-references:
+            - resource: Compute/Instance
+              field: selfLink
+        isPreemptible:
+          type: boolean
+          x-dcl-go-name: IsPreemptible
+          readOnly: true
+          description: Output only. Specifies that this instance group contains preemptible
+            instances.
+          x-kubernetes-immutable: true
+        machineType:
+          type: string
+          x-dcl-go-name: MachineType
+          description: 'Optional. The Compute Engine machine type used for cluster
+            instances. A full URL, partial URI, or short name are valid. Examples:
+            * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2`
+            * `projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2`
+            * `n1-standard-2` **Auto Zone Exception**: If you are using the Dataproc
+            [Auto Zone Placement](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+            feature, you must use the short name of the machine type resource, for
+            example, `n1-standard-2`.'
+          x-kubernetes-immutable: true
+        managedGroupConfig:
+          type: object
+          x-dcl-go-name: ManagedGroupConfig
+          x-dcl-go-type: ClusterInstanceGroupConfigManagedGroupConfig
+          readOnly: true
+          description: Output only. The config for Compute Engine Instance Group Manager
+            that manages this group. This is only used for preemptible instance groups.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          properties:
+            instanceGroupManagerName:
+              type: string
+              x-dcl-go-name: InstanceGroupManagerName
+              readOnly: true
+              description: Output only. The name of the Instance Group Manager for
+                this group.
+              x-kubernetes-immutable: true
+            instanceTemplateName:
+              type: string
+              x-dcl-go-name: InstanceTemplateName
+              readOnly: true
+              description: Output only. The name of the Instance Template used for
+                the Managed Instance Group.
+              x-kubernetes-immutable: true
+        minCpuPlatform:
+          type: string
+          x-dcl-go-name: MinCpuPlatform
+          description: Optional. Specifies the minimum cpu platform for the Instance
+            Group. See [Dataproc -> Minimum CPU Platform](https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+        numInstances:
+          type: integer
+          format: int64
+          x-dcl-go-name: NumInstances
+          description: Optional. The number of VM instances in the instance group.
+            For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability)
+            [master_config](#FIELDS.master_config) groups, **must be set to 3**. For
+            standard cluster [master_config](#FIELDS.master_config) groups, **must
+            be set to 1**.
+          x-kubernetes-immutable: true
+        preemptibility:
+          type: string
+          x-dcl-go-name: Preemptibility
+          x-dcl-go-type: ClusterInstanceGroupConfigPreemptibilityEnum
+          description: 'Optional. Specifies the preemptibility of the instance group.
+            The default value for master and worker groups is `NON_PREEMPTIBLE`. This
+            default cannot be changed. The default value for secondary instances is
+            `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE,
+            PREEMPTIBLE'
+          x-kubernetes-immutable: true
+          enum:
+          - PREEMPTIBILITY_UNSPECIFIED
+          - NON_PREEMPTIBLE
+          - PREEMPTIBLE
+    WorkflowTemplate:
+      title: WorkflowTemplate
+      x-dcl-id: projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}
+      x-dcl-parent-container: project
+      x-dcl-labels: labels
+      type: object
+      required:
+      - name
+      - placement
+      - jobs
+      - project
+      - location
+      properties:
+        createTime:
+          type: string
+          format: date-time
+          x-dcl-go-name: CreateTime
+          readOnly: true
+          description: Output only. The time template was created.
+          x-kubernetes-immutable: true
+        dagTimeout:
+          type: string
+          x-dcl-go-name: DagTimeout
+          description: Optional. Timeout duration for the DAG of jobs, expressed in
+            seconds (see [JSON representation of duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+            The timeout duration must be from 10 minutes ("600s") to 24 hours ("86400s").
+            The timer begins when the first job is submitted. If the workflow is running
+            at the end of the timeout period, any remaining jobs are cancelled, the
+            workflow is ended, and if the workflow was running on a [managed cluster](/dataproc/docs/concepts/workflows/using-workflows#configuring_or_selecting_a_cluster),
+            the cluster is deleted.
+          x-kubernetes-immutable: true
+        jobs:
+          type: array
+          x-dcl-go-name: Jobs
+          description: Required. The Directed Acyclic Graph of Jobs to submit.
+          x-kubernetes-immutable: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: WorkflowTemplateJobs
+            required:
+            - stepId
+            properties:
+              hadoopJob:
+                type: object
+                x-dcl-go-name: HadoopJob
+                x-dcl-go-type: WorkflowTemplateJobsHadoopJob
+                description: Optional. Job is a Hadoop job.
+                x-kubernetes-immutable: true
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      in the working directory of Hadoop drivers and tasks. Supported
+                      file types: .jar, .tar, .tar.gz, .tgz, or .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `-libjars` or `-Dfoo=bar`, that
+                      can be set as job properties, since a collision may occur that
+                      causes an incorrect job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS (Hadoop Compatible Filesystem) URIs
+                      of files to be copied to the working directory of Hadoop drivers
+                      and distributed tasks. Useful for naively parallel tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. Jar file URIs to add to the CLASSPATHs
+                      of the Hadoop driver and tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsHadoopJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainClass:
+                    type: string
+                    x-dcl-go-name: MainClass
+                    description: The name of the driver's main class. The jar file
+                      containing the class must be in the default CLASSPATH or specified
+                      in `jar_file_uris`.
+                    x-kubernetes-immutable: true
+                  mainJarFileUri:
+                    type: string
+                    x-dcl-go-name: MainJarFileUri
+                    description: 'The HCFS URI of the jar file containing the main
+                      class. Examples: ''gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar''
+                      ''hdfs:/tmp/test-samples/custom-wordcount.jar'' ''file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar'''
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Hadoop. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/hadoop/conf/*-site and classes in user code.
+                    x-kubernetes-immutable: true
+              hiveJob:
+                type: object
+                x-dcl-go-name: HiveJob
+                x-dcl-go-type: WorkflowTemplateJobsHiveJob
+                description: Optional. Job is a Hive job.
+                x-kubernetes-immutable: true
+                properties:
+                  continueOnFailure:
+                    type: boolean
+                    x-dcl-go-name: ContinueOnFailure
+                    description: Optional. Whether to continue executing queries if
+                      a query fails. The default value is `false`. Setting to `true`
+                      can be useful when executing independent parallel queries.
+                    x-kubernetes-immutable: true
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
+                      of the Hive server and Hadoop MapReduce (MR) tasks. Can contain
+                      Hive SerDes and UDFs.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names and values,
+                      used to configure Hive. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml,
+                      and classes in user code.
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains Hive queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsHiveJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  scriptVariables:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: ScriptVariables
+                    description: 'Optional. Mapping of query variable names to values
+                      (equivalent to the Hive command: `SET name="value";`).'
+                    x-kubernetes-immutable: true
+              labels:
+                type: object
+                additionalProperties:
+                  type: string
+                x-dcl-go-name: Labels
+                description: 'Optional. The labels to associate with this job. Label
+                  keys must be between 1 and 63 characters long, and must conform
+                  to the following regular expression: p{Ll}p{Lo}{0,62} Label values
+                  must be between 1 and 63 characters long, and must conform to the
+                  following regular expression: [p{Ll}p{Lo}p{N}_-]{0,63} No more than
+                  32 labels can be associated with a given job.'
+                x-kubernetes-immutable: true
+              pigJob:
+                type: object
+                x-dcl-go-name: PigJob
+                x-dcl-go-type: WorkflowTemplateJobsPigJob
+                description: Optional. Job is a Pig job.
+                x-kubernetes-immutable: true
+                properties:
+                  continueOnFailure:
+                    type: boolean
+                    x-dcl-go-name: ContinueOnFailure
+                    description: Optional. Whether to continue executing queries if
+                      a query fails. The default value is `false`. Setting to `true`
+                      can be useful when executing independent parallel queries.
+                    x-kubernetes-immutable: true
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
+                      of the Pig Client and Hadoop MapReduce (MR) tasks. Can contain
+                      Pig UDFs.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsPigJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Pig. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties,
+                      and classes in user code.
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains the Pig
+                      queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsPigJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  scriptVariables:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: ScriptVariables
+                    description: 'Optional. Mapping of query variable names to values
+                      (equivalent to the Pig command: `name=[value]`).'
+                    x-kubernetes-immutable: true
+              prerequisiteStepIds:
+                type: array
+                x-dcl-go-name: PrerequisiteStepIds
+                description: Optional. The optional list of prerequisite job step_ids.
+                  If not specified, the job will start at the beginning of workflow.
+                x-kubernetes-immutable: true
+                x-dcl-send-empty: true
+                x-dcl-list-type: list
+                items:
+                  type: string
+                  x-dcl-go-type: string
+              prestoJob:
+                type: object
+                x-dcl-go-name: PrestoJob
+                x-dcl-go-type: WorkflowTemplateJobsPrestoJob
+                description: Optional. Job is a Presto job.
+                x-kubernetes-immutable: true
+                properties:
+                  clientTags:
+                    type: array
+                    x-dcl-go-name: ClientTags
+                    description: Optional. Presto client tags to attach to this query
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  continueOnFailure:
+                    type: boolean
+                    x-dcl-go-name: ContinueOnFailure
+                    description: Optional. Whether to continue executing queries if
+                      a query fails. The default value is `false`. Setting to `true`
+                      can be useful when executing independent parallel queries.
+                    x-kubernetes-immutable: true
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  outputFormat:
+                    type: string
+                    x-dcl-go-name: OutputFormat
+                    description: Optional. The format in which query output will be
+                      displayed. See the Presto documentation for supported output
+                      formats
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values.
+                      Used to set Presto [session properties](https://prestodb.io/docs/current/sql/set-session.html)
+                      Equivalent to using the --session flag in the Presto CLI
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains SQL queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+              pysparkJob:
+                type: object
+                x-dcl-go-name: PysparkJob
+                x-dcl-go-type: WorkflowTemplateJobsPysparkJob
+                description: Optional. Job is a PySpark job.
+                x-kubernetes-immutable: true
+                required:
+                - mainPythonFileUri
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      into the working directory of each executor. Supported file
+                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `--conf`, that can be set as
+                      job properties, since a collision may occur that causes an incorrect
+                      job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS URIs of files to be placed in the
+                      working directory of each executor. Useful for naively parallel
+                      tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
+                      of the Python driver and tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsPysparkJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainPythonFileUri:
+                    type: string
+                    x-dcl-go-name: MainPythonFileUri
+                    description: Required. The HCFS URI of the main Python file to
+                      use as the driver. Must be a .py file.
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure PySpark. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/spark/conf/spark-defaults.conf and classes in user
+                      code.
+                    x-kubernetes-immutable: true
+                  pythonFileUris:
+                    type: array
+                    x-dcl-go-name: PythonFileUris
+                    description: 'Optional. HCFS file URIs of Python files to pass
+                      to the PySpark framework. Supported file types: .py, .egg, and
+                      .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+              scheduling:
+                type: object
+                x-dcl-go-name: Scheduling
+                x-dcl-go-type: WorkflowTemplateJobsScheduling
+                description: Optional. Job scheduling configuration.
+                x-kubernetes-immutable: true
+                properties:
+                  maxFailuresPerHour:
+                    type: integer
+                    format: int64
+                    x-dcl-go-name: MaxFailuresPerHour
+                    description: Optional. Maximum number of times per hour a driver
+                      may be restarted as a result of driver exiting with non-zero
+                      code before job is reported failed. A job may be reported as
+                      thrashing if driver exits with non-zero code 4 times within
+                      10 minute window. Maximum value is 10.
+                    x-kubernetes-immutable: true
+                  maxFailuresTotal:
+                    type: integer
+                    format: int64
+                    x-dcl-go-name: MaxFailuresTotal
+                    description: Optional. Maximum number of times in total a driver
+                      may be restarted as a result of driver exiting with non-zero
+                      code before job is reported failed. Maximum value is 240.
+                    x-kubernetes-immutable: true
+              sparkJob:
+                type: object
+                x-dcl-go-name: SparkJob
+                x-dcl-go-type: WorkflowTemplateJobsSparkJob
+                description: Optional. Job is a Spark job.
+                x-kubernetes-immutable: true
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      into the working directory of each executor. Supported file
+                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `--conf`, that can be set as
+                      job properties, since a collision may occur that causes an incorrect
+                      job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS URIs of files to be placed in the
+                      working directory of each executor. Useful for naively parallel
+                      tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
+                      of the Spark driver and tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsSparkJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainClass:
+                    type: string
+                    x-dcl-go-name: MainClass
+                    description: The name of the driver's main class. The jar file
+                      that contains the class must be in the default CLASSPATH or
+                      specified in `jar_file_uris`.
+                    x-kubernetes-immutable: true
+                  mainJarFileUri:
+                    type: string
+                    x-dcl-go-name: MainJarFileUri
+                    description: The HCFS URI of the jar file that contains the main
+                      class.
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Spark. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/spark/conf/spark-defaults.conf and classes in user
+                      code.
+                    x-kubernetes-immutable: true
+              sparkRJob:
+                type: object
+                x-dcl-go-name: SparkRJob
+                x-dcl-go-type: WorkflowTemplateJobsSparkRJob
+                description: Optional. Job is a SparkR job.
+                x-kubernetes-immutable: true
+                required:
+                - mainRFileUri
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      into the working directory of each executor. Supported file
+                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `--conf`, that can be set as
+                      job properties, since a collision may occur that causes an incorrect
+                      job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS URIs of files to be placed in the
+                      working directory of each executor. Useful for naively parallel
+                      tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsSparkRJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainRFileUri:
+                    type: string
+                    x-dcl-go-name: MainRFileUri
+                    description: Required. The HCFS URI of the main R file to use
+                      as the driver. Must be a .R file.
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure SparkR. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/spark/conf/spark-defaults.conf and classes in user
+                      code.
+                    x-kubernetes-immutable: true
+              sparkSqlJob:
+                type: object
+                x-dcl-go-name: SparkSqlJob
+                x-dcl-go-type: WorkflowTemplateJobsSparkSqlJob
+                description: Optional. Job is a SparkSql job.
+                x-kubernetes-immutable: true
+                properties:
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to be added to the
+                      Spark CLASSPATH.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Spark SQL's SparkConf. Properties that conflict
+                      with values set by the Dataproc API may be overwritten.
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains SQL queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  scriptVariables:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: ScriptVariables
+                    description: 'Optional. Mapping of query variable names to values
+                      (equivalent to the Spark SQL command: SET `name="value";`).'
+                    x-kubernetes-immutable: true
+              stepId:
+                type: string
+                x-dcl-go-name: StepId
+                description: Required. The step id. The id must be unique among all
+                  jobs within the template. The step id is used as prefix for job
+                  id, as job `goog-dataproc-workflow-step-id` label, and in prerequisiteStepIds
+                  field from other steps. The id must contain only letters (a-z, A-Z),
+                  numbers (0-9), underscores (_), and hyphens (-). Cannot begin or
+                  end with underscore or hyphen. Must consist of between 3 and 50
+                  characters.
+                x-kubernetes-immutable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          x-dcl-go-name: Labels
+          description: Optional. The labels to associate with this template. These
+            labels will be propagated to all jobs and clusters created by the workflow
+            instance. Label **keys** must contain 1 to 63 characters, and must conform
+            to [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt). Label **values**
+            may be empty, but, if present, must contain 1 to 63 characters, and must
+            conform to [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt). No more than
+            32 labels can be associated with a template.
+          x-kubernetes-immutable: true
+        location:
+          type: string
+          x-dcl-go-name: Location
+          description: The location for the resource
+          x-kubernetes-immutable: true
+        name:
+          type: string
+          x-dcl-go-name: Name
+          description: 'Output only. The resource name of the workflow template, as
+            described in https://cloud.google.com/apis/design/resource_names. * For
+            `projects.regions.workflowTemplates`, the resource name of the template
+            has the following format: `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
+            * For `projects.locations.workflowTemplates`, the resource name of the
+            template has the following format: `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`'
+          x-kubernetes-immutable: true
+        parameters:
+          type: array
+          x-dcl-go-name: Parameters
+          description: Optional. Template parameters whose values are substituted
+            into the template. Values for parameters must be provided when the template
+            is instantiated.
+          x-kubernetes-immutable: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: WorkflowTemplateParameters
+            required:
+            - name
+            - fields
+            properties:
+              description:
+                type: string
+                x-dcl-go-name: Description
+                description: Optional. Brief description of the parameter. Must not
+                  exceed 1024 characters.
+                x-kubernetes-immutable: true
+              fields:
+                type: array
+                x-dcl-go-name: Fields
+                description: 'Required. Paths to all fields that the parameter replaces.
+                  A field is allowed to appear in at most one parameter''s list of
+                  field paths. A field path is similar in syntax to a google.protobuf.FieldMask.
+                  For example, a field path that references the zone field of a workflow
+                  template''s cluster selector would be specified as `placement.clusterSelector.zone`.
+                  Also, field paths can reference fields using the following syntax:
+                  * Values in maps can be referenced by key: * labels[''key''] * placement.clusterSelector.clusterLabels[''key'']
+                  * placement.managedCluster.labels[''key''] * placement.clusterSelector.clusterLabels[''key'']
+                  * jobs[''step-id''].labels[''key''] * Jobs in the jobs list can
+                  be referenced by step-id: * jobs[''step-id''].hadoopJob.mainJarFileUri
+                  * jobs[''step-id''].hiveJob.queryFileUri * jobs[''step-id''].pySparkJob.mainPythonFileUri
+                  * jobs[''step-id''].hadoopJob.jarFileUris[0] * jobs[''step-id''].hadoopJob.archiveUris[0]
+                  * jobs[''step-id''].hadoopJob.fileUris[0] * jobs[''step-id''].pySparkJob.pythonFileUris[0]
+                  * Items in repeated fields can be referenced by a zero-based index:
+                  * jobs[''step-id''].sparkJob.args[0] * Other examples: * jobs[''step-id''].hadoopJob.properties[''key'']
+                  * jobs[''step-id''].hadoopJob.args[0] * jobs[''step-id''].hiveJob.scriptVariables[''key'']
+                  * jobs[''step-id''].hadoopJob.mainJarFileUri * placement.clusterSelector.zone
+                  It may not be possible to parameterize maps and repeated fields
+                  in their entirety since only individual map values and individual
+                  items in repeated fields can be referenced. For example, the following
+                  field paths are invalid: - placement.clusterSelector.clusterLabels
+                  - jobs[''step-id''].sparkJob.args'
+                x-kubernetes-immutable: true
+                x-dcl-send-empty: true
+                x-dcl-list-type: list
+                items:
+                  type: string
+                  x-dcl-go-type: string
+              name:
+                type: string
+                x-dcl-go-name: Name
+                description: Required. Parameter name. The parameter name is used
+                  as the key, and paired with the parameter value, which are passed
+                  to the template when the template is instantiated. The name must
+                  contain only capital letters (A-Z), numbers (0-9), and underscores
+                  (_), and must not start with a number. The maximum length is 40
+                  characters.
+                x-kubernetes-immutable: true
+              validation:
+                type: object
+                x-dcl-go-name: Validation
+                x-dcl-go-type: WorkflowTemplateParametersValidation
+                description: Optional. Validation rules to be applied to this parameter's
+                  value.
+                x-kubernetes-immutable: true
+                properties:
+                  regex:
+                    type: object
+                    x-dcl-go-name: Regex
+                    x-dcl-go-type: WorkflowTemplateParametersValidationRegex
+                    description: Validation based on regular expressions.
+                    x-kubernetes-immutable: true
+                    required:
+                    - regexes
+                    properties:
+                      regexes:
+                        type: array
+                        x-dcl-go-name: Regexes
+                        description: Required. RE2 regular expressions used to validate
+                          the parameter's value. The value must match the regex in
+                          its entirety (substring matches are not sufficient).
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  values:
+                    type: object
+                    x-dcl-go-name: Values
+                    x-dcl-go-type: WorkflowTemplateParametersValidationValues
+                    description: Validation based on a list of allowed values.
+                    x-kubernetes-immutable: true
+                    required:
+                    - values
+                    properties:
+                      values:
+                        type: array
+                        x-dcl-go-name: Values
+                        description: Required. List of allowed values for the parameter.
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+        placement:
+          type: object
+          x-dcl-go-name: Placement
+          x-dcl-go-type: WorkflowTemplatePlacement
+          description: Required. WorkflowTemplate scheduling information.
+          x-kubernetes-immutable: true
+          properties:
+            clusterSelector:
+              type: object
+              x-dcl-go-name: ClusterSelector
+              x-dcl-go-type: WorkflowTemplatePlacementClusterSelector
+              description: Optional. A selector that chooses target cluster for jobs
+                based on metadata. The selector is evaluated at the time each job
+                is submitted.
+              x-kubernetes-immutable: true
+              required:
+              - clusterLabels
+              properties:
+                clusterLabels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  x-dcl-go-name: ClusterLabels
+                  description: Required. The cluster labels. Cluster must have all
+                    labels to match.
+                  x-kubernetes-immutable: true
+                zone:
+                  type: string
+                  x-dcl-go-name: Zone
+                  description: Optional. The zone where workflow process executes.
+                    This parameter does not affect the selection of the cluster. If
+                    unspecified, the zone of the first cluster matching the selector
+                    is used.
+                  x-kubernetes-immutable: true
+            managedCluster:
+              type: object
+              x-dcl-go-name: ManagedCluster
+              x-dcl-go-type: WorkflowTemplatePlacementManagedCluster
+              description: A cluster that is managed by the workflow.
+              x-kubernetes-immutable: true
+              required:
+              - clusterName
+              - config
+              properties:
+                clusterName:
+                  type: string
+                  x-dcl-go-name: ClusterName
+                  description: Required. The cluster name prefix. A unique cluster
+                    name will be formed by appending a random suffix. The name must
+                    contain only lower-case letters (a-z), numbers (0-9), and hyphens
+                    (-). Must begin with a letter. Cannot begin or end with hyphen.
+                    Must consist of between 2 and 35 characters.
+                  x-kubernetes-immutable: true
+                config:
+                  $ref: '#/components/schemas/ClusterConfig'
+                  x-dcl-go-name: Config
+                  x-kubernetes-immutable: true
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  x-dcl-go-name: Labels
+                  description: 'Optional. The labels to associate with this cluster.
+                    Label keys must be between 1 and 63 characters long, and must
+                    conform to the following PCRE regular expression: p{Ll}p{Lo}{0,62}
+                    Label values must be between 1 and 63 characters long, and must
+                    conform to the following PCRE regular expression: [p{Ll}p{Lo}p{N}_-]{0,63}
+                    No more than 32 labels can be associated with a given cluster.'
+                  x-kubernetes-immutable: true
+        project:
+          type: string
+          x-dcl-go-name: Project
+          description: The project for the resource
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Cloudresourcemanager/Project
+            field: name
+            parent: true
+        updateTime:
+          type: string
+          format: date-time
+          x-dcl-go-name: UpdateTime
+          readOnly: true
+          description: Output only. The time template was last updated.
+          x-kubernetes-immutable: true
+        version:
+          type: integer
+          format: int64
+          x-dcl-go-name: Version
+          readOnly: true
+          description: Output only. The current version of this workflow template.
+          x-kubernetes-immutable: true

--- a/tpgtools/api/dataproc/workflow_template.yaml
+++ b/tpgtools/api/dataproc/workflow_template.yaml
@@ -11,1640 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-components:
-  schemas:
-    ClusterConfig:
-      description: Required. The cluster configuration.
-      properties:
-        autoscalingConfig:
-          description: Optional. Autoscaling config for the policy associated with
-            the cluster. Cluster does not autoscale if this field is unset.
-          properties:
-            policy:
-              description: 'Optional. The autoscaling policy used by the cluster.
-                Only resource names including projectid and location (region) are
-                valid. Examples: * `https://www.googleapis.com/compute/v1/projects/`
-                Note that the policy must be in the same project and Dataproc region.'
-              type: string
-              x-dcl-go-name: Policy
-              x-dcl-references:
-              - field: name
-                resource: Dataproc/AutoscalingPolicy
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: AutoscalingConfig
-          x-dcl-go-type: ClusterClusterConfigAutoscalingConfig
-          x-kubernetes-immutable: true
-        encryptionConfig:
-          description: Optional. Encryption settings for the cluster.
-          properties:
-            gcePdKmsKeyName:
-              description: Optional. The Cloud KMS key name to use for PD disk encryption
-                for all instances in the cluster.
-              type: string
-              x-dcl-go-name: GcePdKmsKeyName
-              x-dcl-references:
-              - field: selfLink
-                resource: Cloudkms/CryptoKey
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: EncryptionConfig
-          x-dcl-go-type: ClusterClusterConfigEncryptionConfig
-          x-kubernetes-immutable: true
-        endpointConfig:
-          description: Optional. Port/endpoint configuration for this cluster
-          properties:
-            enableHttpPortAccess:
-              description: Optional. If true, enable http access to specific ports
-                on the cluster from external sources. Defaults to false.
-              type: boolean
-              x-dcl-go-name: EnableHttpPortAccess
-              x-kubernetes-immutable: true
-            httpPorts:
-              additionalProperties:
-                type: string
-              description: Output only. The map of port descriptions to URLs. Will
-                only be populated if enable_http_port_access is true.
-              readOnly: true
-              type: object
-              x-dcl-go-name: HttpPorts
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: EndpointConfig
-          x-dcl-go-type: ClusterClusterConfigEndpointConfig
-          x-kubernetes-immutable: true
-        gceClusterConfig:
-          description: Optional. The shared Compute Engine config settings for all
-            instances in a cluster.
-          properties:
-            internalIPOnly:
-              description: Optional. If true, all instances in the cluster will only
-                have internal IP addresses. By default, clusters are not restricted
-                to internal IP addresses, and will have ephemeral external IP addresses
-                assigned to each instance. This `internal_ip_only` restriction can
-                only be enabled for subnetwork enabled networks, and all off-cluster
-                dependencies must be configured to be accessible without external
-                IP addresses.
-              type: boolean
-              x-dcl-go-name: InternalIPOnly
-              x-kubernetes-immutable: true
-              x-dcl-server-default: true
-            metadata:
-              additionalProperties:
-                type: string
-              description: The Compute Engine metadata entries to add to all instances
-                (see (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
-              type: object
-              x-dcl-go-name: Metadata
-              x-kubernetes-immutable: true
-            network:
-              description: Optional. The Compute Engine network to be used for machine
-                communications. Cannot be specified with subnetwork_uri. If neither
-                `network_uri` nor `subnetwork_uri` is specified, the "default" network
-                of the project is used, if it exists. Cannot be a "Custom Subnet Network"
-                (see /regions/global/default` * `default`
-              type: string
-              x-dcl-go-name: Network
-              x-dcl-references:
-              - field: selfLink
-                resource: Compute/Network
-              x-kubernetes-immutable: true
-            nodeGroupAffinity:
-              description: Optional. Node Group Affinity for sole-tenant clusters.
-              properties:
-                nodeGroup:
-                  description: Required. The URI of a sole-tenant /zones/us-central1-a/nodeGroups/node-group-1`
-                    * `node-group-1`
-                  type: string
-                  x-dcl-go-name: NodeGroup
-                  x-dcl-references:
-                  - field: selfLink
-                    resource: Compute/NodeGroup
-                  x-kubernetes-immutable: true
-              required:
-              - nodeGroup
-              type: object
-              x-dcl-go-name: NodeGroupAffinity
-              x-dcl-go-type: ClusterClusterConfigGceClusterConfigNodeGroupAffinity
-              x-kubernetes-immutable: true
-            privateIPv6GoogleAccess:
-              description: 'Optional. The type of IPv6 access for a cluster. Possible
-                values: PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED, INHERIT_FROM_SUBNETWORK,
-                OUTBOUND, BIDIRECTIONAL'
-              enum:
-              - PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
-              - INHERIT_FROM_SUBNETWORK
-              - OUTBOUND
-              - BIDIRECTIONAL
-              type: string
-              x-dcl-go-name: PrivateIPv6GoogleAccess
-              x-dcl-go-type: ClusterClusterConfigGceClusterConfigPrivateIPv6GoogleAccessEnum
-              x-kubernetes-immutable: true
-            reservationAffinity:
-              description: Optional. Reservation Affinity for consuming Zonal reservation.
-              properties:
-                consumeReservationType:
-                  description: 'Optional. Type of reservation to consume Possible
-                    values: TYPE_UNSPECIFIED, NO_RESERVATION, ANY_RESERVATION, SPECIFIC_RESERVATION'
-                  enum:
-                  - TYPE_UNSPECIFIED
-                  - NO_RESERVATION
-                  - ANY_RESERVATION
-                  - SPECIFIC_RESERVATION
-                  type: string
-                  x-dcl-go-name: ConsumeReservationType
-                  x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinityConsumeReservationTypeEnum
-                  x-kubernetes-immutable: true
-                key:
-                  description: Optional. Corresponds to the label key of reservation
-                    resource.
-                  type: string
-                  x-dcl-go-name: Key
-                  x-kubernetes-immutable: true
-                values:
-                  description: Optional. Corresponds to the label values of reservation
-                    resource.
-                  items:
-                    type: string
-                    x-dcl-go-type: string
-                  type: array
-                  x-dcl-go-name: Values
-                  x-dcl-list-type: list
-                  x-kubernetes-immutable: true
-              type: object
-              x-dcl-go-name: ReservationAffinity
-              x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinity
-              x-kubernetes-immutable: true
-            serviceAccount:
-              description: Optional. The (https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
-                is used.
-              type: string
-              x-dcl-go-name: ServiceAccount
-              x-dcl-references:
-              - field: email
-                resource: Iam/ServiceAccount
-              x-kubernetes-immutable: true
-            serviceAccountScopes:
-              description: 'Optional. The URIs of service account scopes to be included
-                in Compute Engine instances. The following base set of scopes is always
-                included: * https://www.googleapis.com/auth/cloud.useraccounts.readonly
-                * https://www.googleapis.com/auth/devstorage.read_write * https://www.googleapis.com/auth/logging.write
-                If no scopes are specified, the following defaults are also provided:
-                * https://www.googleapis.com/auth/bigquery * https://www.googleapis.com/auth/bigtable.admin.table
-                * https://www.googleapis.com/auth/bigtable.data * https://www.googleapis.com/auth/devstorage.full_control'
-              items:
-                type: string
-                x-dcl-go-type: string
-              type: array
-              x-dcl-go-name: ServiceAccountScopes
-              x-dcl-list-type: list
-              x-kubernetes-immutable: true
-            subnetwork:
-              description: 'Optional. The Compute Engine subnetwork to be used for
-                machine communications. Cannot be specified with network_uri. A full
-                URL, partial URI, or short name are valid. Examples: * `https://www.googleapis.com/compute/v1/projects//regions/us-east1/subnetworks/sub0`
-                * `sub0`'
-              type: string
-              x-dcl-go-name: Subnetwork
-              x-dcl-references:
-              - field: selfLink
-                resource: Compute/Subnetwork
-              x-kubernetes-immutable: true
-            tags:
-              description: The Compute Engine tags to add to all instances (see (https://cloud.google.com/compute/docs/label-or-tag-resources#tags)).
-              items:
-                type: string
-                x-dcl-go-type: string
-              type: array
-              x-dcl-go-name: Tags
-              x-dcl-list-type: set
-            zone:
-              description: 'Optional. The zone where the Compute Engine cluster will
-                be located. On a create request, it is required in the "global" region.
-                If omitted in a non-global Dataproc region, the service will pick
-                a zone in the corresponding Compute Engine region. On a get request,
-                zone will always be present. A full URL, partial URI, or short name
-                are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/`
-                * `us-central1-f`'
-              type: string
-              x-dcl-go-name: Zone
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: GceClusterConfig
-          x-dcl-go-type: ClusterClusterConfigGceClusterConfig
-          x-kubernetes-immutable: true
-        initializationActions:
-          description: 'Optional. Commands to execute on each node after config is
-            completed. By default, executables are run on master and all worker nodes.
-            You can test a node''s `role` metadata to run an executable on a master
-            or worker node, as shown below using `curl` (you can also use `wget`):
-            ROLE=$(curl -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)
-            if ; then ... master specific actions ... else ... worker specific actions
-            ... fi'
-          items:
-            properties:
-              executableFile:
-                description: Required. Cloud Storage URI of executable file.
-                type: string
-                x-dcl-go-name: ExecutableFile
-                x-kubernetes-immutable: true
-              executionTimeout:
-                description: Optional. Amount of time executable has to complete.
-                  Default is 10 minutes (see JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-                  Cluster creation fails with an explanatory error message (the name
-                  of the executable that caused the error and the exceeded timeout
-                  period) if the executable is not completed at end of the timeout
-                  period.
-                type: string
-                x-dcl-go-name: ExecutionTimeout
-                x-kubernetes-immutable: true
-            type: object
-            x-dcl-go-type: ClusterClusterConfigInitializationActions
-          type: array
-          x-dcl-go-name: InitializationActions
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        lifecycleConfig:
-          description: Optional. Lifecycle setting for the cluster.
-          properties:
-            autoDeleteTime:
-              description: Optional. The time when cluster will be auto-deleted (see
-                JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-              format: date-time
-              type: string
-              x-dcl-go-name: AutoDeleteTime
-              x-kubernetes-immutable: true
-            autoDeleteTtl:
-              description: Optional. The lifetime duration of cluster. The cluster
-                will be auto-deleted at the end of this period. Minimum value is 10
-                minutes; maximum value is 14 days (see JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-              type: string
-              x-dcl-go-name: AutoDeleteTtl
-              x-kubernetes-immutable: true
-            idleDeleteTtl:
-              description: Optional. The duration to keep the cluster alive while
-                idling (when no jobs are running). Passing this threshold will cause
-                the cluster to be deleted. Minimum value is 5 minutes; maximum value
-                is 14 days (see JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json).
-              type: string
-              x-dcl-go-name: IdleDeleteTtl
-              x-kubernetes-immutable: true
-            idleStartTime:
-              description: Output only. The time when cluster became idle (most recent
-                job finished) and became eligible for deletion due to idleness (see
-                JSON representation of (https://developers.google.com/protocol-buffers/docs/proto3#json)).
-              format: date-time
-              readOnly: true
-              type: string
-              x-dcl-go-name: IdleStartTime
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: LifecycleConfig
-          x-dcl-go-type: ClusterClusterConfigLifecycleConfig
-          x-kubernetes-immutable: true
-        masterConfig:
-          $ref: '#/components/schemas/InstanceGroupConfig'
-          x-dcl-go-name: MasterConfig
-        secondaryWorkerConfig:
-          $ref: '#/components/schemas/InstanceGroupConfig'
-          x-dcl-go-name: SecondaryWorkerConfig
-        securityConfig:
-          description: Optional. Security settings for the cluster.
-          properties:
-            kerberosConfig:
-              description: Kerberos related configuration.
-              properties:
-                crossRealmTrustAdminServer:
-                  description: Optional. The admin server (IP or hostname) for the
-                    remote trusted realm in a cross realm trust relationship.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustAdminServer
-                  x-kubernetes-immutable: true
-                crossRealmTrustKdc:
-                  description: Optional. The KDC (IP or hostname) for the remote trusted
-                    realm in a cross realm trust relationship.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustKdc
-                  x-kubernetes-immutable: true
-                crossRealmTrustRealm:
-                  description: Optional. The remote realm the Dataproc on-cluster
-                    KDC will trust, should the user enable cross realm trust.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustRealm
-                  x-kubernetes-immutable: true
-                crossRealmTrustSharedPassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the shared password between the on-cluster Kerberos
-                    realm and the remote trusted realm, in a cross realm trust relationship.
-                  type: string
-                  x-dcl-go-name: CrossRealmTrustSharedPassword
-                  x-kubernetes-immutable: true
-                enableKerberos:
-                  description: 'Optional. Flag to indicate whether to Kerberize the
-                    cluster (default: false). Set this field to true to enable Kerberos
-                    on a cluster.'
-                  type: boolean
-                  x-dcl-go-name: EnableKerberos
-                  x-kubernetes-immutable: true
-                kdcDbKey:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the master key of the KDC database.
-                  type: string
-                  x-dcl-go-name: KdcDbKey
-                  x-kubernetes-immutable: true
-                keyPassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the password to the user provided key. For the
-                    self-signed certificate, this password is generated by Dataproc.
-                  type: string
-                  x-dcl-go-name: KeyPassword
-                  x-kubernetes-immutable: true
-                keystore:
-                  description: Optional. The Cloud Storage URI of the keystore file
-                    used for SSL encryption. If not provided, Dataproc will provide
-                    a self-signed certificate.
-                  type: string
-                  x-dcl-go-name: Keystore
-                  x-kubernetes-immutable: true
-                keystorePassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the password to the user provided keystore. For
-                    the self-signed certificate, this password is generated by Dataproc.
-                  type: string
-                  x-dcl-go-name: KeystorePassword
-                  x-kubernetes-immutable: true
-                kmsKey:
-                  description: Optional. The uri of the KMS key used to encrypt various
-                    sensitive files.
-                  type: string
-                  x-dcl-go-name: KmsKey
-                  x-dcl-references:
-                  - field: selfLink
-                    resource: Cloudkms/CryptoKey
-                  x-kubernetes-immutable: true
-                realm:
-                  description: Optional. The name of the on-cluster Kerberos realm.
-                    If not specified, the uppercased domain of hostnames will be the
-                    realm.
-                  type: string
-                  x-dcl-go-name: Realm
-                  x-kubernetes-immutable: true
-                rootPrincipalPassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the root principal password.
-                  type: string
-                  x-dcl-go-name: RootPrincipalPassword
-                  x-kubernetes-immutable: true
-                tgtLifetimeHours:
-                  description: Optional. The lifetime of the ticket granting ticket,
-                    in hours. If not specified, or user specifies 0, then default
-                    value 10 will be used.
-                  format: int64
-                  type: integer
-                  x-dcl-go-name: TgtLifetimeHours
-                  x-kubernetes-immutable: true
-                truststore:
-                  description: Optional. The Cloud Storage URI of the truststore file
-                    used for SSL encryption. If not provided, Dataproc will provide
-                    a self-signed certificate.
-                  type: string
-                  x-dcl-go-name: Truststore
-                  x-kubernetes-immutable: true
-                truststorePassword:
-                  description: Optional. The Cloud Storage URI of a KMS encrypted
-                    file containing the password to the user provided truststore.
-                    For the self-signed certificate, this password is generated by
-                    Dataproc.
-                  type: string
-                  x-dcl-go-name: TruststorePassword
-                  x-kubernetes-immutable: true
-              type: object
-              x-dcl-go-name: KerberosConfig
-              x-dcl-go-type: ClusterClusterConfigSecurityConfigKerberosConfig
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: SecurityConfig
-          x-dcl-go-type: ClusterClusterConfigSecurityConfig
-          x-kubernetes-immutable: true
-        softwareConfig:
-          description: Optional. The config settings for software inside the cluster.
-          properties:
-            imageVersion:
-              description: Optional. The version of software inside the cluster. It
-                must be one of the supported (https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
-                If unspecified, it defaults to the latest Debian version.
-              type: string
-              x-dcl-go-name: ImageVersion
-              x-kubernetes-immutable: true
-            properties:
-              additionalProperties:
-                type: string
-              description: 'Optional. The properties to set on daemon config files.
-                Property keys are specified in `prefix:property` format, for example
-                `core:hadoop.tmp.dir`. The following are supported prefixes and their
-                mappings: * capacity-scheduler: `capacity-scheduler.xml` * core: `core-site.xml`
-                * distcp: `distcp-default.xml` * hdfs: `hdfs-site.xml` * hive: `hive-site.xml`
-                * mapred: `mapred-site.xml` * pig: `pig.properties` * spark: `spark-defaults.conf`
-                * yarn: `yarn-site.xml` For more information, see (https://cloud.google.com/dataproc/docs/concepts/cluster-properties).'
-              type: object
-              x-dcl-go-name: Properties
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: SoftwareConfig
-          x-dcl-go-type: ClusterClusterConfigSoftwareConfig
-          x-kubernetes-immutable: true
-        stagingBucket:
-          description: Optional. A Cloud Storage bucket used to stage job dependencies,
-            config files, and job driver console output. If you do not specify a staging
-            bucket, Cloud Dataproc will determine a Cloud Storage location (US, ASIA,
-            or EU) for your cluster's staging bucket according to the Compute Engine
-            zone where your cluster is deployed, and then create and manage this project-level,
-            per-location bucket (see (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
-          type: string
-          x-dcl-go-name: StagingBucket
-          x-dcl-references:
-          - field: name
-            resource: Storage/Bucket
-          x-kubernetes-immutable: true
-        tempBucket:
-          description: Optional. A Cloud Storage bucket used to store ephemeral cluster
-            and jobs data, such as Spark and MapReduce history files. If you do not
-            specify a temp bucket, Dataproc will determine a Cloud Storage location
-            (US, ASIA, or EU) for your cluster's temp bucket according to the Compute
-            Engine zone where your cluster is deployed, and then create and manage
-            this project-level, per-location bucket. The default bucket has a TTL
-            of 90 days, but you can use any TTL (or none) if you specify a bucket.
-          type: string
-          x-dcl-go-name: TempBucket
-          x-dcl-references:
-          - field: name
-            resource: Storage/Bucket
-          x-kubernetes-immutable: true
-        workerConfig:
-          $ref: '#/components/schemas/InstanceGroupConfig'
-          x-dcl-go-name: WorkerConfig
-      type: object
-      x-dcl-go-name: Config
-      x-dcl-go-type: ClusterClusterConfig
-      x-kubernetes-immutable: true
-    InstanceGroupConfig:
-      description: Optional. The Compute Engine config settings for additional worker
-        instances in a cluster.
-      properties:
-        accelerators:
-          description: Optional. The Compute Engine accelerator configuration for
-            these instances.
-          items:
-            properties:
-              acceleratorCount:
-                description: The number of the accelerator cards of this type exposed
-                  to this instance.
-                format: int64
-                type: integer
-                x-dcl-go-name: AcceleratorCount
-                x-kubernetes-immutable: true
-              acceleratorType:
-                description: Full URL, partial URI, or short name of the accelerator
-                  type resource to expose to this instance. See (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
-                  feature, you must use the short name of the accelerator type resource,
-                  for example, `nvidia-tesla-k80`.
-                type: string
-                x-dcl-go-name: AcceleratorType
-                x-kubernetes-immutable: true
-            type: object
-            x-dcl-go-type: ClusterInstanceGroupConfigAccelerators
-          type: array
-          x-dcl-go-name: Accelerators
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        diskConfig:
-          description: Optional. Disk option config settings.
-          properties:
-            bootDiskSizeGb:
-              description: Optional. Size in GB of the boot disk (default is 500GB).
-              format: int64
-              type: integer
-              x-dcl-go-name: BootDiskSizeGb
-              x-kubernetes-immutable: true
-            bootDiskType:
-              description: 'Optional. Type of the boot disk (default is "pd-standard").
-                Valid values: "pd-ssd" (Persistent Disk Solid State Drive) or "pd-standard"
-                (Persistent Disk Hard Disk Drive).'
-              type: string
-              x-dcl-go-name: BootDiskType
-              x-kubernetes-immutable: true
-            numLocalSsds:
-              description: Optional. Number of attached SSDs, from 0 to 4 (default
-                is 0). If SSDs are not attached, the boot disk is used to store runtime
-                logs and (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
-                data. If one or more SSDs are attached, this runtime bulk data is
-                spread across them, and the boot disk contains only basic config and
-                installed binaries.
-              format: int64
-              type: integer
-              x-dcl-go-name: NumLocalSsds
-              x-kubernetes-immutable: true
-              x-dcl-server-default: true
-          type: object
-          x-dcl-go-name: DiskConfig
-          x-dcl-go-type: ClusterInstanceGroupConfigDiskConfig
-          x-kubernetes-immutable: true
-        image:
-          description: 'Optional. The Compute Engine image resource used for cluster
-            instances. The URI can represent an image or image family. Image examples:
-            * `https://www.googleapis.com/compute/beta/projects/` If the URI is unspecified,
-            it will be inferred from `SoftwareConfig.image_version` or the system
-            default.'
-          type: string
-          x-dcl-go-name: Image
-          x-dcl-references:
-          - field: selfLink
-            resource: Compute/Image
-          x-kubernetes-immutable: true
-        instanceNames:
-          description: Output only. The list of instance names. Dataproc derives the
-            names from `cluster_name`, `num_instances`, and the instance group.
-          items:
-            type: string
-            x-dcl-go-type: string
-            x-dcl-references:
-            - field: selfLink
-              resource: Compute/Instance
-          readOnly: true
-          type: array
-          x-dcl-go-name: InstanceNames
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        isPreemptible:
-          description: Output only. Specifies that this instance group contains preemptible
-            instances.
-          readOnly: true
-          type: boolean
-          x-dcl-go-name: IsPreemptible
-          x-kubernetes-immutable: true
-        machineType:
-          description: 'Optional. The Compute Engine machine type used for cluster
-            instances. A full URL, partial URI, or short name are valid. Examples:
-            * `https://www.googleapis.com/compute/v1/projects/(https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
-            feature, you must use the short name of the machine type resource, for
-            example, `n1-standard-2`.'
-          type: string
-          x-dcl-go-name: MachineType
-          x-kubernetes-immutable: true
-        managedGroupConfig:
-          description: Output only. The config for Compute Engine Instance Group Manager
-            that manages this group. This is only used for preemptible instance groups.
-          properties:
-            instanceGroupManagerName:
-              description: Output only. The name of the Instance Group Manager for
-                this group.
-              readOnly: true
-              type: string
-              x-dcl-go-name: InstanceGroupManagerName
-              x-kubernetes-immutable: true
-            instanceTemplateName:
-              description: Output only. The name of the Instance Template used for
-                the Managed Instance Group.
-              readOnly: true
-              type: string
-              x-dcl-go-name: InstanceTemplateName
-              x-kubernetes-immutable: true
-          readOnly: true
-          type: object
-          x-dcl-go-name: ManagedGroupConfig
-          x-dcl-go-type: ClusterInstanceGroupConfigManagedGroupConfig
-          x-kubernetes-immutable: true
-        minCpuPlatform:
-          description: Optional. Specifies the minimum cpu platform for the Instance
-            Group. See (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).
-          type: string
-          x-dcl-go-name: MinCpuPlatform
-          x-kubernetes-immutable: true
-        numInstances:
-          description: Optional. The number of VM instances in the instance group.
-            For master instance groups, must be set to 1.
-          format: int64
-          type: integer
-          x-dcl-go-name: NumInstances
-          x-kubernetes-immutable: true
-        preemptibility:
-          description: 'Optional. Specifies the preemptibility of the instance group.
-            The default value for master and worker groups is `NON_PREEMPTIBLE`. This
-            default cannot be changed. The default value for secondary instances is
-            `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE,
-            PREEMPTIBLE'
-          enum:
-          - PREEMPTIBILITY_UNSPECIFIED
-          - NON_PREEMPTIBLE
-          - PREEMPTIBLE
-          type: string
-          x-dcl-go-name: Preemptibility
-          x-dcl-go-type: ClusterInstanceGroupConfigPreemptibilityEnum
-          x-kubernetes-immutable: true
-      type: object
-      x-dcl-go-name: SecondaryWorkerConfig
-      x-dcl-go-type: ClusterInstanceGroupConfig
-      x-kubernetes-immutable: true
-    WorkflowTemplate:
-      properties:
-        createTime:
-          description: Output only. The time template was created.
-          format: date-time
-          readOnly: true
-          type: string
-          x-dcl-go-name: CreateTime
-          x-kubernetes-immutable: true
-        jobs:
-          description: Required. The Directed Acyclic Graph of Jobs to submit.
-          items:
-            properties:
-              hadoopJob:
-                description: Optional. Job is a Hadoop job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      in the working directory of Hadoop drivers and tasks. Supported
-                      file types: .jar, .tar, .tar.gz, .tgz, or .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `-libjars` or `-Dfoo=bar`, that
-                      can be set as job properties, since a collision may occur that
-                      causes an incorrect job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS (Hadoop Compatible Filesystem) URIs
-                      of files to be copied to the working directory of Hadoop drivers
-                      and distributed tasks. Useful for naively parallel tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. Jar file URIs to add to the CLASSPATHs
-                      of the Hadoop driver and tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsHadoopJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainClass:
-                    description: The name of the driver's main class. The jar file
-                      containing the class must be in the default CLASSPATH or specified
-                      in `jar_file_uris`.
-                    type: string
-                    x-dcl-go-name: MainClass
-                    x-kubernetes-immutable: true
-                  mainJarFileUri:
-                    description: 'The HCFS URI of the jar file containing the main
-                      class. Examples: ''gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar''
-                      ''hdfs:/tmp/test-samples/custom-wordcount.jar'' ''file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar'''
-                    type: string
-                    x-dcl-go-name: MainJarFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Hadoop. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/hadoop/conf/*-site and classes in user code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: HadoopJob
-                x-dcl-go-type: WorkflowTemplateJobsHadoopJob
-                x-kubernetes-immutable: true
-              hiveJob:
-                description: Optional. Job is a Hive job.
-                properties:
-                  continueOnFailure:
-                    description: Optional. Whether to continue executing queries if
-                      a query fails. The default value is `false`. Setting to `true`
-                      can be useful when executing independent parallel queries.
-                    type: boolean
-                    x-dcl-go-name: ContinueOnFailure
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
-                      of the Hive server and Hadoop MapReduce (MR) tasks. Can contain
-                      Hive SerDes and UDFs.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names and values,
-                      used to configure Hive. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml,
-                      and classes in user code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains Hive queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsHiveJobQueryList
-                    x-kubernetes-immutable: true
-                  scriptVariables:
-                    additionalProperties:
-                      type: string
-                    description: 'Optional. Mapping of query variable names to values
-                      (equivalent to the Hive command: `SET name="value";`).'
-                    type: object
-                    x-dcl-go-name: ScriptVariables
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: HiveJob
-                x-dcl-go-type: WorkflowTemplateJobsHiveJob
-                x-kubernetes-immutable: true
-              labels:
-                additionalProperties:
-                  type: string
-                description: 'Optional. The labels to associate with this job. Label
-                  keys must be between 1 and 63 characters long, and must conform
-                  to the following regular expression: {0,63} No more than 32 labels
-                  can be associated with a given job.'
-                type: object
-                x-dcl-go-name: Labels
-                x-kubernetes-immutable: true
-              pigJob:
-                description: Optional. Job is a Pig job.
-                properties:
-                  continueOnFailure:
-                    description: Optional. Whether to continue executing queries if
-                      a query fails. The default value is `false`. Setting to `true`
-                      can be useful when executing independent parallel queries.
-                    type: boolean
-                    x-dcl-go-name: ContinueOnFailure
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
-                      of the Pig Client and Hadoop MapReduce (MR) tasks. Can contain
-                      Pig UDFs.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsPigJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Pig. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties,
-                      and classes in user code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains the Pig
-                      queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsPigJobQueryList
-                    x-kubernetes-immutable: true
-                  scriptVariables:
-                    additionalProperties:
-                      type: string
-                    description: 'Optional. Mapping of query variable names to values
-                      (equivalent to the Pig command: `name=`).'
-                    type: object
-                    x-dcl-go-name: ScriptVariables
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: PigJob
-                x-dcl-go-type: WorkflowTemplateJobsPigJob
-                x-kubernetes-immutable: true
-              prerequisiteStepIds:
-                description: Optional. The optional list of prerequisite job step_ids.
-                  If not specified, the job will start at the beginning of workflow.
-                items:
-                  type: string
-                  x-dcl-go-type: string
-                type: array
-                x-dcl-go-name: PrerequisiteStepIds
-                x-dcl-list-type: list
-                x-kubernetes-immutable: true
-              prestoJob:
-                description: Optional. Job is a Presto job.
-                properties:
-                  clientTags:
-                    description: Optional. Presto client tags to attach to this query
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ClientTags
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  continueOnFailure:
-                    description: Optional. Whether to continue executing queries if
-                      a query fails. The default value is `false`. Setting to `true`
-                      can be useful when executing independent parallel queries.
-                    type: boolean
-                    x-dcl-go-name: ContinueOnFailure
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  outputFormat:
-                    description: Optional. The format in which query output will be
-                      displayed. See the Presto documentation for supported output
-                      formats
-                    type: string
-                    x-dcl-go-name: OutputFormat
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values.
-                      Used to set Presto (https://prestodb.io/docs/current/sql/set-session.html)
-                      Equivalent to using the --session flag in the Presto CLI
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains SQL queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobQueryList
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: PrestoJob
-                x-dcl-go-type: WorkflowTemplateJobsPrestoJob
-                x-kubernetes-immutable: true
-              pysparkJob:
-                description: Optional. Job is a PySpark job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      into the working directory of each executor. Supported file
-                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `--conf`, that can be set as
-                      job properties, since a collision may occur that causes an incorrect
-                      job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS URIs of files to be placed in the
-                      working directory of each executor. Useful for naively parallel
-                      tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
-                      of the Python driver and tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsPysparkJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainPythonFileUri:
-                    description: Required. The HCFS URI of the main Python file to
-                      use as the driver. Must be a .py file.
-                    type: string
-                    x-dcl-go-name: MainPythonFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure PySpark. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/spark/conf/spark-defaults.conf and classes in user
-                      code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  pythonFileUris:
-                    description: 'Optional. HCFS file URIs of Python files to pass
-                      to the PySpark framework. Supported file types: .py, .egg, and
-                      .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: PythonFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                required:
-                - mainPythonFileUri
-                type: object
-                x-dcl-go-name: PysparkJob
-                x-dcl-go-type: WorkflowTemplateJobsPysparkJob
-                x-kubernetes-immutable: true
-              scheduling:
-                description: Optional. Job scheduling configuration.
-                properties:
-                  maxFailuresPerHour:
-                    description: Optional. Maximum number of times per hour a driver
-                      may be restarted as a result of driver exiting with non-zero
-                      code before job is reported failed. A job may be reported as
-                      thrashing if driver exits with non-zero code 4 times within
-                      10 minute window. Maximum value is 10.
-                    format: int64
-                    type: integer
-                    x-dcl-go-name: MaxFailuresPerHour
-                    x-kubernetes-immutable: true
-                  maxFailuresTotal:
-                    description: Optional. Maximum number of times in total a driver
-                      may be restarted as a result of driver exiting with non-zero
-                      code before job is reported failed. Maximum value is 240
-                    format: int64
-                    type: integer
-                    x-dcl-go-name: MaxFailuresTotal
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: Scheduling
-                x-dcl-go-type: WorkflowTemplateJobsScheduling
-                x-kubernetes-immutable: true
-              sparkJob:
-                description: Optional. Job is a Spark job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      into the working directory of each executor. Supported file
-                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `--conf`, that can be set as
-                      job properties, since a collision may occur that causes an incorrect
-                      job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS URIs of files to be placed in the
-                      working directory of each executor. Useful for naively parallel
-                      tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
-                      of the Spark driver and tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsSparkJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainClass:
-                    description: The name of the driver's main class. The jar file
-                      that contains the class must be in the default CLASSPATH or
-                      specified in `jar_file_uris`.
-                    type: string
-                    x-dcl-go-name: MainClass
-                    x-kubernetes-immutable: true
-                  mainJarFileUri:
-                    description: The HCFS URI of the jar file that contains the main
-                      class.
-                    type: string
-                    x-dcl-go-name: MainJarFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Spark. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/spark/conf/spark-defaults.conf and classes in user
-                      code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: SparkJob
-                x-dcl-go-type: WorkflowTemplateJobsSparkJob
-                x-kubernetes-immutable: true
-              sparkRJob:
-                description: Optional. Job is a SparkR job.
-                properties:
-                  archiveUris:
-                    description: 'Optional. HCFS URIs of archives to be extracted
-                      into the working directory of each executor. Supported file
-                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: ArchiveUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  args:
-                    description: Optional. The arguments to pass to the driver. Do
-                      not include arguments, such as `--conf`, that can be set as
-                      job properties, since a collision may occur that causes an incorrect
-                      job submission.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: Args
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  fileUris:
-                    description: Optional. HCFS URIs of files to be placed in the
-                      working directory of each executor. Useful for naively parallel
-                      tasks.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: FileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsSparkRJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  mainRFileUri:
-                    description: Required. The HCFS URI of the main R file to use
-                      as the driver. Must be a .R file.
-                    type: string
-                    x-dcl-go-name: MainRFileUri
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure SparkR. Properties that conflict with values
-                      set by the Dataproc API may be overwritten. Can include properties
-                      set in /etc/spark/conf/spark-defaults.conf and classes in user
-                      code.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                required:
-                - mainRFileUri
-                type: object
-                x-dcl-go-name: SparkRJob
-                x-dcl-go-type: WorkflowTemplateJobsSparkRJob
-                x-kubernetes-immutable: true
-              sparkSqlJob:
-                description: Optional. Job is a SparkSql job.
-                properties:
-                  jarFileUris:
-                    description: Optional. HCFS URIs of jar files to be added to the
-                      Spark CLASSPATH.
-                    items:
-                      type: string
-                      x-dcl-go-type: string
-                    type: array
-                    x-dcl-go-name: JarFileUris
-                    x-dcl-list-type: list
-                    x-kubernetes-immutable: true
-                  loggingConfig:
-                    description: Optional. The runtime log config for job execution.
-                    properties:
-                      driverLogLevels:
-                        additionalProperties:
-                          type: string
-                        description: 'The per-package log levels for the driver. This
-                          may include "root" package name to configure rootLogger.
-                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
-                          = DEBUG'''
-                        type: object
-                        x-dcl-go-name: DriverLogLevels
-                        x-kubernetes-immutable: true
-                    type: object
-                    x-dcl-go-name: LoggingConfig
-                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobLoggingConfig
-                    x-kubernetes-immutable: true
-                  properties:
-                    additionalProperties:
-                      type: string
-                    description: Optional. A mapping of property names to values,
-                      used to configure Spark SQL's SparkConf. Properties that conflict
-                      with values set by the Dataproc API may be overwritten.
-                    type: object
-                    x-dcl-go-name: Properties
-                    x-kubernetes-immutable: true
-                  queryFileUri:
-                    description: The HCFS URI of the script that contains SQL queries.
-                    type: string
-                    x-dcl-go-name: QueryFileUri
-                    x-kubernetes-immutable: true
-                  queryList:
-                    description: A list of queries.
-                    properties:
-                      queries:
-                        description: 'Required. The queries to execute. You do not
-                          need to end a query expression with a semicolon. Multiple
-                          queries can be specified in one string by separating each
-                          with a semicolon. Here is an example of a Dataproc API snippet
-                          that uses a QueryList to specify a HiveJob: "hiveJob": {
-                          "queryList": { "queries": } }'
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Queries
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - queries
-                    type: object
-                    x-dcl-go-name: QueryList
-                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobQueryList
-                    x-kubernetes-immutable: true
-                  scriptVariables:
-                    additionalProperties:
-                      type: string
-                    description: 'Optional. Mapping of query variable names to values
-                      (equivalent to the Spark SQL command: SET `name="value";`).'
-                    type: object
-                    x-dcl-go-name: ScriptVariables
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: SparkSqlJob
-                x-dcl-go-type: WorkflowTemplateJobsSparkSqlJob
-                x-kubernetes-immutable: true
-              stepId:
-                description: Required. The step id. The id must be unique among all
-                  jobs within the template. The step id is used as prefix for job
-                  id, as job `goog-dataproc-workflow-step-id` label, and in field
-                  from other steps. The id must contain only letters (a-z, A-Z), numbers
-                  (0-9), underscores (_), and hyphens (-). Cannot begin or end with
-                  underscore or hyphen. Must consist of between 3 and 50 characters.
-                type: string
-                x-dcl-go-name: StepId
-                x-kubernetes-immutable: true
-            required:
-            - stepId
-            type: object
-            x-dcl-go-type: WorkflowTemplateJobs
-          type: array
-          x-dcl-go-name: Jobs
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        labels:
-          additionalProperties:
-            type: string
-          description: Optional. The labels to associate with this template. These
-            labels will be propagated to all jobs and clusters created by the workflow
-            instance. Label **keys** must contain 1 to 63 characters, and must conform
-            to (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can
-            be associated with a template.
-          type: object
-          x-dcl-go-name: Labels
-          x-kubernetes-immutable: true
-        location:
-          description: The location for the resource
-          type: string
-          x-dcl-go-name: Location
-          x-kubernetes-immutable: true
-        name:
-          description: 'Output only. The resource name of the workflow template, as
-            described in https://cloud.google.com/apis/design/resource_names. * For
-            `projects.regions.workflowTemplates`, the resource name of the template
-            has the following format: `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
-            * For `projects.locations.workflowTemplates`, the resource name of the
-            template has the following format: `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`'
-          type: string
-          x-dcl-go-name: Name
-          x-kubernetes-immutable: true
-        parameters:
-          description: Optional. Template parameters whose values are substituted
-            into the template. Values for parameters must be provided when the template
-            is instantiated.
-          items:
-            properties:
-              description:
-                description: Optional. Brief description of the parameter. Must not
-                  exceed 1024 characters.
-                type: string
-                x-dcl-go-name: Description
-                x-kubernetes-immutable: true
-              fields:
-                description: Required. Paths to all fields that the parameter replaces.
-                  A field is allowed to appear in at most one parameter's list of
-                  field paths. A field path is similar in syntax to a .sparkJob.args
-                items:
-                  type: string
-                  x-dcl-go-type: string
-                type: array
-                x-dcl-go-name: Fields
-                x-dcl-list-type: list
-                x-kubernetes-immutable: true
-              name:
-                description: Required. Parameter name. The parameter name is used
-                  as the key, and paired with the parameter value, which are passed
-                  to the template when the template is instantiated. The name must
-                  contain only capital letters (A-Z), numbers (0-9), and underscores
-                  (_), and must not start with a number. The maximum length is 40
-                  characters.
-                type: string
-                x-dcl-go-name: Name
-                x-kubernetes-immutable: true
-              validation:
-                description: Optional. Validation rules to be applied to this parameter's
-                  value.
-                properties:
-                  regex:
-                    description: Validation based on regular expressions.
-                    properties:
-                      regexes:
-                        description: Required. RE2 regular expressions used to validate
-                          the parameter's value. The value must match the regex in
-                          its entirety (substring matches are not sufficient).
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Regexes
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - regexes
-                    type: object
-                    x-dcl-go-name: Regex
-                    x-dcl-go-type: WorkflowTemplateParametersValidationRegex
-                    x-kubernetes-immutable: true
-                  values:
-                    description: Validation based on a list of allowed values.
-                    properties:
-                      values:
-                        description: Required. List of allowed values for the parameter.
-                        items:
-                          type: string
-                          x-dcl-go-type: string
-                        type: array
-                        x-dcl-go-name: Values
-                        x-dcl-list-type: list
-                        x-kubernetes-immutable: true
-                    required:
-                    - values
-                    type: object
-                    x-dcl-go-name: Values
-                    x-dcl-go-type: WorkflowTemplateParametersValidationValues
-                    x-kubernetes-immutable: true
-                type: object
-                x-dcl-go-name: Validation
-                x-dcl-go-type: WorkflowTemplateParametersValidation
-                x-kubernetes-immutable: true
-            required:
-            - name
-            - fields
-            type: object
-            x-dcl-go-type: WorkflowTemplateParameters
-          type: array
-          x-dcl-go-name: Parameters
-          x-dcl-list-type: list
-          x-kubernetes-immutable: true
-        placement:
-          description: Required. WorkflowTemplate scheduling information.
-          properties:
-            clusterSelector:
-              description: Optional. A selector that chooses target cluster for jobs
-                based on metadata. The selector is evaluated at the time each job
-                is submitted.
-              properties:
-                clusterLabels:
-                  additionalProperties:
-                    type: string
-                  description: Required. The cluster labels. Cluster must have all
-                    labels to match.
-                  type: object
-                  x-dcl-go-name: ClusterLabels
-                  x-kubernetes-immutable: true
-                zone:
-                  description: Optional. The zone where workflow process executes.
-                    This parameter does not affect the selection of the cluster. If
-                    unspecified, the zone of the first cluster matching the selector
-                    is used.
-                  type: string
-                  x-dcl-go-name: Zone
-                  x-kubernetes-immutable: true
-              required:
-              - clusterLabels
-              type: object
-              x-dcl-go-name: ClusterSelector
-              x-dcl-go-type: WorkflowTemplatePlacementClusterSelector
-              x-kubernetes-immutable: true
-            managedCluster:
-              description: A cluster that is managed by the workflow.
-              properties:
-                clusterName:
-                  description: Required. The cluster name prefix. A unique cluster
-                    name will be formed by appending a random suffix. The name must
-                    contain only lower-case letters (a-z), numbers (0-9), and hyphens
-                    (-). Must begin with a letter. Cannot begin or end with hyphen.
-                    Must consist of between 2 and 35 characters.
-                  type: string
-                  x-dcl-go-name: ClusterName
-                  x-kubernetes-immutable: true
-                config:
-                  $ref: '#/components/schemas/ClusterConfig'
-                  x-dcl-go-name: Config
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: 'Optional. The labels to associate with this cluster.
-                    Label keys must be between 1 and 63 characters long, and must
-                    conform to the following PCRE regular expression: {0,63} No more
-                    than 32 labels can be associated with a given cluster.'
-                  type: object
-                  x-dcl-go-name: Labels
-                  x-kubernetes-immutable: true
-              required:
-              - clusterName
-              - config
-              type: object
-              x-dcl-go-name: ManagedCluster
-              x-dcl-go-type: WorkflowTemplatePlacementManagedCluster
-              x-kubernetes-immutable: true
-          type: object
-          x-dcl-go-name: Placement
-          x-dcl-go-type: WorkflowTemplatePlacement
-          x-kubernetes-immutable: true
-        project:
-          description: The project for the resource
-          type: string
-          x-dcl-go-name: Project
-          x-dcl-references:
-          - field: name
-            parent: true
-            resource: Cloudresourcemanager/Project
-          x-kubernetes-immutable: true
-        updateTime:
-          description: Output only. The time template was last updated.
-          format: date-time
-          readOnly: true
-          type: string
-          x-dcl-go-name: UpdateTime
-          x-kubernetes-immutable: true
-        version:
-          description: Optional. Used to perform a consistent read-modify-write. This
-            field should be left blank for a `CreateWorkflowTemplate` request. It
-            is required for an `UpdateWorkflowTemplate` request, and must match the
-            current server version. A typical update template flow would fetch the
-            current template with a `GetWorkflowTemplate` request, which will return
-            the current template with the `version` field filled in with the current
-            server version. The user updates other fields in the template, then returns
-            it as part of the `UpdateWorkflowTemplate` request.
-          format: int64
-          type: integer
-          x-dcl-go-name: Version
-          x-kubernetes-immutable: true
-          x-dcl-server-default: true
-      required:
-      - name
-      - placement
-      - jobs
-      - project
-      - location
-      title: WorkflowTemplate
-      type: object
-      x-dcl-id: projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}
-      x-dcl-labels: labels
-      x-dcl-locations: []
-      x-dcl-parent-container: project
-      x-dcl-uses-state-hint: false
 info:
-  description: DCL Specification for the Dataproc WorkflowTemplate resource
   title: Dataproc/WorkflowTemplate
+  description: DCL Specification for the Dataproc WorkflowTemplate resource
   x-dcl-has-iam: false
 paths:
+  get:
+    description: The function used to get information about a WorkflowTemplate
+    parameters:
+    - name: WorkflowTemplate
+      required: true
+      description: A full instance of a WorkflowTemplate
   apply:
     description: The function used to apply information about a WorkflowTemplate
     parameters:
-    - description: A full instance of a WorkflowTemplate
-      name: WorkflowTemplate
+    - name: WorkflowTemplate
       required: true
+      description: A full instance of a WorkflowTemplate
   delete:
     description: The function used to delete a WorkflowTemplate
     parameters:
-    - description: A full instance of a WorkflowTemplate
-      name: WorkflowTemplate
+    - name: WorkflowTemplate
       required: true
+      description: A full instance of a WorkflowTemplate
   deleteAll:
     description: The function used to delete all WorkflowTemplate
     parameters:
@@ -1656,12 +45,6 @@ paths:
       required: true
       schema:
         type: string
-  get:
-    description: The function used to get information about a WorkflowTemplate
-    parameters:
-    - description: A full instance of a WorkflowTemplate
-      name: WorkflowTemplate
-      required: true
   list:
     description: The function used to list information about many WorkflowTemplate
     parameters:
@@ -1673,3 +56,1755 @@ paths:
       required: true
       schema:
         type: string
+components:
+  schemas:
+    ClusterConfig:
+      type: object
+      x-dcl-go-name: Config
+      x-dcl-go-type: ClusterClusterConfig
+      description: Required. The cluster configuration.
+      x-kubernetes-immutable: true
+      properties:
+        autoscalingConfig:
+          type: object
+          x-dcl-go-name: AutoscalingConfig
+          x-dcl-go-type: ClusterClusterConfigAutoscalingConfig
+          description: Optional. Autoscaling config for the policy associated with
+            the cluster. Cluster does not autoscale if this field is unset.
+          x-kubernetes-immutable: true
+          properties:
+            policy:
+              type: string
+              x-dcl-go-name: Policy
+              description: 'Optional. The autoscaling policy used by the cluster.
+                Only resource names including projectid and location (region) are
+                valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]`
+                * `projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]`
+                Note that the policy must be in the same project and Dataproc region.'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Dataproc/AutoscalingPolicy
+                field: name
+        encryptionConfig:
+          type: object
+          x-dcl-go-name: EncryptionConfig
+          x-dcl-go-type: ClusterClusterConfigEncryptionConfig
+          description: Optional. Encryption settings for the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            gcePdKmsKeyName:
+              type: string
+              x-dcl-go-name: GcePdKmsKeyName
+              description: Optional. The Cloud KMS key name to use for PD disk encryption
+                for all instances in the cluster.
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Cloudkms/CryptoKey
+                field: selfLink
+        endpointConfig:
+          type: object
+          x-dcl-go-name: EndpointConfig
+          x-dcl-go-type: ClusterClusterConfigEndpointConfig
+          description: Optional. Port/endpoint configuration for this cluster
+          x-kubernetes-immutable: true
+          properties:
+            enableHttpPortAccess:
+              type: boolean
+              x-dcl-go-name: EnableHttpPortAccess
+              description: Optional. If true, enable http access to specific ports
+                on the cluster from external sources. Defaults to false.
+              x-kubernetes-immutable: true
+            httpPorts:
+              type: object
+              additionalProperties:
+                type: string
+              x-dcl-go-name: HttpPorts
+              readOnly: true
+              description: Output only. The map of port descriptions to URLs. Will
+                only be populated if enable_http_port_access is true.
+              x-kubernetes-immutable: true
+        gceClusterConfig:
+          type: object
+          x-dcl-go-name: GceClusterConfig
+          x-dcl-go-type: ClusterClusterConfigGceClusterConfig
+          description: Optional. The shared Compute Engine config settings for all
+            instances in a cluster.
+          x-kubernetes-immutable: true
+          properties:
+            internalIPOnly:
+              type: boolean
+              x-dcl-go-name: InternalIPOnly
+              description: Optional. If true, all instances in the cluster will only
+                have internal IP addresses. By default, clusters are not restricted
+                to internal IP addresses, and will have ephemeral external IP addresses
+                assigned to each instance. This `internal_ip_only` restriction can
+                only be enabled for subnetwork enabled networks, and all off-cluster
+                dependencies must be configured to be accessible without external
+                IP addresses.
+              x-kubernetes-immutable: true
+              x-dcl-server-default: true
+            metadata:
+              type: object
+              additionalProperties:
+                type: string
+              x-dcl-go-name: Metadata
+              description: The Compute Engine metadata entries to add to all instances
+                (see [Project and instance metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
+              x-kubernetes-immutable: true
+            network:
+              type: string
+              x-dcl-go-name: Network
+              description: 'Optional. The Compute Engine network to be used for machine
+                communications. Cannot be specified with subnetwork_uri. If neither
+                `network_uri` nor `subnetwork_uri` is specified, the "default" network
+                of the project is used, if it exists. Cannot be a "Custom Subnet Network"
+                (see [Using Subnetworks](https://cloud.google.com/compute/docs/subnetworks)
+                for more information). A full URL, partial URI, or short name are
+                valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default`
+                * `projects/[project_id]/regions/global/default` * `default`'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Compute/Network
+                field: selfLink
+            nodeGroupAffinity:
+              type: object
+              x-dcl-go-name: NodeGroupAffinity
+              x-dcl-go-type: ClusterClusterConfigGceClusterConfigNodeGroupAffinity
+              description: Optional. Node Group Affinity for sole-tenant clusters.
+              x-kubernetes-immutable: true
+              required:
+              - nodeGroup
+              properties:
+                nodeGroup:
+                  type: string
+                  x-dcl-go-name: NodeGroup
+                  description: 'Required. The URI of a sole-tenant [node group resource](https://cloud.google.com/compute/docs/reference/rest/v1/nodeGroups)
+                    that the cluster will be created on. A full URL, partial URI,
+                    or node group name are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-central1-a/nodeGroups/node-group-1`
+                    * `projects/[project_id]/zones/us-central1-a/nodeGroups/node-group-1`
+                    * `node-group-1`'
+                  x-kubernetes-immutable: true
+                  x-dcl-references:
+                  - resource: Compute/NodeGroup
+                    field: selfLink
+            privateIPv6GoogleAccess:
+              type: string
+              x-dcl-go-name: PrivateIPv6GoogleAccess
+              x-dcl-go-type: ClusterClusterConfigGceClusterConfigPrivateIPv6GoogleAccessEnum
+              description: 'Optional. The type of IPv6 access for a cluster. Possible
+                values: PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED, INHERIT_FROM_SUBNETWORK,
+                OUTBOUND, BIDIRECTIONAL'
+              x-kubernetes-immutable: true
+              enum:
+              - PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
+              - INHERIT_FROM_SUBNETWORK
+              - OUTBOUND
+              - BIDIRECTIONAL
+            reservationAffinity:
+              type: object
+              x-dcl-go-name: ReservationAffinity
+              x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinity
+              description: Optional. Reservation Affinity for consuming Zonal reservation.
+              x-kubernetes-immutable: true
+              properties:
+                consumeReservationType:
+                  type: string
+                  x-dcl-go-name: ConsumeReservationType
+                  x-dcl-go-type: ClusterClusterConfigGceClusterConfigReservationAffinityConsumeReservationTypeEnum
+                  description: 'Optional. Type of reservation to consume Possible
+                    values: TYPE_UNSPECIFIED, NO_RESERVATION, ANY_RESERVATION, SPECIFIC_RESERVATION'
+                  x-kubernetes-immutable: true
+                  enum:
+                  - TYPE_UNSPECIFIED
+                  - NO_RESERVATION
+                  - ANY_RESERVATION
+                  - SPECIFIC_RESERVATION
+                key:
+                  type: string
+                  x-dcl-go-name: Key
+                  description: Optional. Corresponds to the label key of reservation
+                    resource.
+                  x-kubernetes-immutable: true
+                values:
+                  type: array
+                  x-dcl-go-name: Values
+                  description: Optional. Corresponds to the label values of reservation
+                    resource.
+                  x-kubernetes-immutable: true
+                  x-dcl-send-empty: true
+                  x-dcl-list-type: list
+                  items:
+                    type: string
+                    x-dcl-go-type: string
+            serviceAccount:
+              type: string
+              x-dcl-go-name: ServiceAccount
+              description: Optional. The [Dataproc service account](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts#service_accounts_in_dataproc)
+                (also see [VM Data Plane identity](https://cloud.google.com/dataproc/docs/concepts/iam/dataproc-principals#vm_service_account_data_plane_identity))
+                used by Dataproc cluster VM instances to access Google Cloud Platform
+                services. If not specified, the [Compute Engine default service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
+                is used.
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Iam/ServiceAccount
+                field: email
+            serviceAccountScopes:
+              type: array
+              x-dcl-go-name: ServiceAccountScopes
+              description: 'Optional. The URIs of service account scopes to be included
+                in Compute Engine instances. The following base set of scopes is always
+                included: * https://www.googleapis.com/auth/cloud.useraccounts.readonly
+                * https://www.googleapis.com/auth/devstorage.read_write * https://www.googleapis.com/auth/logging.write
+                If no scopes are specified, the following defaults are also provided:
+                * https://www.googleapis.com/auth/bigquery * https://www.googleapis.com/auth/bigtable.admin.table
+                * https://www.googleapis.com/auth/bigtable.data * https://www.googleapis.com/auth/devstorage.full_control'
+              x-kubernetes-immutable: true
+              x-dcl-send-empty: true
+              x-dcl-list-type: list
+              items:
+                type: string
+                x-dcl-go-type: string
+            subnetwork:
+              type: string
+              x-dcl-go-name: Subnetwork
+              description: 'Optional. The Compute Engine subnetwork to be used for
+                machine communications. Cannot be specified with network_uri. A full
+                URL, partial URI, or short name are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/subnetworks/sub0`
+                * `projects/[project_id]/regions/us-east1/subnetworks/sub0` * `sub0`'
+              x-kubernetes-immutable: true
+              x-dcl-references:
+              - resource: Compute/Subnetwork
+                field: selfLink
+            tags:
+              type: array
+              x-dcl-go-name: Tags
+              description: The Compute Engine tags to add to all instances (see [Tagging
+                instances](https://cloud.google.com/compute/docs/label-or-tag-resources#tags)).
+              x-kubernetes-immutable: true
+              x-dcl-send-empty: true
+              x-dcl-list-type: set
+              items:
+                type: string
+                x-dcl-go-type: string
+            zone:
+              type: string
+              x-dcl-go-name: Zone
+              description: 'Optional. The zone where the Compute Engine cluster will
+                be located. On a create request, it is required in the "global" region.
+                If omitted in a non-global Dataproc region, the service will pick
+                a zone in the corresponding Compute Engine region. On a get request,
+                zone will always be present. A full URL, partial URI, or short name
+                are valid. Examples: * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]`
+                * `projects/[project_id]/zones/[zone]` * `us-central1-f`'
+              x-kubernetes-immutable: true
+        initializationActions:
+          type: array
+          x-dcl-go-name: InitializationActions
+          description: 'Optional. Commands to execute on each node after config is
+            completed. By default, executables are run on master and all worker nodes.
+            You can test a node''s `role` metadata to run an executable on a master
+            or worker node, as shown below using `curl` (you can also use `wget`):
+            ROLE=$(curl -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)
+            if [[ "${ROLE}" == ''Master'' ]]; then ... master specific actions ...
+            else ... worker specific actions ... fi'
+          x-kubernetes-immutable: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: ClusterClusterConfigInitializationActions
+            properties:
+              executableFile:
+                type: string
+                x-dcl-go-name: ExecutableFile
+                description: Required. Cloud Storage URI of executable file.
+                x-kubernetes-immutable: true
+              executionTimeout:
+                type: string
+                x-dcl-go-name: ExecutionTimeout
+                description: Optional. Amount of time executable has to complete.
+                  Default is 10 minutes (see JSON representation of [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+                  Cluster creation fails with an explanatory error message (the name
+                  of the executable that caused the error and the exceeded timeout
+                  period) if the executable is not completed at end of the timeout
+                  period.
+                x-kubernetes-immutable: true
+        lifecycleConfig:
+          type: object
+          x-dcl-go-name: LifecycleConfig
+          x-dcl-go-type: ClusterClusterConfigLifecycleConfig
+          description: Optional. Lifecycle setting for the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            autoDeleteTime:
+              type: string
+              format: date-time
+              x-dcl-go-name: AutoDeleteTime
+              description: Optional. The time when cluster will be auto-deleted (see
+                JSON representation of [Timestamp](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+            autoDeleteTtl:
+              type: string
+              x-dcl-go-name: AutoDeleteTtl
+              description: Optional. The lifetime duration of cluster. The cluster
+                will be auto-deleted at the end of this period. Minimum value is 10
+                minutes; maximum value is 14 days (see JSON representation of [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+            idleDeleteTtl:
+              type: string
+              x-dcl-go-name: IdleDeleteTtl
+              description: Optional. The duration to keep the cluster alive while
+                idling (when no jobs are running). Passing this threshold will cause
+                the cluster to be deleted. Minimum value is 5 minutes; maximum value
+                is 14 days (see JSON representation of [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+            idleStartTime:
+              type: string
+              format: date-time
+              x-dcl-go-name: IdleStartTime
+              readOnly: true
+              description: Output only. The time when cluster became idle (most recent
+                job finished) and became eligible for deletion due to idleness (see
+                JSON representation of [Timestamp](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+              x-kubernetes-immutable: true
+        masterConfig:
+          $ref: '#/components/schemas/InstanceGroupConfig'
+          x-dcl-go-name: MasterConfig
+          x-kubernetes-immutable: true
+        secondaryWorkerConfig:
+          $ref: '#/components/schemas/InstanceGroupConfig'
+          x-dcl-go-name: SecondaryWorkerConfig
+          x-kubernetes-immutable: true
+        securityConfig:
+          type: object
+          x-dcl-go-name: SecurityConfig
+          x-dcl-go-type: ClusterClusterConfigSecurityConfig
+          description: Optional. Security settings for the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            kerberosConfig:
+              type: object
+              x-dcl-go-name: KerberosConfig
+              x-dcl-go-type: ClusterClusterConfigSecurityConfigKerberosConfig
+              description: Optional. Kerberos related configuration.
+              x-kubernetes-immutable: true
+              properties:
+                crossRealmTrustAdminServer:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustAdminServer
+                  description: Optional. The admin server (IP or hostname) for the
+                    remote trusted realm in a cross realm trust relationship.
+                  x-kubernetes-immutable: true
+                crossRealmTrustKdc:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustKdc
+                  description: Optional. The KDC (IP or hostname) for the remote trusted
+                    realm in a cross realm trust relationship.
+                  x-kubernetes-immutable: true
+                crossRealmTrustRealm:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustRealm
+                  description: Optional. The remote realm the Dataproc on-cluster
+                    KDC will trust, should the user enable cross realm trust.
+                  x-kubernetes-immutable: true
+                crossRealmTrustSharedPassword:
+                  type: string
+                  x-dcl-go-name: CrossRealmTrustSharedPassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the shared password between the on-cluster Kerberos
+                    realm and the remote trusted realm, in a cross realm trust relationship.
+                  x-kubernetes-immutable: true
+                enableKerberos:
+                  type: boolean
+                  x-dcl-go-name: EnableKerberos
+                  description: 'Optional. Flag to indicate whether to Kerberize the
+                    cluster (default: false). Set this field to true to enable Kerberos
+                    on a cluster.'
+                  x-kubernetes-immutable: true
+                kdcDbKey:
+                  type: string
+                  x-dcl-go-name: KdcDbKey
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the master key of the KDC database.
+                  x-kubernetes-immutable: true
+                keyPassword:
+                  type: string
+                  x-dcl-go-name: KeyPassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the password to the user provided key. For the
+                    self-signed certificate, this password is generated by Dataproc.
+                  x-kubernetes-immutable: true
+                keystore:
+                  type: string
+                  x-dcl-go-name: Keystore
+                  description: Optional. The Cloud Storage URI of the keystore file
+                    used for SSL encryption. If not provided, Dataproc will provide
+                    a self-signed certificate.
+                  x-kubernetes-immutable: true
+                keystorePassword:
+                  type: string
+                  x-dcl-go-name: KeystorePassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the password to the user provided keystore. For
+                    the self-signed certificate, this password is generated by Dataproc.
+                  x-kubernetes-immutable: true
+                kmsKey:
+                  type: string
+                  x-dcl-go-name: KmsKey
+                  description: Optional. The uri of the KMS key used to encrypt various
+                    sensitive files.
+                  x-kubernetes-immutable: true
+                  x-dcl-references:
+                  - resource: Cloudkms/CryptoKey
+                    field: selfLink
+                realm:
+                  type: string
+                  x-dcl-go-name: Realm
+                  description: Optional. The name of the on-cluster Kerberos realm.
+                    If not specified, the uppercased domain of hostnames will be the
+                    realm.
+                  x-kubernetes-immutable: true
+                rootPrincipalPassword:
+                  type: string
+                  x-dcl-go-name: RootPrincipalPassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the root principal password.
+                  x-kubernetes-immutable: true
+                tgtLifetimeHours:
+                  type: integer
+                  format: int64
+                  x-dcl-go-name: TgtLifetimeHours
+                  description: Optional. The lifetime of the ticket granting ticket,
+                    in hours. If not specified, or user specifies 0, then default
+                    value 10 will be used.
+                  x-kubernetes-immutable: true
+                truststore:
+                  type: string
+                  x-dcl-go-name: Truststore
+                  description: Optional. The Cloud Storage URI of the truststore file
+                    used for SSL encryption. If not provided, Dataproc will provide
+                    a self-signed certificate.
+                  x-kubernetes-immutable: true
+                truststorePassword:
+                  type: string
+                  x-dcl-go-name: TruststorePassword
+                  description: Optional. The Cloud Storage URI of a KMS encrypted
+                    file containing the password to the user provided truststore.
+                    For the self-signed certificate, this password is generated by
+                    Dataproc.
+                  x-kubernetes-immutable: true
+        softwareConfig:
+          type: object
+          x-dcl-go-name: SoftwareConfig
+          x-dcl-go-type: ClusterClusterConfigSoftwareConfig
+          description: Optional. The config settings for software inside the cluster.
+          x-kubernetes-immutable: true
+          properties:
+            imageVersion:
+              type: string
+              x-dcl-go-name: ImageVersion
+              description: Optional. The version of software inside the cluster. It
+                must be one of the supported [Dataproc Versions](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#supported_dataproc_versions),
+                such as "1.2" (including a subminor version, such as "1.2.29"), or
+                the ["preview" version](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
+                If unspecified, it defaults to the latest Debian version.
+              x-kubernetes-immutable: true
+            optionalComponents:
+              type: array
+              x-dcl-go-name: OptionalComponents
+              description: Optional. The set of components to activate on the cluster.
+              x-kubernetes-immutable: true
+              x-dcl-send-empty: true
+              x-dcl-list-type: list
+              items:
+                type: string
+                x-dcl-go-type: ClusterClusterConfigSoftwareConfigOptionalComponentsEnum
+                enum:
+                - COMPONENT_UNSPECIFIED
+                - ANACONDA
+                - DOCKER
+                - DRUID
+                - FLINK
+                - HBASE
+                - HIVE_WEBHCAT
+                - JUPYTER
+                - KERBEROS
+                - PRESTO
+                - RANGER
+                - SOLR
+                - ZEPPELIN
+                - ZOOKEEPER
+            properties:
+              type: object
+              additionalProperties:
+                type: string
+              x-dcl-go-name: Properties
+              description: 'Optional. The properties to set on daemon config files.
+                Property keys are specified in `prefix:property` format, for example
+                `core:hadoop.tmp.dir`. The following are supported prefixes and their
+                mappings: * capacity-scheduler: `capacity-scheduler.xml` * core: `core-site.xml`
+                * distcp: `distcp-default.xml` * hdfs: `hdfs-site.xml` * hive: `hive-site.xml`
+                * mapred: `mapred-site.xml` * pig: `pig.properties` * spark: `spark-defaults.conf`
+                * yarn: `yarn-site.xml` For more information, see [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties).'
+              x-kubernetes-immutable: true
+        stagingBucket:
+          type: string
+          x-dcl-go-name: StagingBucket
+          description: Optional. A Cloud Storage bucket used to stage job dependencies,
+            config files, and job driver console output. If you do not specify a staging
+            bucket, Cloud Dataproc will determine a Cloud Storage location (US, ASIA,
+            or EU) for your cluster's staging bucket according to the Compute Engine
+            zone where your cluster is deployed, and then create and manage this project-level,
+            per-location bucket (see [Dataproc staging bucket](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
+            **This field requires a Cloud Storage bucket name, not a URI to a Cloud
+            Storage bucket.**
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Storage/Bucket
+            field: name
+        tempBucket:
+          type: string
+          x-dcl-go-name: TempBucket
+          description: Optional. A Cloud Storage bucket used to store ephemeral cluster
+            and jobs data, such as Spark and MapReduce history files. If you do not
+            specify a temp bucket, Dataproc will determine a Cloud Storage location
+            (US, ASIA, or EU) for your cluster's temp bucket according to the Compute
+            Engine zone where your cluster is deployed, and then create and manage
+            this project-level, per-location bucket. The default bucket has a TTL
+            of 90 days, but you can use any TTL (or none) if you specify a bucket.
+            **This field requires a Cloud Storage bucket name, not a URI to a Cloud
+            Storage bucket.**
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Storage/Bucket
+            field: name
+        workerConfig:
+          $ref: '#/components/schemas/InstanceGroupConfig'
+          x-dcl-go-name: WorkerConfig
+          x-kubernetes-immutable: true
+    InstanceGroupConfig:
+      type: object
+      x-dcl-go-name: WorkerConfig
+      x-dcl-go-type: ClusterInstanceGroupConfig
+      description: Optional. The Compute Engine config settings for worker instances
+        in a cluster.
+      x-kubernetes-immutable: true
+      x-dcl-server-default: true
+      properties:
+        accelerators:
+          type: array
+          x-dcl-go-name: Accelerators
+          description: Optional. The Compute Engine accelerator configuration for
+            these instances.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: ClusterInstanceGroupConfigAccelerators
+            properties:
+              acceleratorCount:
+                type: integer
+                format: int64
+                x-dcl-go-name: AcceleratorCount
+                description: The number of the accelerator cards of this type exposed
+                  to this instance.
+                x-kubernetes-immutable: true
+              acceleratorType:
+                type: string
+                x-dcl-go-name: AcceleratorType
+                description: 'Full URL, partial URI, or short name of the accelerator
+                  type resource to expose to this instance. See [Compute Engine AcceleratorTypes](https://cloud.google.com/compute/docs/reference/beta/acceleratorTypes).
+                  Examples: * `https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
+                  * `projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
+                  * `nvidia-tesla-k80` **Auto Zone Exception**: If you are using the
+                  Dataproc [Auto Zone Placement](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                  feature, you must use the short name of the accelerator type resource,
+                  for example, `nvidia-tesla-k80`.'
+                x-kubernetes-immutable: true
+        diskConfig:
+          type: object
+          x-dcl-go-name: DiskConfig
+          x-dcl-go-type: ClusterInstanceGroupConfigDiskConfig
+          description: Optional. Disk option config settings.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          properties:
+            bootDiskSizeGb:
+              type: integer
+              format: int64
+              x-dcl-go-name: BootDiskSizeGb
+              description: Optional. Size in GB of the boot disk (default is 500GB).
+              x-kubernetes-immutable: true
+            bootDiskType:
+              type: string
+              x-dcl-go-name: BootDiskType
+              description: 'Optional. Type of the boot disk (default is "pd-standard").
+                Valid values: "pd-balanced" (Persistent Disk Balanced Solid State
+                Drive), "pd-ssd" (Persistent Disk Solid State Drive), or "pd-standard"
+                (Persistent Disk Hard Disk Drive). See [Disk types](https://cloud.google.com/compute/docs/disks#disk-types).'
+              x-kubernetes-immutable: true
+            numLocalSsds:
+              type: integer
+              format: int64
+              x-dcl-go-name: NumLocalSsds
+              description: Optional. Number of attached SSDs, from 0 to 4 (default
+                is 0). If SSDs are not attached, the boot disk is used to store runtime
+                logs and [HDFS](https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
+                data. If one or more SSDs are attached, this runtime bulk data is
+                spread across them, and the boot disk contains only basic config and
+                installed binaries.
+              x-kubernetes-immutable: true
+              x-dcl-server-default: true
+        image:
+          type: string
+          x-dcl-go-name: Image
+          description: 'Optional. The Compute Engine image resource used for cluster
+            instances. The URI can represent an image or image family. Image examples:
+            * `https://www.googleapis.com/compute/beta/projects/[project_id]/global/images/[image-id]`
+            * `projects/[project_id]/global/images/[image-id]` * `image-id` Image
+            family examples. Dataproc will use the most recent image from the family:
+            * `https://www.googleapis.com/compute/beta/projects/[project_id]/global/images/family/[custom-image-family-name]`
+            * `projects/[project_id]/global/images/family/[custom-image-family-name]`
+            If the URI is unspecified, it will be inferred from `SoftwareConfig.image_version`
+            or the system default.'
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Compute/Image
+            field: selfLink
+        instanceNames:
+          type: array
+          x-dcl-go-name: InstanceNames
+          readOnly: true
+          description: Output only. The list of instance names. Dataproc derives the
+            names from `cluster_name`, `num_instances`, and the instance group.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          x-dcl-list-type: list
+          items:
+            type: string
+            x-dcl-go-type: string
+            x-dcl-references:
+            - resource: Compute/Instance
+              field: selfLink
+        isPreemptible:
+          type: boolean
+          x-dcl-go-name: IsPreemptible
+          readOnly: true
+          description: Output only. Specifies that this instance group contains preemptible
+            instances.
+          x-kubernetes-immutable: true
+        machineType:
+          type: string
+          x-dcl-go-name: MachineType
+          description: 'Optional. The Compute Engine machine type used for cluster
+            instances. A full URL, partial URI, or short name are valid. Examples:
+            * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2`
+            * `projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2`
+            * `n1-standard-2` **Auto Zone Exception**: If you are using the Dataproc
+            [Auto Zone Placement](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+            feature, you must use the short name of the machine type resource, for
+            example, `n1-standard-2`.'
+          x-kubernetes-immutable: true
+        managedGroupConfig:
+          type: object
+          x-dcl-go-name: ManagedGroupConfig
+          x-dcl-go-type: ClusterInstanceGroupConfigManagedGroupConfig
+          readOnly: true
+          description: Output only. The config for Compute Engine Instance Group Manager
+            that manages this group. This is only used for preemptible instance groups.
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+          properties:
+            instanceGroupManagerName:
+              type: string
+              x-dcl-go-name: InstanceGroupManagerName
+              readOnly: true
+              description: Output only. The name of the Instance Group Manager for
+                this group.
+              x-kubernetes-immutable: true
+            instanceTemplateName:
+              type: string
+              x-dcl-go-name: InstanceTemplateName
+              readOnly: true
+              description: Output only. The name of the Instance Template used for
+                the Managed Instance Group.
+              x-kubernetes-immutable: true
+        minCpuPlatform:
+          type: string
+          x-dcl-go-name: MinCpuPlatform
+          description: Optional. Specifies the minimum cpu platform for the Instance
+            Group. See [Dataproc -> Minimum CPU Platform](https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).
+          x-kubernetes-immutable: true
+          x-dcl-server-default: true
+        numInstances:
+          type: integer
+          format: int64
+          x-dcl-go-name: NumInstances
+          description: Optional. The number of VM instances in the instance group.
+            For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability)
+            [master_config](#FIELDS.master_config) groups, **must be set to 3**. For
+            standard cluster [master_config](#FIELDS.master_config) groups, **must
+            be set to 1**.
+          x-kubernetes-immutable: true
+        preemptibility:
+          type: string
+          x-dcl-go-name: Preemptibility
+          x-dcl-go-type: ClusterInstanceGroupConfigPreemptibilityEnum
+          description: 'Optional. Specifies the preemptibility of the instance group.
+            The default value for master and worker groups is `NON_PREEMPTIBLE`. This
+            default cannot be changed. The default value for secondary instances is
+            `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE,
+            PREEMPTIBLE'
+          x-kubernetes-immutable: true
+          enum:
+          - PREEMPTIBILITY_UNSPECIFIED
+          - NON_PREEMPTIBLE
+          - PREEMPTIBLE
+    WorkflowTemplate:
+      title: WorkflowTemplate
+      x-dcl-id: projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}
+      x-dcl-parent-container: project
+      x-dcl-labels: labels
+      type: object
+      required:
+      - name
+      - placement
+      - jobs
+      - project
+      - location
+      properties:
+        createTime:
+          type: string
+          format: date-time
+          x-dcl-go-name: CreateTime
+          readOnly: true
+          description: Output only. The time template was created.
+          x-kubernetes-immutable: true
+        dagTimeout:
+          type: string
+          x-dcl-go-name: DagTimeout
+          description: Optional. Timeout duration for the DAG of jobs, expressed in
+            seconds (see [JSON representation of duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+            The timeout duration must be from 10 minutes ("600s") to 24 hours ("86400s").
+            The timer begins when the first job is submitted. If the workflow is running
+            at the end of the timeout period, any remaining jobs are cancelled, the
+            workflow is ended, and if the workflow was running on a [managed cluster](/dataproc/docs/concepts/workflows/using-workflows#configuring_or_selecting_a_cluster),
+            the cluster is deleted.
+          x-kubernetes-immutable: true
+        jobs:
+          type: array
+          x-dcl-go-name: Jobs
+          description: Required. The Directed Acyclic Graph of Jobs to submit.
+          x-kubernetes-immutable: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: WorkflowTemplateJobs
+            required:
+            - stepId
+            properties:
+              hadoopJob:
+                type: object
+                x-dcl-go-name: HadoopJob
+                x-dcl-go-type: WorkflowTemplateJobsHadoopJob
+                description: Optional. Job is a Hadoop job.
+                x-kubernetes-immutable: true
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      in the working directory of Hadoop drivers and tasks. Supported
+                      file types: .jar, .tar, .tar.gz, .tgz, or .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `-libjars` or `-Dfoo=bar`, that
+                      can be set as job properties, since a collision may occur that
+                      causes an incorrect job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS (Hadoop Compatible Filesystem) URIs
+                      of files to be copied to the working directory of Hadoop drivers
+                      and distributed tasks. Useful for naively parallel tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. Jar file URIs to add to the CLASSPATHs
+                      of the Hadoop driver and tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsHadoopJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainClass:
+                    type: string
+                    x-dcl-go-name: MainClass
+                    description: The name of the driver's main class. The jar file
+                      containing the class must be in the default CLASSPATH or specified
+                      in `jar_file_uris`.
+                    x-kubernetes-immutable: true
+                  mainJarFileUri:
+                    type: string
+                    x-dcl-go-name: MainJarFileUri
+                    description: 'The HCFS URI of the jar file containing the main
+                      class. Examples: ''gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar''
+                      ''hdfs:/tmp/test-samples/custom-wordcount.jar'' ''file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar'''
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Hadoop. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/hadoop/conf/*-site and classes in user code.
+                    x-kubernetes-immutable: true
+              hiveJob:
+                type: object
+                x-dcl-go-name: HiveJob
+                x-dcl-go-type: WorkflowTemplateJobsHiveJob
+                description: Optional. Job is a Hive job.
+                x-kubernetes-immutable: true
+                properties:
+                  continueOnFailure:
+                    type: boolean
+                    x-dcl-go-name: ContinueOnFailure
+                    description: Optional. Whether to continue executing queries if
+                      a query fails. The default value is `false`. Setting to `true`
+                      can be useful when executing independent parallel queries.
+                    x-kubernetes-immutable: true
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
+                      of the Hive server and Hadoop MapReduce (MR) tasks. Can contain
+                      Hive SerDes and UDFs.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names and values,
+                      used to configure Hive. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml,
+                      and classes in user code.
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains Hive queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsHiveJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  scriptVariables:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: ScriptVariables
+                    description: 'Optional. Mapping of query variable names to values
+                      (equivalent to the Hive command: `SET name="value";`).'
+                    x-kubernetes-immutable: true
+              labels:
+                type: object
+                additionalProperties:
+                  type: string
+                x-dcl-go-name: Labels
+                description: 'Optional. The labels to associate with this job. Label
+                  keys must be between 1 and 63 characters long, and must conform
+                  to the following regular expression: p{Ll}p{Lo}{0,62} Label values
+                  must be between 1 and 63 characters long, and must conform to the
+                  following regular expression: [p{Ll}p{Lo}p{N}_-]{0,63} No more than
+                  32 labels can be associated with a given job.'
+                x-kubernetes-immutable: true
+              pigJob:
+                type: object
+                x-dcl-go-name: PigJob
+                x-dcl-go-type: WorkflowTemplateJobsPigJob
+                description: Optional. Job is a Pig job.
+                x-kubernetes-immutable: true
+                properties:
+                  continueOnFailure:
+                    type: boolean
+                    x-dcl-go-name: ContinueOnFailure
+                    description: Optional. Whether to continue executing queries if
+                      a query fails. The default value is `false`. Setting to `true`
+                      can be useful when executing independent parallel queries.
+                    x-kubernetes-immutable: true
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATH
+                      of the Pig Client and Hadoop MapReduce (MR) tasks. Can contain
+                      Pig UDFs.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsPigJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Pig. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties,
+                      and classes in user code.
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains the Pig
+                      queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsPigJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  scriptVariables:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: ScriptVariables
+                    description: 'Optional. Mapping of query variable names to values
+                      (equivalent to the Pig command: `name=[value]`).'
+                    x-kubernetes-immutable: true
+              prerequisiteStepIds:
+                type: array
+                x-dcl-go-name: PrerequisiteStepIds
+                description: Optional. The optional list of prerequisite job step_ids.
+                  If not specified, the job will start at the beginning of workflow.
+                x-kubernetes-immutable: true
+                x-dcl-send-empty: true
+                x-dcl-list-type: list
+                items:
+                  type: string
+                  x-dcl-go-type: string
+              prestoJob:
+                type: object
+                x-dcl-go-name: PrestoJob
+                x-dcl-go-type: WorkflowTemplateJobsPrestoJob
+                description: Optional. Job is a Presto job.
+                x-kubernetes-immutable: true
+                properties:
+                  clientTags:
+                    type: array
+                    x-dcl-go-name: ClientTags
+                    description: Optional. Presto client tags to attach to this query
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  continueOnFailure:
+                    type: boolean
+                    x-dcl-go-name: ContinueOnFailure
+                    description: Optional. Whether to continue executing queries if
+                      a query fails. The default value is `false`. Setting to `true`
+                      can be useful when executing independent parallel queries.
+                    x-kubernetes-immutable: true
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  outputFormat:
+                    type: string
+                    x-dcl-go-name: OutputFormat
+                    description: Optional. The format in which query output will be
+                      displayed. See the Presto documentation for supported output
+                      formats
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values.
+                      Used to set Presto [session properties](https://prestodb.io/docs/current/sql/set-session.html)
+                      Equivalent to using the --session flag in the Presto CLI
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains SQL queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsPrestoJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+              pysparkJob:
+                type: object
+                x-dcl-go-name: PysparkJob
+                x-dcl-go-type: WorkflowTemplateJobsPysparkJob
+                description: Optional. Job is a PySpark job.
+                x-kubernetes-immutable: true
+                required:
+                - mainPythonFileUri
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      into the working directory of each executor. Supported file
+                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `--conf`, that can be set as
+                      job properties, since a collision may occur that causes an incorrect
+                      job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS URIs of files to be placed in the
+                      working directory of each executor. Useful for naively parallel
+                      tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
+                      of the Python driver and tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsPysparkJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainPythonFileUri:
+                    type: string
+                    x-dcl-go-name: MainPythonFileUri
+                    description: Required. The HCFS URI of the main Python file to
+                      use as the driver. Must be a .py file.
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure PySpark. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/spark/conf/spark-defaults.conf and classes in user
+                      code.
+                    x-kubernetes-immutable: true
+                  pythonFileUris:
+                    type: array
+                    x-dcl-go-name: PythonFileUris
+                    description: 'Optional. HCFS file URIs of Python files to pass
+                      to the PySpark framework. Supported file types: .py, .egg, and
+                      .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+              scheduling:
+                type: object
+                x-dcl-go-name: Scheduling
+                x-dcl-go-type: WorkflowTemplateJobsScheduling
+                description: Optional. Job scheduling configuration.
+                x-kubernetes-immutable: true
+                properties:
+                  maxFailuresPerHour:
+                    type: integer
+                    format: int64
+                    x-dcl-go-name: MaxFailuresPerHour
+                    description: Optional. Maximum number of times per hour a driver
+                      may be restarted as a result of driver exiting with non-zero
+                      code before job is reported failed. A job may be reported as
+                      thrashing if driver exits with non-zero code 4 times within
+                      10 minute window. Maximum value is 10.
+                    x-kubernetes-immutable: true
+                  maxFailuresTotal:
+                    type: integer
+                    format: int64
+                    x-dcl-go-name: MaxFailuresTotal
+                    description: Optional. Maximum number of times in total a driver
+                      may be restarted as a result of driver exiting with non-zero
+                      code before job is reported failed. Maximum value is 240.
+                    x-kubernetes-immutable: true
+              sparkJob:
+                type: object
+                x-dcl-go-name: SparkJob
+                x-dcl-go-type: WorkflowTemplateJobsSparkJob
+                description: Optional. Job is a Spark job.
+                x-kubernetes-immutable: true
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      into the working directory of each executor. Supported file
+                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `--conf`, that can be set as
+                      job properties, since a collision may occur that causes an incorrect
+                      job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS URIs of files to be placed in the
+                      working directory of each executor. Useful for naively parallel
+                      tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to add to the CLASSPATHs
+                      of the Spark driver and tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsSparkJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainClass:
+                    type: string
+                    x-dcl-go-name: MainClass
+                    description: The name of the driver's main class. The jar file
+                      that contains the class must be in the default CLASSPATH or
+                      specified in `jar_file_uris`.
+                    x-kubernetes-immutable: true
+                  mainJarFileUri:
+                    type: string
+                    x-dcl-go-name: MainJarFileUri
+                    description: The HCFS URI of the jar file that contains the main
+                      class.
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Spark. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/spark/conf/spark-defaults.conf and classes in user
+                      code.
+                    x-kubernetes-immutable: true
+              sparkRJob:
+                type: object
+                x-dcl-go-name: SparkRJob
+                x-dcl-go-type: WorkflowTemplateJobsSparkRJob
+                description: Optional. Job is a SparkR job.
+                x-kubernetes-immutable: true
+                required:
+                - mainRFileUri
+                properties:
+                  archiveUris:
+                    type: array
+                    x-dcl-go-name: ArchiveUris
+                    description: 'Optional. HCFS URIs of archives to be extracted
+                      into the working directory of each executor. Supported file
+                      types: .jar, .tar, .tar.gz, .tgz, and .zip.'
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  args:
+                    type: array
+                    x-dcl-go-name: Args
+                    description: Optional. The arguments to pass to the driver. Do
+                      not include arguments, such as `--conf`, that can be set as
+                      job properties, since a collision may occur that causes an incorrect
+                      job submission.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  fileUris:
+                    type: array
+                    x-dcl-go-name: FileUris
+                    description: Optional. HCFS URIs of files to be placed in the
+                      working directory of each executor. Useful for naively parallel
+                      tasks.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsSparkRJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  mainRFileUri:
+                    type: string
+                    x-dcl-go-name: MainRFileUri
+                    description: Required. The HCFS URI of the main R file to use
+                      as the driver. Must be a .R file.
+                    x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure SparkR. Properties that conflict with values
+                      set by the Dataproc API may be overwritten. Can include properties
+                      set in /etc/spark/conf/spark-defaults.conf and classes in user
+                      code.
+                    x-kubernetes-immutable: true
+              sparkSqlJob:
+                type: object
+                x-dcl-go-name: SparkSqlJob
+                x-dcl-go-type: WorkflowTemplateJobsSparkSqlJob
+                description: Optional. Job is a SparkSql job.
+                x-kubernetes-immutable: true
+                properties:
+                  jarFileUris:
+                    type: array
+                    x-dcl-go-name: JarFileUris
+                    description: Optional. HCFS URIs of jar files to be added to the
+                      Spark CLASSPATH.
+                    x-kubernetes-immutable: true
+                    x-dcl-send-empty: true
+                    x-dcl-list-type: list
+                    items:
+                      type: string
+                      x-dcl-go-type: string
+                  loggingConfig:
+                    type: object
+                    x-dcl-go-name: LoggingConfig
+                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobLoggingConfig
+                    description: Optional. The runtime log config for job execution.
+                    x-kubernetes-immutable: true
+                    properties:
+                      driverLogLevels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-dcl-go-name: DriverLogLevels
+                        description: 'The per-package log levels for the driver. This
+                          may include "root" package name to configure rootLogger.
+                          Examples: ''com.google = FATAL'', ''root = INFO'', ''org.apache
+                          = DEBUG'''
+                        x-kubernetes-immutable: true
+                  properties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: Properties
+                    description: Optional. A mapping of property names to values,
+                      used to configure Spark SQL's SparkConf. Properties that conflict
+                      with values set by the Dataproc API may be overwritten.
+                    x-kubernetes-immutable: true
+                  queryFileUri:
+                    type: string
+                    x-dcl-go-name: QueryFileUri
+                    description: The HCFS URI of the script that contains SQL queries.
+                    x-kubernetes-immutable: true
+                  queryList:
+                    type: object
+                    x-dcl-go-name: QueryList
+                    x-dcl-go-type: WorkflowTemplateJobsSparkSqlJobQueryList
+                    description: A list of queries.
+                    x-kubernetes-immutable: true
+                    required:
+                    - queries
+                    properties:
+                      queries:
+                        type: array
+                        x-dcl-go-name: Queries
+                        description: 'Required. The queries to execute. You do not
+                          need to end a query expression with a semicolon. Multiple
+                          queries can be specified in one string by separating each
+                          with a semicolon. Here is an example of a Dataproc API snippet
+                          that uses a QueryList to specify a HiveJob: "hiveJob": {
+                          "queryList": { "queries": [ "query1", "query2", "query3;query4",
+                          ] } }'
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  scriptVariables:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-dcl-go-name: ScriptVariables
+                    description: 'Optional. Mapping of query variable names to values
+                      (equivalent to the Spark SQL command: SET `name="value";`).'
+                    x-kubernetes-immutable: true
+              stepId:
+                type: string
+                x-dcl-go-name: StepId
+                description: Required. The step id. The id must be unique among all
+                  jobs within the template. The step id is used as prefix for job
+                  id, as job `goog-dataproc-workflow-step-id` label, and in prerequisiteStepIds
+                  field from other steps. The id must contain only letters (a-z, A-Z),
+                  numbers (0-9), underscores (_), and hyphens (-). Cannot begin or
+                  end with underscore or hyphen. Must consist of between 3 and 50
+                  characters.
+                x-kubernetes-immutable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          x-dcl-go-name: Labels
+          description: Optional. The labels to associate with this template. These
+            labels will be propagated to all jobs and clusters created by the workflow
+            instance. Label **keys** must contain 1 to 63 characters, and must conform
+            to [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt). Label **values**
+            may be empty, but, if present, must contain 1 to 63 characters, and must
+            conform to [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt). No more than
+            32 labels can be associated with a template.
+          x-kubernetes-immutable: true
+        location:
+          type: string
+          x-dcl-go-name: Location
+          description: The location for the resource
+          x-kubernetes-immutable: true
+        name:
+          type: string
+          x-dcl-go-name: Name
+          description: 'Output only. The resource name of the workflow template, as
+            described in https://cloud.google.com/apis/design/resource_names. * For
+            `projects.regions.workflowTemplates`, the resource name of the template
+            has the following format: `projects/{project_id}/regions/{region}/workflowTemplates/{template_id}`
+            * For `projects.locations.workflowTemplates`, the resource name of the
+            template has the following format: `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`'
+          x-kubernetes-immutable: true
+        parameters:
+          type: array
+          x-dcl-go-name: Parameters
+          description: Optional. Template parameters whose values are substituted
+            into the template. Values for parameters must be provided when the template
+            is instantiated.
+          x-kubernetes-immutable: true
+          x-dcl-send-empty: true
+          x-dcl-list-type: list
+          items:
+            type: object
+            x-dcl-go-type: WorkflowTemplateParameters
+            required:
+            - name
+            - fields
+            properties:
+              description:
+                type: string
+                x-dcl-go-name: Description
+                description: Optional. Brief description of the parameter. Must not
+                  exceed 1024 characters.
+                x-kubernetes-immutable: true
+              fields:
+                type: array
+                x-dcl-go-name: Fields
+                description: 'Required. Paths to all fields that the parameter replaces.
+                  A field is allowed to appear in at most one parameter''s list of
+                  field paths. A field path is similar in syntax to a google.protobuf.FieldMask.
+                  For example, a field path that references the zone field of a workflow
+                  template''s cluster selector would be specified as `placement.clusterSelector.zone`.
+                  Also, field paths can reference fields using the following syntax:
+                  * Values in maps can be referenced by key: * labels[''key''] * placement.clusterSelector.clusterLabels[''key'']
+                  * placement.managedCluster.labels[''key''] * placement.clusterSelector.clusterLabels[''key'']
+                  * jobs[''step-id''].labels[''key''] * Jobs in the jobs list can
+                  be referenced by step-id: * jobs[''step-id''].hadoopJob.mainJarFileUri
+                  * jobs[''step-id''].hiveJob.queryFileUri * jobs[''step-id''].pySparkJob.mainPythonFileUri
+                  * jobs[''step-id''].hadoopJob.jarFileUris[0] * jobs[''step-id''].hadoopJob.archiveUris[0]
+                  * jobs[''step-id''].hadoopJob.fileUris[0] * jobs[''step-id''].pySparkJob.pythonFileUris[0]
+                  * Items in repeated fields can be referenced by a zero-based index:
+                  * jobs[''step-id''].sparkJob.args[0] * Other examples: * jobs[''step-id''].hadoopJob.properties[''key'']
+                  * jobs[''step-id''].hadoopJob.args[0] * jobs[''step-id''].hiveJob.scriptVariables[''key'']
+                  * jobs[''step-id''].hadoopJob.mainJarFileUri * placement.clusterSelector.zone
+                  It may not be possible to parameterize maps and repeated fields
+                  in their entirety since only individual map values and individual
+                  items in repeated fields can be referenced. For example, the following
+                  field paths are invalid: - placement.clusterSelector.clusterLabels
+                  - jobs[''step-id''].sparkJob.args'
+                x-kubernetes-immutable: true
+                x-dcl-send-empty: true
+                x-dcl-list-type: list
+                items:
+                  type: string
+                  x-dcl-go-type: string
+              name:
+                type: string
+                x-dcl-go-name: Name
+                description: Required. Parameter name. The parameter name is used
+                  as the key, and paired with the parameter value, which are passed
+                  to the template when the template is instantiated. The name must
+                  contain only capital letters (A-Z), numbers (0-9), and underscores
+                  (_), and must not start with a number. The maximum length is 40
+                  characters.
+                x-kubernetes-immutable: true
+              validation:
+                type: object
+                x-dcl-go-name: Validation
+                x-dcl-go-type: WorkflowTemplateParametersValidation
+                description: Optional. Validation rules to be applied to this parameter's
+                  value.
+                x-kubernetes-immutable: true
+                properties:
+                  regex:
+                    type: object
+                    x-dcl-go-name: Regex
+                    x-dcl-go-type: WorkflowTemplateParametersValidationRegex
+                    description: Validation based on regular expressions.
+                    x-kubernetes-immutable: true
+                    required:
+                    - regexes
+                    properties:
+                      regexes:
+                        type: array
+                        x-dcl-go-name: Regexes
+                        description: Required. RE2 regular expressions used to validate
+                          the parameter's value. The value must match the regex in
+                          its entirety (substring matches are not sufficient).
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+                  values:
+                    type: object
+                    x-dcl-go-name: Values
+                    x-dcl-go-type: WorkflowTemplateParametersValidationValues
+                    description: Validation based on a list of allowed values.
+                    x-kubernetes-immutable: true
+                    required:
+                    - values
+                    properties:
+                      values:
+                        type: array
+                        x-dcl-go-name: Values
+                        description: Required. List of allowed values for the parameter.
+                        x-kubernetes-immutable: true
+                        x-dcl-send-empty: true
+                        x-dcl-list-type: list
+                        items:
+                          type: string
+                          x-dcl-go-type: string
+        placement:
+          type: object
+          x-dcl-go-name: Placement
+          x-dcl-go-type: WorkflowTemplatePlacement
+          description: Required. WorkflowTemplate scheduling information.
+          x-kubernetes-immutable: true
+          properties:
+            clusterSelector:
+              type: object
+              x-dcl-go-name: ClusterSelector
+              x-dcl-go-type: WorkflowTemplatePlacementClusterSelector
+              description: Optional. A selector that chooses target cluster for jobs
+                based on metadata. The selector is evaluated at the time each job
+                is submitted.
+              x-kubernetes-immutable: true
+              required:
+              - clusterLabels
+              properties:
+                clusterLabels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  x-dcl-go-name: ClusterLabels
+                  description: Required. The cluster labels. Cluster must have all
+                    labels to match.
+                  x-kubernetes-immutable: true
+                zone:
+                  type: string
+                  x-dcl-go-name: Zone
+                  description: Optional. The zone where workflow process executes.
+                    This parameter does not affect the selection of the cluster. If
+                    unspecified, the zone of the first cluster matching the selector
+                    is used.
+                  x-kubernetes-immutable: true
+            managedCluster:
+              type: object
+              x-dcl-go-name: ManagedCluster
+              x-dcl-go-type: WorkflowTemplatePlacementManagedCluster
+              description: A cluster that is managed by the workflow.
+              x-kubernetes-immutable: true
+              required:
+              - clusterName
+              - config
+              properties:
+                clusterName:
+                  type: string
+                  x-dcl-go-name: ClusterName
+                  description: Required. The cluster name prefix. A unique cluster
+                    name will be formed by appending a random suffix. The name must
+                    contain only lower-case letters (a-z), numbers (0-9), and hyphens
+                    (-). Must begin with a letter. Cannot begin or end with hyphen.
+                    Must consist of between 2 and 35 characters.
+                  x-kubernetes-immutable: true
+                config:
+                  $ref: '#/components/schemas/ClusterConfig'
+                  x-dcl-go-name: Config
+                  x-kubernetes-immutable: true
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  x-dcl-go-name: Labels
+                  description: 'Optional. The labels to associate with this cluster.
+                    Label keys must be between 1 and 63 characters long, and must
+                    conform to the following PCRE regular expression: p{Ll}p{Lo}{0,62}
+                    Label values must be between 1 and 63 characters long, and must
+                    conform to the following PCRE regular expression: [p{Ll}p{Lo}p{N}_-]{0,63}
+                    No more than 32 labels can be associated with a given cluster.'
+                  x-kubernetes-immutable: true
+        project:
+          type: string
+          x-dcl-go-name: Project
+          description: The project for the resource
+          x-kubernetes-immutable: true
+          x-dcl-references:
+          - resource: Cloudresourcemanager/Project
+            field: name
+            parent: true
+        updateTime:
+          type: string
+          format: date-time
+          x-dcl-go-name: UpdateTime
+          readOnly: true
+          description: Output only. The time template was last updated.
+          x-kubernetes-immutable: true
+        version:
+          type: integer
+          format: int64
+          x-dcl-go-name: Version
+          readOnly: true
+          description: Output only. The current version of this workflow template.
+          x-kubernetes-immutable: true

--- a/tpgtools/override.go
+++ b/tpgtools/override.go
@@ -74,7 +74,7 @@ const (
 	GenerateIfNotSet                  = "GENERATE_IF_NOT_SET"
 	CustomListSize                    = "CUSTOM_LIST_SIZE_CONSTRAINT"
 	CustomDefault                     = "CUSTOM_DEFAULT"
-	CustomRequired                    = "REQUIRED_OVERRIDE"
+	CustomSchemaValues                = "CUSTOM_SCHEMA_VALUES"
 )
 
 // Overrides represents the type a resource's override file can be marshalled

--- a/tpgtools/override_details.go
+++ b/tpgtools/override_details.go
@@ -141,11 +141,10 @@ type CustomListSizeConstraintDetails struct {
 	Max int64
 }
 
-type CustomRequiredDetails struct {
+type CustomSchemaValuesDetails struct {
 	Required bool
 	Optional bool
 	Computed bool
-	ForceNew bool
 }
 
 type ImportFormatDetails struct {

--- a/tpgtools/overrides/compute/beta/forwarding_rule.yaml
+++ b/tpgtools/overrides/compute/beta/forwarding_rule.yaml
@@ -9,7 +9,7 @@
   details:
     title: forwarding_rule
   location: region
-- type: REQUIRED_OVERRIDE
+- type: CUSTOM_SCHEMA_VALUES
   location: global
   field: target
   details:

--- a/tpgtools/overrides/compute/forwarding_rule.yaml
+++ b/tpgtools/overrides/compute/forwarding_rule.yaml
@@ -9,7 +9,7 @@
   details:
     title: forwarding_rule
   location: region
-- type: REQUIRED_OVERRIDE
+- type: CUSTOM_SCHEMA_VALUES
   location: global
   field: target
   details:

--- a/tpgtools/overrides/dataproc/beta/workflow_template.yaml
+++ b/tpgtools/overrides/dataproc/beta/workflow_template.yaml
@@ -1,0 +1,6 @@
+- type: CUSTOM_SCHEMA_VALUES
+  field: version
+  details:
+    required: false
+    optional: true
+    computed: true

--- a/tpgtools/overrides/dataproc/beta/workflow_template.yaml
+++ b/tpgtools/overrides/dataproc/beta/workflow_template.yaml
@@ -4,3 +4,8 @@
     required: false
     optional: true
     computed: true
+- type: DEPRECATED
+  field: version
+  details:
+    message: >-
+      version is not useful as a configurable field, and will be removed in the future.

--- a/tpgtools/overrides/dataproc/workflow_template.yaml
+++ b/tpgtools/overrides/dataproc/workflow_template.yaml
@@ -1,0 +1,6 @@
+- type: CUSTOM_SCHEMA_VALUES
+  field: version
+  details:
+    required: false
+    optional: true
+    computed: true

--- a/tpgtools/overrides/dataproc/workflow_template.yaml
+++ b/tpgtools/overrides/dataproc/workflow_template.yaml
@@ -4,3 +4,8 @@
     required: false
     optional: true
     computed: true
+- type: DEPRECATED
+  field: version
+  details:
+    message: >-
+      version is not useful as a configurable field, and will be removed in the future.

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -632,8 +632,8 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 			} else {
 				p.Optional = true
 			}
-			cr := CustomRequiredDetails{}
-			crOk, err := overrides.PropertyOverrideWithDetails(CustomRequired, p, &cr, location)
+			cr := CustomSchemaValuesDetails{}
+			crOk, err := overrides.PropertyOverrideWithDetails(CustomSchemaValues, p, &cr, location)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode custom required details")
 			}

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -625,7 +625,6 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 			}
 		}
 
-
 		if !p.Computed {
 			glog.Infof("Looking for %q in %v.", v.Title, schema.Required)
 			if stringInSlice(v.Title, schema.Required) {
@@ -634,16 +633,16 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 				p.Optional = true
 			}
 		}
-			cr := CustomSchemaValuesDetails{}
-			crOk, err := overrides.PropertyOverrideWithDetails(CustomSchemaValues, p, &cr, location)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode custom required details")
-			}
-			if crOk {
-				p.Required = cr.Required
-				p.Optional = cr.Optional
-				p.Computed = cr.Computed
-			}
+		cr := CustomSchemaValuesDetails{}
+		crOk, err := overrides.PropertyOverrideWithDetails(CustomSchemaValues, p, &cr, location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode custom required details")
+		}
+		if crOk {
+			p.Required = cr.Required
+			p.Optional = cr.Optional
+			p.Computed = cr.Computed
+		}
 
 		// Handle settable fields. If the field is computed it's not settable but
 		// if it's also optional (O+C), it is.

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -625,6 +625,7 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 			}
 		}
 
+
 		if !p.Computed {
 			glog.Infof("Looking for %q in %v.", v.Title, schema.Required)
 			if stringInSlice(v.Title, schema.Required) {
@@ -632,6 +633,7 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 			} else {
 				p.Optional = true
 			}
+		}
 			cr := CustomSchemaValuesDetails{}
 			crOk, err := overrides.PropertyOverrideWithDetails(CustomSchemaValues, p, &cr, location)
 			if err != nil {
@@ -643,6 +645,9 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 				p.Computed = cr.Computed
 			}
 
+		// Handle settable fields. If the field is computed it's not settable but
+		// if it's also optional (O+C), it is.
+		if !p.Computed || (p.Optional) {
 			p.Settable = true
 
 			// NOTE: x-kubernetes-immmutable implies that all children of a field


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Changes the name of REQUIRED_OVERRIDE to CUSTOM_SCHEMA_VALUES as that makes a little more sense (it applies to more than required) and removes the `ForceNew` value since it wasn't hooked up anywhere.

This updates the Dataproc WorkflowTemplate resource, fixing the `version` field retyping that was otherwise blocking https://github.com/GoogleCloudPlatform/magic-modules/pull/5197. I deprecated it- not sure if it's on the docket for `4.0.0`, I haven't rolled it in yet (we already have enough to do)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
dataproc: deprecated the `google_dataproc_workflow_template.version` field, as it wasn't actually useful. The field is used during updates, but updates aren't currently possible with the resource.
```
