### PR TITLE
Deprecate the Runtime Configurator service in the GA provider

### DIFF
--- a/mmv1/api/resource/iam_policy.rb
+++ b/mmv1/api/resource/iam_policy.rb
@@ -97,6 +97,11 @@ module Api
       # [Optional] Version number in the request payload.
       # if set, it overrides the default iamPolicyVersion
       attr_reader :iam_policy_version
+
+      # [Optional] If true, this resource has been deprecated at GA only.
+      # This can probably be removed after `4.0.0`.
+      attr_reader :ga_deprecation
+
       def validate
         super
 
@@ -121,6 +126,7 @@ module Api
           type: String, default: 'templates/terraform/iam/iam_attributes.tf.erb'
         )
         check :iam_policy_version, type: String
+        check :ga_deprecation, type: :boolean, default: false
       end
     end
   end

--- a/mmv1/products/runtimeconfig/api.yaml
+++ b/mmv1/products/runtimeconfig/api.yaml
@@ -36,6 +36,7 @@ objects:
       parent_resource_attribute: 'config'
       method_name_separator: ':'
       exclude: false
+      ga_deprecation: true
     parameters:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/mmv1/third_party/terraform/data_sources/data_source_runtimeconfig_config.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_runtimeconfig_config.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -15,6 +16,9 @@ func dataSourceGoogleRuntimeconfigConfig() *schema.Resource {
 	return &schema.Resource{
 		Read:   dataSourceGoogleRuntimeconfigConfigRead,
 		Schema: dsSchema,
+<% if version == 'ga' -%>
+		DeprecationMessage: "This datasource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.",
+<% end -%>
 	}
 }
 

--- a/mmv1/third_party/terraform/resources/resource_iam_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_iam_policy.go
@@ -37,12 +37,21 @@ func iamPolicyImport(resourceIdParser resourceIdParserFunc) schema.StateFunc {
 	}
 }
 
-func ResourceIamPolicy(parentSpecificSchema map[string]*schema.Schema, newUpdaterFunc newResourceIamUpdaterFunc, resourceIdParser resourceIdParserFunc) *schema.Resource {
+func ResourceIamPolicy(parentSpecificSchema map[string]*schema.Schema, newUpdaterFunc newResourceIamUpdaterFunc, resourceIdParser resourceIdParserFunc, options ...func(*IamSettings)) *schema.Resource {
+	settings := &IamSettings{}
+	for _, o := range options {
+		o(settings)
+	}
+
 	return &schema.Resource{
 		Create: ResourceIamPolicyCreate(newUpdaterFunc),
 		Read:   ResourceIamPolicyRead(newUpdaterFunc),
 		Update: ResourceIamPolicyUpdate(newUpdaterFunc),
 		Delete: ResourceIamPolicyDelete(newUpdaterFunc),
+
+		// if non-empty, this will be used to send a deprecation message when the
+		// resource is used.
+		DeprecationMessage: settings.DeprecationMessage,
 
 		Schema: mergeSchemas(IamPolicyBaseSchema, parentSpecificSchema),
 		Importer: &schema.ResourceImporter{

--- a/mmv1/third_party/terraform/resources/resource_runtimeconfig_config.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_runtimeconfig_config.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -16,6 +17,10 @@ func resourceRuntimeconfigConfig() *schema.Resource {
 		Read:   resourceRuntimeconfigConfigRead,
 		Update: resourceRuntimeconfigConfigUpdate,
 		Delete: resourceRuntimeconfigConfigDelete,
+
+<% unless version == 'ga' -%>
+		DeprecationMessage: "This resource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.",
+<% end -%>
 
 		Importer: &schema.ResourceImporter{
 			State: resourceRuntimeconfigConfigImport,

--- a/mmv1/third_party/terraform/resources/resource_runtimeconfig_variable.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_runtimeconfig_variable.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -14,6 +15,10 @@ func resourceRuntimeconfigVariable() *schema.Resource {
 		Read:   resourceRuntimeconfigVariableRead,
 		Update: resourceRuntimeconfigVariableUpdate,
 		Delete: resourceRuntimeconfigVariableDelete,
+
+<% unless version == 'ga' -%>
+		DeprecationMessage: "This resource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.",
+<% end -%>
 
 		Importer: &schema.ResourceImporter{
 			State: resourceRuntimeconfigVariableImport,

--- a/mmv1/third_party/terraform/utils/iam.go.erb
+++ b/mmv1/third_party/terraform/utils/iam.go.erb
@@ -449,3 +449,21 @@ func compareAuditConfigs(a, b []*cloudresourcemanager.AuditConfig) bool {
 	bMap := createIamAuditConfigsMap(b)
 	return reflect.DeepEqual(aMap, bMap)
 }
+
+type IamSettings struct {
+	DeprecationMessage string
+}
+
+func IamWithDeprecationMessage(message string) func(s *IamSettings) {
+	return func(s *IamSettings) {
+		s.DeprecationMessage = message
+	}
+}
+
+func IamWithGAResourceDeprecation() func (s *IamSettings) {
+	<% if version == 'ga' -%>
+	return IamWithDeprecationMessage("This resource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.")
+	<% else -%>
+	return IamWithDeprecationMessage("")
+	<% end -%>
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -353,9 +353,9 @@ products.each do |product|
 	unless iam_policy.nil? || iam_policy.exclude
 	  iam_class_name = product_definition.name + object.name
 -%>
-	"<%= terraform_name -%>_iam_binding":              ResourceIamBinding(<%= iam_class_name -%>IamSchema, <%= iam_class_name -%>IamUpdaterProducer, <%= iam_class_name -%>IdParseFunc),
-	"<%= terraform_name -%>_iam_member":               ResourceIamMember(<%= iam_class_name -%>IamSchema, <%= iam_class_name -%>IamUpdaterProducer, <%= iam_class_name -%>IdParseFunc),
-	"<%= terraform_name -%>_iam_policy":               ResourceIamPolicy(<%= iam_class_name -%>IamSchema, <%= iam_class_name -%>IamUpdaterProducer, <%= iam_class_name -%>IdParseFunc),
+	"<%= terraform_name -%>_iam_binding":              ResourceIamBinding(<%= iam_class_name -%>IamSchema, <%= iam_class_name -%>IamUpdaterProducer, <%= iam_class_name -%>IdParseFunc<% if iam_policy.ga_deprecation %>, IamWithGAResourceDeprecation()<% end %>),
+	"<%= terraform_name -%>_iam_member":               ResourceIamMember(<%= iam_class_name -%>IamSchema, <%= iam_class_name -%>IamUpdaterProducer, <%= iam_class_name -%>IdParseFunc<% if iam_policy.ga_deprecation %>, IamWithGAResourceDeprecation()<% end %>),
+	"<%= terraform_name -%>_iam_policy":               ResourceIamPolicy(<%= iam_class_name -%>IamSchema, <%= iam_class_name -%>IamUpdaterProducer, <%= iam_class_name -%>IdParseFunc<% if iam_policy.ga_deprecation %>, IamWithGAResourceDeprecation()<% end %>),
 <%
 	end # unless iam_policy.nil? || iam_policy.exclude
   end   # product_definition.objects.each do

--- a/mmv1/third_party/terraform/website/docs/d/runtimeconfig_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/runtimeconfig_config.html.markdown
@@ -11,6 +11,9 @@ description: |-
 
 To get more information about RuntimeConfigs, see:
 
+
+!> This datasource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.
+
 * [API documentation](https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/v1beta1/projects.configs)
 * How-to Guides
     * [Runtime Configurator Fundamentals](https://cloud.google.com/deployment-manager/runtime-configurator/)

--- a/mmv1/third_party/terraform/website/docs/guides/version_4_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_4_upgrade.html.markdown
@@ -106,9 +106,45 @@ terraform {
 
 ## Provider
 
-### Provider-level change example
+### Runtime Configurator (`runtimeconfig`) resources have been removed from the GA provider
 
-Description of the change and how users should adjust their configuration (if needed).
+Earlier versions of the provider accidentally included the Runtime Configurator
+service at GA. `4.0.0` has corrected that error, and Runtime Configurator is
+only available in `google-beta`.
+
+Affected Resources:
+
+    * `google_runtimeconfig_config`
+    * `google_runtimeconfig_variable`
+    * `google_runtimeconfig_config_iam_policy`
+    * `google_runtimeconfig_config_iam_binding`
+    * `google_runtimeconfig_config_iam_member`
+
+Affected Datasources:
+
+    * `google_runtimeconfig_config`
+
+
+If you have a configuration using the `google` provider like the following:
+
+```
+resource "google_runtimeconfig_config" "my-runtime-config" {
+  name        = "my-service-runtime-config"
+  description = "Runtime configuration values for my service"
+}
+```
+
+Add the `google-beta` provider to your configuration:
+
+```
+resource "google_runtimeconfig_config" "my-runtime-config" {
+  provider = google-beta
+
+  name        = "my-service-runtime-config"
+  description = "Runtime configuration values for my service"
+}
+```
+
 
 ## Datasource: `google_product_resource`
 

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages a RuntimeConfig resource in Google Cloud.
 
+!> This resource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.
+
 To get more information about RuntimeConfigs, see:
 
 * [API documentation](https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/v1beta1/projects.configs)

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -14,6 +14,8 @@ Manages a RuntimeConfig variable in Google Cloud. For more information, see the
 or the
 [JSON API](https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/).
 
+!> This resource has been deprecated in the google (GA) provider, and will only be available in the google-beta provider in a future release.
+
 ## Example Usage
 
 Example creating a RuntimeConfig variable.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

4.0.0 pre-work for https://github.com/hashicorp/terraform-provider-google/issues/8696

Implemented functional options (https://golang.cafe/blog/golang-functional-options-pattern.html) rather than messing w/ another function overload. I've gotta switch batching over, but this PR didn't feel like the place. Filed https://github.com/hashicorp/terraform-provider-google/issues/10209.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
runtimeconfig: deprecated the Runtime Configurator service in the `google` (GA) provider including `google_runtimeconfig_config`, `google_runtimeconfig_variable`, `google_runtimeconfig_config_iam_policy`, `google_runtimeconfig_config_iam_binding`, `google_runtimeconfig_config_iam_member`, `data.google_runtimeconfig_config`. They will only be available in the `google-beta` provider in a future release, as the underlying service is in beta.
```
