### PR TITLE
Composer enable_ip_masq_agent flag support (beta) (#9698)

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -209,6 +209,13 @@ func resourceComposerEnvironment() *schema.Resource {
 										ValidateFunc:     validation.IntBetween(8, 110),
 										Description:      `The maximum pods per node in the GKE cluster allocated during environment creation. Lowering this value reduces IP address consumption by the Cloud Composer Kubernetes cluster. This value can only be set during environment creation, and only if the environment is VPC-Native. The range of possible values is 8-110, and the default is 32.`,
 									},
+									"enable_ip_masq_agent": {
+										Type:             schema.TypeBool,
+										Computed:         true,
+										Optional:         true,
+										ForceNew:         true,
+										Description:      `Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for all destination addresses, except between pods traffic. See: https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent`,
+									},
 <% end -%>
 									"tags": {
 										Type:     schema.TypeSet,
@@ -1019,6 +1026,7 @@ func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig) in
 	transformed["oauth_scopes"] = flattenComposerEnvironmentConfigNodeConfigOauthScopes(nodeCfg.OauthScopes)
 <% unless version == "ga" -%>
 	transformed["max_pods_per_node"] = nodeCfg.MaxPodsPerNode
+	transformed["enable_ip_masq_agent"] = nodeCfg.EnableIpMasqAgent
 <% end -%>
 	transformed["tags"] = flattenComposerEnvironmentConfigNodeConfigTags(nodeCfg.Tags)
 	transformed["ip_allocation_policy"] = flattenComposerEnvironmentConfigNodeConfigIPAllocationPolicy(nodeCfg.IpAllocationPolicy)
@@ -1312,6 +1320,10 @@ func expandComposerEnvironmentConfigNodeConfig(v interface{}, d *schema.Resource
 <% unless version == "ga" -%>
 	if transformedMaxPodsPerNode, ok := original["max_pods_per_node"]; ok {
 		transformed.MaxPodsPerNode = int64(transformedMaxPodsPerNode.(int))
+	}
+
+	if transformedEnableIpMasqAgent, ok := original["enable_ip_masq_agent"]; ok {
+		transformed.EnableIpMasqAgent = transformedEnableIpMasqAgent.(bool)
 	}
 <% end -%>
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1021,6 +1021,7 @@ resource "google_composer_environment" "test" {
 			service_account = google_service_account.test.name
 <% unless version == "ga" -%>
 			max_pods_per_node = 33
+			enable_ip_masq_agent = true
 <% end -%>
 			ip_allocation_policy {
 				use_ip_aliases          = true

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1011,7 +1011,7 @@ func testAccComposerEnvironment_nodeCfg(environment, network, subnetwork, servic
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
 	name   = "%s"
-	region = "us-central1"
+	region = "us-east1"  # later should be changed to us-central1, when feature is accessible globally
 	config {
 		node_config {
 			network    = google_compute_network.test.self_link

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1016,7 +1016,7 @@ resource "google_composer_environment" "test" {
 		node_config {
 			network    = google_compute_network.test.self_link
 			subnetwork = google_compute_subnetwork.test.self_link
-			zone       = "us-central1-a"
+			zone       = "us-east1-b"   # later should be changed to us-central1, when feature is accessible globally
 
 			service_account = google_service_account.test.name
 <% unless version == "ga" -%>
@@ -1040,7 +1040,7 @@ resource "google_compute_network" "test" {
 resource "google_compute_subnetwork" "test" {
 	name          = "%s"
 	ip_cidr_range = "10.2.0.0/16"
-	region        = "us-central1"
+	region        = "us-east1"  # later should be changed to us-central1, when feature is accessible globally
 	network       = google_compute_network.test.self_link
 }
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1011,12 +1011,12 @@ func testAccComposerEnvironment_nodeCfg(environment, network, subnetwork, servic
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
 	name   = "%s"
-	region = "us-east1"  # later should be changed to us-central1, when feature is accessible globally
+	region = "us-east1"  # later should be changed to us-central1, when ip_masq_agent feature is accessible globally
 	config {
 		node_config {
 			network    = google_compute_network.test.self_link
 			subnetwork = google_compute_subnetwork.test.self_link
-			zone       = "us-east1-b"   # later should be changed to us-central1, when feature is accessible globally
+			zone       = "us-east1-b"   # later should be changed to us-central1-a, when ip_masq_agent feature is accessible globally
 
 			service_account = google_service_account.test.name
 <% unless version == "ga" -%>
@@ -1040,7 +1040,7 @@ resource "google_compute_network" "test" {
 resource "google_compute_subnetwork" "test" {
 	name          = "%s"
 	ip_cidr_range = "10.2.0.0/16"
-	region        = "us-east1"  # later should be changed to us-central1, when feature is accessible globally
+	region        = "us-east1"  # later should be changed to us-central1, when ip_masq_agent feature is accessible globally
 	network       = google_compute_network.test.self_link
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -259,6 +259,13 @@ The `node_config` block supports:
   The range of possible values is 8-110, and the default is 32.
   Cannot be updated.
 
+* `enable_ip_masq_agent` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines
+  nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for
+  all destination addresses, except between pods traffic.
+  See the [documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent).
+
 The `software_config` block supports:
 
 * `airflow_config_overrides` -


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add enable_ip_masq_agent to google_composer_environment (beta)

fixes hashicorp/terraform-provider-google#9698

I should be applied instead of similar PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/5142

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added field `enable_ip_masq_agent` to resource `google_composer_environment` (beta)
```
