### PR TITLE
Add region tag to Storage HMAC key Terraform sample

### DIFF
--- a/mmv1/templates/terraform/examples/storage_hmac_key.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_hmac_key.tf.erb
@@ -1,7 +1,11 @@
+# [START storage_hmac_key]
+# Create a new service account
 resource "google_service_account" "service_account" {
   account_id = "<%= ctx[:vars]['account_id'] %>"
 }
 
+#Create the HMAC key for the associated service account 
 resource "google_storage_hmac_key" "<%= ctx[:primary_resource_id] %>" {
   service_account_email = google_service_account.service_account.email
 }
+# [END storage_hmac_key]


### PR DESCRIPTION
Intended to the Terraform content on this page:

https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create

If this PR is for Terraform, I acknowledge that I have:

[x ] Searched through the issue tracker for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
[x ] Generated Terraform, and ran make test and make lint to ensure it passes unit and linter tests.
[ x] Ensured that all new fields I added that can be set by a user appear in at least one example (for generated resources) or third_party test (for handwritten resources or update tests).
[x ] Ran relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
[ x] Read the Release Notes Guide before writing my release note below.

```release-note:none
```
