### PR TITLE
Revert "Revert "Feature/NetLB connection tracking""

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -2721,6 +2721,7 @@ objects:
           - :CLIENT_IP_NO_DESTINATION
       - !ruby/object:Api::Type::NestedObject
         name: 'connectionTrackingPolicy'
+        min_version: 'beta'
         description: |
           Connection Tracking configuration for this BackendService.
           This is available only for Layer 4 Internal Load Balancing and

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -2718,6 +2718,60 @@ objects:
           - :GENERATED_COOKIE
           - :HEADER_FIELD
           - :HTTP_COOKIE
+          - :CLIENT_IP_NO_DESTINATION
+      - !ruby/object:Api::Type::NestedObject
+        name: 'connectionTrackingPolicy'
+        description: |
+          Connection Tracking configuration for this BackendService.
+          This is available only for Layer 4 Internal Load Balancing and
+          Network Load Balancing.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'idleTimeoutSec'
+            description: |
+              Specifies how long to keep a Connection Tracking entry while there is
+              no matching traffic (in seconds). 
+
+              For L4 ILB the minimum(default) is 10 minutes and maximum is 16 hours.
+
+              For NLB the minimum(default) is 60 seconds and the maximum is 16 hours.
+          - !ruby/object:Api::Type::Enum
+            name: 'trackingMode'
+            description: |
+              Specifies the key used for connection tracking. There are two options:
+              `PER_CONNECTION`: The Connection Tracking is performed as per the
+              Connection Key (default Hash Method) for the specific protocol.
+              
+              `PER_SESSION`: The Connection Tracking is performed as per the
+              configured Session Affinity. It matches the configured Session Affinity.
+            default_value: :PER_CONNECTION
+            values:
+              - :PER_CONNECTION
+              - :PER_SESSION
+          - !ruby/object:Api::Type::Enum
+            name: 'connectionPersistenceOnUnhealthyBackends'
+            description: |
+              Specifies connection persistence when backends are unhealthy.
+
+              If set to `DEFAULT_FOR_PROTOCOL`, the existing connections persist on
+              unhealthy backends only for connection-oriented protocols (TCP and SCTP)
+              and only if the Tracking Mode is PER_CONNECTION (default tracking mode)
+              or the Session Affinity is configured for 5-tuple. They do not persist
+              for UDP.
+
+              If set to `NEVER_PERSIST`, after a backend becomes unhealthy, the existing
+              connections on the unhealthy backend are never persisted on the unhealthy
+              backend. They are always diverted to newly selected healthy backends
+              (unless all backends are unhealthy).
+
+              If set to `ALWAYS_PERSIST`, existing connections always persist on
+              unhealthy backends regardless of protocol and session affinity. It is
+              generally not recommended to use this mode overriding the default.
+            default_value: :DEFAULT_FOR_PROTOCOL
+            values:
+              - :DEFAULT_FOR_PROTOCOL
+              - :NEVER_PERSIST
+              - :ALWAYS_PERSIST
       - !ruby/object:Api::Type::Integer
         name: 'timeoutSec'
         description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -377,6 +377,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "rbs-net"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_connection_tracking"
+        min_version: 'beta'
         primary_resource_id: "default"
         vars:
           region_backend_service_name: "region-service"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -375,6 +375,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           rigm_name: "rbs-rigm"
           region_health_check_name: "rbs-health-check"
           network_name: "rbs-net"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "region_backend_service_connection_tracking"
+        primary_resource_id: "default"
+        vars:
+          region_backend_service_name: "region-service"
+          health_check_name: "rbs-health-check"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/region_backend_service.go.erb
       encoder: templates/terraform/encoders/region_backend_service.go.erb
@@ -448,6 +454,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       timeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      connectionTrackingPolicy.idleTimeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
   RegionInstanceGroupManager: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true

--- a/mmv1/templates/terraform/examples/region_backend_service_connection_tracking.tf.erb
+++ b/mmv1/templates/terraform/examples/region_backend_service_connection_tracking.tf.erb
@@ -1,0 +1,23 @@
+resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name                            = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  region                          = "us-central1"
+  health_checks                   = [google_compute_region_health_check.health_check.id]
+  connection_draining_timeout_sec = 10
+  session_affinity                = "CLIENT_IP"
+  protocol                        = "TCP"
+  load_balancing_scheme           = "EXTERNAL"
+  connection_tracking_policy {
+    tracking_mode                                = "PER_SESSION"
+    connection_persistence_on_unhealthy_backends = "NEVER_PERSIST"
+    idle_timeout_sec                             = 60
+  }
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  name               = "<%= ctx[:vars]['health_check_name'] %>"
+  region             = "us-central1"
+
+  tcp_health_check {
+    port = 22
+  }
+}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#5272 to re-add the NetLB connection tracking (but beta-only)

```release-note:enhancement
 compute: added NetLB support for Connection Tracking as `connectionTrackingPolicy` in `RegionBackendService`(beta)
```