### PR TITLE
Remove send_empty_value for client_ttl and default_ttl

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -176,10 +176,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       cdnPolicy.clientTtl: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-        send_empty_value: true
       cdnPolicy.defaultTtl: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-        send_empty_value: true
       cdnPolicy.maxTtl: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       cdnPolicy.signedUrlCacheMaxAgeSec: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
@@ -210,7 +210,6 @@ resource "google_storage_bucket" "bucket" {
 `, backendName, age, max_ttl, ttl, ttl, ttl, code, ttl, storageName)
 }
 
-
 func testAccComputeBackendBucket_withCdnPolicy4(backendName, storageName string, age, code, ttl int) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_bucket" "foobar" {

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
@@ -91,6 +91,14 @@ func TestAccComputeBackendBucket_withCdnPolicy(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeBackendBucket_withCdnPolicy4(backendName, storageName, 0, 404, 0),
+			},
+			{
+				ResourceName:      "google_compute_backend_bucket.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -200,4 +208,30 @@ resource "google_storage_bucket" "bucket" {
   location = "EU"
 }
 `, backendName, age, max_ttl, ttl, ttl, ttl, code, ttl, storageName)
+}
+
+
+func testAccComputeBackendBucket_withCdnPolicy4(backendName, storageName string, age, code, ttl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_bucket" "foobar" {
+  name        = "%s"
+  bucket_name = google_storage_bucket.bucket.name
+  enable_cdn  = true
+  cdn_policy {
+	cache_mode                   = "USE_ORIGIN_HEADERS"
+	signed_url_cache_max_age_sec = %d
+	serve_while_stale            = %d
+	negative_caching_policy {
+		code = %d
+		ttl = %d
+	}
+	negative_caching = true
+  }
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "EU"
+}
+`, backendName, age, ttl, code, ttl, storageName)
 }


### PR DESCRIPTION
Fixes
https://github.com/hashicorp/terraform-provider-google/issues/10622.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a bug when `cache_mode` is set to USE_ORIGIN_HEADERS on `google_compute_backend_bucket`
```
