### PR TITLE
Fixed typo in comment and made other improvements to comments

### DIFF
--- a/mmv1/templates/terraform/examples/internal_http_lb_with_mig_backend.tf.erb
+++ b/mmv1/templates/terraform/examples/internal_http_lb_with_mig_backend.tf.erb
@@ -1,7 +1,7 @@
 # Internal HTTP load balancer with a managed instance group backend
 
 # [START cloudloadbalancing_int_http_gce]
-# VPC
+# VPC network
 resource "google_compute_network" "ilb_network" {
   name                    = "<%= ctx[:vars]['ilb_network_name'] %>"
   provider                = google-beta
@@ -19,7 +19,7 @@ resource "google_compute_subnetwork" "proxy_subnet" {
   network       = google_compute_network.ilb_network.id
 }
 
-# backed subnet
+# backend subnet
 resource "google_compute_subnetwork" "ilb_subnet" {
   name          = "<%= ctx[:vars]['backend_subnet_name'] %>"
   provider      = google-beta
@@ -43,7 +43,7 @@ resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
   network_tier          = "PREMIUM"
 }
 
-# http proxy
+# HTTP target proxy
 resource "google_compute_region_target_http_proxy" "default" {
   name     = "<%= ctx[:vars]['target_http_proxy_name'] %>"
   provider = google-beta
@@ -51,7 +51,7 @@ resource "google_compute_region_target_http_proxy" "default" {
   url_map  = google_compute_region_url_map.default.id
 }
 
-# url map
+# URL map
 resource "google_compute_region_url_map" "default" {
   name            = "<%= ctx[:vars]['regional_url_map_name'] %>"
   provider        = google-beta


### PR DESCRIPTION
This example lives here:
https://cloud.google.com/load-balancing/docs/l7-internal/int-https-lb-tf-examples


```release-note:none
```