### PR TITLE
Cloud Composer connection subnetwork

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -677,6 +677,7 @@ func resourceComposerEnvironment() *schema.Resource {
 						"environment_size": {
               Type:         schema.TypeString,
               Optional:     true,
+							Computed:			true,
               ForceNew:     false,
               AtLeastOneOf: composerConfigKeys,
               ValidateFunc: validation.StringInSlice([]string{"ENVIRONMENT_SIZE_SMALL", "ENVIRONMENT_SIZE_MEDIUM", "ENVIRONMENT_SIZE_LARGE"}, false),

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -67,6 +67,18 @@ var (
 <% end -%>
 	}
 
+	composerPrivateEnvironmentConfig = []string{
+		"config.0.private_environment_config.0.enable_private_endpoint",
+		"config.0.private_environment_config.0.master_ipv4_cidr_block",
+		"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
+		"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
+<% unless version == "ga" -%>
+		"config.0.private_environment_config.0.cloud_composer_network_ipv4_cidr_block",
+		"config.0.private_environment_config.0.enable_privately_used_public_ips",
+		"config.0.private_environment_config.0.cloud_composer_connection_subnetwork",
+<% end -%>
+	}
+
 	composerIpAllocationPolicyKeys = []string{
 		"config.0.node_config.0.ip_allocation_policy.0.use_ip_aliases",
 		"config.0.node_config.0.ip_allocation_policy.0.cluster_secondary_range_name",
@@ -373,14 +385,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:     schema.TypeBool,
 										Optional: true,
 										Default:  true,
-										AtLeastOneOf: []string{
-											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.master_ipv4_cidr_block",
-											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
-											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
-<% unless version == "ga" -%>
-											"config.0.private_environment_config.0.cloud_composer_network_ipv4_cidr_block",
-<% end -%>										},
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew:    true,
 										Description: `If true, access to the public endpoint of the GKE cluster is denied. If this field is set to true, ip_allocation_policy.use_ip_aliases must be set to true for Cloud Composer environments in versions composer-1.*.*-airflow-*.*.*.`,
 									},
@@ -388,14 +393,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
-										AtLeastOneOf: []string{
-											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.master_ipv4_cidr_block",
-											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
-											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
-<% unless version == "ga" -%>
-											"config.0.private_environment_config.0.cloud_composer_network_ipv4_cidr_block",
-<% end -%>										},
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew:    true,
 										Description: `The IP range in CIDR notation to use for the hosted master network. This range is used for assigning internal IP addresses to the cluster master or set of masters and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.`,
 									},
@@ -403,14 +401,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
-										AtLeastOneOf: []string{
-											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.master_ipv4_cidr_block",
-											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
-											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
-<% unless version == "ga" -%>
-											"config.0.private_environment_config.0.cloud_composer_network_ipv4_cidr_block",
-<% end -%>										},
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew:    true,
 										Description: `The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-*.*.*.`,
 									},
@@ -418,15 +409,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
-										AtLeastOneOf: []string{
-											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.master_ipv4_cidr_block",
-											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
-											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
-<% unless version == "ga" -%>
-											"config.0.private_environment_config.0.cloud_composer_network_ipv4_cidr_block",
-<% end -%>
-										},
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew:    true,
 										Description: `The CIDR block from which IP range in tenant project will be reserved for Cloud SQL. Needs to be disjoint from web_server_ipv4_cidr_block.`,
 									},
@@ -435,13 +418,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
-										AtLeastOneOf: []string{
-											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.master_ipv4_cidr_block",
-											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
-											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
-											"config.0.private_environment_config.0.cloud_composer_network_ipv4_cidr_block",
-										},
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew: true,
 										Description: `The CIDR block from which IP range for Cloud Composer Network in tenant project will be reserved. Needs to be disjoint from private_cluster_config.master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
 									},
@@ -449,10 +426,19 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:     schema.TypeBool,
 										Optional: true,
 										Computed: true,
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew: true,
 										Description: `When enabled, IPs from public (non-RFC1918) ranges can be used for ip_allocation_policy.cluster_ipv4_cidr_block and ip_allocation_policy.service_ipv4_cidr_block.`,
 									},
-<% end -%>
+									"cloud_composer_connection_subnetwork": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
+										ForceNew: true,
+										Description: `When specified, the environment will use Private Service Connect instead of VPC peerings to connect to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP address from this subnetwork. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
+									},
+									<% end -%>
 								},
 							},
 						},
@@ -1252,6 +1238,8 @@ func flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg *composer.P
 <% unless version == "ga" -%>
 	transformed["cloud_composer_network_ipv4_cidr_block"] = envCfg.CloudComposerNetworkIpv4CidrBlock
 	transformed["enable_privately_used_public_ips"] = envCfg.EnablePrivatelyUsedPublicIps
+	transformed["cloud_composer_connection_subnetwork"] = envCfg.CloudComposerConnectionSubnetwork
+
 <% end -%>
 
 	return []interface{}{transformed}
@@ -1604,6 +1592,11 @@ func expandComposerEnvironmentConfigPrivateEnvironmentConfig(v interface{}, d *s
 	if v, ok := original["enable_privately_used_public_ips"]; ok {
 		transformed.EnablePrivatelyUsedPublicIps = v.(bool)
 	}
+
+	if v, ok := original["cloud_composer_connection_subnetwork"]; ok {
+		transformed.CloudComposerConnectionSubnetwork = v.(string)
+	}
+
 <% end -%>
 
 	transformed.PrivateClusterConfig = subBlock

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -371,7 +371,6 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
   envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
   network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
   subnetwork := network + "-1"
-
   vcrTest(t, resource.TestCase{
     PreCheck:     func() { testAccPreCheck(t) },
     Providers:    testAccProviders,
@@ -987,7 +986,7 @@ locals {
 }
 resource "google_composer_environment" "test" {
 	name   = "%s"
-	region = "us-central1"
+	region = "us-east1"
 
 		config {
 			node_config {
@@ -999,7 +998,8 @@ resource "google_composer_environment" "test" {
     	}
 
   		software_config {
-  		  image_version = local.matching_images[0]
+  		  # image_version = local.matching_images[0]
+				image_version = "composer-2.0.0-preview.6-airflow-2.1.4"
   		}
 
   		maintenance_window {
@@ -1034,7 +1034,7 @@ resource "google_composer_environment" "test" {
   			cloud_composer_network_ipv4_cidr_block 	= "10.3.192.0/24"
         master_ipv4_cidr_block 									= "172.16.194.0/23"
         cloud_sql_ipv4_cidr_block 							= "10.3.224.0/20"
-				cloud_composer_connection_subnetwork		= "projects/%s/regions/us-central1/subnetworks/default"  # consider using same value as node_config.subnetwork if that one doesn't work
+				cloud_composer_connection_subnetwork		= google_compute_subnetwork.test.self_link
   		}
   	}
 
@@ -1048,12 +1048,12 @@ resource "google_compute_network" "test" {
 resource "google_compute_subnetwork" "test" {
 	name          = "%s"
 	ip_cidr_range = "10.2.0.0/16"
-	region        = "us-central1"
+	region        = "us-east1"
  	network       = google_compute_network.test.self_link
 	private_ip_google_access = true
 }
 
-`, envName, envName, network, subnetwork)
+`, envName, network, subnetwork)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1034,6 +1034,7 @@ resource "google_composer_environment" "test" {
   			cloud_composer_network_ipv4_cidr_block 	= "10.3.192.0/24"
         master_ipv4_cidr_block 									= "172.16.194.0/23"
         cloud_sql_ipv4_cidr_block 							= "10.3.224.0/20"
+				cloud_composer_connection_subnetwork		= "projects/%s/regions/us-central1/subnetworks/default"  # consider using same value as node_config.subnetwork if that one doesn't work
   		}
   	}
 
@@ -1052,7 +1053,7 @@ resource "google_compute_subnetwork" "test" {
 	private_ip_google_access = true
 }
 
-`, envName, network, subnetwork)
+`, envName, envName, network, subnetwork)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -396,6 +396,39 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
     },
   })
 }
+
+func TestAccComposerEnvironment_ComposerV2PrivateServiceConnect(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_composerV2PrivateServiceConnect(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_composerV2PrivateServiceConnect(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
 <% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
 func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
@@ -1034,7 +1067,6 @@ resource "google_composer_environment" "test" {
   			cloud_composer_network_ipv4_cidr_block 	= "10.3.192.0/24"
         master_ipv4_cidr_block 									= "172.16.194.0/23"
         cloud_sql_ipv4_cidr_block 							= "10.3.224.0/20"
-				cloud_composer_connection_subnetwork		= google_compute_subnetwork.test.self_link
   		}
   	}
 
@@ -1056,7 +1088,56 @@ resource "google_compute_subnetwork" "test" {
 `, envName, network, subnetwork)
 }
 
+
+func testAccComposerEnvironment_composerV2PrivateServiceConnect(envName, network, subnetwork string) string {
+	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+locals {
+	composer_version = "2"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
+	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+
+		config {
+			node_config {
+      	network    			= google_compute_network.test.self_link
+      	subnetwork 			= google_compute_subnetwork.test.self_link
+    	}
+
+  		software_config {
+  		  image_version = local.matching_images[0]
+				# image_version = "composer-2.0.0-preview.6-airflow-2.1.4"
+  		}
+  		private_environment_config {
+				cloud_composer_connection_subnetwork		= google_compute_subnetwork.test.self_link
+  		}
+  	}
+
+}
+
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+ 	network       = google_compute_network.test.self_link
+	private_ip_google_access = true
+}
+
+`, envName, network, subnetwork)
+}
 <% end -%>
+
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_composer_image_versions" "all" {

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -397,7 +397,7 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
   })
 }
 
-func TestAccComposerEnvironment_ComposerV2PrivateServiceConnect(t *testing.T) {
+func TestAccComposerEnvironment_composerV2PrivateServiceConnect(t *testing.T) {
 	t.Parallel()
 
 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
@@ -1112,7 +1112,6 @@ resource "google_composer_environment" "test" {
 
   		software_config {
   		  image_version = local.matching_images[0]
-				# image_version = "composer-2.0.0-preview.6-airflow-2.1.4"
   		}
   		private_environment_config {
 				cloud_composer_connection_subnetwork		= google_compute_subnetwork.test.self_link

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -747,6 +747,13 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
   When enabled, IPs from public (non-RFC1918) ranges can be used for
   `ip_allocation_policy.cluster_ipv4_cidr_block` and `ip_allocation_policy.service_ipv4_cidr_block`.
+  
+* `cloud_composer_connection_subnetwork"` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  When specified, the environment will use Private Service Connect instead of VPC peerings to connect
+  to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP 
+  address from this subnetwork. This field is supported for Cloud Composer environments in 
+  versions `composer-2.*.*-airflow-*.*.*` and newer.
 
 
 The `ip_allocation_policy` block supports:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for Private Service Connect by adding cloud_composer_connection_subnetwork field. 

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10550



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added support for Private Service Connect by adding field `cloud_composer_connection_subnetwork` in `google_composer_environment` 
```
