### PR TITLE
kms: Add support for the MAC key purpose.

### DIFF
--- a/mmv1/products/kms/api.yaml
+++ b/mmv1/products/kms/api.yaml
@@ -115,6 +115,7 @@ objects:
           - "ENCRYPT_DECRYPT"
           - "ASYMMETRIC_SIGN"
           - "ASYMMETRIC_DECRYPT"
+          - "MAC"
         default_value: :ENCRYPT_DECRYPT
         input: true
       - !ruby/object:Api::Type::String

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -371,6 +371,41 @@ func TestAccKmsCryptoKey_importOnly(t *testing.T) {
 	})
 }
 
+func TestAccKmsCryptoKey_hsmMacKey(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", randInt(t))
+	projectOrg := getTestOrgFromEnv(t)
+	location := getTestRegionFromEnv()
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKey_hsmMacKey(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				ResourceName:      "google_kms_crypto_key.crypto_key",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
+			{
+				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
+					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
+					testAccCheckGoogleKmsCryptoKeyRotationDisabled(t, projectId, location, keyRingName, cryptoKeyName),
+				),
+			},
+		},
+	})
+}
+
 // KMS KeyRings cannot be deleted. This ensures that the CryptoKey resource was removed from state,
 // even though the server-side resource was not removed.
 func testAccCheckGoogleKmsCryptoKeyWasRemovedFromState(resourceName string) resource.TestCheckFunc {
@@ -633,6 +668,38 @@ resource "google_kms_crypto_key" "crypto_key" {
   }
   skip_initial_version_creation = true
   import_only = true
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKey_hsmMacKey(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "acceptance" {
+  project = google_project.acceptance.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = google_project_service.acceptance.project
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "%s"
+  key_ring = google_kms_key_ring.key_ring.self_link
+  purpose = "MAC"
+  version_template = {
+    protection_level = "HSM"
+    algorithm = "HMAC_SHA256"
+  }
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -696,7 +696,7 @@ resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.self_link
   purpose = "MAC"
-  version_template = {
+  version_template {
     protection_level = "HSM"
     algorithm = "HMAC_SHA256"
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for the [new](https://cloud.google.com/kms/docs/release-notes#August_20_2021) *MAC* key purpose in Cloud KMS.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).

   **Tests failed to run:**
```
 ❯ make testacc TEST=./google TESTARGS='-run=TestAccKmsCryptoKey_hsmMacKey'

==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
go generate  ./...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccKmsCryptoKey_hsmMacKey -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
# github.com/hashicorp/terraform-provider-google/google [github.com/hashicorp/terraform-provider-google/google.test]
google/privateca_operation.go:50:167: undefined: time
google/privateca_operation.go:58:9: undefined: json
google/privateca_operation.go:61:121: undefined: time
google/provider.go:1086:68: undefined: resourcePubsubLiteReservation
FAIL    github.com/hashicorp/terraform-provider-google/google [build failed]
FAIL
make: *** [testacc] Error 2
```
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
kms: Added support for the MAC key purpose
```