### PR TITLE
Use a datasource schema for Spanner Instance DS

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_spanner_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_spanner_instance.go
@@ -1,15 +1,18 @@
 package google
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceSpannerInstance() *schema.Resource {
 
-	dsSchema := (resourceSpannerInstance().Schema)
+	dsSchema := datasourceSchemaFromResourceSchema(resourceSpannerInstance().Schema)
+
 	addRequiredFieldsToSchema(dsSchema, "name")
-	addOptionalFieldsToSchema(dsSchema, "config")
-	addOptionalFieldsToSchema(dsSchema, "display_name")
+	addOptionalFieldsToSchema(dsSchema, "config")       // not sure why this is configurable
+	addOptionalFieldsToSchema(dsSchema, "display_name") // not sure why this is configurable
 	addOptionalFieldsToSchema(dsSchema, "project")
 
 	return &schema.Resource{
@@ -19,7 +22,13 @@ func dataSourceSpannerInstance() *schema.Resource {
 }
 
 func dataSourceSpannerInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	id, err := replaceVars(d, config, "{{project}}/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
 
 	return resourceSpannerInstanceRead(d, meta)
-
 }

--- a/mmv1/third_party/terraform/tests/data_source_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_spanner_instance_test.go
@@ -42,7 +42,7 @@ resource "google_spanner_instance" "bar" {
 }
 
 data "google_spanner_instance" "foo" {
-    name = google_spanner_instance.bar.name
+	name = google_spanner_instance.bar.name
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This didn't seem to cause a failure before but does now w/ the changes to `node_count` and `processing_units`. The datasourceSchema call was missing in the initial impl in https://github.com/GoogleCloudPlatform/magic-modules/pull/4111


```
$ make testacc TEST=./google-beta TESTARGS='-run=TestAccDataSourceSpannerInstance_basic'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -v -run=TestAccDataSourceSpannerInstance_basic -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceSpannerInstance_basic
=== PAUSE TestAccDataSourceSpannerInstance_basic
=== CONT  TestAccDataSourceSpannerInstance_basic
--- PASS: TestAccDataSourceSpannerInstance_basic (24.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-google-beta/google-beta	25.776s
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
spanner: fixed the schema for `data.google_spanner_instance` so that non-configurable fields are considered outputs
```
