### PR TITLE
Add Pub/Sub Lite reservation support to terraform.

### DIFF
--- a/mmv1/products/pubsublite/api.yaml
+++ b/mmv1/products/pubsublite/api.yaml
@@ -26,14 +26,47 @@ apis_required:
     url: https://console.cloud.google.com/apis/library/pubsublite.googleapis.com/
 objects:
   - !ruby/object:Api::Resource
+    name: 'Reservation'
+    description: |
+      A named resource representing a shared pool of capacity.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Managing Reservations':
+          'https://cloud.google.com/pubsub/lite/docs/reservations'
+      api: 'https://cloud.google.com/pubsub/lite/docs/reference/rest/v1/admin.projects.locations.reservations'
+    base_url: projects/{{project}}/locations/{{region}}/reservations
+    create_url: projects/{{project}}/locations/{{region}}/reservations?reservationId={{name}}
+    update_verb: :PATCH
+    update_mask: true
+    update_url: projects/{{project}}/locations/{{region}}/reservations/{{name}}
+    parameters:
+    - !ruby/object:Api::Type::String
+      name: region
+      description: The region of the pubsub lite reservation.
+      url_param_only: true
+    - !ruby/object:Api::Type::String
+      name: 'name'
+      description: 'Name of the reservation.'
+      required: true
+      input: true
+      url_param_only: true
+    properties:
+    - !ruby/object:Api::Type::Integer
+      name: 'throughput_capacity'
+      description: |
+        The reserved throughput capacity. Every unit of throughput capacity is
+        equivalent to 1 MiB/s of published messages or 2 MiB/s of subscribed
+        messages.
+      required: true
+  - !ruby/object:Api::Resource
     name: 'Topic'
     description: |
       A named resource to which messages are sent by publishers.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Managing Topics':
-          'https://cloud.google.com/pubsub/docs/admin#managing_topics'
-      api: 'https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics'
+          'https://cloud.google.com/pubsub/lite/docs/topics'
+      api: 'https://cloud.google.com/pubsub/lite/docs/reference/rest/v1/admin.projects.locations.topics'
     base_url: projects/{{project}}/locations/{{zone}}/topics
     create_url: projects/{{project}}/locations/{{zone}}/topics?topicId={{name}}
     update_verb: :PATCH
@@ -97,6 +130,18 @@ objects:
             description: |
               How long a published message is retained. If unset, messages will be retained as
               long as the bytes retained for each partition is below perPartitionBytes.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'reservationConfig'
+        description: |
+          The settings for this topic's Reservation usage.
+        properties:
+        - !ruby/object:Api::Type::ResourceRef
+          name: 'throughput_reservation'
+          resource: 'Reservation'
+          imports: 'name'
+          description: |
+            The Reservation to use for this topic's throughput capacity.
+          pattern: 'projects/{{project}}/locations/{{region}}/reservations/{{name}}'
   - !ruby/object:Api::Resource
     name: 'Subscription'
     description: |
@@ -105,8 +150,8 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Managing Subscriptions':
-          'https://cloud.google.com/pubsub/docs/admin#managing_subscriptions'
-      api: 'https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions'
+          'https://cloud.google.com/pubsub/lite/docs/subscriptions'
+      api: 'https://cloud.google.com/pubsub/lite/docs/reference/rest/v1/admin.projects.locations.subscriptions'
     base_url: projects/{{project}}/locations/{{zone}}/subscriptions
     create_url: projects/{{project}}/locations/{{zone}}/subscriptions?subscriptionId={{name}}
     update_verb: :PATCH

--- a/mmv1/products/pubsublite/api.yaml
+++ b/mmv1/products/pubsublite/api.yaml
@@ -52,7 +52,7 @@ objects:
       url_param_only: true
     properties:
     - !ruby/object:Api::Type::Integer
-      name: 'throughput_capacity'
+      name: 'throughputCapacity'
       description: |
         The reserved throughput capacity. Every unit of throughput capacity is
         equivalent to 1 MiB/s of published messages or 2 MiB/s of subscribed
@@ -136,7 +136,7 @@ objects:
           The settings for this topic's Reservation usage.
         properties:
         - !ruby/object:Api::Type::ResourceRef
-          name: 'throughput_reservation'
+          name: 'throughputReservation'
           resource: 'Reservation'
           imports: 'name'
           description: |

--- a/mmv1/products/pubsublite/terraform.yaml
+++ b/mmv1/products/pubsublite/terraform.yaml
@@ -38,6 +38,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
+      reservationConfig.throughputReservation: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+        custom_expand: templates/terraform/custom_expand/pubsublite_topic_reservation_config_throughput_reservation.go.erb
+
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/pubsub_lite.erb
     #   update_encoder: templates/terraform/update_encoder/pubsub_topic.erb

--- a/mmv1/products/pubsublite/terraform.yaml
+++ b/mmv1/products/pubsublite/terraform.yaml
@@ -24,8 +24,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-        custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
-        custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   Topic: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/pubsublite/terraform.yaml
+++ b/mmv1/products/pubsublite/terraform.yaml
@@ -33,6 +33,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "example"
         primary_resource_name: "fmt.Sprintf(\"tf-test-example-topic%s\", context[\"random_suffix\"])"
         vars:
+          reservation_name: "example-reservation"
           topic_name: "example-topic"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/pubsublite/terraform.yaml
+++ b/mmv1/products/pubsublite/terraform.yaml
@@ -13,6 +13,19 @@
 
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Reservation: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+    - !ruby/object:Provider::Terraform::Examples
+      name: "pubsub_lite_reservation_basic"
+      primary_resource_id: "example"
+      primary_resource_name: "fmt.Sprintf(\"tf-test-example-reservation%s\", context[\"random_suffix\"])"
+      vars:
+        reservation_name: "example-reservation"
+    properties:
+      name: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+        custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
+        custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   Topic: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/templates/terraform/custom_expand/pubsublite_topic_reservation_config_throughput_reservation.go.erb
+++ b/mmv1/templates/terraform/custom_expand/pubsublite_topic_reservation_config_throughput_reservation.go.erb
@@ -1,0 +1,22 @@
+<%# # the license inside this if block pertains to this file
+		# Copyright 2020 Google Inc.
+		# Licensed under the Apache License, Version 2.0 (the "License");
+		# you may not use this file except in compliance with the License.
+		# You may obtain a copy of the License at
+		#
+		#     http://www.apache.org/licenses/LICENSE-2.0
+		#
+		# Unless required by applicable law or agreed to in writing, software
+		# distributed under the License is distributed on an "AS IS" BASIS,
+		# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+		# See the License for the specific language governing permissions and
+		# limitations under the License.
+#%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	f, err := parseRegionalFieldValue("reservations", v.(string), "project", "region", "zone", d, config, true)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid value for throughput_reservation: %s", err)
+	}
+        // Custom due to "locations" rather than "regions".
+	return fmt.Sprintf("projects/%s/locations/%s/reservations/%s", f.Project, f.Region, f.Name), nil
+}

--- a/mmv1/templates/terraform/examples/pubsub_lite_reservation_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_lite_reservation_basic.tf.erb
@@ -1,0 +1,8 @@
+resource "google_pubsub_lite_reservation" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['reservation_name'] %>"
+  project = data.google_project.project.number
+  throughput_capacity = 2
+}
+
+data "google_project" "project" {
+}

--- a/mmv1/templates/terraform/examples/pubsub_lite_topic_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_lite_topic_basic.tf.erb
@@ -1,3 +1,9 @@
+resource "google_pubsub_lite_reservation" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['reservation_name'] %>"
+  project = data.google_project.project.number
+  throughput_capacity = 2
+}
+
 resource "google_pubsub_lite_topic" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['topic_name'] %>"
   project = data.google_project.project.number
@@ -12,6 +18,10 @@ resource "google_pubsub_lite_topic" "<%= ctx[:primary_resource_id] %>" {
 
   retention_config {
     per_partition_bytes = 32212254720
+  }
+
+  reservation_config {
+    throughput_reservation = google_pubsub_lite_reservation.<%= ctx[:primary_resource_id] %>.name
   }
 }
 


### PR DESCRIPTION
Also fix doc links for Pub/Sub Lite.

fixes https://github.com/hashicorp/terraform-provider-google/issues/10257

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


```release-note:new-resource
`google_pubsub_lite_reservation`
```
```release-note:enhancement
pubsub:  Added support for references to `google_pubsub_lite_reservation` to `google_pubsub_lite_topic`.
```
