### PR TITLE
These bigquery fields cannot be updated.

### DIFF
--- a/mmv1/products/bigquery/api.yaml
+++ b/mmv1/products/bigquery/api.yaml
@@ -1521,16 +1521,19 @@ objects:
             name: 'datasetId'
             description: The ID of the dataset containing this routine
             required: true
+            input: true
           - !ruby/object:Api::Type::String
             name: 'projectId'
             description: The ID of the project containing this routine
             required: true
+            input: true
           - !ruby/object:Api::Type::String
             name: 'routineId'
             description: The ID of the the routine. The ID must contain only
               letters (a-z, A-Z), numbers (0-9), or underscores (_).
               The maximum length is 256 characters.
             required: true
+            input: true
       - !ruby/object:Api::Type::Enum
         name: 'routineType'
         input: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10264.

Relevant snippet:
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.dev-terraform.module.udfs_and_procedures.google_bigquery_routine.procedure_variables_t5 will be updated in-place
  ~ resource "google_bigquery_routine" "procedure_variables_t5" {
        id                 = "projects/myproject/datasets/mydataset/routines/variables_m5"
      ~ routine_id         = "variables_m5" -> "vars_t5"
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

```
Error: Error updating Routine "projects/myproject/datasets/mydataset/routines/variables_m5": 
  googleapi: Error 404: Not found: Routine myproject:variables.vars_t5, notFound
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fix update failure when attempting to change non-updatable fields in `google_bigquery_routine`.
```
