### PR TITLE
Version container based on provider, stop using containerbeta client

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -76,7 +76,7 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	}
 
 	location = fmt.Sprintf("projects/%s/locations/%s", project, location)
-	resp, err := config.NewContainerBetaClient(userAgent).Projects.Locations.GetServerConfig(location).Do()
+	resp, err := config.NewContainerClient(userAgent).Projects.Locations.GetServerConfig(location).Do()
 	if err != nil {
 		return fmt.Errorf("Error retrieving available container cluster versions: %s", err.Error())
 	}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -15,7 +15,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	containerBeta "google.golang.org/api/container/v1beta1"
+<% if version == "ga" -%>
+	"google.golang.org/api/container/v1"
+<% else -%>
+	"google.golang.org/api/container/v1beta1"
+<% end -%>
 )
 
 var (
@@ -1441,7 +1445,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	cluster := &containerBeta.Cluster{
+	cluster := &container.Cluster{
 		Name:                           clusterName,
 		InitialNodeCount:               int64(d.Get("initial_node_count").(int)),
 		MaintenancePolicy:              expandMaintenancePolicy(d, meta),
@@ -1449,7 +1453,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		InitialClusterVersion:          d.Get("min_master_version").(string),
 		ClusterIpv4Cidr:                d.Get("cluster_ipv4_cidr").(string),
 		Description:                    d.Get("description").(string),
-		LegacyAbac: &containerBeta.LegacyAbac{
+		LegacyAbac: &container.LegacyAbac{
 			Enabled:         d.Get("enable_legacy_abac").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
@@ -1463,11 +1467,11 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		PodSecurityPolicyConfig: expandPodSecurityPolicyConfig(d.Get("pod_security_policy_config")),
 <% end -%>
 		Autoscaling:             expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
-		BinaryAuthorization: &containerBeta.BinaryAuthorization{
+		BinaryAuthorization: &container.BinaryAuthorization{
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-		Autopilot: &containerBeta.Autopilot{
+		Autopilot: &container.Autopilot{
 			Enabled:         d.Get("enable_autopilot").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
@@ -1476,7 +1480,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		ClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
 <% end -%>
 		EnableTpu:               d.Get("enable_tpu").(bool),
-		NetworkConfig: &containerBeta.NetworkConfig{
+		NetworkConfig: &container.NetworkConfig{
 			EnableIntraNodeVisibility: d.Get("enable_intranode_visibility").(bool),
 			DefaultSnatStatus:         expandDefaultSnatStatus(d.Get("default_snat_status")),
 		    DatapathProvider:          d.Get("datapath_provider").(string),
@@ -1499,7 +1503,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	v:= d.Get("enable_shielded_nodes")
-	cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
+	cluster.ShieldedNodes = &container.ShieldedNodes{
 		Enabled:         v.(bool),
 		ForceSendFields: []string{"Enabled"},
 	}
@@ -1552,7 +1556,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	nodePoolsCount := d.Get("node_pool.#").(int)
 	if nodePoolsCount > 0 {
-		nodePools := make([]*containerBeta.NodePool, 0, nodePoolsCount)
+		nodePools := make([]*container.NodePool, 0, nodePoolsCount)
 		for i := 0; i < nodePoolsCount; i++ {
 			prefix := fmt.Sprintf("node_pool.%d.", i)
 			nodePool, err := expandNodePool(d, prefix)
@@ -1604,7 +1608,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.MonitoringConfig = expandMonitoringConfig(v)
 	}
 
-	req := &containerBeta.CreateClusterRequest{
+	req := &container.CreateClusterRequest{
 		Cluster: cluster,
 	}
 
@@ -1612,9 +1616,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	defer mutexKV.Unlock(containerClusterMutexKey(project, location, clusterName))
 
 	parent := fmt.Sprintf("projects/%s/locations/%s", project, location)
-	var op *containerBeta.Operation
+	var op *container.Operation
 	err = retry(func() error {
-		clusterCreateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Create(parent, req)
+		clusterCreateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Create(parent, req)
 		if config.UserProjectOverride {
 			clusterCreateCall.Header().Add("X-Goog-User-Project", project)
 		}
@@ -1645,7 +1649,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			// leaving default case to ensure this is non blocking
 		}
 		// Try a GET on the cluster so we can see the state in debug logs. This will help classify error states.
-		clusterGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Get(containerClusterFullName(project, location, clusterName))
+		clusterGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Get(containerClusterFullName(project, location, clusterName))
 		if config.UserProjectOverride {
 			clusterGetCall.Header().Add("X-Goog-User-Project", project)
 		}
@@ -1671,7 +1675,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	if d.Get("remove_default_node_pool").(bool) {
 		parent := fmt.Sprintf("%s/nodePools/%s", containerClusterFullName(project, location, clusterName), "default-pool")
 		err = retry(func() error {
-			clusterNodePoolDeleteCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Delete(parent)
+			clusterNodePoolDeleteCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Delete(parent)
 			if config.UserProjectOverride {
 				clusterNodePoolDeleteCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -1723,7 +1727,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	operation := d.Get("operation").(string)
 	if operation != "" {
 		log.Printf("[DEBUG] in progress operation detected at %v, attempting to resume", operation)
-		op := &containerBeta.Operation{
+		op := &container.Operation{
 			Name: operation,
 		}
 		if err := d.Set("operation", ""); err != nil {
@@ -1737,7 +1741,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 
 	clusterName := d.Get("name").(string)
 	name := containerClusterFullName(project, location, clusterName)
-	clusterGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Get(name)
+	clusterGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Get(name)
 	if config.UserProjectOverride {
 		clusterGetCall.Header().Add("X-Goog-User-Project", project)
 	}
@@ -1984,10 +1988,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	lockKey := containerClusterMutexKey(project, location, clusterName)
 
-	updateFunc := func(req *containerBeta.UpdateClusterRequest, updateDescription string) func() error {
+	updateFunc := func(req *container.UpdateClusterRequest, updateDescription string) func() error {
 		return func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2005,8 +2009,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	// if the order of updating fields does matter, it is called out explicitly.
 	if d.HasChange("master_authorized_networks_config") {
 		c := d.Get("master_authorized_networks_config")
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredMasterAuthorizedNetworksConfig: expandMasterAuthorizedNetworksConfig(c),
 			},
 		}
@@ -2020,8 +2024,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("addons_config") {
 		if ac, ok := d.GetOk("addons_config"); ok {
-			req := &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredAddonsConfig: expandClusterAddonsConfig(ac),
 				},
 			}
@@ -2037,8 +2041,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("cluster_autoscaling") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredClusterAutoscaling: expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
 			}}
 
@@ -2053,9 +2057,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("enable_binary_authorization") {
 		enabled := d.Get("enable_binary_authorization").(bool)
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
-				DesiredBinaryAuthorization: &containerBeta.BinaryAuthorization{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredBinaryAuthorization: &container.BinaryAuthorization{
 					Enabled:         enabled,
 					ForceSendFields: []string{"Enabled"},
 				},
@@ -2073,9 +2077,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("enable_shielded_nodes") {
 		enabled := d.Get("enable_shielded_nodes").(bool)
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
-				DesiredShieldedNodes: &containerBeta.ShieldedNodes{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredShieldedNodes: &container.ShieldedNodes{
 					Enabled:         enabled,
 					ForceSendFields: []string{"Enabled"},
 				},
@@ -2092,15 +2096,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("release_channel") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredReleaseChannel: expandReleaseChannel(d.Get("release_channel")),
 			},
 		}
 		updateF := func() error {
 			log.Println("[DEBUG] updating release_channel")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2125,9 +2129,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("enable_intranode_visibility") {
 		enabled := d.Get("enable_intranode_visibility").(bool)
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
-				DesiredIntraNodeVisibilityConfig: &containerBeta.IntraNodeVisibilityConfig{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredIntraNodeVisibilityConfig: &container.IntraNodeVisibilityConfig{
 					Enabled:         enabled,
 					ForceSendFields: []string{"Enabled"},
 				},
@@ -2136,7 +2140,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		updateF := func() error {
 			log.Println("[DEBUG] updating enable_intranode_visibility")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2160,15 +2164,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("private_ipv6_google_access") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredPrivateIpv6GoogleAccess: d.Get("private_ipv6_google_access").(string),
 			},
 		}
 		updateF := func() error {
 			log.Println("[DEBUG] updating private_ipv6_google_access")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2195,9 +2199,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("enable_l4_ilb_subsetting") {
 	// This field can be changed from false to true but not from false to true. CustomizeDiff handles that check.
 		enabled := d.Get("enable_l4_ilb_subsetting").(bool)
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
-				DesiredL4ilbSubsettingConfig: &containerBeta.ILBSubsettingConfig{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredL4ilbSubsettingConfig: &container.ILBSubsettingConfig{
 					Enabled:         enabled,
 					ForceSendFields: []string{"Enabled"},
 				},
@@ -2206,7 +2210,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		updateF := func() error {
 			log.Println("[DEBUG] updating enable_l4_ilb_subsetting")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2231,15 +2235,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 <% end -%>
 
 	if d.HasChange("default_snat_status") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredDefaultSnatStatus: expandDefaultSnatStatus(d.Get("default_snat_status")),
 			},
 		}
 		updateF := func() error {
 			log.Println("[DEBUG] updating default_snat_status")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2263,13 +2267,13 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("maintenance_policy") {
-		req := &containerBeta.SetMaintenancePolicyRequest{
+		req := &container.SetMaintenancePolicyRequest{
 			MaintenancePolicy: expandMaintenancePolicy(d, meta),
 		}
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetMaintenancePolicyCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.SetMaintenancePolicy(name, req)
+			clusterSetMaintenancePolicyCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.SetMaintenancePolicy(name, req)
 			if config.UserProjectOverride {
 				clusterSetMaintenancePolicyCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2306,8 +2310,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			azSet.Add(location)
 		}
 
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredLocations: convertStringSet(azSet),
 			},
 		}
@@ -2322,8 +2326,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			azSetNew.Add(location)
 		}
 		if !azSet.Equal(azSetNew) {
-			req = &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req = &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredLocations: convertStringSet(azSetNew),
 				},
 			}
@@ -2340,7 +2344,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("enable_legacy_abac") {
 		enabled := d.Get("enable_legacy_abac").(bool)
-		req := &containerBeta.SetLegacyAbacRequest{
+		req := &container.SetLegacyAbacRequest{
 			Enabled:         enabled,
 			ForceSendFields: []string{"Enabled"},
 		}
@@ -2348,7 +2352,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		updateF := func() error {
 			log.Println("[DEBUG] updating enable_legacy_abac")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetLegacyAbacCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.SetLegacyAbac(name, req)
+			clusterSetLegacyAbacCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.SetLegacyAbac(name, req)
 			if config.UserProjectOverride {
 				clusterSetLegacyAbacCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2377,13 +2381,13 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			req := &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredMonitoringService: monitoring,
 					DesiredLoggingService:    logging,
 				},
 			}
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2406,14 +2410,14 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("network_policy") {
 		np := d.Get("network_policy")
-		req := &containerBeta.SetNetworkPolicyRequest{
+		req := &container.SetNetworkPolicyRequest{
 			NetworkPolicy: expandNetworkPolicy(np),
 		}
 
 		updateF := func() error {
 			log.Println("[DEBUG] updating network_policy")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetNetworkPolicyCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.SetNetworkPolicy(name, req)
+			clusterSetNetworkPolicyCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.SetNetworkPolicy(name, req)
 			if config.UserProjectOverride {
 				clusterSetNetworkPolicyCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2466,8 +2470,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		// Only upgrade the master if the current version is lower than the desired version
 		if cur.LessThan(des) {
-			req := &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredMasterVersion: ver,
 				},
 			}
@@ -2490,8 +2494,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				key := fmt.Sprintf("node_pool.%d.", i)
 				if d.Get(key+"name").(string) == "default-pool" {
 					desiredNodeVersion := d.Get("node_version").(string)
-					req := &containerBeta.UpdateClusterRequest{
-						Update: &containerBeta.ClusterUpdate{
+					req := &container.UpdateClusterRequest{
+						Update: &container.ClusterUpdate{
 							DesiredNodeVersion: desiredNodeVersion,
 							DesiredNodePoolId:  "default-pool",
 						},
@@ -2516,15 +2520,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("node_config") {
 		if d.HasChange("node_config.0.image_type") {
 			it := d.Get("node_config.0.image_type").(string)
-			req := &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredImageType: it,
 				},
 			}
 
 			updateF := func() error {
 				name := containerClusterFullName(project, location, clusterName)
-				clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+				clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 				if config.UserProjectOverride {
 					clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 				}
@@ -2548,15 +2552,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 <% unless version == 'ga' -%>
 	if d.HasChange("notification_config") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredNotificationConfig: expandNotificationConfig(d.Get("notification_config")),
 			},
 		}
 		updateF := func() error {
 			log.Println("[DEBUG] updating notification_config")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2581,16 +2585,16 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 <% end -%>
 
 	if d.HasChange("master_auth") {
-		var req *containerBeta.SetMasterAuthRequest
+		var req *container.SetMasterAuthRequest
 		if ma, ok := d.GetOk("master_auth"); ok {
-			req = &containerBeta.SetMasterAuthRequest{
+			req = &container.SetMasterAuthRequest{
 				Action: "SET_USERNAME",
 				Update: expandMasterAuth(ma),
 			}
 		} else {
-			req = &containerBeta.SetMasterAuthRequest{
+			req = &container.SetMasterAuthRequest{
 				Action: "SET_USERNAME",
-				Update: &containerBeta.MasterAuth{
+				Update: &container.MasterAuth{
 					Username: "admin",
 				},
 			}
@@ -2598,7 +2602,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetMasterAuthCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.SetMasterAuth(name, req)
+			clusterSetMasterAuthCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.SetMasterAuth(name, req)
 			if config.UserProjectOverride {
 				clusterSetMasterAuthCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2621,8 +2625,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("vertical_pod_autoscaling") {
 		if ac, ok := d.GetOk("vertical_pod_autoscaling"); ok {
-			req := &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredVerticalPodAutoscaling: expandVerticalPodAutoscaling(ac),
 				},
 			}
@@ -2639,15 +2643,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("database_encryption") {
 		c := d.Get("database_encryption")
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredDatabaseEncryption: expandDatabaseEncryption(c),
 			},
 		}
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2667,15 +2671,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 <% unless version == 'ga' -%>
 	if d.HasChange("pod_security_policy_config") {
 		c := d.Get("pod_security_policy_config")
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredPodSecurityPolicyConfig: expandPodSecurityPolicyConfig(c),
 			},
 		}
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2697,16 +2701,16 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		// Because GKE uses a non-RESTful update function, when removing the
 		// feature you need to specify a fairly full request body or it fails:
 		// "update": {"desiredWorkloadIdentityConfig": {"identityNamespace": ""}}
-		req := &containerBeta.UpdateClusterRequest{}
+		req := &container.UpdateClusterRequest{}
 		if v, ok := d.GetOk("workload_identity_config"); !ok {
-			req.Update = &containerBeta.ClusterUpdate{
-				DesiredWorkloadIdentityConfig: &containerBeta.WorkloadIdentityConfig{
-					IdentityNamespace: "",
-					ForceSendFields:   []string{"IdentityNamespace"},
+			req.Update = &container.ClusterUpdate{
+				DesiredWorkloadIdentityConfig: &container.WorkloadIdentityConfig{
+					WorkloadPool: "",
+					ForceSendFields:   []string{"WorkloadPool"},
 				},
 			}
 		} else {
-			req.Update = &containerBeta.ClusterUpdate{
+			req.Update = &container.ClusterUpdate{
 				DesiredWorkloadIdentityConfig: expandWorkloadIdentityConfig(v),
 			}
 		}
@@ -2721,8 +2725,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("logging_config") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredLoggingConfig: expandContainerClusterLoggingConfig(d.Get("logging_config")),
 			},
 		}
@@ -2736,8 +2740,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("monitoring_config") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredMonitoringConfig: expandMonitoringConfig(d.Get("monitoring_config")),
 			},
 		}
@@ -2753,13 +2757,13 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("resource_labels") {
 		resourceLabels := d.Get("resource_labels").(map[string]interface{})
 		labelFingerprint := d.Get("label_fingerprint").(string)
-		req := &containerBeta.SetLabelsRequest{
+		req := &container.SetLabelsRequest{
 			ResourceLabels:   convertStringMap(resourceLabels),
 			LabelFingerprint: labelFingerprint,
 		}
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetResourceLabelsCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.SetResourceLabels(name, req)
+			clusterSetResourceLabelsCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.SetResourceLabels(name, req)
 			if config.UserProjectOverride {
 				clusterSetResourceLabelsCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2780,7 +2784,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("remove_default_node_pool") && d.Get("remove_default_node_pool").(bool) {
 		name := fmt.Sprintf("%s/nodePools/%s", containerClusterFullName(project, location, clusterName), "default-pool")
-		clusterNodePoolDeleteCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Delete(name)
+		clusterNodePoolDeleteCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Delete(name)
 		if config.UserProjectOverride {
 			clusterNodePoolDeleteCall.Header().Add("X-Goog-User-Project", project)
 		}
@@ -2800,15 +2804,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("resource_usage_export_config") {
 		c := d.Get("resource_usage_export_config")
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredResourceUsageExportConfig: expandResourceUsageExportConfig(c),
 			},
 		}
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2829,15 +2833,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 <% unless version == 'ga' -%>
 	if d.HasChange("cluster_telemetry") {
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
 				DesiredClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
 			},
 		}
 		updateF := func() error {
 			log.Println("[DEBUG] updating cluster_telemetry")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
 			}
@@ -2899,13 +2903,13 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 	mutexKV.Lock(containerClusterMutexKey(project, location, clusterName))
 	defer mutexKV.Unlock(containerClusterMutexKey(project, location, clusterName))
 
-	var op *containerBeta.Operation
+	var op *container.Operation
 	var count = 0
 	err = resource.Retry(30*time.Second, func() *resource.RetryError {
 		count++
 
 		name := containerClusterFullName(project, location, clusterName)
-		clusterDeleteCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Delete(name)
+		clusterDeleteCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Delete(name)
 		if config.UserProjectOverride {
 			clusterDeleteCall.Header().Add("X-Goog-User-Project", project)
 		}
@@ -2965,7 +2969,7 @@ func cleanFailedContainerCluster(d *schema.ResourceData, meta interface{}) error
 	fullName := containerClusterFullName(project, location, clusterName)
 
 	log.Printf("[DEBUG] Cleaning up failed GKE cluster %s", d.Get("name").(string))
-	clusterDeleteCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Delete(fullName)
+	clusterDeleteCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Delete(fullName)
 	if config.UserProjectOverride {
 		clusterDeleteCall.Header().Add("X-Goog-User-Project", project)
 	}
@@ -2995,7 +2999,7 @@ var containerClusterRestingStates = RestingStates{
 func containerClusterAwaitRestingState(config *Config, project, location, clusterName, userAgent string, timeout time.Duration) (state string, err error) {
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		name := containerClusterFullName(project, location, clusterName)
-		clusterGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Get(name)
+		clusterGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Get(name)
 		if config.UserProjectOverride {
 			clusterGetCall.Header().Add("X-Goog-User-Project", project)
 		}
@@ -3045,18 +3049,18 @@ func getInstanceGroupUrlsFromManagerUrls(config *Config, userAgent string, igmUr
 	return instanceGroupURLs, nil
 }
 
-func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConfig {
+func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	config := l[0].(map[string]interface{})
-	ac := &containerBeta.AddonsConfig{}
+	ac := &container.AddonsConfig{}
 
 	if v, ok := config["http_load_balancing"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.HttpLoadBalancing = &containerBeta.HttpLoadBalancing{
+		ac.HttpLoadBalancing = &container.HttpLoadBalancing{
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
@@ -3064,7 +3068,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 	if v, ok := config["horizontal_pod_autoscaling"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.HorizontalPodAutoscaling = &containerBeta.HorizontalPodAutoscaling{
+		ac.HorizontalPodAutoscaling = &container.HorizontalPodAutoscaling{
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
@@ -3072,7 +3076,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 	if v, ok := config["network_policy_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.NetworkPolicyConfig = &containerBeta.NetworkPolicyConfig{
+		ac.NetworkPolicyConfig = &container.NetworkPolicyConfig{
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
@@ -3080,7 +3084,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 	if v, ok := config["cloudrun_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.CloudRunConfig = &containerBeta.CloudRunConfig{
+		ac.CloudRunConfig = &container.CloudRunConfig{
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
@@ -3092,7 +3096,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 <% unless version == 'ga' -%>
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.IstioConfig = &containerBeta.IstioConfig{
+		ac.IstioConfig = &container.IstioConfig{
 			Disabled:        addon["disabled"].(bool),
 			Auth:            addon["auth"].(string),
 			ForceSendFields: []string{"Disabled"},
@@ -3101,7 +3105,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 	if v, ok := config["dns_cache_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.DnsCacheConfig = &containerBeta.DnsCacheConfig{
+		ac.DnsCacheConfig = &container.DnsCacheConfig{
 			Enabled:         addon["enabled"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
@@ -3109,7 +3113,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 	if v, ok := config["gce_persistent_disk_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.GcePersistentDiskCsiDriverConfig = &containerBeta.GcePersistentDiskCsiDriverConfig{
+		ac.GcePersistentDiskCsiDriverConfig = &container.GcePersistentDiskCsiDriverConfig{
 			Enabled:         addon["enabled"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
@@ -3117,14 +3121,14 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 	if v, ok := config["kalm_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.KalmConfig = &containerBeta.KalmConfig{
+		ac.KalmConfig = &container.KalmConfig{
 			Enabled:         addon["enabled"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
 	}
 	if v, ok := config["config_connector_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.ConfigConnectorConfig = &containerBeta.ConfigConnectorConfig{
+		ac.ConfigConnectorConfig = &container.ConfigConnectorConfig{
 			Enabled:         addon["enabled"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
@@ -3134,20 +3138,20 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 	return ac
 }
 
-func expandIPAllocationPolicy(configured interface{}, networkingMode string) (*containerBeta.IPAllocationPolicy, error) {
+func expandIPAllocationPolicy(configured interface{}, networkingMode string) (*container.IPAllocationPolicy, error) {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		if networkingMode == "VPC_NATIVE" {
 			return nil, fmt.Errorf("`ip_allocation_policy` block is required for VPC_NATIVE clusters.")
 		}
-		return &containerBeta.IPAllocationPolicy{
+		return &container.IPAllocationPolicy{
 			UseIpAliases:    false,
 			ForceSendFields: []string{"UseIpAliases"},
 		}, nil
 	}
 
 	config := l[0].(map[string]interface{})
-	return &containerBeta.IPAllocationPolicy{
+	return &container.IPAllocationPolicy{
 		UseIpAliases:          networkingMode == "VPC_NATIVE" || networkingMode == "",
 		ClusterIpv4CidrBlock:  config["cluster_ipv4_cidr_block"].(string),
 		ServicesIpv4CidrBlock: config["services_ipv4_cidr_block"].(string),
@@ -3159,7 +3163,7 @@ func expandIPAllocationPolicy(configured interface{}, networkingMode string) (*c
 	}, nil
 }
 
-func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containerBeta.MaintenancePolicy {
+func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *container.MaintenancePolicy {
 	config := meta.(*Config)
 	// We have to perform a full Get() as part of this, to get the fingerprint.  We can't do this
 	// at any other time, because the fingerprint update might happen between plan and apply.
@@ -3172,13 +3176,13 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 	if err != nil {
 		return nil
 	}
-	clusterGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Get(name)
+	clusterGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Get(name)
 	if config.UserProjectOverride {
 		clusterGetCall.Header().Add("X-Goog-User-Project", project)
 	}
 	cluster, _ := clusterGetCall.Do()
 	resourceVersion := ""
-	exclusions := make(map[string]containerBeta.TimeWindow)
+	exclusions := make(map[string]container.TimeWindow)
 	if cluster != nil && cluster.MaintenancePolicy != nil {
 		// If the cluster doesn't exist or if there is a read error of any kind, we will pass in an empty
 		// resourceVersion.  If there happens to be a change to maintenance policy, we will fail at that
@@ -3196,9 +3200,9 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 	configured := d.Get("maintenance_policy")
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
-		return &containerBeta.MaintenancePolicy{
+		return &container.MaintenancePolicy{
 			ResourceVersion: resourceVersion,
-			Window: &containerBeta.MaintenanceWindow{
+			Window: &container.MaintenanceWindow{
 				MaintenanceExclusions: exclusions,
 			},
 		}
@@ -3211,7 +3215,7 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 		}
 		for _, me := range maintenanceExclusions.(*schema.Set).List() {
 			exclusion := me.(map[string]interface{})
-			exclusions[exclusion["exclusion_name"].(string)] = containerBeta.TimeWindow{
+			exclusions[exclusion["exclusion_name"].(string)] = container.TimeWindow{
 				StartTime: exclusion["start_time"].(string),
 				EndTime:   exclusion["end_time"].(string),
 			}
@@ -3221,10 +3225,10 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 	if dailyMaintenanceWindow, ok := maintenancePolicy["daily_maintenance_window"]; ok && len(dailyMaintenanceWindow.([]interface{})) > 0 {
 		dmw := dailyMaintenanceWindow.([]interface{})[0].(map[string]interface{})
 		startTime := dmw["start_time"].(string)
-		return &containerBeta.MaintenancePolicy{
-			Window: &containerBeta.MaintenanceWindow{
+		return &container.MaintenancePolicy{
+			Window: &container.MaintenanceWindow{
 				MaintenanceExclusions: exclusions,
-				DailyMaintenanceWindow: &containerBeta.DailyMaintenanceWindow{
+				DailyMaintenanceWindow: &container.DailyMaintenanceWindow{
 					StartTime: startTime,
 				},
 			},
@@ -3233,11 +3237,11 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 	}
 	if recurringWindow, ok := maintenancePolicy["recurring_window"]; ok && len(recurringWindow.([]interface{})) > 0 {
 		rw := recurringWindow.([]interface{})[0].(map[string]interface{})
-		return &containerBeta.MaintenancePolicy{
-			Window: &containerBeta.MaintenanceWindow{
+		return &container.MaintenancePolicy{
+			Window: &container.MaintenanceWindow{
 				MaintenanceExclusions: exclusions,
-				RecurringWindow: &containerBeta.RecurringTimeWindow{
-					Window: &containerBeta.TimeWindow{
+				RecurringWindow: &container.RecurringTimeWindow{
+					Window: &container.TimeWindow{
 						StartTime: rw["start_time"].(string),
 						EndTime:   rw["end_time"].(string),
 					},
@@ -3250,13 +3254,13 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 	return nil
 }
 
-func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *containerBeta.ClusterAutoscaling {
+func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *container.ClusterAutoscaling {
 	l, ok := configured.([]interface{})
 	if !ok || l == nil || len(l) == 0 || l[0] == nil {
 		if v, ok := d.GetOk("enable_autopilot"); ok && v == true {
 			return nil
 		}
-		return &containerBeta.ClusterAutoscaling{
+		return &container.ClusterAutoscaling{
 			EnableNodeAutoprovisioning: false,
 			ForceSendFields:            []string{"EnableNodeAutoprovisioning"},
 		}
@@ -3270,14 +3274,14 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 	// auto-provisioning is disabled at time of writing. This may change API-side
 	// in the future though, as the feature is intended to apply to both node
 	// auto-provisioning and node autoscaling.
-	var resourceLimits []*containerBeta.ResourceLimit
+	var resourceLimits []*container.ResourceLimit
 	if limits, ok := config["resource_limits"]; ok {
-		resourceLimits = make([]*containerBeta.ResourceLimit, 0)
+		resourceLimits = make([]*container.ResourceLimit, 0)
 		if lmts, ok := limits.([]interface{}); ok {
 			for _, v := range lmts {
 				limit := v.(map[string]interface{})
 				resourceLimits = append(resourceLimits,
-					&containerBeta.ResourceLimit{
+					&container.ResourceLimit{
 						ResourceType: limit["resource_type"].(string),
 						// Here we're relying on *not* setting ForceSendFields for 0-values.
 						Minimum: int64(limit["minimum"].(int)),
@@ -3286,7 +3290,7 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 			}
 		}
 	}
-	return &containerBeta.ClusterAutoscaling{
+	return &container.ClusterAutoscaling{
 		EnableNodeAutoprovisioning: config["enabled"].(bool),
 		ResourceLimits:             resourceLimits,
 		<% unless version == 'ga' -%>
@@ -3296,14 +3300,14 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 	}
 }
 
-func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceData) *containerBeta.AutoprovisioningNodePoolDefaults {
+func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceData) *container.AutoprovisioningNodePoolDefaults {
 	l, ok := configured.([]interface{})
 	if !ok || l == nil || len(l) == 0 || l[0] == nil {
-		return &containerBeta.AutoprovisioningNodePoolDefaults{}
+		return &container.AutoprovisioningNodePoolDefaults{}
 	}
 	config := l[0].(map[string]interface{})
 
-	npd := &containerBeta.AutoprovisioningNodePoolDefaults{
+	npd := &container.AutoprovisioningNodePoolDefaults{
 		OauthScopes:    convertStringArr(config["oauth_scopes"].([]interface{})),
 		ServiceAccount: config["service_account"].(string),
 	}
@@ -3319,12 +3323,12 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 	return npd
 }
 
-func expandAuthenticatorGroupsConfig(configured interface{}) *containerBeta.AuthenticatorGroupsConfig {
+func expandAuthenticatorGroupsConfig(configured interface{}) *container.AuthenticatorGroupsConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
-	result := &containerBeta.AuthenticatorGroupsConfig{}
+	result := &container.AuthenticatorGroupsConfig{}
 	config := l[0].(map[string]interface{})
 	if securityGroup, ok := config["security_group"]; ok {
 		result.Enabled = true
@@ -3334,11 +3338,11 @@ func expandAuthenticatorGroupsConfig(configured interface{}) *containerBeta.Auth
 }
 
 <% unless version == 'ga' -%>
-func expandNotificationConfig(configured interface{}) *containerBeta.NotificationConfig {
+func expandNotificationConfig(configured interface{}) *container.NotificationConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
-		return &containerBeta.NotificationConfig{
-			Pubsub: &containerBeta.PubSub{
+		return &container.NotificationConfig{
+			Pubsub: &container.PubSub{
 				Enabled: false,
 			},
 		}
@@ -3349,8 +3353,8 @@ func expandNotificationConfig(configured interface{}) *containerBeta.Notificatio
 		if len(v.([]interface{})) > 0 {
 			pubsub := notificationConfig["pubsub"].([]interface{})[0].(map[string]interface{})
 
-			return &containerBeta.NotificationConfig{
-				Pubsub: &containerBeta.PubSub{
+			return &container.NotificationConfig{
+				Pubsub: &container.PubSub{
 					Enabled: pubsub["enabled"].(bool),
 					Topic:   pubsub["topic"].(string),
 				},
@@ -3358,8 +3362,8 @@ func expandNotificationConfig(configured interface{}) *containerBeta.Notificatio
 		}
 	}
 
-	return &containerBeta.NotificationConfig{
-		Pubsub: &containerBeta.PubSub{
+	return &container.NotificationConfig{
+		Pubsub: &container.PubSub{
 			Enabled: false,
 		},
 	}
@@ -3367,26 +3371,26 @@ func expandNotificationConfig(configured interface{}) *containerBeta.Notificatio
 <% end -%>
 
 <% unless version == 'ga' -%>
-func expandConfidentialNodes(configured interface{}) *containerBeta.ConfidentialNodes {
+func expandConfidentialNodes(configured interface{}) *container.ConfidentialNodes {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.ConfidentialNodes{
+	return &container.ConfidentialNodes{
 		Enabled: config["enabled"].(bool),
 	}
 }
 <% end -%>
 
-func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
+func expandMasterAuth(configured interface{}) *container.MasterAuth {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	masterAuth := l[0].(map[string]interface{})
-	result := &containerBeta.MasterAuth{
+	result := &container.MasterAuth{
 		Username: masterAuth["username"].(string),
 		Password: masterAuth["password"].(string),
 	}
@@ -3395,7 +3399,7 @@ func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 		if len(v.([]interface{})) > 0 {
 			clientCertificateConfig := masterAuth["client_certificate_config"].([]interface{})[0].(map[string]interface{})
 
-			result.ClientCertificateConfig = &containerBeta.ClientCertificateConfig{
+			result.ClientCertificateConfig = &container.ClientCertificateConfig{
 				IssueClientCertificate: clientCertificateConfig["issue_client_certificate"].(bool),
 			}
 		}
@@ -3404,23 +3408,23 @@ func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 	return result
 }
 
-func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta.MasterAuthorizedNetworksConfig {
+func expandMasterAuthorizedNetworksConfig(configured interface{}) *container.MasterAuthorizedNetworksConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
-		return &containerBeta.MasterAuthorizedNetworksConfig{
+		return &container.MasterAuthorizedNetworksConfig{
 			Enabled: false,
 		}
 	}
-	result := &containerBeta.MasterAuthorizedNetworksConfig{
+	result := &container.MasterAuthorizedNetworksConfig{
 		Enabled: true,
 	}
 	if config, ok := l[0].(map[string]interface{}); ok {
 		if _, ok := config["cidr_blocks"]; ok {
 			cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
-			result.CidrBlocks = make([]*containerBeta.CidrBlock, 0)
+			result.CidrBlocks = make([]*container.CidrBlock, 0)
 			for _, v := range cidrBlocks {
 				cidrBlock := v.(map[string]interface{})
-				result.CidrBlocks = append(result.CidrBlocks, &containerBeta.CidrBlock{
+				result.CidrBlocks = append(result.CidrBlocks, &container.CidrBlock{
 					CidrBlock:   cidrBlock["cidr_block"].(string),
 					DisplayName: cidrBlock["display_name"].(string),
 				})
@@ -3430,12 +3434,12 @@ func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta
 	return result
 }
 
-func expandNetworkPolicy(configured interface{}) *containerBeta.NetworkPolicy {
+func expandNetworkPolicy(configured interface{}) *container.NetworkPolicy {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
-	result := &containerBeta.NetworkPolicy{}
+	result := &container.NetworkPolicy{}
 	config := l[0].(map[string]interface{})
 	if enabled, ok := config["enabled"]; ok && enabled.(bool) {
 		result.Enabled = true
@@ -3446,13 +3450,13 @@ func expandNetworkPolicy(configured interface{}) *containerBeta.NetworkPolicy {
 	return result
 }
 
-func expandPrivateClusterConfig(configured interface{}) *containerBeta.PrivateClusterConfig {
+func expandPrivateClusterConfig(configured interface{}) *container.PrivateClusterConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.PrivateClusterConfig{
+	return &container.PrivateClusterConfig{
 		EnablePrivateEndpoint:    config["enable_private_endpoint"].(bool),
 		EnablePrivateNodes:       config["enable_private_nodes"].(bool),
 		MasterIpv4CidrBlock:      config["master_ipv4_cidr_block"].(string),
@@ -3461,81 +3465,81 @@ func expandPrivateClusterConfig(configured interface{}) *containerBeta.PrivateCl
 	}
 }
 
-func expandPrivateClusterConfigMasterGlobalAccessConfig(configured interface{}) *containerBeta.PrivateClusterMasterGlobalAccessConfig {
+func expandPrivateClusterConfigMasterGlobalAccessConfig(configured interface{}) *container.PrivateClusterMasterGlobalAccessConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.PrivateClusterMasterGlobalAccessConfig{
+	return &container.PrivateClusterMasterGlobalAccessConfig{
 		Enabled: config["enabled"].(bool),
 		ForceSendFields:       []string{"Enabled"},
 	}
 }
 
-func expandVerticalPodAutoscaling(configured interface{}) *containerBeta.VerticalPodAutoscaling {
+func expandVerticalPodAutoscaling(configured interface{}) *container.VerticalPodAutoscaling {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.VerticalPodAutoscaling{
+	return &container.VerticalPodAutoscaling{
 		Enabled: config["enabled"].(bool),
 	}
 }
 
-func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEncryption {
+func expandDatabaseEncryption(configured interface{}) *container.DatabaseEncryption {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.DatabaseEncryption{
+	return &container.DatabaseEncryption{
 		State:   config["state"].(string),
 		KeyName: config["key_name"].(string),
 	}
 }
 
-func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
+func expandReleaseChannel(configured interface{}) *container.ReleaseChannel {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.ReleaseChannel{
+	return &container.ReleaseChannel{
 		Channel: config["channel"].(string),
 	}
 }
 
 <% unless version == 'ga' -%>
-func expandClusterTelemetry(configured interface{}) *containerBeta.ClusterTelemetry {
+func expandClusterTelemetry(configured interface{}) *container.ClusterTelemetry {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.ClusterTelemetry{
+	return &container.ClusterTelemetry{
 		Type: config["type"].(string),
 	}
 }
 
 <% end -%>
-func expandDefaultSnatStatus(configured interface{}) *containerBeta.DefaultSnatStatus {
+func expandDefaultSnatStatus(configured interface{}) *container.DefaultSnatStatus {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &containerBeta.DefaultSnatStatus{
+	return &container.DefaultSnatStatus{
 		Disabled:        config["disabled"].(bool),
 		ForceSendFields: []string{"Disabled"},
 	}
 
 }
 
-func expandWorkloadIdentityConfig(configured interface{}) *containerBeta.WorkloadIdentityConfig {
+func expandWorkloadIdentityConfig(configured interface{}) *container.WorkloadIdentityConfig {
 	l := configured.([]interface{})
-	v := &containerBeta.WorkloadIdentityConfig{}
+	v := &container.WorkloadIdentityConfig{}
 
 	// this API considers unset and set-to-empty equivalent. Note that it will
 	// always return an empty block given that we always send one, but clusters
@@ -3546,44 +3550,45 @@ func expandWorkloadIdentityConfig(configured interface{}) *containerBeta.Workloa
 
 	config := l[0].(map[string]interface{})
 	v.WorkloadPool = config["workload_pool"].(string)
+
 	return v
 }
 
 <% unless version == 'ga' -%>
-func expandPodSecurityPolicyConfig(configured interface{}) *containerBeta.PodSecurityPolicyConfig {
+func expandPodSecurityPolicyConfig(configured interface{}) *container.PodSecurityPolicyConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	config := l[0].(map[string]interface{})
-	return &containerBeta.PodSecurityPolicyConfig{
+	return &container.PodSecurityPolicyConfig{
 		Enabled:         config["enabled"].(bool),
 		ForceSendFields: []string{"Enabled"},
 	}
 }
 <% end -%>
 
-func expandDefaultMaxPodsConstraint(v interface{}) *containerBeta.MaxPodsConstraint {
+func expandDefaultMaxPodsConstraint(v interface{}) *container.MaxPodsConstraint {
 	if v == nil {
 		return nil
 	}
 
-	return &containerBeta.MaxPodsConstraint{
+	return &container.MaxPodsConstraint{
 		MaxPodsPerNode: int64(v.(int)),
 	}
 }
-func expandResourceUsageExportConfig(configured interface{}) *containerBeta.ResourceUsageExportConfig {
+func expandResourceUsageExportConfig(configured interface{}) *container.ResourceUsageExportConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
-		return &containerBeta.ResourceUsageExportConfig{}
+		return &container.ResourceUsageExportConfig{}
 	}
 
 	resourceUsageConfig := l[0].(map[string]interface{})
 
-	result := &containerBeta.ResourceUsageExportConfig{
+	result := &container.ResourceUsageExportConfig{
 		EnableNetworkEgressMetering: resourceUsageConfig["enable_network_egress_metering"].(bool),
-		ConsumptionMeteringConfig: &containerBeta.ConsumptionMeteringConfig{
+		ConsumptionMeteringConfig: &container.ConsumptionMeteringConfig{
 			Enabled:         resourceUsageConfig["enable_resource_consumption_metering"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
@@ -3594,7 +3599,7 @@ func expandResourceUsageExportConfig(configured interface{}) *containerBeta.Reso
 		if len(destinationArr) > 0 && destinationArr[0] != nil {
 			bigqueryDestination := destinationArr[0].(map[string]interface{})
 			if _, ok := bigqueryDestination["dataset_id"]; ok {
-				result.BigqueryDestination = &containerBeta.BigQueryDestination{
+				result.BigqueryDestination = &container.BigQueryDestination{
 					DatasetId: bigqueryDestination["dataset_id"].(string),
 				}
 			}
@@ -3604,14 +3609,14 @@ func expandResourceUsageExportConfig(configured interface{}) *containerBeta.Reso
 }
 
 <% unless version == 'ga' -%>
-func expandDnsConfig(configured interface{}) *containerBeta.DNSConfig {
+func expandDnsConfig(configured interface{}) *container.DNSConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	config := l[0].(map[string]interface{})
-	return &containerBeta.DNSConfig{
+	return &container.DNSConfig{
 		ClusterDns:       config["cluster_dns"].(string),
 		ClusterDnsScope:  config["cluster_dns_scope"].(string),
 		ClusterDnsDomain: config["cluster_dns_domain"].(string),
@@ -3619,36 +3624,36 @@ func expandDnsConfig(configured interface{}) *containerBeta.DNSConfig {
 }
 <% end -%>
 
-func expandContainerClusterLoggingConfig(configured interface{}) *containerBeta.LoggingConfig {
+func expandContainerClusterLoggingConfig(configured interface{}) *container.LoggingConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	config := l[0].(map[string]interface{})
-	return &containerBeta.LoggingConfig{
-		ComponentConfig: &containerBeta.LoggingComponentConfig{
+	return &container.LoggingConfig{
+		ComponentConfig: &container.LoggingComponentConfig{
 			EnableComponents: convertStringArr(config["enable_components"].([]interface{})),
 		},
 	}
 }
 
-func expandMonitoringConfig(configured interface{}) *containerBeta.MonitoringConfig {
+func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	config := l[0].(map[string]interface{})
-	return &containerBeta.MonitoringConfig{
-		ComponentConfig: &containerBeta.MonitoringComponentConfig{
+	return &container.MonitoringConfig{
+		ComponentConfig: &container.MonitoringComponentConfig{
 			EnableComponents: convertStringArr(config["enable_components"].([]interface{})),
 		},
 	}
 }
 
 <% unless version == 'ga' -%>
-func flattenNotificationConfig(c *containerBeta.NotificationConfig) []map[string]interface{} {
+func flattenNotificationConfig(c *container.NotificationConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -3667,7 +3672,7 @@ func flattenNotificationConfig(c *containerBeta.NotificationConfig) []map[string
 <% end -%>
 
 <% unless version == 'ga' -%>
-func flattenConfidentialNodes(c *containerBeta.ConfidentialNodes) []map[string]interface{} {
+func flattenConfidentialNodes(c *container.ConfidentialNodes) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -3678,7 +3683,7 @@ func flattenConfidentialNodes(c *containerBeta.ConfidentialNodes) []map[string]i
 }
 <% end -%>
 
-func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface{} {
+func flattenNetworkPolicy(c *container.NetworkPolicy) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -3695,7 +3700,7 @@ func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface
 	return result
 }
 
-func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]interface{} {
+func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interface{} {
 	result := make(map[string]interface{})
 	if c == nil {
 		return nil
@@ -3777,7 +3782,7 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 	return []map[string]interface{}{result}
 }
 
-func flattenClusterNodePools(d *schema.ResourceData, config *Config, c []*containerBeta.NodePool) ([]map[string]interface{}, error) {
+func flattenClusterNodePools(d *schema.ResourceData, config *Config, c []*container.NodePool) ([]map[string]interface{}, error) {
 	nodePools := make([]map[string]interface{}, 0, len(c))
 
 	for i, np := range c {
@@ -3791,7 +3796,7 @@ func flattenClusterNodePools(d *schema.ResourceData, config *Config, c []*contai
 	return nodePools, nil
 }
 
-func flattenAuthenticatorGroupsConfig(c *containerBeta.AuthenticatorGroupsConfig) []map[string]interface{} {
+func flattenAuthenticatorGroupsConfig(c *container.AuthenticatorGroupsConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -3802,7 +3807,7 @@ func flattenAuthenticatorGroupsConfig(c *containerBeta.AuthenticatorGroupsConfig
 	}
 }
 
-func flattenPrivateClusterConfig(c *containerBeta.PrivateClusterConfig) []map[string]interface{} {
+func flattenPrivateClusterConfig(c *container.PrivateClusterConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -3822,7 +3827,7 @@ func flattenPrivateClusterConfig(c *containerBeta.PrivateClusterConfig) []map[st
 // Like most GKE blocks, this is not returned from the API at all when false. This causes trouble
 // for users who've set enabled = false in config as they will get a permadiff. Always setting the
 // field resolves that. We can assume if it was not returned, it's false.
-func flattenPrivateClusterConfigMasterGlobalAccessConfig(c *containerBeta.PrivateClusterMasterGlobalAccessConfig) []map[string]interface{} {
+func flattenPrivateClusterConfigMasterGlobalAccessConfig(c *container.PrivateClusterMasterGlobalAccessConfig) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
 			"enabled": c != nil && c.Enabled,
@@ -3830,7 +3835,7 @@ func flattenPrivateClusterConfigMasterGlobalAccessConfig(c *containerBeta.Privat
 	}
 }
 
-func flattenVerticalPodAutoscaling(c *containerBeta.VerticalPodAutoscaling) []map[string]interface{} {
+func flattenVerticalPodAutoscaling(c *container.VerticalPodAutoscaling) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -3841,7 +3846,7 @@ func flattenVerticalPodAutoscaling(c *containerBeta.VerticalPodAutoscaling) []ma
 	}
 }
 
-func flattenReleaseChannel(c *containerBeta.ReleaseChannel) []map[string]interface{} {
+func flattenReleaseChannel(c *container.ReleaseChannel) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil && c.Channel != "" {
 		result = append(result, map[string]interface{}{
@@ -3858,7 +3863,7 @@ func flattenReleaseChannel(c *containerBeta.ReleaseChannel) []map[string]interfa
 
 <% unless version == 'ga' -%>
 
-func flattenClusterTelemetry(c *containerBeta.ClusterTelemetry) []map[string]interface{} {
+func flattenClusterTelemetry(c *container.ClusterTelemetry) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -3870,7 +3875,7 @@ func flattenClusterTelemetry(c *containerBeta.ClusterTelemetry) []map[string]int
 
 <% end -%>
 
-func flattenDefaultSnatStatus(c *containerBeta.DefaultSnatStatus) []map[string]interface{} {
+func flattenDefaultSnatStatus(c *container.DefaultSnatStatus) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -3880,7 +3885,7 @@ func flattenDefaultSnatStatus(c *containerBeta.DefaultSnatStatus) []map[string]i
 	return result
 }
 
-func flattenWorkloadIdentityConfig(c *containerBeta.WorkloadIdentityConfig, d *schema.ResourceData, config *Config) []map[string]interface{} {
+func flattenWorkloadIdentityConfig(c *container.WorkloadIdentityConfig, d *schema.ResourceData, config *Config) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -3892,7 +3897,7 @@ func flattenWorkloadIdentityConfig(c *containerBeta.WorkloadIdentityConfig, d *s
 	}
 }
 
-func flattenIPAllocationPolicy(c *containerBeta.Cluster, d *schema.ResourceData, config *Config) ([]map[string]interface{}, error) {
+func flattenIPAllocationPolicy(c *container.Cluster, d *schema.ResourceData, config *Config) ([]map[string]interface{}, error) {
 	// If IP aliasing isn't enabled, none of the values in this block can be set.
 	if c == nil || c.IpAllocationPolicy == nil || !c.IpAllocationPolicy.UseIpAliases {
 		if err := d.Set("networking_mode", "ROUTES"); err != nil {
@@ -3915,7 +3920,7 @@ func flattenIPAllocationPolicy(c *containerBeta.Cluster, d *schema.ResourceData,
 	}, nil
 }
 
-func flattenMaintenancePolicy(mp *containerBeta.MaintenancePolicy) []map[string]interface{} {
+func flattenMaintenancePolicy(mp *container.MaintenancePolicy) []map[string]interface{} {
 	if mp == nil || mp.Window == nil {
 		return nil
 	}
@@ -3961,7 +3966,7 @@ func flattenMaintenancePolicy(mp *containerBeta.MaintenancePolicy) []map[string]
 	return nil
 }
 
-func flattenMasterAuth(ma *containerBeta.MasterAuth) []map[string]interface{} {
+func flattenMasterAuth(ma *container.MasterAuth) []map[string]interface{} {
 	if ma == nil {
 		return nil
 	}
@@ -3989,7 +3994,7 @@ func flattenMasterAuth(ma *containerBeta.MasterAuth) []map[string]interface{} {
 	return masterAuth
 }
 
-func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string]interface{} {
+func flattenClusterAutoscaling(a *container.ClusterAutoscaling) []map[string]interface{} {
 	r := make(map[string]interface{})
 	if a == nil {
 		r["enabled"] = false
@@ -4018,7 +4023,7 @@ func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string
 	return []map[string]interface{}{r}
 }
 
-func flattenAutoProvisioningDefaults(a *containerBeta.AutoprovisioningNodePoolDefaults) []map[string]interface{} {
+func flattenAutoProvisioningDefaults(a *container.AutoprovisioningNodePoolDefaults) []map[string]interface{} {
 	r := make(map[string]interface{})
 	r["oauth_scopes"] = a.OauthScopes
 	r["service_account"] = a.ServiceAccount
@@ -4029,7 +4034,7 @@ func flattenAutoProvisioningDefaults(a *containerBeta.AutoprovisioningNodePoolDe
 	return []map[string]interface{}{r}
 }
 
-func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetworksConfig) []map[string]interface{} {
+func flattenMasterAuthorizedNetworksConfig(c *container.MasterAuthorizedNetworksConfig) []map[string]interface{} {
 	if c == nil || !c.Enabled {
 		return nil
 	}
@@ -4048,7 +4053,7 @@ func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetw
 }
 
 <% unless version == 'ga' -%>
-func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []map[string]interface{} {
+func flattenPodSecurityPolicyConfig(c *container.PodSecurityPolicyConfig) []map[string]interface{} {
 	if c == nil {
 		return []map[string]interface{}{
 			{
@@ -4065,7 +4070,7 @@ func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []
 
 <% end -%>
 
-func flattenResourceUsageExportConfig(c *containerBeta.ResourceUsageExportConfig) []map[string]interface{} {
+func flattenResourceUsageExportConfig(c *container.ResourceUsageExportConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -4086,7 +4091,7 @@ func flattenResourceUsageExportConfig(c *containerBeta.ResourceUsageExportConfig
 	}
 }
 
-func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string]interface{} {
+func flattenDatabaseEncryption(c *container.DatabaseEncryption) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -4099,7 +4104,7 @@ func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string
 }
 
 <% unless version == 'ga' -%>
-func flattenDnsConfig(c *containerBeta.DNSConfig) []map[string]interface{} {
+func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -4113,7 +4118,7 @@ func flattenDnsConfig(c *containerBeta.DNSConfig) []map[string]interface{} {
 }
 <% end -%>
 
-func flattenContainerClusterLoggingConfig(c *containerBeta.LoggingConfig) []map[string]interface{} {
+func flattenContainerClusterLoggingConfig(c *container.LoggingConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -4125,7 +4130,7 @@ func flattenContainerClusterLoggingConfig(c *containerBeta.LoggingConfig) []map[
 	}
 }
 
-func flattenMonitoringConfig(c *containerBeta.MonitoringConfig) []map[string]interface{} {
+func flattenMonitoringConfig(c *container.MonitoringConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}

--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -12,7 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	containerBeta "google.golang.org/api/container/v1beta1"
+<% if version == "ga" -%>
+	"google.golang.org/api/container/v1"
+<% else -%>
+	"google.golang.org/api/container/v1beta1"
+<% end -%>
 )
 
 var clusterIdRegex = regexp.MustCompile("projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/clusters/(?P<name>[^/]+)")
@@ -331,7 +335,7 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 	mutexKV.Lock(nodePoolInfo.lockKey())
 	defer mutexKV.Unlock(nodePoolInfo.lockKey())
 
-	req := &containerBeta.CreateNodePoolRequest{
+	req := &container.CreateNodePoolRequest{
 		NodePool: nodePool,
 	}
 
@@ -341,7 +345,7 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 	// we attempt to prefetch the node pool to make sure it doesn't exist before creation
 	var id = fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", nodePoolInfo.project, nodePoolInfo.location, nodePoolInfo.cluster, nodePool.Name)
 	name := getNodePoolName(id)
-	clusterNodePoolsGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
+	clusterNodePoolsGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
 	if config.UserProjectOverride {
 		clusterNodePoolsGetCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 	}
@@ -355,9 +359,9 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("resource - %s - already exists", id)
 	}
 
-	var operation *containerBeta.Operation
+	var operation *container.Operation
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		clusterNodePoolsCreateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Create(nodePoolInfo.parent(), req)
+		clusterNodePoolsCreateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Create(nodePoolInfo.parent(), req)
 		if config.UserProjectOverride {
 			clusterNodePoolsCreateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 		}
@@ -446,7 +450,7 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 	operation := d.Get("operation").(string)
 	if operation != "" {
 		log.Printf("[DEBUG] in progress operation detected at %v, attempting to resume", operation)
-		op := &containerBeta.Operation{
+		op := &container.Operation{
 			Name: operation,
 		}
 		if err := d.Set("operation", ""); err != nil {
@@ -460,7 +464,7 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 
 	name := getNodePoolName(d.Id())
 
-	clusterNodePoolsGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
+	clusterNodePoolsGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
 	if config.UserProjectOverride {
 		clusterNodePoolsGetCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 	}
@@ -576,9 +580,9 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 	timeout := d.Timeout(schema.TimeoutDelete)
 	startTime := time.Now()
 
-	var operation *containerBeta.Operation
+	var operation *container.Operation
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		clusterNodePoolsDeleteCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Delete(nodePoolInfo.fullyQualifiedName(name))
+		clusterNodePoolsDeleteCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Delete(nodePoolInfo.fullyQualifiedName(name))
 		if config.UserProjectOverride {
 			clusterNodePoolsDeleteCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 		}
@@ -628,7 +632,7 @@ func resourceContainerNodePoolExists(d *schema.ResourceData, meta interface{}) (
 	}
 
 	name := getNodePoolName(d.Id())
-	clusterNodePoolsGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
+	clusterNodePoolsGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
 	if config.UserProjectOverride {
 		clusterNodePoolsGetCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 	}
@@ -686,7 +690,7 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 	return []*schema.ResourceData{d}, nil
 }
 
-func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodePool, error) {
+func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool, error) {
 	var name string
 	if v, ok := d.GetOk(prefix + "name"); ok {
 		if _, ok := d.GetOk(prefix + "name_prefix"); ok {
@@ -715,7 +719,7 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 		locations = convertStringSet(v.(*schema.Set))
 	}
 
-	np := &containerBeta.NodePool{
+	np := &container.NodePool{
 		Name:             name,
 		InitialNodeCount: int64(nodeCount),
 		Config:           expandNodeConfig(d.Get(prefix + "node_config")),
@@ -728,7 +732,7 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 
 	if v, ok := d.GetOk(prefix + "autoscaling"); ok {
 		autoscaling := v.([]interface{})[0].(map[string]interface{})
-		np.Autoscaling = &containerBeta.NodePoolAutoscaling{
+		np.Autoscaling = &container.NodePoolAutoscaling{
 			Enabled:         true,
 			MinNodeCount:    int64(autoscaling["min_node_count"].(int)),
 			MaxNodeCount:    int64(autoscaling["max_node_count"].(int)),
@@ -737,14 +741,14 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 	}
 
 	if v, ok := d.GetOk(prefix + "max_pods_per_node"); ok {
-		np.MaxPodsConstraint = &containerBeta.MaxPodsConstraint{
+		np.MaxPodsConstraint = &container.MaxPodsConstraint{
 			MaxPodsPerNode: int64(v.(int)),
 		}
 	}
 
 	if v, ok := d.GetOk(prefix + "management"); ok {
 		managementConfig := v.([]interface{})[0].(map[string]interface{})
-		np.Management = &containerBeta.NodeManagement{}
+		np.Management = &container.NodeManagement{}
 
 		if v, ok := managementConfig["auto_repair"]; ok {
 			np.Management.AutoRepair = v.(bool)
@@ -757,7 +761,7 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 
 	if v, ok := d.GetOk(prefix + "upgrade_settings"); ok {
 		upgradeSettingsConfig := v.([]interface{})[0].(map[string]interface{})
-		np.UpgradeSettings = &containerBeta.UpgradeSettings{}
+		np.UpgradeSettings = &container.UpgradeSettings{}
 
 		if v, ok := upgradeSettingsConfig["max_surge"]; ok {
 			np.UpgradeSettings.MaxSurge = int64(v.(int))
@@ -771,7 +775,7 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 	return np, nil
 }
 
-func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.NodePool, prefix string) (map[string]interface{}, error) {
+func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodePool, prefix string) (map[string]interface{}, error) {
 	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
 		return nil, err
@@ -856,7 +860,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 }
 
 <% unless version == 'ga' -%>
-func flattenNodeNetworkConfig(c *containerBeta.NodeNetworkConfig, d *schema.ResourceData, prefix string) []map[string]interface{} {
+func flattenNodeNetworkConfig(c *container.NodeNetworkConfig, d *schema.ResourceData, prefix string) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -868,10 +872,10 @@ func flattenNodeNetworkConfig(c *containerBeta.NodeNetworkConfig, d *schema.Reso
 	return result
 }
 
-func expandNodeNetworkConfig(v interface{}) *containerBeta.NodeNetworkConfig {
+func expandNodeNetworkConfig(v interface{}) *container.NodeNetworkConfig {
 	networkNodeConfigs := v.([]interface{})
 
-	nnc := &containerBeta.NodeNetworkConfig{}
+	nnc := &container.NodeNetworkConfig{}
 
 	if len(networkNodeConfigs) == 0 {
 		return nnc
@@ -909,29 +913,29 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "autoscaling") {
-		update := &containerBeta.ClusterUpdate{
+		update := &container.ClusterUpdate{
 			DesiredNodePoolId: name,
 		}
 		if v, ok := d.GetOk(prefix + "autoscaling"); ok {
 			autoscaling := v.([]interface{})[0].(map[string]interface{})
-			update.DesiredNodePoolAutoscaling = &containerBeta.NodePoolAutoscaling{
+			update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
 				Enabled:         true,
 				MinNodeCount:    int64(autoscaling["min_node_count"].(int)),
 				MaxNodeCount:    int64(autoscaling["max_node_count"].(int)),
 				ForceSendFields: []string{"MinNodeCount"},
 			}
 		} else {
-			update.DesiredNodePoolAutoscaling = &containerBeta.NodePoolAutoscaling{
+			update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
 				Enabled: false,
 			}
 		}
 
-		req := &containerBeta.UpdateClusterRequest{
+		req := &container.UpdateClusterRequest{
 			Update: update,
 		}
 
 		updateF := func() error {
-			clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(nodePoolInfo.parent(), req)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(nodePoolInfo.parent(), req)
 			if config.UserProjectOverride {
 				clusterUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 			}
@@ -957,15 +961,15 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 
 	if d.HasChange(prefix + "node_config") {
 		if d.HasChange(prefix + "node_config.0.image_type") {
-			req := &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
 					DesiredNodePoolId: name,
 					DesiredImageType:  d.Get(prefix + "node_config.0.image_type").(string),
 				},
 			}
 
 			updateF := func() error {
-				clusterUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.Update(nodePoolInfo.parent(), req)
+				clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(nodePoolInfo.parent(), req)
 				if config.UserProjectOverride {
 					clusterUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 				}
@@ -990,7 +994,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 
 		if d.HasChange(prefix + "node_config.0.workload_metadata_config") {
-			req := &containerBeta.UpdateNodePoolRequest{
+			req := &container.UpdateNodePoolRequest{
 				NodePoolId: name,
 				WorkloadMetadataConfig: expandWorkloadMetadataConfig(
 					d.Get(prefix + "node_config.0.workload_metadata_config")),
@@ -999,7 +1003,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				req.ForceSendFields = []string{"WorkloadMetadataConfig"}
 			}
 			updateF := func() error {
-				clusterNodePoolsUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
 				if config.UserProjectOverride {
 					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 				}
@@ -1027,7 +1031,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 
 <% unless version == 'ga' -%>
 		if d.HasChange(prefix + "node_config.0.kubelet_config") {
-			req := &containerBeta.UpdateNodePoolRequest{
+			req := &container.UpdateNodePoolRequest{
 				NodePoolId: name,
 				KubeletConfig: expandKubeletConfig(
 					d.Get(prefix + "node_config.0.kubelet_config")),
@@ -1036,7 +1040,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				req.ForceSendFields = []string{"KubeletConfig"}
 			}
 			updateF := func() error {
-				clusterNodePoolsUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
 				if config.UserProjectOverride {
 					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 				}
@@ -1061,7 +1065,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			log.Printf("[INFO] Updated kubelet_config for node pool %s", name)
 		}
 		if d.HasChange(prefix + "node_config.0.linux_node_config") {
-			req := &containerBeta.UpdateNodePoolRequest{
+			req := &container.UpdateNodePoolRequest{
 				NodePoolId: name,
 				LinuxNodeConfig: expandLinuxNodeConfig(
 					d.Get(prefix + "node_config.0.linux_node_config")),
@@ -1070,7 +1074,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				req.ForceSendFields = []string{"LinuxNodeConfig"}
 			}
 			updateF := func() error {
-				clusterNodePoolsUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
 				if config.UserProjectOverride {
 					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 				}
@@ -1100,11 +1104,11 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 
 	if d.HasChange(prefix + "node_count") {
 		newSize := int64(d.Get(prefix + "node_count").(int))
-		req := &containerBeta.SetNodePoolSizeRequest{
+		req := &container.SetNodePoolSizeRequest{
 			NodeCount: newSize,
 		}
 		updateF := func() error {
-			clusterNodePoolsSetSizeCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.SetSize(nodePoolInfo.fullyQualifiedName(name),req)
+			clusterNodePoolsSetSizeCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.SetSize(nodePoolInfo.fullyQualifiedName(name),req)
 			if config.UserProjectOverride {
 				clusterNodePoolsSetSizeCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 			}
@@ -1130,19 +1134,19 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "management") {
-		management := &containerBeta.NodeManagement{}
+		management := &container.NodeManagement{}
 		if v, ok := d.GetOk(prefix + "management"); ok {
 			managementConfig := v.([]interface{})[0].(map[string]interface{})
 			management.AutoRepair = managementConfig["auto_repair"].(bool)
 			management.AutoUpgrade = managementConfig["auto_upgrade"].(bool)
 			management.ForceSendFields = []string{"AutoRepair", "AutoUpgrade"}
 		}
-		req := &containerBeta.SetNodePoolManagementRequest{
+		req := &container.SetNodePoolManagementRequest{
 			Management: management,
 		}
 
 		updateF := func() error {
-			clusterNodePoolsSetManagementCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.SetManagement(nodePoolInfo.fullyQualifiedName(name),req)
+			clusterNodePoolsSetManagementCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.SetManagement(nodePoolInfo.fullyQualifiedName(name),req)
 			if config.UserProjectOverride {
 				clusterNodePoolsSetManagementCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 			}
@@ -1167,12 +1171,12 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "version") {
-		req := &containerBeta.UpdateNodePoolRequest{
+		req := &container.UpdateNodePoolRequest{
 			NodePoolId:  name,
 			NodeVersion: d.Get(prefix + "version").(string),
 		}
 		updateF := func() error {
-			clusterNodePoolsUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+			clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
 			if config.UserProjectOverride {
 				clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 			}
@@ -1197,11 +1201,11 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "node_locations") {
-		req := &containerBeta.UpdateNodePoolRequest{
+		req := &container.UpdateNodePoolRequest{
 			Locations: convertStringSet(d.Get(prefix + "node_locations").(*schema.Set)),
 		}
 		updateF := func() error {
-			clusterNodePoolsUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+			clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
 			if config.UserProjectOverride {
 				clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 			}
@@ -1224,17 +1228,17 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "upgrade_settings") {
-		upgradeSettings := &containerBeta.UpgradeSettings{}
+		upgradeSettings := &container.UpgradeSettings{}
 		if v, ok := d.GetOk(prefix + "upgrade_settings"); ok {
 			upgradeSettingsConfig := v.([]interface{})[0].(map[string]interface{})
 			upgradeSettings.MaxSurge = int64(upgradeSettingsConfig["max_surge"].(int))
 			upgradeSettings.MaxUnavailable = int64(upgradeSettingsConfig["max_unavailable"].(int))
 		}
-		req := &containerBeta.UpdateNodePoolRequest{
+		req := &container.UpdateNodePoolRequest{
 			UpgradeSettings: upgradeSettings,
 		}
 		updateF := func() error {
-			clusterNodePoolsUpdateCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+			clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
 			if config.UserProjectOverride {
 				clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
 			}
@@ -1275,7 +1279,7 @@ var containerNodePoolRestingStates = RestingStates{
 // returns a state with no error if the state is a resting state, and the last state with an error otherwise
 func containerNodePoolAwaitRestingState(config *Config, name, project, userAgent string, timeout time.Duration) (state string, err error) {
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		clusterNodePoolsGetCall := config.NewContainerBetaClient(userAgent).Projects.Locations.Clusters.NodePools.Get(name)
+		clusterNodePoolsGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Get(name)
 		if config.UserProjectOverride {
 			clusterNodePoolsGetCall.Header().Add("X-Goog-User-Project", project)
 		}

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -970,7 +970,7 @@ func testAccCheckContainerNodePoolDestroyProducer(t *testing.T) func(s *terrafor
 					attributes["cluster"],
 					attributes["name"],
 				)
-				_, err = config.NewContainerBetaClient(config.userAgent).Projects.Locations.Clusters.NodePools.Get(name).Do()
+				_, err = config.NewContainerClient(config.userAgent).Projects.Locations.Clusters.NodePools.Get(name).Do()
 			}
 
 			if err == nil {

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -41,8 +41,11 @@ import (
 <% else -%>
 	"google.golang.org/api/compute/v0.beta"
 <% end -%>
+<% if version == 'ga' -%>
 	"google.golang.org/api/container/v1"
-	containerBeta "google.golang.org/api/container/v1beta1"
+<% else -%>
+	"google.golang.org/api/container/v1beta1"
+<% end -%>
 	dataflow "google.golang.org/api/dataflow/v1b3"
 <% unless version == 'ga' -%>
 	dataproc "google.golang.org/api/dataproc/v1beta2"
@@ -115,7 +118,6 @@ type Config struct {
 	CloudBillingBasePath string
 	ComposerBasePath string
 	ContainerBasePath string
-	ContainerBetaBasePath string
 	DataprocBetaBasePath string
 	DataflowBasePath string
 	IamCredentialsBasePath string
@@ -152,7 +154,6 @@ const CloudBillingBasePathKey = "CloudBilling"
 const ComposerBasePathKey = "Composer"
 const ContainerBasePathKey = "Container"
 const DataprocBetaBasePathKey = "DataprocBeta"
-const ContainerBetaBasePathKey = "ContainerBeta"
 const DataflowBasePathKey = "Dataflow"
 const IAMBasePathKey = "IAM"
 const IamCredentialsBasePathKey = "IamCredentials"
@@ -173,8 +174,11 @@ var DefaultBasePaths = map[string]string{
 <% else -%>
 	ComposerBasePathKey : "https://composer.googleapis.com/v1beta1/",
 <% end -%>
+<% if version == "ga" -%>
 	ContainerBasePathKey : "https://container.googleapis.com/v1/",
-	ContainerBetaBasePathKey : "https://container.googleapis.com/v1beta1/",
+<% else -%>
+	ContainerBasePathKey : "https://container.googleapis.com/v1beta1/",
+<% end -%>
 	DataprocBetaBasePathKey : "https://dataproc.googleapis.com/v1beta2/",
 	DataflowBasePathKey : "https://dataflow.googleapis.com/v1b3/",
 	IAMBasePathKey : "https://iam.googleapis.com/v1/",
@@ -382,20 +386,6 @@ func (c *Config) NewContainerClient(userAgent string) *container.Service {
 	clientContainer.BasePath = containerClientBasePath
 
 	return clientContainer
-}
-
-func (c *Config) NewContainerBetaClient(userAgent string) *containerBeta.Service {
-	containerBetaClientBasePath := removeBasePathVersion(c.ContainerBetaBasePath)
-	log.Printf("[INFO] Instantiating GKE Beta client for path %s", containerBetaClientBasePath)
-	clientContainerBeta, err := containerBeta.NewService(c.context, option.WithHTTPClient(c.client))
-	if err != nil {
-		log.Printf("[WARN] Error creating client container beta: %s", err)
-		return nil
-	}
-	clientContainerBeta.UserAgent = userAgent
-	clientContainerBeta.BasePath = containerBetaClientBasePath
-
-	return clientContainerBeta
 }
 
 func (c *Config) NewDnsClient(userAgent string) *dns.Service {
@@ -967,7 +957,6 @@ func ConfigureBasePaths(c *Config) {
 	c.CloudBillingBasePath = DefaultBasePaths[CloudBillingBasePathKey]
 	c.ComposerBasePath = DefaultBasePaths[ComposerBasePathKey]
 	c.ContainerBasePath = DefaultBasePaths[ContainerBasePathKey]
-	c.ContainerBetaBasePath = DefaultBasePaths[ContainerBetaBasePathKey]
 	c.DataprocBasePath = DefaultBasePaths[DataprocBasePathKey]
 	c.DataflowBasePath = DefaultBasePaths[DataflowBasePathKey]
 	c.IamCredentialsBasePath = DefaultBasePaths[IamCredentialsBasePathKey]

--- a/mmv1/third_party/terraform/utils/container_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/container_operation.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -7,7 +8,11 @@ import (
 	"log"
 	"time"
 
-	container "google.golang.org/api/container/v1beta1"
+<% if version == "ga" -%>
+	"google.golang.org/api/container/v1"
+<% else -%>
+	"google.golang.org/api/container/v1beta1"
+<% end -%>
 )
 
 type ContainerOperationWaiter struct {
@@ -104,7 +109,7 @@ func (w *ContainerOperationWaiter) TargetStates() []string {
 
 func containerOperationWait(config *Config, op *container.Operation, project, location, activity, userAgent string, timeout time.Duration) error {
 	w := &ContainerOperationWaiter{
-		Service:             config.NewContainerBetaClient(userAgent),
+		Service:             config.NewContainerClient(userAgent),
 		Context:             config.context,
 		Op:                  op,
 		Project:             project,

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -6,7 +6,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	containerBeta "google.golang.org/api/container/v1beta1"
+<% if version == "ga" -%>
+	"google.golang.org/api/container/v1"
+<% else -%>
+	"google.golang.org/api/container/v1beta1"
+<% end -%>
 )
 
 // Matches gke-default scope from https://cloud.google.com/sdk/gcloud/reference/container/clusters/create
@@ -357,9 +361,9 @@ func schemaNodeConfig() *schema.Schema {
 	}
 }
 
-func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
+func expandNodeConfig(v interface{}) *container.NodeConfig {
 	nodeConfigs := v.([]interface{})
-	nc := &containerBeta.NodeConfig{
+	nc := &container.NodeConfig{
 		// Defaults can't be set on a list/set in the schema, so set the default on create here.
 		OauthScopes: defaultOauthScopes,
 	}
@@ -375,13 +379,13 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 
 	if v, ok := nodeConfig["guest_accelerator"]; ok {
 		accels := v.([]interface{})
-		guestAccelerators := make([]*containerBeta.AcceleratorConfig, 0, len(accels))
+		guestAccelerators := make([]*container.AcceleratorConfig, 0, len(accels))
 		for _, raw := range accels {
 			data := raw.(map[string]interface{})
 			if data["count"].(int) == 0 {
 				continue
 			}
-			guestAccelerators = append(guestAccelerators, &containerBeta.AcceleratorConfig{
+			guestAccelerators = append(guestAccelerators, &container.AcceleratorConfig{
 				AcceleratorCount: int64(data["count"].(int)),
 				AcceleratorType:  data["type"].(string),
 				GpuPartitionSize: data["gpu_partition_size"].(string),
@@ -405,7 +409,7 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 <% unless version == 'ga' -%>
 	if v, ok := nodeConfig["ephemeral_storage_config"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
-		nc.EphemeralStorageConfig = &containerBeta.EphemeralStorageConfig{
+		nc.EphemeralStorageConfig = &container.EphemeralStorageConfig{
 			LocalSsdCount: int64(conf["local_ssd_count"].(int)),
 		}
 	}
@@ -458,7 +462,7 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 
 	if v, ok := nodeConfig["shielded_instance_config"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
-		nc.ShieldedInstanceConfig = &containerBeta.ShieldedInstanceConfig{
+		nc.ShieldedInstanceConfig = &container.ShieldedInstanceConfig{
 			EnableSecureBoot:          conf["enable_secure_boot"].(bool),
 			EnableIntegrityMonitoring: conf["enable_integrity_monitoring"].(bool),
 		}
@@ -473,10 +477,10 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 
 	if v, ok := nodeConfig["taint"]; ok && len(v.([]interface{})) > 0 {
 		taints := v.([]interface{})
-		nodeTaints := make([]*containerBeta.NodeTaint, 0, len(taints))
+		nodeTaints := make([]*container.NodeTaint, 0, len(taints))
 		for _, raw := range taints {
 			data := raw.(map[string]interface{})
-			taint := &containerBeta.NodeTaint{
+			taint := &container.NodeTaint{
 				Key:    data["key"].(string),
 				Value:  data["value"].(string),
 				Effect: data["effect"].(string),
@@ -494,7 +498,7 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 <% unless version == 'ga' -%>
 	if v, ok := nodeConfig["sandbox_config"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
-		nc.SandboxConfig = &containerBeta.SandboxConfig{
+		nc.SandboxConfig = &container.SandboxConfig{
 			SandboxType: conf["sandbox_type"].(string),
 		}
 	}
@@ -517,7 +521,7 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 	return nc
 }
 
-func expandWorkloadMetadataConfig(v interface{}) *containerBeta.WorkloadMetadataConfig {
+func expandWorkloadMetadataConfig(v interface{}) *container.WorkloadMetadataConfig {
 	if v == nil {
 		return nil
 	}
@@ -525,7 +529,7 @@ func expandWorkloadMetadataConfig(v interface{}) *containerBeta.WorkloadMetadata
 	if len(ls) == 0 {
 		return nil
 	}
-	wmc := &containerBeta.WorkloadMetadataConfig{}
+	wmc := &container.WorkloadMetadataConfig{}
 
 	cfg := ls[0].(map[string]interface{})
 
@@ -537,7 +541,7 @@ func expandWorkloadMetadataConfig(v interface{}) *containerBeta.WorkloadMetadata
 }
 
 <% unless version == 'ga' -%>
-func expandKubeletConfig(v interface{}) *containerBeta.NodeKubeletConfig {
+func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 	if v == nil {
 		return nil
 	}
@@ -546,7 +550,7 @@ func expandKubeletConfig(v interface{}) *containerBeta.NodeKubeletConfig {
 		return nil
 	}
 	cfg := ls[0].(map[string]interface{})
-	kConfig := &containerBeta.NodeKubeletConfig{}
+	kConfig := &container.NodeKubeletConfig{}
 	if cpuManagerPolicy, ok := cfg["cpu_manager_policy"]; ok {
 		kConfig.CpuManagerPolicy = cpuManagerPolicy.(string)
 	}
@@ -560,7 +564,7 @@ func expandKubeletConfig(v interface{}) *containerBeta.NodeKubeletConfig {
 	return kConfig
 }
 
-func expandLinuxNodeConfig(v interface{}) *containerBeta.LinuxNodeConfig {
+func expandLinuxNodeConfig(v interface{}) *container.LinuxNodeConfig {
 	if v == nil {
 		return nil
 	}
@@ -577,14 +581,14 @@ func expandLinuxNodeConfig(v interface{}) *containerBeta.LinuxNodeConfig {
 	for k, v := range sysCfgRaw.(map[string]interface{}) {
 		m[k] = v.(string)
 	}
-	return &containerBeta.LinuxNodeConfig{
+	return &container.LinuxNodeConfig{
 		Sysctls: m,
 	}
 }
 
 <% end -%>
 
-func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
+func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 	config := make([]map[string]interface{}, 0, 1)
 
 	if c == nil {
@@ -627,7 +631,7 @@ func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
 	return config
 }
 
-func flattenContainerGuestAccelerators(c []*containerBeta.AcceleratorConfig) []map[string]interface{} {
+func flattenContainerGuestAccelerators(c []*container.AcceleratorConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	for _, accel := range c {
 		result = append(result, map[string]interface{}{
@@ -639,7 +643,7 @@ func flattenContainerGuestAccelerators(c []*containerBeta.AcceleratorConfig) []m
 	return result
 }
 
-func flattenShieldedInstanceConfig(c *containerBeta.ShieldedInstanceConfig) []map[string]interface{} {
+func flattenShieldedInstanceConfig(c *container.ShieldedInstanceConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -651,7 +655,7 @@ func flattenShieldedInstanceConfig(c *containerBeta.ShieldedInstanceConfig) []ma
 }
 
 <% unless version == 'ga' -%>
-func flattenEphemeralStorageConfig(c *containerBeta.EphemeralStorageConfig) []map[string]interface{} {
+func flattenEphemeralStorageConfig(c *container.EphemeralStorageConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -662,7 +666,7 @@ func flattenEphemeralStorageConfig(c *containerBeta.EphemeralStorageConfig) []ma
 }
 <% end -%>
 
-func flattenTaints(c []*containerBeta.NodeTaint) []map[string]interface{} {
+func flattenTaints(c []*container.NodeTaint) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	for _, taint := range c {
 		result = append(result, map[string]interface{}{
@@ -675,7 +679,7 @@ func flattenTaints(c []*containerBeta.NodeTaint) []map[string]interface{} {
 }
 
 
-func flattenWorkloadMetadataConfig(c *containerBeta.WorkloadMetadataConfig) []map[string]interface{} {
+func flattenWorkloadMetadataConfig(c *container.WorkloadMetadataConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -685,7 +689,7 @@ func flattenWorkloadMetadataConfig(c *containerBeta.WorkloadMetadataConfig) []ma
 	return result
 }
 <% unless version.nil? || version == 'ga' -%>
-func flattenSandboxConfig(c *containerBeta.SandboxConfig) []map[string]interface{} {
+func flattenSandboxConfig(c *container.SandboxConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -812,7 +816,7 @@ func containerNodePoolTaintSuppress(k, old, new string, d *schema.ResourceData) 
 <% end -%>
 
 <% unless version == 'ga' -%>
-func flattenKubeletConfig(c *containerBeta.NodeKubeletConfig) []map[string]interface{} {
+func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{
@@ -824,7 +828,7 @@ func flattenKubeletConfig(c *containerBeta.NodeKubeletConfig) []map[string]inter
 	return result
 }
 
-func flattenLinuxNodeConfig(c *containerBeta.LinuxNodeConfig) []map[string]interface{} {
+func flattenLinuxNodeConfig(c *container.LinuxNodeConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
 		result = append(result, map[string]interface{}{

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -164,7 +164,6 @@ func Provider() *schema.Provider {
 			CloudBillingCustomEndpointEntryKey:           CloudBillingCustomEndpointEntry,
 			ComposerCustomEndpointEntryKey:               ComposerCustomEndpointEntry,
 			ContainerCustomEndpointEntryKey:              ContainerCustomEndpointEntry,
-			ContainerBetaCustomEndpointEntryKey:          ContainerBetaCustomEndpointEntry,
 			DataprocBetaCustomEndpointEntryKey:           DataprocBetaCustomEndpointEntry,
 			DataflowCustomEndpointEntryKey:               DataflowCustomEndpointEntry,
 			IamCredentialsCustomEndpointEntryKey:         IamCredentialsCustomEndpointEntry,
@@ -638,7 +637,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	config.CloudBillingBasePath = d.Get(CloudBillingCustomEndpointEntryKey).(string)
 	config.ComposerBasePath = d.Get(ComposerCustomEndpointEntryKey).(string)
 	config.ContainerBasePath = d.Get(ContainerCustomEndpointEntryKey).(string)
-	config.ContainerBetaBasePath = d.Get(ContainerBetaCustomEndpointEntryKey).(string)
 	config.DataprocBetaBasePath = d.Get(DataprocBetaCustomEndpointEntryKey).(string)
 	config.DataflowBasePath = d.Get(DataflowCustomEndpointEntryKey).(string)
 	config.IamCredentialsBasePath = d.Get(IamCredentialsCustomEndpointEntryKey).(string)

--- a/mmv1/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
@@ -39,16 +39,6 @@ var ContainerCustomEndpointEntry = &schema.Schema{
 	}, DefaultBasePaths[ContainerBasePathKey]),
 }
 
-var ContainerBetaCustomEndpointEntryKey = "container_beta_custom_endpoint"
-var ContainerBetaCustomEndpointEntry = &schema.Schema{
-	Type:         schema.TypeString,
-	Optional:     true,
-	ValidateFunc: validateCustomEndpoint,
-	DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-		"GOOGLE_CONTAINER_BETA_CUSTOM_ENDPOINT",
-	}, DefaultBasePaths[ContainerBetaBasePathKey]),
-}
-
 var DataprocBetaCustomEndpointEntryKey = "dataproc_beta_custom_endpoint"
 var DataprocBetaCustomEndpointEntry = &schema.Schema{
 	Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -321,7 +321,6 @@ be used for configuration are below:
 * `composer_custom_endpoint` (`GOOGLE_COMPOSER_CUSTOM_ENDPOINT`) - `https://composer.googleapis.com/v1beta1/`
 * `compute_custom_endpoint` (`GOOGLE_COMPUTE_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/compute/v1/` | `https://www.googleapis.com/compute/beta/`
 * `container_custom_endpoint` (`GOOGLE_CONTAINER_CUSTOM_ENDPOINT`) - `https://container.googleapis.com/v1/`
-* `container_beta_custom_endpoint` (`GOOGLE_CONTAINER_BETA_CUSTOM_ENDPOINT`) - `https://container.googleapis.com/v1beta1/`
 * `dataproc_custom_endpoint` (`GOOGLE_DATAPROC_CUSTOM_ENDPOINT`) - `https://dataproc.googleapis.com/v1/`
 * `dataproc_beta_custom_endpoint` (`GOOGLE_DATAPROC_BETA_CUSTOM_ENDPOINT`) - `https://dataproc.googleapis.com/v1beta2/`
 * `dataflow_custom_endpoint` (`GOOGLE_DATAFLOW_CUSTOM_ENDPOINT`) - `https://dataflow.googleapis.com/v1b3/`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of hashicorp/terraform-provider-google#8696


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
container: Google Kubernetes Engine resources will now call the endpoint appropriate to the provider version rather than the beta endpoint by default
```
