### PR TITLE
support CUSTOM_TIMEOUT in tpgtools

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
@@ -549,7 +549,7 @@ func testAccCheckGkeHubFeatureMembershipPresent(t *testing.T, project, location,
       Project:    dcl.String(project),
     }
 
-    _, err := NewDCLGkeHubClient(config, "", "").GetFeatureMembership(context.Background(), obj)
+    _, err := NewDCLGkeHubClient(config, "", "", 0).GetFeatureMembership(context.Background(), obj)
     if err != nil {
       return err
     }
@@ -567,7 +567,7 @@ func testAccCheckGkeHubFeatureMembershipNotPresent(t *testing.T, project, locati
       Project:    dcl.String(project),
     }
 
-    _, err := NewDCLGkeHubClient(config, "", "").GetFeatureMembership(context.Background(), obj)
+    _, err := NewDCLGkeHubClient(config, "", "", 0).GetFeatureMembership(context.Background(), obj)
     if err == nil {
       return fmt.Errorf("Did not expect to find GKE Feature Membership for projects/%s/locations/%s/features/%s/membershipId/%s", project, location, feature, membership)
     }

--- a/tpgtools/override.go
+++ b/tpgtools/override.go
@@ -52,6 +52,7 @@ const (
 	CustomSerializer                   = "CUSTOM_SERIALIZER"
 	TerraformProductName               = "CUSTOM_TERRAFORM_PRODUCT_NAME"
 	UseDCLID                           = "USE_DCL_ID"
+	CustomTimeout                      = "CUSTOM_TIMEOUT"
 )
 
 // Field-level Overrides

--- a/tpgtools/override_details.go
+++ b/tpgtools/override_details.go
@@ -212,3 +212,7 @@ type ProductDocsSectionDetails struct {
 	DocsSection string
 }
 
+type CustomTimeoutDetails struct {
+	// The overriding Timeouts in Terraform
+	TimeoutMinutes int
+}

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -392,10 +392,22 @@ func createResource(schema *openapi.Schema, typeFetcher *TypeFetcher, overrides 
 		versionMetadata:      version,
 		Description:          schema.Description,
 		location:             location,
-		InsertTimeoutMinutes: 30,
-		UpdateTimeoutMinutes: 30,
-		DeleteTimeoutMinutes: 30,
+		InsertTimeoutMinutes: 10,
+		UpdateTimeoutMinutes: 10,
+		DeleteTimeoutMinutes: 10,
 		UseDCLID:             overrides.ResourceOverride(UseDCLID, location),
+	}
+
+	// Resource Override: Custom Timeout
+	ctd := CustomTimeoutDetails{}
+	ctdOk, err := overrides.ResourceOverrideWithDetails(CustomTimeout, &ctd, location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode custom timeout details: %v", err)
+	}
+	if ctdOk {
+		res.InsertTimeoutMinutes = ctd.TimeoutMinutes
+		res.UpdateTimeoutMinutes = ctd.TimeoutMinutes
+		res.DeleteTimeoutMinutes = ctd.TimeoutMinutes
 	}
 
 	crname := CustomResourceNameDetails{}

--- a/tpgtools/templates/provider_dcl_client_creation.go.tmpl
+++ b/tpgtools/templates/provider_dcl_client_creation.go.tmpl
@@ -37,13 +37,16 @@ import (
 )
 
 {{range $index, $pkg := .}}
-func NewDCL{{$pkg.ProductType}}Client(config *Config, userAgent, billingProject string ) *{{$pkg.PackageName}}.Client {
+func NewDCL{{$pkg.ProductType}}Client(config *Config, userAgent, billingProject string, timeout time.Duration) *{{$pkg.PackageName}}.Client {
 	configOptions := []dcl.ConfigOption{
 		dcl.WithHTTPClient(config.client),
 		dcl.WithUserAgent(userAgent),
 		dcl.WithLogger(dclLogger{}),
-		dcl.WithTimeout(30 * time.Minute),
 		dcl.WithBasePath(config.{{$pkg.BasePathIdentifier}}BasePath),
+	}
+
+	if (timeout != 0){
+		configOptions = append(configOptions, dcl.WithTimeout(timeout))
 	}
 
 	if config.UserProjectOverride {

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -265,7 +265,7 @@ should be converted to use the DCL's ID method, so normalization can be uniform.
 	if bp, err := getBillingProject(d, config); err == nil {
 		billingProject = bp
 	}
-	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
+	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject, d.Timeout(schema.TimeoutCreate))
 	{{- if $.AppendToBasePath }}
 	client.Config.BasePath += "{{$.AppendToBasePath}}"
 	{{- end }}
@@ -339,7 +339,7 @@ func resource{{$.PathType}}Read(d *schema.ResourceData, meta interface{}) error 
 	if bp, err := getBillingProject(d, config); err == nil {
 		billingProject = bp
 	}
-	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
+	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject, d.Timeout(schema.TimeoutRead))
 	{{- if $.AppendToBasePath }}
 	client.Config.BasePath += "{{$.AppendToBasePath}}"
 	{{- end }}
@@ -415,7 +415,7 @@ func resource{{$.PathType}}Update(d *schema.ResourceData, meta interface{}) erro
 	if bp, err := getBillingProject(d, config); err == nil {
 		billingProject = bp
 	}
-	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
+	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject, d.Timeout(schema.TimeoutUpdate))
 	{{- if $.AppendToBasePath }}
 	client.Config.BasePath += "{{$.AppendToBasePath}}"
 	{{- end }}
@@ -494,7 +494,7 @@ func resource{{$.PathType}}Delete(d *schema.ResourceData, meta interface{}) erro
 	if bp, err := getBillingProject(d, config); err == nil {
 		billingProject = bp
 	}
-	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
+	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject, d.Timeout(schema.TimeoutDelete))
 	{{- if $.AppendToBasePath }}
 	client.Config.BasePath += "{{$.AppendToBasePath}}"
 	{{- end }}

--- a/tpgtools/templates/sweeper.go.tmpl
+++ b/tpgtools/templates/sweeper.go.tmpl
@@ -71,7 +71,7 @@ func testSweep{{$.SweeperName}}(region string) error {
 		"billing_account":billingId,
 	}
 
-	client := NewDCL{{$.ProductType}}Client(config, config.userAgent, "")
+	client := NewDCL{{$.ProductType}}Client(config, config.userAgent, "", 0)
 	err = client.DeleteAll{{$.DCLTitle}}(context.Background(), {{$.SweeperFunctionArgs}} isDeletable{{$.SweeperName}})
 	if err != nil {
 		return err

--- a/tpgtools/templates/test_file.go.tmpl
+++ b/tpgtools/templates/test_file.go.tmpl
@@ -130,7 +130,7 @@ func testAccCheck{{$.PathType}}DestroyProducer(t *testing.T) func(s *terraform.S
 				{{- end }}
 			}
 
-			client := NewDCL{{$.ProductType}}Client(config, config.userAgent, billingProject)
+			client := NewDCL{{$.ProductType}}Client(config, config.userAgent, billingProject, 0)
 			_, err := client.Get{{$.DCLTitle}}(context.Background(), obj)
 			if err == nil {
 				return fmt.Errorf("{{$.TerraformName}} still exists %v", obj)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Support CUSTOM_TIMEOUT override in tpgtools which can override the DCL client timeout now. 
Also change the default timeout back to 10m, which was bumped to 30m as a short-term solution in a previous PR https://github.com/GoogleCloudPlatform/magic-modules/pull/5429


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
