### PR TITLE
Add warning documenting behavior of the google_service_account_key resource for certain cases where the project cannot be inferred by terraform

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -15,6 +15,7 @@ Creates and manages service account keys, which allow the use of a service accou
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 
+~> **Warning:** If the `project` field in the google provider configuration is absent and the `service_account_id` field is not specified using the `{ACCOUNT}` syntax, then this resource will produce the following error: `Error: project: required field is not set`. Ensure the `service_account_id` is specified using the `{ACCOUNT}` syntax so that the project is inferred from the account.
 
 ## Example Usage, creating a new Key
 

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -15,6 +15,7 @@ Creates and manages service account keys, which allow the use of a service accou
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 
+
 ## Example Usage, creating a new Key
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -82,10 +82,12 @@ resource "kubernetes_secret" "google-application-credentials" {
 The following arguments are supported:
 
 * `service_account_id` - (Required) The Service account id of the Key. This can be a string in the format
-`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the **full** email address of the
-service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account. Likewise,
-if the `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}` syntax is used, substituting `-` as a wildcard for the
-`{PROJECT_ID}` will infer the project from the account.
+`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. If the `{ACCOUNT}`-only syntax is used, either
+the **full** email address of the service account or its name can be specified as a value, in which case the project will
+automatically be inferred from the account. Otherwise, if the `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`
+syntax is used, the `{ACCOUNT}` specified can be the full email address of the service account, the service
+account's name, or the service account's unique id. Substituting `-` as a wildcard for the `{PROJECT_ID}` will infer the
+project from the account.
 
 * `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
 Valid values are listed at

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -85,9 +85,8 @@ The following arguments are supported:
 `{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. If the `{ACCOUNT}`-only syntax is used, either
 the **full** email address of the service account or its name can be specified as a value, in which case the project will
 automatically be inferred from the account. Otherwise, if the `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`
-syntax is used, the `{ACCOUNT}` specified can be the full email address of the service account, the service
-account's name, or the service account's unique id. Substituting `-` as a wildcard for the `{PROJECT_ID}` will infer the
-project from the account.
+syntax is used, the `{ACCOUNT}` specified can be the full email address of the service account or the service account's
+unique id. Substituting `-` as a wildcard for the `{PROJECT_ID}` will infer the project from the account.
 
 * `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
 Valid values are listed at

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -15,8 +15,6 @@ Creates and manages service account keys, which allow the use of a service accou
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 
-~> **Warning:** If the `project` field in the google provider configuration is absent and the `service_account_id` field is not specified using the `{ACCOUNT}` syntax, then this resource will produce the following error: `Error: project: required field is not set`. Ensure the `service_account_id` is specified using the `{ACCOUNT}` syntax so that the project is inferred from the account.
-
 ## Example Usage, creating a new Key
 
 ```hcl
@@ -83,8 +81,8 @@ resource "kubernetes_secret" "google-application-credentials" {
 The following arguments are supported:
 
 * `service_account_id` - (Required) The Service account id of the Key. This can be a string in the format
-`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the email address or
-unique id of the service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
+`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the **full** email address of the
+service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
 
 * `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
 Valid values are listed at

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -83,7 +83,9 @@ The following arguments are supported:
 
 * `service_account_id` - (Required) The Service account id of the Key. This can be a string in the format
 `{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the **full** email address of the
-service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
+service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account. Likewise,
+if the `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}` syntax is used, substituting `-` as a wildcard for the
+`{PROJECT_ID}` will infer the project from the account.
 
 * `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
 Valid values are listed at


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-google/issues/9617.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
iam: added warning regarding `google_service_account_key` behavior when the project cannot be inferred from the `service_account_id` field.
```