### PR TITLE
Remove redundant default scopes

### DIFF
--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -182,11 +182,7 @@ var DefaultBasePaths = map[string]string{
 }
 
 var DefaultClientScopes = []string{
-	"https://www.googleapis.com/auth/compute",
 	"https://www.googleapis.com/auth/cloud-platform",
-	"https://www.googleapis.com/auth/cloud-identity",
-	"https://www.googleapis.com/auth/ndev.clouddns.readwrite",
-	"https://www.googleapis.com/auth/devstorage.full_control",
 	"https://www.googleapis.com/auth/userinfo.email",
 }
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -265,10 +265,7 @@ an access token using the service account key specified in `credentials`.
 
     By default, the following scopes are configured:
 
-    * https://www.googleapis.com/auth/compute
     * https://www.googleapis.com/auth/cloud-platform
-    * https://www.googleapis.com/auth/ndev.clouddns.readwrite
-    * https://www.googleapis.com/auth/devstorage.full_control
     * https://www.googleapis.com/auth/userinfo.email
 
 * `request_reason` - (Optional) Send a Request Reason [System Parameter](https://cloud.google.com/apis/docs/system-parameters) for each API call made by the provider.  The `X-Goog-Request-Reason` header value is used to provide a user-supplied justification into GCP AuditLogs. Alternatively, this can be specified using the `CLOUDSDK_CORE_REQUEST_REASON` environment variable.

--- a/mmv1/third_party/terraform/website/docs/guides/version_4_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_4_upgrade.html.markdown
@@ -12,6 +12,7 @@ description: |-
   - [I accidentally upgraded to 4.0.0, how do I downgrade to `3.X`?](#i-accidentally-upgraded-to-400-how-do-i-downgrade-to-3x)
   - [Provider Version Configuration](#provider-version-configuration)
   - [Provider](#provider)
+    - [Redundant default scopes are removed](#redundant-default-scopes-are-removed)
     - [Runtime Configurator (`runtimeconfig`) resources have been removed from the GA provider](#runtime-configurator-runtimeconfig-resources-have-been-removed-from-the-ga-provider)
   - [Datasource: `google_product_resource`](#datasource-google_product_resource)
     - [Datasource-level change example](#datasource-level-change-example)
@@ -153,6 +154,26 @@ terraform {
 ```
 
 ## Provider
+
+### Redundant default scopes are removed
+
+Several default scopes are removed from the provider:
+
+* "https://www.googleapis.com/auth/compute"
+* "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+* "https://www.googleapis.com/auth/devstorage.full_control"
+* "https://www.googleapis.com/auth/cloud-identity"
+
+They are redundant with the "https://www.googleapis.com/auth/cloud-platform"
+scope per [Access scopes](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam).
+After this change the following scopes are enabled, in line with `gcloud`'s
+[list of scopes](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login):
+
+* "https://www.googleapis.com/auth/cloud-platform"
+* "https://www.googleapis.com/auth/userinfo.email"
+
+This change is believed to have no user impact. If you find that Terraform
+behaves incorrectly as a result of this change, please report a [bug](https://github.com/hashicorp/terraform-provider-google/issues/new?assignees=&labels=bug&template=bug.md).
 
 ### Runtime Configurator (`runtimeconfig`) resources have been removed from the GA provider
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8031


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
provider: removed redundant default scopes. The provider's default scopes when authenticating with credentials are now exclusively "https://www.googleapis.com/auth/cloud-platform" and "https://www.googleapis.com/auth/userinfo.email".
```
