### PR TITLE
getAssetName for all backend references since this url can include escaped words {{}}

### DIFF
--- a/mmv1/templates/validator/resource_converter.go.erb
+++ b/mmv1/templates/validator/resource_converter.go.erb
@@ -52,7 +52,7 @@ func Get<%= resource_name -%>CaiObject(d TerraformResourceData, config *Config) 
             Type: <%= resource_name -%>AssetType,
             Resource: &AssetResource{
                 Version: "<%= api_version -%>",
-                DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/<%= product_backend_name.downcase -%>/<%= api_version -%>/rest",
+                DiscoveryDocumentURI: assetName("https://www.googleapis.com/discovery/v1/apis/<%= product_backend_name.downcase -%>/<%= api_version -%>/rest"),
                 DiscoveryName: "<%= object.name -%>",
                 Data: obj,
             },

--- a/mmv1/templates/validator/resource_converter_iam.go.erb
+++ b/mmv1/templates/validator/resource_converter_iam.go.erb
@@ -122,7 +122,7 @@ func Fetch<%= resource_name -%>IamPolicy(d TerraformResourceData, config *Config
 		<%= resource_name -%>IamUpdaterProducer,
 		d,
 		config,
-		"//<%= product_backend_name.downcase  -%>.googleapis.com/{{<%= object.name.downcase -%>}}",
+		assetName("//<%= product_backend_name.downcase  -%>.googleapis.com/{{<%= object.name.downcase -%>}}"),
 		<%= resource_name -%>IAMAssetType,
 	)
 }


### PR DESCRIPTION
terraform validator internal change to get asset name for any references to backend_url

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
