### PR TITLE
Feat: Add min_instances to cloudfunctions functions

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -656,7 +656,7 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("min_instances") {
-		function.MaxInstances = int64(d.Get("min_instances").(int))
+		function.MinInstances = int64(d.Get("min_instances").(int))
 		updateMaskArr = append(updateMaskArr, "minInstances")
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -127,7 +127,7 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"source_repository": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				MaxItems:      2,
+				MaxItems:      1,
 				Description:   `Represents parameters related to source repository where a function is hosted. Cannot be set alongside source_archive_bucket or source_archive_object.`,
 				ConflictsWith: []string{"source_archive_bucket", "source_archive_object"},
 				Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -127,7 +127,7 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"source_repository": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				MaxItems:      1,
+				MaxItems:      2,
 				Description:   `Represents parameters related to source repository where a function is hosted. Cannot be set alongside source_archive_bucket or source_archive_object.`,
 				ConflictsWith: []string{"source_archive_bucket", "source_archive_object"},
 				Elem: &schema.Resource{
@@ -293,6 +293,13 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 				Description:  `The limit on the maximum number of function instances that may coexist at a given time.`,
 			},
 
+			"min_instances": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  `The limit on the minimum number of function instances that may coexist at a given time.`,
+			},
+
 			"project": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -407,6 +414,10 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 
 	if v, ok := d.GetOk("max_instances"); ok {
 		function.MaxInstances = int64(v.(int))
+	}
+
+	if v, ok := d.GetOk("min_instances"); ok {
+		function.MinInstances = int64(v.(int))
 	}
 
 	log.Printf("[DEBUG] Creating cloud function: %s", function.Name)
@@ -527,6 +538,9 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	if err := d.Set("max_instances", function.MaxInstances); err != nil {
 		return fmt.Errorf("Error setting max_instances: %s", err)
 	}
+	if err := d.Set("min_instances", function.MinInstances); err != nil {
+		return fmt.Errorf("Error setting min_instances: %s", err)
+	}
 	if err := d.Set("region", cloudFuncId.Region); err != nil {
 		return fmt.Errorf("Error setting region: %s", err)
 	}
@@ -639,6 +653,11 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("max_instances") {
 		function.MaxInstances = int64(d.Get("max_instances").(int))
 		updateMaskArr = append(updateMaskArr, "maxInstances")
+	}
+
+	if d.HasChange("min_instances") {
+		function.MaxInstances = int64(d.Get("min_instances").(int))
+		updateMaskArr = append(updateMaskArr, "minInstances")
 	}
 
 	if len(updateMaskArr) > 0 {

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -146,6 +146,8 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 						"available_memory_mb", "128"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"max_instances", "10"),
+          resource.TestCheckResourceAttr(funcResourceName,
+						"min_instances", "3"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"ingress_settings", "ALLOW_INTERNAL_ONLY"),
 					testAccCloudFunctionsFunctionSource(fmt.Sprintf("gs://%s/index.zip", bucketName), &function),
@@ -216,6 +218,8 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 						"timeout", "91"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"max_instances", "15"),
+          resource.TestCheckResourceAttr(funcResourceName,
+						"min_instances", "5"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"ingress_settings", "ALLOW_ALL"),
 					testAccCloudFunctionsFunctionHasLabel("my-label", "my-updated-label-value", &function),
@@ -665,6 +669,7 @@ resource "google_cloudfunctions_function" "function" {
     NEW_ENV_VARIABLE  = "new-build-env-variable-value"
   }
   max_instances = 15
+  min_instances = 5
 }
 `, bucketName, zipFilePath, functionName)
 }
@@ -904,6 +909,7 @@ resource "google_cloudfunctions_function" "function" {
 	TEST_ENV_VARIABLE = "test-env-variable-value"
   }
   max_instances = 10
+  min_instances = 3
   vpc_connector = google_vpc_access_connector.%s.self_link
   vpc_connector_egress_settings = "PRIVATE_RANGES_ONLY"
 

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -628,6 +628,7 @@ resource "google_cloudfunctions_function" "function" {
     TEST_ENV_VARIABLE = "test-build-env-variable-value"
   }
   max_instances = 10
+  min_instances = 3
 }
 `, bucketName, zipFilePath, functionName)
 }

--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -150,6 +150,8 @@ Eg. `"nodejs10"`, `"nodejs12"`, `"nodejs14"`, `"python37"`, `"python38"`, `"pyth
 
 * `max_instances` - (Optional) The limit on the maximum number of function instances that may coexist at a given time.
 
+* `min_instances` - (Optional) The limit on the minimum number of function instances that may coexist at a given time.
+
 <a name="nested_event_trigger"></a>The `event_trigger` block supports:
 
 * `event_type` - (Required) The type of event to observe. For example: `"google.storage.object.finalize"`.


### PR DESCRIPTION
Support `min_instances` in Cloud Functions.

https://pkg.go.dev/google.golang.org/api/cloudfunctions/v1#CloudFunction

SVRL-749

See: https://github.com/hashicorp/terraform-provider-google/pull/10675

---

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
cloudfunctions: added support for `min_instances` to `google_cloudfunctions_function`
```
