### PR TITLE
Fix more uses of kms key self link

### DIFF
--- a/mmv1/templates/terraform/examples/container_analysis_occurrence_kms.tf.erb
+++ b/mmv1/templates/terraform/examples/container_analysis_occurrence_kms.tf.erb
@@ -32,7 +32,7 @@ data "google_kms_crypto_key" "crypto-key" {
 }
 
 data "google_kms_crypto_key_version" "version" {
-  crypto_key = data.google_kms_crypto_key.crypto-key.self_link
+  crypto_key = data.google_kms_crypto_key.crypto-key.id
 }
 
 resource "google_container_analysis_occurrence" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3388,7 +3388,7 @@ resource "google_container_cluster" "with_boot_disk_kms_key" {
 
     image_type = "COS_CONTAINERD"
 
-    boot_disk_kms_key = google_kms_crypto_key.example-key.self_link
+    boot_disk_kms_key = google_kms_crypto_key.example-key.id
   }
 }
 `, project, clusterName, clusterName, clusterName)

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1797,7 +1797,7 @@ resource "google_container_node_pool" "with_boot_disk_kms_key" {
 
   node_config {
     image_type = "COS_CONTAINERD"
-    boot_disk_kms_key = google_kms_crypto_key.example-key.self_link
+    boot_disk_kms_key = google_kms_crypto_key.example-key.id
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",

--- a/mmv1/third_party/terraform/tests/resource_dataflow_job_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataflow_job_test.go.erb
@@ -867,7 +867,7 @@ resource "google_dataflow_job" "big_data" {
   machine_type      = "e2-standard-2"
   template_gcs_path = "%s"
   temp_gcs_location = google_storage_bucket.temp.url
-  kms_key_name		= google_kms_crypto_key.crypto_key.self_link
+  kms_key_name		= google_kms_crypto_key.crypto_key.id
   parameters = {
     inputFile = "%s"
     output    = "${google_storage_bucket.temp.url}/output"

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -1504,7 +1504,7 @@ resource "google_storage_bucket" "bucket" {
   location      = "US"
   force_destroy = true
   encryption {
-    default_kms_key_name = google_kms_crypto_key.crypto_key.self_link
+    default_kms_key_name = google_kms_crypto_key.crypto_key.id
   }
 
   depends_on = [google_kms_crypto_key_iam_member.iam]

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret.html.markdown
@@ -56,7 +56,7 @@ Finally, reference the encrypted ciphertext in your resource definitions:
 
 ```hcl
 data "google_kms_secret" "sql_user_password" {
-  crypto_key = google_kms_crypto_key.my_crypto_key.self_link
+  crypto_key = google_kms_crypto_key.my_crypto_key.id
   ciphertext = "CiQAqD+xX4SXOSziF4a8JYvq4spfAuWhhYSNul33H85HnVtNQW4SOgDu2UZ46dQCRFl5MF6ekabviN8xq+F+2035ZJ85B+xTYXqNf4mZs0RJitnWWuXlYQh6axnnJYu3kDU="
 }
 

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
@@ -43,7 +43,7 @@ Next, encrypt some sensitive information and use the encrypted data in your reso
 
 ```hcl
 data "google_kms_secret_ciphertext" "my_password" {
-  crypto_key = google_kms_crypto_key.my_crypto_key.self_link
+  crypto_key = google_kms_crypto_key.my_crypto_key.id
   plaintext  = "my-secret-password"
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Apparently I did a bad job finding uses originally


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
