### PR TITLE
issue #475: add doc about GKE node pools in terraform

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -61,6 +61,10 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 }
 ```
 
+~> **Note:** It is recommended that node pools be created and managed as separate resources as in the example above.
+This allows node pools to be added and removed without recreating the cluster.  Node pools defined directly in the
+`google_container_cluster` resource cannot be removed without re-creating the cluster.
+
 ## Example Usage - with the default node pool
 
 ```hcl


### PR DESCRIPTION
Adds brief explanation about why GKE node pools should be defined separately from the cluster resource
when using terraform.

Related to issue https://github.com/hashicorp/terraform-provider-google/issues/475.  PR #1329 added an example to the terraform docs that indicates that it is recommended to create node pools separately from the cluster definition, but there was no information in the docs about why this is recommended.  This PR 

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:note
container: Added note about why node pools should be defined separately from the cluster
```
