### PR TITLE
Updated docs that reference how to base64 encode binary files

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/endpoints_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/endpoints_service.html.markdown
@@ -24,7 +24,7 @@ resource "google_endpoints_service" "grpc_service" {
   service_name         = "api-name.endpoints.project-id.cloud.goog"
   project              = "project-id"
   grpc_config          = file("service_spec.yml")
-  protoc_output_base64 = base64encode(file("compiled_descriptor_file.pb"))
+  protoc_output_base64 = filebase64("compiled_descriptor_file.pb")
 }
 ```
 

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -47,7 +47,7 @@ resource "google_runtimeconfig_config" "my-runtime-config" {
 resource "google_runtimeconfig_variable" "my-secret" {
   parent = google_runtimeconfig_config.my-runtime-config.name
   name   = "secret"
-  value  = base64encode(file("my-encrypted-secret.dat"))
+  value  = filebase64("my-encrypted-secret.dat")
 }
 ```
 


### PR DESCRIPTION
file only opens utf8-encoded files https://www.terraform.io/docs/language/functions/filebase64.html Ran into this while working on https://github.com/hashicorp/terraform-provider-google/issues/10164

```release-note:none

```
