### PR TITLE
Clarified docs around compute instance networking

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -266,12 +266,16 @@ The `network_performance_config` block supports:
 The `network_interface` block supports:
 
 * `network` - (Optional) The name or self_link of the network to attach this interface to.
-    Either `network` or `subnetwork` must be provided.
+    Either `network` or `subnetwork` must be provided. If network isn't provided it will
+    be inferred from the subnetwork.
 
 *  `subnetwork` - (Optional) The name or self_link of the subnetwork to attach this
-    interface to. The subnetwork must exist in the same region this instance will be
-    created in. If network isn't provided it will be inferred from the subnetwork.
-    Either `network` or `subnetwork` must be provided.
+    interface to. Either `network` or `subnetwork` must be provided. If network isn't provided
+    it will be inferred from the subnetwork. The subnetwork must exist in the same region this
+    instance will be created in. If the network resource is in
+    [legacy](https://cloud.google.com/vpc/docs/legacy) mode, do not specify this field. If the
+    network is in auto subnet mode, specifying the subnetwork is optional. If the network is
+    in custom subnet mode, specifying the subnetwork is required.
 
 *  `subnetwork_project` - (Optional) The project in which the subnetwork belongs.
    If the `subnetwork` is a self_link, this field is ignored in favor of the project


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/10133. Made docs for networking more closely match each other & https://cloud.google.com/compute/docs/reference/rest/v1/instances

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
