### PR TITLE
Add support for bigquery_table resource to terraform-validator.

### DIFF
--- a/mmv1/templates/validator/resource_converters.go.erb
+++ b/mmv1/templates/validator/resource_converters.go.erb
@@ -48,6 +48,7 @@ func ResourceConverters() map[string][]ResourceConverter {
 		"google_bigquery_dataset_iam_policy":              {resourceConverterBigqueryDatasetIamPolicy()},
 		"google_bigquery_dataset_iam_binding":             {resourceConverterBigqueryDatasetIamBinding()},
 		"google_bigquery_dataset_iam_member":              {resourceConverterBigqueryDatasetIamMember()},
+		"google_bigquery_table":                           {resourceConverterBigQueryTable()},
 		"google_spanner_instance":                         {resourceConverterSpannerInstance()},
 		"google_project_service":                          {resourceConverterServiceUsage()},
 		"google_pubsub_subscription":                      {resourceConverterPubsubSubscription()},

--- a/mmv1/third_party/validator/bigquery_table.go
+++ b/mmv1/third_party/validator/bigquery_table.go
@@ -4,25 +4,34 @@ import (
 	"reflect"
 )
 
-func GetBigQueryTableCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+const BigQueryTableAssetType string = "bigquery.googleapis.com/Table"
+
+func resourceConverterBigQueryTable() ResourceConverter {
+	return ResourceConverter{
+		AssetType: BigQueryTableAssetType,
+		Convert:   GetBigQueryTableCaiObject,
+	}
+}
+
+func GetBigQueryTableCaiObject(d TerraformResourceData, config *Config) ([]Asset, error) {
 	name, err := assetName(d, config, "//bigquery.googleapis.com/projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
 
 	if err != nil {
-		return Asset{}, err
+		return []Asset{}, err
 	}
 	if obj, err := GetBigQueryTableApiObject(d, config); err == nil {
-		return Asset{
+		return []Asset{{
 			Name: name,
-			Type: "bigquery.googleapis.com/Table",
+			Type: BigQueryTableAssetType,
 			Resource: &AssetResource{
 				Version:              "v2",
 				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
 				DiscoveryName:        "Table",
 				Data:                 obj,
 			},
-		}, nil
+		}}, nil
 	} else {
-		return Asset{}, err
+		return []Asset{}, err
 	}
 }
 
@@ -36,7 +45,7 @@ func GetBigQueryTableApiObject(d TerraformResourceData, config *Config) (map[str
 		obj["tableReference"] = tableReferenceProp
 	}
 
-    descriptionProp, err := expandBigQueryTableDescription(d.Get("description"), d, config)
+	descriptionProp, err := expandBigQueryTableDescription(d.Get("description"), d, config)
 	if err != nil {
 		return nil, err
 	} else if v, ok := d.GetOkExists("description"); !isEmptyValue(reflect.ValueOf(descriptionProp)) && (ok || !reflect.DeepEqual(v, descriptionProp)) {
@@ -49,7 +58,7 @@ func GetBigQueryTableApiObject(d TerraformResourceData, config *Config) (map[str
 	} else if v, ok := d.GetOkExists("friendly_name"); !isEmptyValue(reflect.ValueOf(friendlyNameProp)) && (ok || !reflect.DeepEqual(v, friendlyNameProp)) {
 		obj["friendlyName"] = friendlyNameProp
 	}
-	
+
 	labelsProp, err := expandBigQueryTableLabels(d.Get("labels"), d, config)
 	if err != nil {
 		return nil, err
@@ -63,7 +72,7 @@ func GetBigQueryTableApiObject(d TerraformResourceData, config *Config) (map[str
 	} else if v, ok := d.GetOkExists("location"); !isEmptyValue(reflect.ValueOf(locationProp)) && (ok || !reflect.DeepEqual(v, locationProp)) {
 		obj["location"] = locationProp
 	}
-	
+
 	expirationTimeProp, err := expandBigQueryTableExpirationTime(nil, d, config)
 	if err != nil {
 		return nil, err
@@ -90,7 +99,7 @@ func GetBigQueryTableApiObject(d TerraformResourceData, config *Config) (map[str
 
 func expandBigQueryTableTableReference(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	transformed := make(map[string]interface{})
-	
+
 	transformedProjectId, err := expandBigQueryTableTableReferenceProjectId(d.Get("project"), d, config)
 	if err != nil {
 		return nil, err
@@ -109,7 +118,7 @@ func expandBigQueryTableTableReference(v interface{}, d TerraformResourceData, c
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedTableId); val.IsValid() && !isEmptyValue(val) {
-		transformed["tableId"] = transformedDatasetId
+		transformed["tableId"] = transformedTableId
 	}
 
 	return transformed, nil
@@ -117,7 +126,7 @@ func expandBigQueryTableTableReference(v interface{}, d TerraformResourceData, c
 
 func expandBigQueryTableExpirationTime(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	transformed := make(map[string]interface{})
-	
+
 	transformedExpirationTimeValue, err := expandBigQueryTableExpirationTimeValue(d.Get("expiration_time"), d, config)
 
 	if err != nil {
@@ -139,7 +148,7 @@ func expandBigQueryTableEncyptionConfiguration(v interface{}, d TerraformResourc
 	transformed := make(map[string]interface{})
 
 	transformedKmsKeyName, err := expandBigQueryTableEncyptionConfigurationKmsKeyName(original["kms_key_name"], d, config)
-	
+
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedKmsKeyName); val.IsValid() && !isEmptyValue(val) {
@@ -178,7 +187,7 @@ func expandBigQueryTableTimePartition(v interface{}, d TerraformResourceData, co
 	transformed := make(map[string]interface{})
 
 	transformedType, err := expandBigQueryTableTimePartitionType(original["type"], d, config)
-	
+
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedType); val.IsValid() && !isEmptyValue(val) {
@@ -186,7 +195,7 @@ func expandBigQueryTableTimePartition(v interface{}, d TerraformResourceData, co
 	}
 
 	transformedExpirationMs, err := expandBigQueryTableTimePartitionExpirationMs(original["expiration_ms"], d, config)
-	
+
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedExpirationMs); val.IsValid() && !isEmptyValue(val) {
@@ -194,15 +203,15 @@ func expandBigQueryTableTimePartition(v interface{}, d TerraformResourceData, co
 	}
 
 	transformedField, err := expandBigQueryTableTimeField(original["field"], d, config)
-	
+
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedField); val.IsValid() && !isEmptyValue(val) {
 		transformed["field"] = transformedField
 	}
-	
+
 	transformedRequirePartitionFilter, err := expandBigQueryTableRequirePartitionFilter(original["require_partition_filter"], d, config)
-	
+
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedRequirePartitionFilter); val.IsValid() && !isEmptyValue(val) {
@@ -221,7 +230,7 @@ func expandBigQueryTableTimePartitionExpirationMs(v interface{}, d TerraformReso
 
 func expandBigQueryTableTimeField(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	transformed := make(map[string]interface{})
-	
+
 	transformedValue, err := expandBigQueryTableTimeFieldValue(v, d, config)
 
 	if err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added google_bigquery_table entry to resource_converters.go.erb for adding support in tfv.
Updated the handwritten converter for bigquery_table resource to conform to resourceConverter interface.
Fixed a small bug in the converter which was wrongly setting `tableId` field to the value of `datasetId` field.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
