### PR TITLE
Allow the downstream builder to use a non-master base branch

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -199,10 +199,12 @@ if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
     if [ $? != 0 ]; then
         exit $?
     fi
+    echo "Created PR $NEW_PR_URL"
     NEW_PR_NUMBER=$(echo $NEW_PR_URL | awk -F '/' '{print $NF}')
 
     # Wait a few seconds, then merge the PR.
     sleep 5
+    echo "Merging PR $NEW_PR_URL"
     curl -L -H "Authorization: token ${GITHUB_TOKEN}" \
         -X PUT \
         -d '{"merge_method": "squash"}' \


### PR DESCRIPTION
This is currently built & working for building all downstreams.

```release-note:none

```
