### PR TITLE
Updated README for generating terraform-validator instead of terraform-google-conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ It's worth noting that Magic Modules will only generate new files when run
 locally. The "Magician"- the Magic Modules CI system- handles deletion of old
 files when creating PRs.
 
-#### Generating terraform-google-conversion
+#### Generating terraform-validator
 
-You can compile terraform-google-conversion by running the following command.
+You can compile terraform-validator by running the following command.
 If Magic Modules has been installed correctly, you'll get no errors.
 
 ```bash
-make validator OUTPUT_PATH="/path/to/your/terraform-google-conversion"
+make validator OUTPUT_PATH="/path/to/your/terraform-validator"
 ```
 
 ### Making changes to resources


### PR DESCRIPTION
Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/237


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
