### PR TITLE
Adds support for public access prevention (beta)

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (

--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -343,7 +343,14 @@ func resourceStorageBucket() *schema.Resource {
 				Computed:    true,
 				Description: `Enables uniform bucket-level access on a bucket.`,
 			},
+<% unless version == "ga" -%>
+			"public_access_prevention": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Prevents public access to a bucket.`,
+			},
 		},
+<% end -%>
 		UseJSONNumber: true,
 	}
 }
@@ -584,12 +591,11 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if d.HasChange("uniform_bucket_level_access") {
+	if d.HasChange("uniform_bucket_level_access") <% unless version == "ga" -%> || d.HasChange("public_access_prevention") <% end -%> {
 		sb.IamConfiguration = expandIamConfiguration(d)
 	}
 
 	res, err := config.NewStorageClient(userAgent).Buckets.Patch(d.Get("name").(string), sb).Do()
-
 	if err != nil {
 		return err
 	}
@@ -1119,13 +1125,19 @@ func expandBucketWebsite(v interface{}) *storage.BucketWebsite {
 }
 
 func expandIamConfiguration(d *schema.ResourceData) *storage.BucketIamConfiguration {
-	return &storage.BucketIamConfiguration{
+	cfg := &storage.BucketIamConfiguration{
 		ForceSendFields: []string{"UniformBucketLevelAccess"},
 		UniformBucketLevelAccess: &storage.BucketIamConfigurationUniformBucketLevelAccess{
 			Enabled:         d.Get("uniform_bucket_level_access").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
 	}
+<% unless version == "ga" -%>
+	if v, ok := d.GetOk("public_access_prevention"); ok {
+		cfg.PublicAccessPrevention = v.(string)
+	}
+<% end -%>
+	return cfg
 }
 
 func expandStorageBucketLifecycle(v interface{}) (*storage.BucketLifecycle, error) {

--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -742,6 +742,12 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if res.IamConfiguration != nil && res.IamConfiguration.PublicAccessPrevention != "" {
+		if err := d.Set("public_access_prevention", res.IamConfiguration.PublicAccessPrevention); err != nil {
+			return fmt.Errorf("Error setting public_access_prevention: %s", err)
+		}
+	}
+
 	if res.Billing == nil {
 		if err := d.Set("requester_pays", nil); err != nil {
 			return fmt.Errorf("Error setting requester_pays: %s", err)

--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -350,8 +350,8 @@ func resourceStorageBucket() *schema.Resource {
 				Optional:    true,
 				Description: `Prevents public access to a bucket.`,
 			},
-		},
 <% end -%>
+		},
 		UseJSONNumber: true,
 	}
 }
@@ -592,7 +592,7 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if d.HasChange("uniform_bucket_level_access") <% unless version == "ga" -%> || d.HasChange("public_access_prevention") <% end -%> {
+	if d.HasChange("uniform_bucket_level_access")<% unless version == "ga" -%> || d.HasChange("public_access_prevention")<% end -%> {
 		sb.IamConfiguration = expandIamConfiguration(d)
 	}
 
@@ -1134,10 +1134,12 @@ func expandIamConfiguration(d *schema.ResourceData) *storage.BucketIamConfigurat
 		},
 	}
 <% unless version == "ga" -%>
+
 	if v, ok := d.GetOk("public_access_prevention"); ok {
 		cfg.PublicAccessPrevention = v.(string)
 	}
 <% end -%>
+
 	return cfg
 }
 

--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -348,6 +348,7 @@ func resourceStorageBucket() *schema.Resource {
 			"public_access_prevention": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `Prevents public access to a bucket.`,
 			},
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -767,7 +767,6 @@ func TestAccStorageBucket_encryption(t *testing.T) {
 	})
 }
 
-<% unless version == "ga" -%>
 func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 	t.Parallel()
 
@@ -789,7 +788,6 @@ func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccStorageBucket_uniformBucketAccessOnly(t *testing.T) {
 	t.Parallel()
@@ -1489,7 +1487,6 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName, enabled)
 }
 
-<% unless version == 'ga' -%>
 func testAccStorageBucket_publicAccessPrevention(bucketName string, prevention string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
@@ -1501,7 +1498,6 @@ resource "google_storage_bucket" "bucket" {
 }
 `, bucketName, prevention)
 }
-<% end -%>
 
 func testAccStorageBucket_encryption(context map[string]interface{}) string {
 	return Nprintf(`

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -767,6 +767,7 @@ func TestAccStorageBucket_encryption(t *testing.T) {
 	})
 }
 
+<% unless version == "ga" -%>
 func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 	t.Parallel()
 
@@ -788,6 +789,7 @@ func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccStorageBucket_uniformBucketAccessOnly(t *testing.T) {
 	t.Parallel()
@@ -1487,6 +1489,7 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName, enabled)
 }
 
+<% unless version == "ga" -%>
 func testAccStorageBucket_publicAccessPrevention(bucketName string, prevention string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
@@ -1498,6 +1501,7 @@ resource "google_storage_bucket" "bucket" {
 }
 `, bucketName, prevention)
 }
+<% end -%>
 
 func testAccStorageBucket_encryption(context map[string]interface{}) string {
 	return Nprintf(`

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -590,6 +590,7 @@ func TestAccStorageBucket_forceDestroyObjectDeleteError(t *testing.T) {
 		},
 	})
 }
+
 func TestAccStorageBucket_versioning(t *testing.T) {
 	t.Parallel()
 
@@ -765,6 +766,30 @@ func TestAccStorageBucket_encryption(t *testing.T) {
 		},
 	})
 }
+
+<% unless version == "ga" -%>
+func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
+	t.Parallel()
+
+	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", randInt(t))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_publicAccessPrevention(bucketName, "enforced"),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+<% end -%>
 
 func TestAccStorageBucket_uniformBucketAccessOnly(t *testing.T) {
 	t.Parallel()
@@ -1463,6 +1488,20 @@ resource "google_storage_bucket" "bucket" {
 }
 `, bucketName, enabled)
 }
+
+<% unless version == 'ga' -%>
+func testAccStorageBucket_publicAccessPrevention(bucketName string, prevention string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  provider                  = google-beta
+  name                      = "%s"
+  location                  = "US"
+  public_access_prevention  = "%s"
+  force_destroy             = true
+}
+`, bucketName, prevention)
+}
+<% end -%>
 
 func testAccStorageBucket_encryption(context map[string]interface{}) string {
 	return Nprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/9519

Adds Public Access Prevention support for Cloud Storage to the beta provider. See issue here:

https://github.com/hashicorp/terraform-provider-google/issues/9519

and downstream PR here:

https://github.com/hashicorp/terraform-provider-google/pull/10670

Tagging @ScottSuarez for review, will work through the checklist below now.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `public_access_prevention` to resource `bucket` (beta)
```
