### PR TITLE
enableStrongAffinity feature

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -2736,6 +2736,10 @@ objects:
               For L4 ILB the minimum(default) is 10 minutes and maximum is 16 hours.
 
               For NLB the minimum(default) is 60 seconds and the maximum is 16 hours.
+          - !ruby/object:Api::Type::Boolean
+            name: 'enableStrongAffinity'
+            description: |
+              Enable Strong Session Affinity. Not currently available publicly.
           - !ruby/object:Api::Type::Enum
             name: 'trackingMode'
             description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -382,6 +382,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           region_backend_service_name: "region-service"
           health_check_name: "rbs-health-check"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "region_backend_service_strong_affinity"
+        min_version: 'beta'
+        primary_resource_id: "default"
+        vars:
+          region_backend_service_name: "region-service"
+          health_check_name: "rbs-health-check"
+        skip_docs: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/region_backend_service.go.erb
       encoder: templates/terraform/encoders/region_backend_service.go.erb
@@ -457,6 +465,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       connectionTrackingPolicy.idleTimeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      connectionTrackingPolicy.enableStrongAffinity: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
   RegionInstanceGroupManager: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true

--- a/mmv1/templates/terraform/examples/region_backend_service_strong_affinity.tf.erb
+++ b/mmv1/templates/terraform/examples/region_backend_service_strong_affinity.tf.erb
@@ -1,0 +1,21 @@
+resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name                            = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  region                          = "us-west1"
+  health_checks                   = [google_compute_region_health_check.health_check.id]
+  connection_draining_timeout_sec = 10
+  session_affinity                = "CLIENT_IP"
+  protocol                        = "TCP"
+  load_balancing_scheme           = "EXTERNAL"
+  connection_tracking_policy {
+    enable_strong_affinity = true
+  }
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  name     = "<%= ctx[:vars]['health_check_name'] %>"
+  region   = "us-west1"
+
+  tcp_health_check {
+    port = 22
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
compute: added enableStrongAffinity switch to `connectionTrackingPolicy` in `RegionBackendService`

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added enableStrongAffinity switch to `connectionTrackingPolicy` in `RegionBackendService`

```
