### PR TITLE
Add supported values for 'peeringCidrRange' on 'google_apigee_instance' resource

### DIFF
--- a/mmv1/products/apigee/api.yaml
+++ b/mmv1/products/apigee/api.yaml
@@ -175,9 +175,14 @@ objects:
         description: |
           The size of the CIDR block range that will be reserved by the instance.
         values:
+          - "CIDR_RANGE_UNSPECIFIED"
           - "SLASH_16"
+          - "SLASH_17"
+          - "SLASH_18"
+          - "SLASH_19"
           - "SLASH_20"
           - "SLASH_22"
+          - "SLASH_23"
       - !ruby/object:Api::Type::String
         name: 'description'
         description: |

--- a/mmv1/products/apigee/api.yaml
+++ b/mmv1/products/apigee/api.yaml
@@ -170,19 +170,11 @@ objects:
           subscriptions, the location must be a Compute Engine zone. For paid organization
           subscriptions, it should correspond to a Compute Engine region.
         required: true
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'peeringCidrRange'
         description: |
-          The size of the CIDR block range that will be reserved by the instance.
-        values:
-          - "CIDR_RANGE_UNSPECIFIED"
-          - "SLASH_16"
-          - "SLASH_17"
-          - "SLASH_18"
-          - "SLASH_19"
-          - "SLASH_20"
-          - "SLASH_22"
-          - "SLASH_23"
+          The size of the CIDR block range that will be reserved by the instance. For valid values, 
+          see [CidrRange](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances#CidrRange) on the documentation.
       - !ruby/object:Api::Type::String
         name: 'description'
         description: |

--- a/mmv1/products/apigee/terraform.yaml
+++ b/mmv1/products/apigee/terraform.yaml
@@ -72,6 +72,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       # Resource creation race
       skip_vcr: true
     - !ruby/object:Provider::Terraform::Examples
+      name: "apigee_instance_cidr_range"
+      skip_test: true      
+    - !ruby/object:Provider::Terraform::Examples
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test.
+      name: "apigee_instance_cidr_range_test"
+      primary_resource_id: "apigee_instance"
+      test_env_vars:
+        org_id: :ORG_ID
+        billing_account: :BILLING_ACCT
+      skip_docs: true
+      # Resource creation race
+      skip_vcr: true
+    - !ruby/object:Provider::Terraform::Examples
       name: "apigee_instance_full"
       skip_test: true
     - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/templates/terraform/examples/apigee_instance_cidr_range.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_instance_cidr_range.tf.erb
@@ -1,0 +1,33 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 22
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "google_apigee_instance" "apigee_instance" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1-b"
+  org_id   = google_apigee_organization.apigee_org.id
+  peering_cidr_range = "SLASH_22"
+}

--- a/mmv1/templates/terraform/examples/apigee_instance_cidr_range_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_instance_cidr_range_test.tf.erb
@@ -1,0 +1,60 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 22
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_instance" "<%= ctx[:primary_resource_id] %>" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+  peering_cidr_range = "SLASH_22"
+}


### PR DESCRIPTION
Add supported values for `peeringCidrRange` on `google_apigee_instance` resource. Supported values from the documentation: https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances#CidrRange

Added test. Since Evaluation organizations support only 22 and 23, I tested 22.

fixes https://github.com/hashicorp/terraform-provider-google/issues/10112

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Google Apigee Instance: Add supported values for 'peeringCidrRange'.
```
