### PR TITLE
Add missing HELM format in the artifact registry repository resource

### DIFF
--- a/mmv1/products/artifactregistry/api.yaml
+++ b/mmv1/products/artifactregistry/api.yaml
@@ -99,6 +99,8 @@ objects:
         - PYTHON ([Preview](https://cloud.google.com/products#product-launch-stages))
         - APT ([alpha](https://cloud.google.com/products#product-launch-stages))
         - YUM ([alpha](https://cloud.google.com/products#product-launch-stages))
+        - HELM ([alpha](https://cloud.google.com/products#product-launch-stages))
+        
       required: true
       input: true
     - !ruby/object:Api::Type::String


### PR DESCRIPTION
## Description

Add the missing HELM format in the `google_artifact_registry_repository` resource.

Related to [Artifact registry documentation](https://cloud.google.com/artifact-registry/docs/helm).

Related to https://github.com/hashicorp/terraform-provider-google-beta/pull/3762

```release-note:none
```