### PR TITLE
Upstream firewalls DSF update to allow unknown values

### DIFF
--- a/mmv1/templates/terraform/constants/firewall.erb
+++ b/mmv1/templates/terraform/constants/firewall.erb
@@ -70,10 +70,10 @@ func resourceComputeFirewallSourceFieldsCustomizeDiff(_ context.Context, diff *s
 		_, sasOk := diff.GetOk("source_service_accounts")
 
 		_, tagsExist := diff.GetOkExists("source_tags")
-		// ranges is computed, but this is what we're trying to avoid, so we're not going to check this
+		_, rangesExist := diff.GetOkExists("source_ranges")
 		_, sasExist := diff.GetOkExists("source_service_accounts")
 
-		if !tagsOk && !rangesOk && !sasOk && !tagsExist && !sasExist {
+		if !tagsOk && !rangesOk && !sasOk && !tagsExist && !rangesExist && !sasExist {
 			return fmt.Errorf("one of source_tags, source_ranges, or source_service_accounts must be defined")
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_compute_firewall_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_firewall_test.go.erb
@@ -240,6 +240,29 @@ func TestAccComputeFirewall_enableLogging(t *testing.T) {
 	})
 }
 
+func TestAccComputeFirewall_moduleOutput(t *testing.T) {
+	t.Parallel()
+
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeFirewallDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeFirewall_moduleOutput(networkName, firewallName),
+			},
+			{
+				ResourceName:      "google_compute_firewall.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeFirewall_basic(network, firewall string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -444,4 +467,41 @@ resource "google_compute_firewall" "foobar" {
   %s
 }
 `, network, firewall, enableLoggingCfg)
+}
+
+func testAccComputeFirewall_moduleOutput(network, firewall string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.foobar.name
+}
+
+resource "google_compute_address" "foobar" {
+	name         = "%s-address"
+	subnetwork   = google_compute_subnetwork.foobar.id
+	address_type = "INTERNAL"
+	region       = "us-central1"
+  }
+
+resource "google_compute_firewall" "foobar" {
+  name        = "%s"
+  description = "Resource created for Terraform acceptance testing"
+  network     = google_compute_network.foobar.name
+  direction   = "INGRESS"
+
+  source_ranges = ["${google_compute_address.foobar.address}/32"]
+  target_tags   = ["foo"]
+
+  allow {
+    protocol = "tcp"
+  }
+}
+`, network, network, network, firewall)
 }


### PR DESCRIPTION

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Upstreams: https://github.com/hashicorp/terraform-provider-google/pull/10668

It's unclear to me if this is the best that we can do, it's not *quite* correct, but probably a better failure mode than exists right now

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a bug where `google_compute_firewall` would incorrectly find `source_ranges` to be empty during validation
```
