### PR TITLE
Support timeouts override in tpgtools

### DIFF
--- a/tpgtools/override.go
+++ b/tpgtools/override.go
@@ -52,6 +52,7 @@ const (
 	CustomSerializer                   = "CUSTOM_SERIALIZER"
 	TerraformProductName               = "CUSTOM_TERRAFORM_PRODUCT_NAME"
 	UseDCLID                           = "USE_DCL_ID"
+	CustomTimeout                      = "CUSTOM_TIMEOUT"
 )
 
 // Field-level Overrides

--- a/tpgtools/override_details.go
+++ b/tpgtools/override_details.go
@@ -211,3 +211,8 @@ type ProductDocsSectionDetails struct {
 	// alternative name to be used for the product resources in docs.
 	DocsSection string
 }
+
+type CustomTimeoutDetails struct {
+	// The overriding Timeouts in Terraform
+	TimeoutMinutes int
+}

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -398,6 +398,19 @@ func createResource(schema *openapi.Schema, typeFetcher *TypeFetcher, overrides 
 		UseDCLID:             overrides.ResourceOverride(UseDCLID, location),
 	}
 
+	// Resource Override: Custom Timeout
+	ctd := CustomTimeoutDetails{}
+	ctdOk, err := overrides.ResourceOverrideWithDetails(CustomTimeout, &ctd, location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode custom timeout details: %v", err)
+	}
+
+	if ctdOk {
+		res.InsertTimeoutMinutes = ctd.TimeoutMinutes
+		res.UpdateTimeoutMinutes = ctd.TimeoutMinutes
+		res.DeleteTimeoutMinutes = ctd.TimeoutMinutes
+	}
+
 	crname := CustomResourceNameDetails{}
 	crnameOk, err := overrides.ResourceOverrideWithDetails(CustomResourceName, &crname, location)
 	if err != nil {

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -404,7 +404,6 @@ func createResource(schema *openapi.Schema, typeFetcher *TypeFetcher, overrides 
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode custom timeout details: %v", err)
 	}
-
 	if ctdOk {
 		res.InsertTimeoutMinutes = ctd.TimeoutMinutes
 		res.UpdateTimeoutMinutes = ctd.TimeoutMinutes


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Support custom timeouts override in tpgtools, while currently we have a 10-minute default timeout.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
