### PR TITLE
Composer environment size fix

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -986,6 +986,17 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
+
+		if d.HasChange("config.0.environment_size") {
+			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+			if config != nil {
+				patchObj.Config.EnvironmentSize = config.EnvironmentSize
+			}
+			err = resourceComposerEnvironmentPatchField("config.EnvironmentSize", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
 <% end -%>
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -367,7 +367,6 @@ func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
 func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
   t.Parallel()
 
-  pid := getTestProjectFromEnv()
   envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
   network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
   subnetwork := network + "-1"
@@ -378,7 +377,7 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
     CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccComposerEnvironment_composerV2(pid, envName, network, subnetwork),
+        Config: testAccComposerEnvironment_composerV2(envName, network, subnetwork),
       },
       {
         ResourceName:      "google_composer_environment.test",
@@ -391,11 +390,47 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
       {
         PlanOnly:           true,
         ExpectNonEmptyPlan: false,
-        Config:             testAccComposerEnvironment_composerV2(pid, envName, network, subnetwork),
+        Config:             testAccComposerEnvironment_composerV2(envName, network, subnetwork),
         Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
       },
     },
   })
+}
+
+func TestAccComposerEnvironment_UpdateComposerV2(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_composerV2(envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_updateComposerV2(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_updateComposerV2(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
 }
 <% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
@@ -974,7 +1009,7 @@ resource "google_compute_subnetwork" "test" {
 `, envName, network, subnetwork)
 }
 
-func testAccComposerEnvironment_composerV2(pid, envName, network, subnetwork string) string {
+func testAccComposerEnvironment_composerV2(envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_composer_image_versions" "all" {
 }
@@ -1000,12 +1035,6 @@ resource "google_composer_environment" "test" {
 
   		software_config {
   		  image_version = local.matching_images[0]
-  		}
-
-  		maintenance_window {
-  			start_time 	= "2019-08-01T01:00:00Z"
-  			end_time 		= "2019-08-01T07:00:00Z"
-  			recurrence 	= "FREQ=WEEKLY;BYDAY=TU,WE"
   		}
 
   		workloads_config {
@@ -1127,6 +1156,82 @@ resource "google_compute_subnetwork" "test" {
 }
 `, name, network, subnetwork)
 }
+
+<% unless version == "ga" -%>
+func testAccComposerEnvironment_updateComposerV2(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+locals {
+	composer_version = "2"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
+	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+
+		config {
+			node_config {
+      	network    			= google_compute_network.test.self_link
+      	subnetwork 			= google_compute_subnetwork.test.self_link
+				ip_allocation_policy {
+					cluster_ipv4_cidr_block = "10.0.0.0/16"
+				}
+    	}
+
+  		software_config {
+  		  image_version = local.matching_images[0]
+  		}
+
+  		workloads_config {
+  			scheduler {
+  				cpu 				= 2.25
+  				memory_gb 	= 3.5
+  				storage_gb 	= 6.4
+  				count 			= 3
+  			}
+  			web_server {
+  				cpu 				= 2.75
+  				memory_gb 	= 4.0
+  				storage_gb 	= 5.4
+  			}
+  			worker {
+  				cpu 				= 1.5
+  				memory_gb 	= 3.0
+  				storage_gb 	= 4.4
+  				min_count 	= 3
+  				max_count 	= 6
+  			}
+  		}
+			environment_size = "ENVIRONMENT_SIZE_LARGE"
+  		private_environment_config {
+  			enable_private_endpoint 								= true
+  			cloud_composer_network_ipv4_cidr_block 	= "10.3.192.0/24"
+        master_ipv4_cidr_block 									= "172.16.194.0/23"
+        cloud_sql_ipv4_cidr_block 							= "10.3.224.0/20"
+  		}
+  	}
+
+}
+
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+ 	network       = google_compute_network.test.self_link
+	private_ip_google_access = true
+}
+`, name, network, subnetwork)
+}
+<% end %>
 
 func testAccComposerEnvironment_nodeCfg(environment, network, subnetwork, serviceAccount string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1231,7 +1231,7 @@ resource "google_compute_subnetwork" "test" {
 }
 `, name, network, subnetwork)
 }
-<% end %>
+<% end -%>
 
 func testAccComposerEnvironment_nodeCfg(environment, network, subnetwork, serviceAccount string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fix problem with in-place updates of environment_size in composer v2. Also adds tests for composer v2 updates

fixes: https://github.com/hashicorp/terraform-provider-google/issues/10631

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fix Cloud Composer v2 environment_size updates.
```
