### PR TITLE
Redis MRR Support

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -192,7 +192,7 @@ objects:
         description: |
           The TLS mode of the Redis instance, If not provided, TLS is disabled for the instance.
 
-          - SERVER_AUTHENTICATION: Client to Server traffic encryption enabled with server authentcation
+          - SERVER_AUTHENTICATION: Client to Server traffic encryption enabled with server authentication
         values:
           - :SERVER_AUTHENTICATION
           - :DISABLED
@@ -232,13 +232,15 @@ objects:
       - !ruby/object:Api::Type::Integer
         name: replicaCount
         description: |
-          Optional. The number of replica nodes. Valid range for standard tier is [1-5]
-          and defaults to 2. Valid value for basic tier is 0 and defaults to 0.
+          Optional. The number of replica nodes. The valid range for the Standard Tier with 
+          read replicas enabled is [1-5] and defaults to 2. If read replicas are not enabled
+          for a Standard Tier instance, the only valid value is 1 and the default is 1. 
+          The valid value for basic tier is 0 and the default is also 0.
         min_version: beta
       - !ruby/object:Api::Type::Array
         name: nodes
         description: |
-          Info per node
+          Output only. Info per node.
         output: true
         min_version: beta
         item_type: !ruby/object:Api::Type::NestedObject
@@ -256,22 +258,22 @@ objects:
       - !ruby/object:Api::Type::String
         name: readEndpoint
         description: |
-          Hostname or IP address of the exposed readonly Redis endpoint. Standard tier only. 
-          Targets all healthy replica nodes in instance. Replication is asynchronous and replica 
-          nodes will exhibit some lag behind the primary. Write requests must target 'host'.
+          Output only. Hostname or IP address of the exposed readonly Redis endpoint. Standard tier only.
+          Targets all healthy replica nodes in instance. Replication is asynchronous and replica nodes
+          will exhibit some lag behind the primary. Write requests must target 'host'.
         output: true
         min_version: beta
       - !ruby/object:Api::Type::Integer
         name: readEndpointPort
         description: |
-          The port number of the exposed readonly redis endpoint. Standard tier only. 
+          Output only. The port number of the exposed readonly redis endpoint. Standard tier only. 
           Write requests should target 'port'.
         output: true
         min_version: beta
       - !ruby/object:Api::Type::Enum
         name: readReplicasMode
         description: |
-          Optional. Read replica mode.
+          Optional. Read replica mode. Can only be specified when trying to create the instance.
           If not set, Memorystore Redis backend will default to READ_REPLICAS_DISABLED.
           - READ_REPLICAS_DISABLED: If disabled, read endpoint will not be provided and the 
           instance cannot scale up or down the number of replicas.

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -284,3 +284,4 @@ objects:
           - :READ_REPLICAS_ENABLED
         default_value: :READ_REPLICAS_DISABLED
         min_version: beta
+        input: true

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -229,3 +229,56 @@ objects:
               output: true
               description: |
                 Sha1 Fingerprint of the certificate.
+      - !ruby/object:Api::Type::Integer
+        name: replicaCount
+        description: |
+          Optional. The number of replica nodes. Valid range for standard tier is [1-5]
+          and defaults to 2. Valid value for basic tier is 0 and defaults to 0.
+        min_version: beta
+      - !ruby/object:Api::Type::Array
+        name: nodes
+        description: |
+          Info per node
+        output: true
+        min_version: beta
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'id'
+              output: true
+              description: |
+                Node identifying string. e.g. 'node-0', 'node-1'
+            - !ruby/object:Api::Type::String
+              name: 'zone'
+              output: true
+              description: |
+                Location of the node.
+      - !ruby/object:Api::Type::String
+        name: readEndpoint
+        description: |
+          Hostname or IP address of the exposed readonly Redis endpoint. Standard tier only. 
+          Targets all healthy replica nodes in instance. Replication is asynchronous and replica 
+          nodes will exhibit some lag behind the primary. Write requests must target 'host'.
+        output: true
+        min_version: beta
+      - !ruby/object:Api::Type::Integer
+        name: readEndpointPort
+        description: |
+          The port number of the exposed readonly redis endpoint. Standard tier only. 
+          Write requests should target 'port'.
+        output: true
+        min_version: beta
+      - !ruby/object:Api::Type::Enum
+        name: readReplicasMode
+        description: |
+          Optional. Read replica mode.
+          If not set, Memorystore Redis backend will pick the mode based on other fields in the request.
+          - READ_REPLICAS_DISABLED: If disabled, read endpoint will not be provided and the 
+          instance cannot scale up or down the number of replicas.
+          - READ_REPLICAS_ENABLED: If enabled, read endpoint will be provided and the instance 
+          can scale up and down the number of replicas.
+        values:
+          - :READ_REPLICAS_DISABLED
+          - :READ_REPLICAS_ENABLED
+        default_value: :READ_REPLICAS_DISABLED
+        min_version: beta

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -272,7 +272,7 @@ objects:
         name: readReplicasMode
         description: |
           Optional. Read replica mode.
-          If not set, Memorystore Redis backend will pick the mode based on other fields in the request.
+          If not set, Memorystore Redis backend will default to READ_REPLICAS_DISABLED.
           - READ_REPLICAS_DISABLED: If disabled, read endpoint will not be provided and the 
           instance cannot scale up or down the number of replicas.
           - READ_REPLICAS_ENABLED: If enabled, read endpoint will be provided and the instance 

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -53,6 +53,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "redis-test-network"
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "redis-private")'
+      - !ruby/object:Provider::Terraform::Examples
+        name: "redis_instance_mrr"
+        primary_resource_id: "cache"
+        vars:
+          instance_name: "mrr-memory-cache"
+          network_name: "redis-test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-mrr")'
+        min_version: beta
     properties:
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
@@ -60,7 +69,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
         custom_expand: 'templates/terraform/custom_expand/redis_instance_authorized_network.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-      locationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -69,6 +69,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
         custom_expand: 'templates/terraform/custom_expand/redis_instance_authorized_network.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
+      locationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -86,6 +86,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       reservedIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      replicaCount: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/examples/redis_instance_mrr.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_mrr.tf.erb
@@ -11,7 +11,7 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
 
   redis_version     = "REDIS_6_X"
   display_name      = "Terraform Test Instance"
-  reserved_ip_range = "192.168.0.0/29"
+  reserved_ip_range = "192.168.0.0/28"
   replica_count     = 5
   read_replicas_mode = "READ_REPLICAS_ENABLED"
 

--- a/mmv1/templates/terraform/examples/redis_instance_mrr.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_mrr.tf.erb
@@ -1,0 +1,34 @@
+resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name           = "<%= ctx[:vars]['instance_name'] %>"
+  tier           = "STANDARD_HA"
+  memory_size_gb = 5
+
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
+
+  authorized_network = data.google_compute_network.redis-network.id
+
+  redis_version     = "REDIS_6_X"
+  display_name      = "Terraform Test Instance"
+  reserved_ip_range = "192.168.0.0/29"
+  replica_count     = 5
+  read_replicas_mode = "READ_REPLICAS_ENABLED"
+
+  labels = {
+    my_key    = "my_val"
+    other_key = "other_val"
+  }
+}
+
+// This example assumes this network already exists.
+// The API creates a tenant network per network authorized for a
+// Redis instance and that network is not deleted when the user-created
+// network (authorized_network) is deleted, so this prevents issues
+// with tenant network quota.
+// If this network hasn't been created and you are using this example in your
+// config, add an additional network resource or change
+// this from "data"to "resource"
+data "google_compute_network" "redis-network" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}


### PR DESCRIPTION
Changes to support Multi read replica feature on Cloud Memorystor redis

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). - Unable to run these tests target testacc unavailable
- [ X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: Added Multi read replica field `replicaCount `, `nodes`,  `readEndpoint`, `readEndpointPort`, `readReplicasMode` in `google_redis_instance `

```
