### PR TITLE
Use correct beta provider in beta-only GFR tests

### DIFF
--- a/mmv1/templates/terraform/examples/external_http_lb_mig_backend_custom_header.tf.erb
+++ b/mmv1/templates/terraform/examples/external_http_lb_mig_backend_custom_header.tf.erb
@@ -5,14 +5,14 @@
 # VPC
 resource "google_compute_network" "default" {
   name                    = "<%= ctx[:vars]['xlb_network_name'] %>"
-  provider                = google
+  provider                = google-beta
   auto_create_subnetworks = false
 }
 
 # backend subnet
 resource "google_compute_subnetwork" "default" {
   name          = "<%= ctx[:vars]['backend_subnet_name'] %>"
-  provider      = google
+  provider      = google-beta
   ip_cidr_range = "10.0.1.0/24"
   region        = "us-central1"
   network       = google_compute_network.default.id
@@ -20,13 +20,14 @@ resource "google_compute_subnetwork" "default" {
 
 # reserved IP address
 resource "google_compute_global_address" "default" {
+  provider = google-beta
   name = "<%= ctx[:vars]['address_name'] %>"
 }
 
 # forwarding rule
 resource "google_compute_global_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
   name                  = "<%= ctx[:vars]['forwarding_rule_name'] %>"
-  provider              = google
+  provider              = google-beta
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
   port_range            = "80"
@@ -37,14 +38,14 @@ resource "google_compute_global_forwarding_rule" "<%= ctx[:primary_resource_id] 
 # http proxy
 resource "google_compute_target_http_proxy" "default" {
   name     = "<%= ctx[:vars]['target_http_proxy_name'] %>"
-  provider = google
+  provider = google-beta
   url_map  = google_compute_url_map.default.id
 }
 
 # url map
 resource "google_compute_url_map" "default" {
   name            = "<%= ctx[:vars]['url_map_name'] %>"
-  provider        = google
+  provider        = google-beta
   default_service = google_compute_backend_service.default.id
 }
 
@@ -70,7 +71,7 @@ resource "google_compute_backend_service" "default" {
 # instance template
 resource "google_compute_instance_template" "default" {
   name         = "<%= ctx[:vars]['mig_template_name'] %>"
-  provider     = google
+  provider     = google-beta
   machine_type = "e2-small"
   tags         = ["allow-health-check"]
 
@@ -118,7 +119,7 @@ resource "google_compute_instance_template" "default" {
 # health check
 resource "google_compute_health_check" "default" {
   name     = "<%= ctx[:vars]['hc_name'] %>"
-  provider = google
+  provider = google-beta
   http_health_check {
     port_specification = "USE_SERVING_PORT"
   }
@@ -127,7 +128,7 @@ resource "google_compute_health_check" "default" {
 # MIG
 resource "google_compute_instance_group_manager" "default" {
   name     = "<%= ctx[:vars]['mig_name'] %>"
-  provider = google
+  provider = google-beta
   zone     = "us-central1-c"
   named_port {
     name = "http"
@@ -144,7 +145,7 @@ resource "google_compute_instance_group_manager" "default" {
 # allow access from health check ranges
 resource "google_compute_firewall" "default" {
   name          = "<%= ctx[:vars]['fw_allow_hc_name'] %>"
-  provider      = google
+  provider      = google-beta
   direction     = "INGRESS"
   network       = google_compute_network.default.id
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]

--- a/mmv1/templates/terraform/examples/external_tcp_proxy_lb_mig_backend_custom_header.tf.erb
+++ b/mmv1/templates/terraform/examples/external_tcp_proxy_lb_mig_backend_custom_header.tf.erb
@@ -4,14 +4,14 @@
 # VPC
 resource "google_compute_network" "default" {
   name                    = "<%= ctx[:vars]['tcp_proxy_xlb_network'] %>"
-  provider                = google
+  provider                = google-beta
   auto_create_subnetworks = false
 }
 
 # backend subnet
 resource "google_compute_subnetwork" "default" {
   name          = "<%= ctx[:vars]['tcp_proxy_xlb_subnet'] %>"
-  provider      = google
+  provider      = google-beta
   ip_cidr_range = "10.0.1.0/24"
   region        = "us-central1"
   network       = google_compute_network.default.id
@@ -19,13 +19,14 @@ resource "google_compute_subnetwork" "default" {
 
 # reserved IP address
 resource "google_compute_global_address" "default" {
+  provider = google-beta
   name = "<%= ctx[:vars]['tcp_proxy_xlb_ip'] %>"
 }
 
 # forwarding rule
 resource "google_compute_global_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
   name                  = "<%= ctx[:vars]['tcp_proxy_xlb_forwarding_rule'] %>"
-  provider              = google
+  provider              = google-beta
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
   port_range            = "110"
@@ -34,12 +35,14 @@ resource "google_compute_global_forwarding_rule" "<%= ctx[:primary_resource_id] 
 }
 
 resource "google_compute_target_tcp_proxy" "default" {
+  provider = google-beta
   name            = "<%= ctx[:vars]['test_proxy_health_check'] %>"
   backend_service = google_compute_backend_service.default.id
 }
 
 # backend service
 resource "google_compute_backend_service" "default" {
+  provider = google-beta
   name                  = "<%= ctx[:vars]['tcp_proxy_xlb_backend_service'] %>"
   protocol              = "TCP"
   port_name             = "tcp"
@@ -55,6 +58,7 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider = google-beta
   name               = "<%= ctx[:vars]['tcp_proxy_health_check'] %>"
   timeout_sec        = 1
   check_interval_sec = 1
@@ -67,7 +71,7 @@ resource "google_compute_health_check" "default" {
 # instance template
 resource "google_compute_instance_template" "default" {
   name         = "<%= ctx[:vars]['tcp_proxy_xlb_mig_template'] %>"
-  provider     = google
+  provider     = google-beta
   machine_type = "e2-small"
   tags         = ["allow-health-check"]
 
@@ -112,7 +116,7 @@ resource "google_compute_instance_template" "default" {
 # MIG
 resource "google_compute_instance_group_manager" "default" {
   name     = "<%= ctx[:vars]['tcp_proxy_xlb_mig1'] %>"
-  provider = google
+  provider = google-beta
   zone     = "us-central1-c"
   named_port {
     name = "tcp"
@@ -129,7 +133,7 @@ resource "google_compute_instance_group_manager" "default" {
 # allow access from health check ranges
 resource "google_compute_firewall" "default" {
   name          = "<%= ctx[:vars]['tcp_proxy_xlb_fw_allow_hc'] %>"
-  provider      = google
+  provider      = google-beta
   direction     = "INGRESS"
   network       = google_compute_network.default.id
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Not sure why this existed in its current state



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
