### PR TITLE
remove send_empty_value for max_ttl

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -182,7 +182,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         send_empty_value: true
       cdnPolicy.maxTtl: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-        send_empty_value: true
       cdnPolicy.signedUrlCacheMaxAgeSec: !ruby/object:Overrides::Terraform::PropertyOverride
         send_empty_value: true
       cdnPolicy.negativeCachingPolicy.ttl: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
@@ -68,7 +68,7 @@ func TestAccComputeBackendBucket_withCdnPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendBucket_withCdnPolicy2(backendName, storageName, 0, 404, 0, 0),
+				Config: testAccComputeBackendBucket_withCdnPolicy2(backendName, storageName, 0, 404, 86400, 0),
 			},
 			{
 				ResourceName:      "google_compute_backend_bucket.foobar",
@@ -77,6 +77,14 @@ func TestAccComputeBackendBucket_withCdnPolicy(t *testing.T) {
 			},
 			{
 				Config: testAccComputeBackendBucket_withCdnPolicy(backendName, storageName),
+			},
+			{
+				ResourceName:      "google_compute_backend_bucket.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendBucket_withCdnPolicy3(backendName, storageName, 0, 404, 0, 0),
 			},
 			{
 				ResourceName:      "google_compute_backend_bucket.foobar",
@@ -146,6 +154,34 @@ resource "google_compute_backend_bucket" "foobar" {
   enable_cdn  = true
   cdn_policy {
 	cache_mode                   = "CACHE_ALL_STATIC"
+	signed_url_cache_max_age_sec = %d
+	max_ttl                      = %d
+	default_ttl                  = %d
+	client_ttl                   = %d
+	serve_while_stale            = %d
+	negative_caching_policy {
+		code = %d
+		ttl = %d
+	}
+	negative_caching = true
+  }
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "EU"
+}
+`, backendName, age, max_ttl, ttl, ttl, ttl, code, ttl, storageName)
+}
+
+func testAccComputeBackendBucket_withCdnPolicy3(backendName, storageName string, age, code, max_ttl, ttl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_bucket" "foobar" {
+  name        = "%s"
+  bucket_name = google_storage_bucket.bucket.name
+  enable_cdn  = true
+  cdn_policy {
+	cache_mode                   = "FORCE_CACHE_ALL"
 	signed_url_cache_max_age_sec = %d
 	max_ttl                      = %d
 	default_ttl                  = %d


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10560


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a bug when `cache_mode` is set to FORCE_CACHE_ALL on `google_compute_backend_bucket`
```
