### PR TITLE
GA encrypted_interconnect_router on compute router

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13160,9 +13160,6 @@ objects:
         description: |
           Field to indicate if a router is dedicated to use with encrypted
           Interconnect Attachment (IPsec-encrypted Cloud Interconnect feature).
-
-          Not currently available publicly.
-        min_version: beta
   - !ruby/object:Api::Resource
     name: 'RouterNat'
     base_url: projects/{{project}}/regions/{{region}}/routers/{{router}}

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13160,6 +13160,8 @@ objects:
         description: |
           Field to indicate if a router is dedicated to use with encrypted
           Interconnect Attachment (IPsec-encrypted Cloud Interconnect feature).
+
+          Not currently available publicly.
   - !ruby/object:Api::Resource
     name: 'RouterNat'
     base_url: projects/{{project}}/regions/{{region}}/routers/{{router}}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes tests in GA provider that were passing in beta provider.

This field should hav been released in GA along with https://github.com/GoogleCloudPlatform/magic-modules/pull/4983 and https://github.com/GoogleCloudPlatform/magic-modules/pull/4777

```
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeHaVpnGateway_computeHaVpnGatewayEncryptedInterconnectExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeHaVpnGateway_computeHaVpnGatewayEncryptedInterconnectExample
=== PAUSE TestAccComputeHaVpnGateway_computeHaVpnGatewayEncryptedInterconnectExample
=== CONT  TestAccComputeHaVpnGateway_computeHaVpnGatewayEncryptedInterconnectExample
--- PASS: TestAccComputeHaVpnGateway_computeHaVpnGatewayEncryptedInterconnectExample (105.92s)
PASS
```
```
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeInterconnectAttachment_computeInterconnectAttachmentIpsecEncryptionExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInterconnectAttachment_computeInterconnectAttachmentIpsecEncryptionExample
=== PAUSE TestAccComputeInterconnectAttachment_computeInterconnectAttachmentIpsecEncryptionExample
=== CONT  TestAccComputeInterconnectAttachment_computeInterconnectAttachmentIpsecEncryptionExample
--- PASS: TestAccComputeInterconnectAttachment_computeInterconnectAttachmentIpsecEncryptionExample (82.78s)
PASS
```
```
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeRouter_computeRouterEncryptedInterconnectExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeRouter_computeRouterEncryptedInterconnectExample
=== PAUSE TestAccComputeRouter_computeRouterEncryptedInterconnectExample
=== CONT  TestAccComputeRouter_computeRouterEncryptedInterconnectExample
--- PASS: TestAccComputeRouter_computeRouterEncryptedInterconnectExample (59.94s)
PASS
```
in the GA provider.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `encrypted_interconnect_router` to `google_compute_router` (GA only)
```
