### PR TITLE
Add Retention Duration to `google_pubsub_topic`

### DIFF
--- a/mmv1/products/pubsub/api.yaml
+++ b/mmv1/products/pubsub/api.yaml
@@ -100,6 +100,16 @@ objects:
               - :ENCODING_UNSPECIFIED
               - :JSON
               - :BINARY
+      - !ruby/object:Api::Type::String
+        name: 'messageRetentionDuration'
+        description: |
+          Indicates the minimum duration to retain a message after it is published
+          to the topic. If this field is set, messages published to the topic in
+          the last messageRetentionDuration are always available to subscribers.
+          For instance, it allows any attached subscription to seek to a timestamp
+          that is up to messageRetentionDuration in the past. If this field is not
+          set, message retention is controlled by settings on individual subscriptions.
+          Cannot be more than 7 days or less than 10 minutes.
   - !ruby/object:Api::Resource
     name: 'Subscription'
     description: |

--- a/mmv1/templates/terraform/examples/pubsub_topic_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_topic_basic.tf.erb
@@ -4,4 +4,6 @@ resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
   labels = {
     foo = "bar"
   }
+
+  message_retention_duration = "86600s"
 }


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10175

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: added `message_retention_duration` field to `google_pubsub_topic`
```
