### PR TITLE
Remove unnecessary dependencies for CAI feed examples.

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
@@ -25,11 +25,6 @@ resource "google_cloud_asset_folder_feed" "<%= ctx[:primary_resource_id] %>" {
     title = "created"
     description = "Send notifications on creation events"
   }
-
-  # Wait for the permission to be ready on the destination topic.
-  depends_on = [
-    google_pubsub_topic_iam_member.cloud_asset_writer,
-  ]
 }
 
 # The topic where the resource change notifications will be sent.
@@ -48,13 +43,4 @@ resource "google_folder" "my_folder" {
 # the asset change notifications.
 data "google_project" "project" {
   project_id = "<%= ctx[:test_env_vars]["project"] %>"
-}
-
-# Allow the publishing role to the Cloud Asset service account of the project that
-# was used for sending the notifications.
-resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
-  project = "<%= ctx[:test_env_vars]["project"] %>"
-  topic   = google_pubsub_topic.feed_output.id
-  role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/cloud_asset_organization_feed.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_asset_organization_feed.tf.erb
@@ -25,11 +25,6 @@ resource "google_cloud_asset_organization_feed" "<%= ctx[:primary_resource_id] %
     title = "created"
     description = "Send notifications on creation events"
   }
-
-  # Wait for the permission to be ready on the destination topic.
-  depends_on = [
-    google_pubsub_topic_iam_member.cloud_asset_writer,
-  ]
 }
 
 # The topic where the resource change notifications will be sent.
@@ -42,13 +37,4 @@ resource "google_pubsub_topic" "feed_output" {
 # the asset change notifications.
 data "google_project" "project" {
   project_id = "<%= ctx[:test_env_vars]["project"] %>"
-}
-
-# Allow the publishing role to the Cloud Asset service account of the project that
-# was used for sending the notifications.
-resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
-  project = "<%= ctx[:test_env_vars]["project"] %>"
-  topic   = google_pubsub_topic.feed_output.id
-  role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/cloud_asset_project_feed.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_asset_project_feed.tf.erb
@@ -23,11 +23,6 @@ resource "google_cloud_asset_project_feed" "<%= ctx[:primary_resource_id] %>" {
     title = "created"
     description = "Send notifications on creation events"
   }
-
-  # Wait for the permission to be ready on the destination topic.
-  depends_on = [
-    google_pubsub_topic_iam_member.cloud_asset_writer,
-  ]
 }
 
 # The topic where the resource change notifications will be sent.
@@ -40,13 +35,4 @@ resource "google_pubsub_topic" "feed_output" {
 # the asset change notifications.
 data "google_project" "project" {
   project_id = "<%= ctx[:test_env_vars]["project"] %>"
-}
-
-# Allow the publishing role to the Cloud Asset service account of the project that
-# was used for sending the notifications.
-resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
-  project = "<%= ctx[:test_env_vars]["project"] %>"
-  topic   = google_pubsub_topic.feed_output.id
-  role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove unnecessary dependencies for asset feed examples. Service account creation happens when the customer first call Cloud Asset's API, so the feed creation shouldn't depend on that.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
asset: remove unnecessary service account dependency for asset feed examples.
```
