### PR TITLE
Made cloud identity groups updatable and updated documentation

### DIFF
--- a/mmv1/products/cloudidentity/api.yaml
+++ b/mmv1/products/cloudidentity/api.yaml
@@ -129,13 +129,16 @@ objects:
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         required: true
-        input: true
         description: |
-          The labels that apply to the Group.
+          One or more label entries that apply to the Group. Currently supported labels contain a key with an empty value.
 
-          Must not contain more than one entry. Must contain the entry
-          'cloudidentity.googleapis.com/groups.discussion_forum': '' if the Group is a Google Group or
-          'system/groups/external': '' if the Group is an external-identity-mapped group.
+          Google Groups are the default type of group and have a label with a key of cloudidentity.googleapis.com/groups.discussion_forum and an empty value.
+
+          Existing Google Groups can have an additional label with a key of cloudidentity.googleapis.com/groups.security and an empty value added to them. This is an immutable change and the security label cannot be removed once added.
+
+          Dynamic groups have a label with a key of cloudidentity.googleapis.com/groups.dynamic.
+
+          Identity-mapped groups for Cloud Search have a label with a key of system/groups/external and an empty value.
   - !ruby/object:Api::Resource
     name: 'GroupMembership'
     base_url: '{{group}}/memberships'

--- a/mmv1/third_party/terraform/tests/resource_cloud_identity_group_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_identity_group_test.go
@@ -44,6 +44,7 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
 
   labels = {
     "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+    "cloudidentity.googleapis.com/groups.security" = ""
   }
 }
 `, context)


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/7991

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudidentity: for group resource, made security label settable by making labels updatable
```
