### PR TITLE
Remove references to self_link in test and datasource docs for KMS

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_analysis_occurrence_test.go
+++ b/mmv1/third_party/terraform/tests/resource_container_analysis_occurrence_test.go
@@ -249,11 +249,11 @@ data "google_kms_crypto_key" "crypto-key2" {
 }
 
 data "google_kms_crypto_key_version" "version-key1" {
-  crypto_key = data.google_kms_crypto_key.crypto-key1.self_link
+  crypto_key = data.google_kms_crypto_key.crypto-key1.id
 }
 
 data "google_kms_crypto_key_version" "version-key2" {
-  crypto_key = data.google_kms_crypto_key.crypto-key2.self_link
+  crypto_key = data.google_kms_crypto_key.crypto-key2.id
 }
 
 resource "google_container_analysis_occurrence" "occurrence" {

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `name` - (Required) The CryptoKey's name.
     A CryptoKey’s name belonging to the specified Google Cloud Platform KeyRing and match the regular expression `[a-zA-Z0-9_-]{1,63}`
 
-* `key_ring` - (Required) The `self_link` of the Google Cloud Platform KeyRing to which the key belongs.
+* `key_ring` - (Required) The `id` of the Google Cloud Platform KeyRing to which the key belongs.
 
 ## Attributes Reference
 
@@ -51,5 +51,5 @@ exported:
 
 * `purpose` - Defines the cryptographic capabilities of the key.
 
-* `self_link` - The self link of the created CryptoKey. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}/cryptoKeys/{cryptoKeyName}`.
+* `id` - The identifier of the created CryptoKey. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}/cryptoKeys/{cryptoKeyName}`.
 

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version.html.markdown
@@ -38,7 +38,7 @@ data "google_kms_crypto_key_version" "my_crypto_key_version" {
 
 The following arguments are supported:
 
-* `crypto_key` - (Required) The `self_link` of the Google Cloud Platform CryptoKey to which the key version belongs. This is also the `id` field of the 
+* `crypto_key` - (Required) The `id` of the Google Cloud Platform CryptoKey to which the key version belongs. This is also the `id` field of the 
 `google_kms_crypto_key` resource/datasource.
 
 * `version` - (Optional) The version number for this CryptoKeyVersion. Defaults to `1`.

--- a/mmv1/third_party/terraform/website/docs/d/kms_key_ring.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_key_ring.html.markdown
@@ -46,4 +46,4 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `self_link` - The self link of the created KeyRing. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}`.
+* `id` - The identifier of the created KeyRing. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}`.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This field is removed in 4.0.0



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
