### PR TITLE
Fix pubsub_config and webhook_config

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -124,8 +124,6 @@ objects:
         exactly_one_of:
           - trigger_template
           - github
-          - pubsub_config
-          - webhook_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'projectId'
@@ -183,8 +181,6 @@ objects:
         exactly_one_of:
           - trigger_template
           - github
-          - pubsub_config
-          - webhook_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'owner'
@@ -255,8 +251,6 @@ objects:
         exactly_one_of:
           - trigger_template
           - github
-          - pubsub_config
-          - webhook_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'subscription'
@@ -286,8 +280,6 @@ objects:
         exactly_one_of:
           - trigger_template
           - github
-          - pubsub_config
-          - webhook_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'secret'


### PR DESCRIPTION
Cloudbuild API allows github and trigger_template to co-exist with
webhook_config and pubsub_config. This should be reflected here.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: allowed `pubsub_config` and `webhook_config` to be configured at the same time in `google_cloudbuild_trigger`
```
