### PR TITLE
fix membership check for vcr

### DIFF
--- a/.ci/containers/terraform-vcr-community/reverse_check_membership.sh
+++ b/.ci/containers/terraform-vcr-community/reverse_check_membership.sh
@@ -9,7 +9,7 @@ USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
 
 # This image runs tests for community PRs. This script reverses check_membership.sh to exit without running tests
 # for users for who tests are automatically run.
-if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson -e melinath -e scottsuarez -e shuyama1); then
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson -e melinath -e ScottSuarez -e shuyama1); then
 	echo "User is on the list, skipping."
 	exit 0
 else

--- a/.ci/containers/terraform-vcr-tester/check_membership.sh
+++ b/.ci/containers/terraform-vcr-tester/check_membership.sh
@@ -8,7 +8,7 @@ USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${pr_number}" | jq -r .user.login)
 
 # Only run tests for safe users
-if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson -e melinath -e scottsuarez -e shuyama1); then
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson -e melinath -e ScottSuarez -e shuyama1); then
 	echo "User is on the list, not skipping."
 else
 	echo "Checking GCP org membership"


### PR DESCRIPTION
I noticed vcr tests got skipped for me in this pr
https://github.com/GoogleCloudPlatform/magic-modules/pull/5419#pullrequestreview-796993824

strange that this just started happening
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
