### PR TITLE
Docs: Prepared a tf snippet for creating a new Cloud Storage bucket

### DIFF
--- a/mmv1/products/storage/terraform.yaml
+++ b/mmv1/products/storage/terraform.yaml
@@ -23,6 +23,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           name: "my-bucket"
         primary_resource_name: "fmt.Sprintf(\"tf-test-my-bucket%s\", context[\"random_suffix\"])"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "storage_new_bucket"
+        primary_resource_id: "static"
+        vars:
+          new_bucket: "new-bucket"
+        min_version: beta
+        # ignore_read_extra:
+        #   - "port_range"
+        #   - "target"
+        #   - "ip_address"
   BucketAccessControl: !ruby/object:Overrides::Terraform::ResourceOverride
     description: |
       Bucket ACLs can be managed authoritatively using the

--- a/mmv1/templates/terraform/examples/storage_new_bucket.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_new_bucket.tf.erb
@@ -1,0 +1,13 @@
+# [START storage_create_new_bucket_tf]
+
+# Create new storage bucket in the US region
+# with coldline storage
+resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
+  name          = "<%= ctx[:vars]['new_bucket'] %>"
+  location      = "US"
+  storage_class = "COLDLINE"
+
+  uniform_bucket_level_access = true
+}
+
+# [END storage_create_new_bucket_tf]


### PR DESCRIPTION
Intending to use this snippet on the following page: https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-console 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
