### PR TITLE
Add node_pool.managed_instance_group_urls with IG URL

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -160,6 +160,13 @@ var schemaNodePool = map[string]*schema.Schema{
 		Description: `The resource URLs of the managed instance groups associated with this node pool.`,
 	},
 
+	"managed_instance_group_urls": {
+		Type:        schema.TypeList,
+		Computed:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Description: `List of instance group URLs which have been assigned to this node pool.`,
+	},
+
 	"management": {
 		Type:        schema.TypeList,
 		Optional:    true,
@@ -786,6 +793,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodeP
 	// failed or something else strange happened, we'll just use the average size.
 	size := 0
 	igmUrls := []string{}
+	managedIgmUrls := []string{}
 	for _, url := range np.InstanceGroupUrls {
 		// retrieve instance group manager (InstanceGroupUrls are actually URLs for InstanceGroupManagers)
 		matches := instanceGroupManagerURL.FindStringSubmatch(url)
@@ -802,6 +810,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodeP
 		}
 		size += int(igm.TargetSize)
 		igmUrls = append(igmUrls, url)
+		managedIgmUrls = append(managedIgmUrls, igm.InstanceGroup)
 	}
 	nodeCount := 0
 	if len(igmUrls) > 0 {
@@ -815,6 +824,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodeP
 		"node_count":          nodeCount,
 		"node_config":         flattenNodeConfig(np.Config),
 		"instance_group_urls": igmUrls,
+		"managed_instance_group_urls": managedIgmUrls,
 		"version":             np.Version,
 <% unless version == 'ga' -%>
 		"network_config":      flattenNodeNetworkConfig(np.NetworkConfig, d, prefix),

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3428,7 +3428,7 @@ resource "google_compute_backend_service" "my-backend-service" {
   protocol  = "HTTP"
 
   backend {
-    group = element(google_container_cluster.primary.node_pool[0].instance_group_urls, 1)
+    group = element(google_container_cluster.primary.node_pool[0].managed_instance_group_urls, 1)
   }
 
   health_checks = [google_compute_http_health_check.default.self_link]

--- a/mmv1/third_party/terraform/website/docs/guides/version_4_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_4_upgrade.html.markdown
@@ -293,7 +293,7 @@ Unless explicitly configured, users may see a diff changing `enable_shielded_nod
 
 ### `instance_group_urls` is now removed
 
-`instance_group_urls` has been removed in favor of `node_pool.instance_group_urls`
+`instance_group_urls` has been removed in favor of `node_pool.managed_instance_group_urls`
 
 ### `master_auth.username` and `master_auth.password` are now removed
 

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -203,6 +203,8 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `instance_group_urls` - The resource URLs of the managed instance groups associated with this node pool.
 
+* `managed_instance_group_urls` - List of instance group URLs which have been assigned to this node pool.
+
 <a id="timeouts"></a>
 ## Timeouts
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Mirrors old value of cluster.instance_group_urls for use in backends.

Follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/5378


```
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -v -run=TestAccContainerCluster_backend -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccContainerCluster_backend
=== PAUSE TestAccContainerCluster_backend
=== CONT  TestAccContainerCluster_backend
--- PASS: TestAccContainerCluster_backend (394.77s)
PASS
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `managed_instance_group_urls` to `google_container_node_pool` to replace `instance_group_urls` on `google_container_cluster`
```
