### PR TITLE
Cloud composer maintenance window GA

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -359,7 +359,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										AtLeastOneOf: composerSoftwareConfigKeys,
 										Elem:         &schema.Schema{Type: schema.TypeString},
 										ValidateFunc: validateComposerEnvironmentEnvVariables,
-										Description:  `Additional environment variables to provide to the Apache Airflow schedulerf, worker, and webserver processes. Environment variable names must match the regular expression [a-zA-Z_][a-zA-Z0-9_]*. They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+), and they cannot match any of the following reserved names: AIRFLOW_HOME C_FORCE_ROOT CONTAINER_NAME DAGS_FOLDER GCP_PROJECT GCS_BUCKET GKE_CLUSTER_NAME SQL_DATABASE SQL_INSTANCE SQL_PASSWORD SQL_PROJECT SQL_REGION SQL_USER.`,
+										Description:  `Additional environment variables to provide to the Apache Airflow scheduler, worker, and webserver processes. Environment variable names must match the regular expression [a-zA-Z_][a-zA-Z0-9_]*. They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+), and they cannot match any of the following reserved names: AIRFLOW_HOME C_FORCE_ROOT CONTAINER_NAME DAGS_FOLDER GCP_PROJECT GCS_BUCKET GKE_CLUSTER_NAME SQL_DATABASE SQL_INSTANCE SQL_PASSWORD SQL_PROJECT SQL_REGION SQL_USER.`,
 									},
 									"image_version": {
 										Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -60,9 +60,7 @@ var (
 		"config.0.database_config",
 		"config.0.web_server_config",
 		"config.0.encryption_config",
-<% unless version == "ga" -%>
 		"config.0.maintenance_window",
-<% end -%>
 		"config.0.workloads_config",
 		"config.0.environment_size",
 <% unless version == "ga" -%>
@@ -530,7 +528,6 @@ func resourceComposerEnvironment() *schema.Resource {
 								},
 							},
 						},
-<% unless version == "ga" -%>
 						"maintenance_window": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -561,8 +558,6 @@ func resourceComposerEnvironment() *schema.Resource {
 								},
 							},
 						},
-<% end -%>
-
 						"workloads_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -992,7 +987,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-<% unless version == "ga" -%>
 		if d.HasChange("config.0.maintenance_window") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {
@@ -1003,7 +997,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
-<% end -%>
+
 		if d.HasChange("config.0.workloads_config") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {
@@ -1158,9 +1152,7 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
 	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
 	transformed["encryption_config"] = flattenComposerEnvironmentConfigEncryptionConfig(envCfg.EncryptionConfig)
-<% unless version == "ga" -%>
 	transformed["maintenance_window"] = flattenComposerEnvironmentConfigMaintenanceWindow(envCfg.MaintenanceWindow)
-<% end -%>
 	transformed["workloads_config"] = flattenComposerEnvironmentConfigWorkloadsConfig(envCfg.WorkloadsConfig)
 	transformed["environment_size"] = envCfg.EnvironmentSize
 <% unless version == "ga" -%>
@@ -1223,8 +1215,6 @@ func flattenComposerEnvironmentConfigEncryptionConfig(encryptionCfg *composer.En
 	return []interface{}{transformed}
 }
 
-<% unless version == "ga" -%>
-
 func flattenComposerEnvironmentConfigMaintenanceWindow(maintenanceWindow *composer.MaintenanceWindow) interface{} {
 	if maintenanceWindow == nil {
 		return nil
@@ -1237,8 +1227,6 @@ func flattenComposerEnvironmentConfigMaintenanceWindow(maintenanceWindow *compos
 
 	return []interface{}{transformed}
 }
-
-<% end -%>
 
 func flattenComposerEnvironmentConfigWorkloadsConfig(workloadsConfig *composer.WorkloadsConfig) interface{} {
 	if workloadsConfig == nil {
@@ -1453,13 +1441,11 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 	}
 	transformed.EncryptionConfig = transformedEncryptionConfig
 
-<% unless version == "ga" -%>
 	transformedMaintenanceWindow, err := expandComposerEnvironmentConfigMaintenanceWindow(original["maintenance_window"], d, config)
 	if err != nil {
 		return nil, err
 	}
 	transformed.MaintenanceWindow = transformedMaintenanceWindow
-<% end -%>
 	transformedWorkloadsConfig, err := expandComposerEnvironmentConfigWorkloadsConfig(original["workloads_config"], d, config)
 	if err != nil {
 		return nil, err
@@ -1589,7 +1575,6 @@ func expandComposerEnvironmentConfigEncryptionConfig(v interface{}, d *schema.Re
 	return transformed, nil
 }
 
-<% unless version == "ga" -%>
 func expandComposerEnvironmentConfigMaintenanceWindow(v interface{}, d *schema.ResourceData, config *Config) (*composer.MaintenanceWindow, error) {
 	l := v.([]interface{})
 	if len(l) == 0 {
@@ -1613,8 +1598,6 @@ func expandComposerEnvironmentConfigMaintenanceWindow(v interface{}, d *schema.R
 
 	return transformed, nil
 }
-
-<% end -%>
 
 func expandComposerEnvironmentConfigWorkloadsConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.WorkloadsConfig, error) {
 	l := v.([]interface{})

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -326,7 +326,6 @@ func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
   })
 }
 
-<% unless version == "ga" -%>
 func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
   t.Parallel()
 
@@ -360,7 +359,6 @@ func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
     },
   })
 }
-<% end -%>
 
 func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
   t.Parallel()
@@ -1143,7 +1141,7 @@ resource "google_compute_subnetwork" "test" {
 `, pid, kmsKey, name, kmsKey, network, subnetwork)
 }
 
-<% unless version == "ga" -%>
+
 func testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
@@ -1172,9 +1170,8 @@ resource "google_compute_subnetwork" "test" {
 
 `, envName, network, subnetwork)
 }
-<% end -%>
 
-func testAccComposerEnvironment_composerV2(envName, network, subnetwork string) string {
+func testAccComposerEnvironment_composerV2(pid, envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_composer_image_versions" "all" {
 }

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -329,7 +329,6 @@ func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
 func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
   t.Parallel()
 
-  pid := getTestProjectFromEnv()
   envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
   network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
   subnetwork := network + "-1"
@@ -340,7 +339,7 @@ func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
     CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork),
+        Config: testAccComposerEnvironment_maintenanceWindow(envName, network, subnetwork),
       },
       {
         ResourceName:      "google_composer_environment.test",
@@ -353,11 +352,47 @@ func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
       {
         PlanOnly:           true,
         ExpectNonEmptyPlan: false,
-        Config:             testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork),
+        Config:             testAccComposerEnvironment_maintenanceWindow(envName, network, subnetwork),
         Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
       },
     },
   })
+}
+
+func TestAccComposerEnvironment_maintenanceWindowUpdate(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_maintenanceWindow(envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_maintenanceWindowUpdate(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO: Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_maintenanceWindowUpdate(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
 }
 
 func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
@@ -1142,7 +1177,7 @@ resource "google_compute_subnetwork" "test" {
 }
 
 
-func testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork string) string {
+func testAccComposerEnvironment_maintenanceWindow(envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
 	name   = "%s"
@@ -1171,7 +1206,36 @@ resource "google_compute_subnetwork" "test" {
 `, envName, network, subnetwork)
 }
 
-func testAccComposerEnvironment_composerV2(pid, envName, network, subnetwork string) string {
+func testAccComposerEnvironment_maintenanceWindowUpdate(envName, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		maintenance_window {
+			start_time = "2019-08-01T01:00:00Z"
+			end_time = "2019-08-01T07:00:00Z"
+			recurrence = "FREQ=DAILY"
+		}
+	}
+}
+
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+
+`, envName, network, subnetwork)
+}
+
+func testAccComposerEnvironment_composerV2(envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_composer_image_versions" "all" {
 }

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -656,7 +656,7 @@ The `config` block supports:
   below.
 
 * `maintenance_window` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  (Optional)
   The configuration settings for Cloud Composer maintenance windows.
 
 * `workloads_config` -


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for Cloud Composer maintenance window in GA.

It is just a preview of change, it should work on beta envs, but won't on GA envs until composer v2 fields are added to go API: https://pkg.go.dev/google.golang.org/api@v0.60.0/composer/v1

fixes : https://github.com/hashicorp/terraform-provider-google/issues/10616

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added support for Cloud Composer maintenance window in GA
```
