### PR TITLE
resource_storage_bucket_object: add arg content_base64

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -41,10 +41,12 @@ The following arguments are supported:
 
 One of the following is required:
 
-* `content` - (Optional, Sensitive) Data as `string` to be uploaded. Must be defined if `source` is not. **Note**: The `content` field is marked as sensitive. To view the raw contents of the object, please define an [output](/docs/configuration/outputs.html).
+* `content_base64` - (Optional, Sensitive) Data as base64 encoded `string` to be uploaded. Must be defined if `source` and `content` are not. **Note**: The `content` field is marked as sensitive. To view the raw contents of the object, please define an [output](/docs/configuration/outputs.html).
 
-* `source` - (Optional) A path to the data you want to upload. Must be defined
-    if `content` is not.
+* `content` - (Optional, Sensitive) Data as `string` to be uploaded. Must be defined if `source` and `content_base64` are not. **Note**: The `content` field is marked as sensitive. To view the raw contents of the object, please define an [output](/docs/configuration/outputs.html).
+
+* `source` - (Optional) A path to the data you want to upload. Must be defined if `content` and `content_base64`
+    if `content` and `content_base64` are not.
 
 - - -
 


### PR DESCRIPTION
Add a new argument that can be used to upload binary data to a GCS blob.

It can be used in conjunction with filebase64() or any other base64 property.


If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](hhttps://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).

I cannot run the GCS test in the /experimental folder due to policies

- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


```release-note:enhancement
Add a new argument that can be used to upload binary data to a GCS blob.
```