### PR TITLE
Cloud Composer support for master authorized networks

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -65,6 +65,9 @@ var (
 		"config.0.workloads_config",
 		"config.0.environment_size",
 <% end -%>
+<% unless version == "ga" -%>
+		"config.0.master_authorized_networks_config",
+<% end -%>
 	}
 
 	composerPrivateEnvironmentConfig = []string{
@@ -103,6 +106,23 @@ var (
 		},
 	}
 
+<% end -%>
+
+<% unless version == "ga" -%>
+	cidrBlocks = &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     		schema.TypeString,
+				Required: 		true,
+				Description:  `display_name is a field for users to identify CIDR blocks.`,
+			},
+			"cidr_block": {
+				Type:     		schema.TypeString,
+				Required: 		true,
+				Description:  `cidr_block must be specified in CIDR notation.`,
+			},
+		},
+	}
 <% end -%>
 )
 
@@ -447,6 +467,7 @@ func resourceComposerEnvironment() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							Computed:    true,
+							AtLeastOneOf: composerConfigKeys,
 							MaxItems:    1,
 							Description: `The network-level access control policy for the Airflow web server. If unspecified, no network-level access restrictions will be applied. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-*.*.*.`,
 							Elem: &schema.Resource{
@@ -683,6 +704,32 @@ func resourceComposerEnvironment() *schema.Resource {
               ValidateFunc: validation.StringInSlice([]string{"ENVIRONMENT_SIZE_SMALL", "ENVIRONMENT_SIZE_MEDIUM", "ENVIRONMENT_SIZE_LARGE"}, false),
               Description:  `The size of the Cloud Composer environment. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
             },
+<% end -%>
+<% unless version == "ga" -%>
+						"master_authorized_networks_config": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							AtLeastOneOf: composerConfigKeys,
+							MaxItems:    1,
+							Description: `Configuration options for the master authorized networks feature. Enabled master authorized networks will disallow all external traffic to access Kubernetes master through HTTPS except traffic from the given CIDR blocks, Google Compute Engine Public IPs and Google Prod IPs.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether or not master authorized networks is enabled.`,
+									},
+									"cidr_block": {
+										Type:        schema.TypeSet,
+										Computed:    true,
+										Optional:    true,
+										Elem:        cidrBlocks,
+										Description: `cidr_blocks define up to 50 external networks that could access Kubernetes master through HTTPS.`,
+									},
+								},
+							},
+						},
 <% end -%>
 						"airflow_uri": {
 							Type:        schema.TypeString,
@@ -1100,6 +1147,7 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["maintenance_window"] = flattenComposerEnvironmentConfigMaintenanceWindow(envCfg.MaintenanceWindow)
 	transformed["workloads_config"] = flattenComposerEnvironmentConfigWorkloadsConfig(envCfg.WorkloadsConfig)
 	transformed["environment_size"] = envCfg.EnvironmentSize
+	transformed["master_authorized_networks_config"] = flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(envCfg.MasterAuthorizedNetworksConfig)
 <% end -%>
 
 	return []interface{}{transformed}
@@ -1308,6 +1356,30 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	transformed["scheduler_count"] = softwareCfg.SchedulerCount
 	return []interface{}{transformed}
 }
+
+<% unless version == "ga" -%>
+func flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(masterAuthNetsCfg *composer.MasterAuthorizedNetworksConfig) interface{} {
+	if masterAuthNetsCfg == nil {
+		return nil
+	}
+
+	transformed := make([]interface{}, 0, len(masterAuthNetsCfg.CidrBlocks) + 1)
+	// TODO how make flatten/expand fo master authorized networks ie. what type should be transformed etc.
+	for _, ipRange := range accessControl.AllowedIpRanges {
+		data := map[string]interface{}{
+			"value":       ipRange.Value,
+			"description": ipRange.Description,
+		}
+		transformed = append(transformed, data)
+	}
+
+	webServerNetworkAccessControl := make(map[string]interface{})
+
+	webServerNetworkAccessControl["allowed_ip_range"] = schema.NewSet(schema.HashResource(allowedIpRangesConfig), transformed)
+
+	return []interface{}{webServerNetworkAccessControl}
+}
+<% end -%>
 
 func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.EnvironmentConfig, error) {
 	l := v.([]interface{})

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -113,7 +113,7 @@ var (
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:     		schema.TypeString,
-				Required: 		true,
+				Optional: 		true,
 				Description:  `display_name is a field for users to identify CIDR blocks.`,
 			},
 			"cidr_block": {
@@ -719,7 +719,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Required:    true,
 										Description: `Whether or not master authorized networks is enabled.`,
 									},
-									"cidr_block": {
+									"cidr_blocks": {
 										Type:        schema.TypeSet,
 										Optional:    true,
 										Elem:        cidrBlocks,
@@ -1383,7 +1383,7 @@ func flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(masterAuthNe
 
 	masterAuthorizedNetworksConfig := make(map[string]interface{})
 	masterAuthorizedNetworksConfig["enabled"] = masterAuthNetsCfg.Enabled
-	masterAuthorizedNetworksConfig["cidr_block"] = schema.NewSet(schema.HashResource(cidrBlocks), transformed)
+	masterAuthorizedNetworksConfig["cidr_blocks"] = schema.NewSet(schema.HashResource(cidrBlocks), transformed)
 
 	return []interface{}{masterAuthorizedNetworksConfig}
 }
@@ -1529,19 +1529,22 @@ func expandComposerEnvironmentConfigMasterAuthorizedNetworksConfig(v interface{}
 	raw := l[0]
 	original := raw.(map[string]interface{})
 
-	cidrBlocksRaw := original["cidr_block"].(*schema.Set).List()
+	cidrBlocksRaw := original["cidr_blocks"].(*schema.Set).List()
 
-	transformed := &composer.ConfigMasterAuthorizedNetworksConfig{}
-	cidrBlocks := make([]*composer.cidrBlocks, 0, len(original))
+	transformed := &composer.MasterAuthorizedNetworksConfig{}
+	cidrBlocks := make([]*composer.CidrBlock, 0, len(original))
 
 	for _, originalCidrBlock := range cidrBlocksRaw {
 		originalCidrBlockRaw := originalCidrBlock.(map[string]interface{})
-		transformedCidrBlock.DisplayName = originalCidrBlockRaw["display_name"].(string)
+		transformedCidrBlock := &composer.CidrBlock{}
+		if v, ok := originalCidrBlockRaw["display_name"]; ok {
+			transformedCidrBlock.DisplayName = v.(string)
+		}
 		transformedCidrBlock.CidrBlock = originalCidrBlockRaw["cidr_block"].(string)
 		cidrBlocks = append(cidrBlocks, transformedCidrBlock)
 	}
 	transformed.Enabled = original["enabled"].(bool)
-	transformed.cidrBlocks = cidrBlocks
+	transformed.CidrBlocks = cidrBlocks
 	return transformed, nil
 }
 

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -1361,21 +1361,20 @@ func flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(masterAuthNe
 		return nil
 	}
 
-	transformed := make([]interface{}, 0, len(masterAuthNetsCfg.CidrBlocks) + 1)
-	// TODO how make flatten/expand fo master authorized networks ie. what type should be transformed etc.
-	for _, ipRange := range accessControl.AllowedIpRanges {
+	transformed := make([]interface{}, 0, len(masterAuthNetsCfg.CidrBlocks))
+	for _, cidrBlock := range masterAuthNetsCfg.CidrBlocks {
 		data := map[string]interface{}{
-			"value":       ipRange.Value,
-			"description": ipRange.Description,
+			"display_name": cidrBlock.DisplayName,
+			"cidr_block": cidrBlock.CidrBlock,
 		}
 		transformed = append(transformed, data)
 	}
 
-	webServerNetworkAccessControl := make(map[string]interface{})
+	masterAuthorizedNetworksConfig := make(map[string]interface{})
+	masterAuthorizedNetworksConfig["enabled"] = masterAuthNetsCfg.Enabled
+	masterAuthorizedNetworksConfig["cidr_block"] = schema.NewSet(schema.HashResource(cidrBlocks), transformed)
 
-	webServerNetworkAccessControl["allowed_ip_range"] = schema.NewSet(schema.HashResource(allowedIpRangesConfig), transformed)
-
-	return []interface{}{webServerNetworkAccessControl}
+	return []interface{}{masterAuthorizedNetworksConfig}
 }
 <% end -%>
 
@@ -1459,6 +1458,15 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
   	}
   	transformed.EnvironmentSize = transformedEnvironmentSize
 <% end -%>
+
+<% unless version == "ga" -%>
+	transformedMasterAuthorizedNetworksConfig, err := expandComposerEnvironmentConfigMasterAuthorizedNetworksConfig(original["master_authorized_networks_config"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.MasterAuthorizedNetworksConfig = transformedMasterAuthorizedNetworksConfig
+
+<% end -%>
 	return transformed, nil
 }
 
@@ -1496,6 +1504,36 @@ func expandComposerEnvironmentConfigWebServerNetworkAccessControl(v interface{},
 	}
 
 	transformed.AllowedIpRanges = allowedIpRanges
+	return transformed, nil
+}
+
+<% end -%>
+
+<% unless version == "ga" -%>
+func expandComposerEnvironmentConfigMasterAuthorizedNetworksConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.MasterAuthorizedNetworksConfig, error) {
+	l := v.([]interface{})
+	if len(l) == 0 {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	cidrBlocksRaw := original["cidr_block"].(*schema.Set).List()
+
+	transformed := &composer.ConfigMasterAuthorizedNetworksConfig{}
+	cidrBlocks := make([]*composer.cidrBlocks, 0, len(original))
+
+	for _, originalCidrBlock := range cidrBlocksRaw {
+		originalCidrBlockRaw := originalCidrBlock.(map[string]interface{})
+		transformedCidrBlock := &composer.cidrBlocks{Value: originalCidrBlockRaw["value"].(string)}
+		transformedCidrBlock := &composer.cidrBlocks{Value: originalCidrBlockRaw["value"].(string)}
+		if v, ok := originalCidrBlockRaw["description"]; ok {
+			transformedCidrBlock.Description = v.(string)
+		}
+		cidrBlocks = append(cidrBlocks, transformedCidrBlock)
+	}
+	transformed.Enabled = original["enabled"].(bool)
+	transformed.cidrBlocks = cidrBlocks
 	return transformed, nil
 }
 

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -707,11 +707,11 @@ func resourceComposerEnvironment() *schema.Resource {
 <% end -%>
 <% unless version == "ga" -%>
 						"master_authorized_networks_config": {
-							Type:        schema.TypeList,
-							Optional:    true,
+							Type:        	schema.TypeList,
+							Optional:    	true,
 							AtLeastOneOf: composerConfigKeys,
-							MaxItems:    1,
-							Description: `Configuration options for the master authorized networks feature. Enabled master authorized networks will disallow all external traffic to access Kubernetes master through HTTPS except traffic from the given CIDR blocks, Google Compute Engine Public IPs and Google Prod IPs.`,
+							MaxItems:    	1,
+							Description: 	`Configuration options for the master authorized networks feature. Enabled master authorized networks will disallow all external traffic to access Kubernetes master through HTTPS except traffic from the given CIDR blocks, Google Compute Engine Public IPs and Google Prod IPs.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -1014,6 +1014,17 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				patchObj.Config.WorkloadsConfig = config.WorkloadsConfig
 			}
 			err = resourceComposerEnvironmentPatchField("config.WorkloadsConfig", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
+
+		if d.HasChange("config.0.master_authorized_networks_config") {
+			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+			if config != nil {
+				patchObj.Config.MasterAuthorizedNetworksConfig = config.MasterAuthorizedNetworksConfig
+			}
+			err = resourceComposerEnvironmentPatchField("config.MasterAuthorizedNetworksConfig", userAgent, patchObj, d, tfConfig)
 			if err != nil {
 				return err
 			}
@@ -1525,11 +1536,8 @@ func expandComposerEnvironmentConfigMasterAuthorizedNetworksConfig(v interface{}
 
 	for _, originalCidrBlock := range cidrBlocksRaw {
 		originalCidrBlockRaw := originalCidrBlock.(map[string]interface{})
-		transformedCidrBlock := &composer.cidrBlocks{Value: originalCidrBlockRaw["value"].(string)}
-		transformedCidrBlock := &composer.cidrBlocks{Value: originalCidrBlockRaw["value"].(string)}
-		if v, ok := originalCidrBlockRaw["description"]; ok {
-			transformedCidrBlock.Description = v.(string)
-		}
+		transformedCidrBlock.DisplayName = originalCidrBlockRaw["display_name"].(string)
+		transformedCidrBlock.CidrBlock = originalCidrBlockRaw["cidr_block"].(string)
 		cidrBlocks = append(cidrBlocks, transformedCidrBlock)
 	}
 	transformed.Enabled = original["enabled"].(bool)

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -709,7 +709,6 @@ func resourceComposerEnvironment() *schema.Resource {
 						"master_authorized_networks_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
 							AtLeastOneOf: composerConfigKeys,
 							MaxItems:    1,
 							Description: `Configuration options for the master authorized networks feature. Enabled master authorized networks will disallow all external traffic to access Kubernetes master through HTTPS except traffic from the given CIDR blocks, Google Compute Engine Public IPs and Google Prod IPs.`,
@@ -722,7 +721,6 @@ func resourceComposerEnvironment() *schema.Resource {
 									},
 									"cidr_block": {
 										Type:        schema.TypeSet,
-										Computed:    true,
 										Optional:    true,
 										Elem:        cidrBlocks,
 										Description: `cidr_blocks define up to 50 external networks that could access Kubernetes master through HTTPS.`,

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -429,6 +429,140 @@ func TestAccComposerEnvironment_composerV2PrivateServiceConnect(t *testing.T) {
 	})
 }
 
+
+func TestAccComposerEnvironment_composerV1MasterAuthNetworks(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_MasterAuthNetworks("1", "1", envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_MasterAuthNetworks("1", "1", envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
+func TestAccComposerEnvironment_composerV2MasterAuthNetworks(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_MasterAuthNetworks("2", "2", envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_MasterAuthNetworks("2", "2", envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
+func TestAccComposerEnvironment_composerV1MasterAuthNetworksUpdate(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_MasterAuthNetworks("1", "1", envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_MasterAuthNetworksUpdate("1", "1", envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_MasterAuthNetworksUpdate("1", "1", envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
+func TestAccComposerEnvironment_composerV2MasterAuthNetworksUpdate(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_MasterAuthNetworks("2", "2", envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_MasterAuthNetworksUpdate("2", "2", envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_MasterAuthNetworksUpdate("2", "2", envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
 <% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
 func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
@@ -1135,6 +1269,111 @@ resource "google_compute_subnetwork" "test" {
 
 `, envName, network, subnetwork)
 }
+
+func testAccComposerEnvironment_MasterAuthNetworks(compVersion, airflowVersion, envName, network, subnetwork string) string {
+	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+locals {
+	composer_version = "%s"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
+	airflow_version = "%s"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+
+	config {
+		node_config {
+			network    		= google_compute_network.test.self_link
+			subnetwork 		= google_compute_subnetwork.test.self_link
+		}
+
+		software_config {
+			image_version = local.matching_images[0]
+		}
+
+		master_authorized_networks_config {
+			enabled	= true
+			cidr_blocks {
+				display_name	= "foo"
+				cidr_block		= "8.8.8.8/32"
+			}
+			cidr_blocks {
+				cidr_block		= "8.8.8.8/24"
+			}
+		}
+	}
+}
+
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+
+`, compVersion, airflowVersion, envName, network, subnetwork)
+}
+
+
+func testAccComposerEnvironment_MasterAuthNetworksUpdate(compVersion, airflowVersion, envName, network, subnetwork string) string {
+	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+locals {
+	composer_version = "%s"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
+	airflow_version = "%s"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+
+	config {
+		node_config {
+			network    		= google_compute_network.test.self_link
+			subnetwork 		= google_compute_subnetwork.test.self_link
+		}
+
+		software_config {
+			image_version = local.matching_images[0]
+		}
+
+		master_authorized_networks_config {
+			enabled	= true
+			cidr_blocks {
+				display_name	= "foo_update"
+				cidr_block		= "9.9.9.9/30"
+			}
+		}
+	}
+}
+
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+
+`, compVersion, airflowVersion, envName, network, subnetwork)
+}
+
 <% end -%>
 
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1151,7 +1151,7 @@ locals {
 
 resource "google_composer_environment" "test" {
 	name   = "%s"
-	region = "us-central1"
+	region = "us-east1"
 
 	config {
 		node_count = 4
@@ -1379,7 +1379,7 @@ resource "google_compute_network" "test" {
 resource "google_compute_subnetwork" "test" {
 	name          = "%s"
 	ip_cidr_range = "10.2.0.0/16"
-	region        = "us-central1"
+	region        = "us-east1"
 	network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -296,6 +296,14 @@ The following arguments are supported:
 * `maintenance_window` -
   (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
   The configuration settings for Cloud Composer maintenance windows.
+ 
+* `master_authorized_networks_config` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  Configuration options for the master authorized networks feature. Enabled 
+  master authorized networks will disallow all external traffic to access 
+  Kubernetes master through HTTPS except traffic from the given CIDR blocks, 
+  Google Compute Engine Public IPs and Google Prod IPs. Structure is
+  [documented below](#nested_master_authorized_networks_config).
 
 <a name="nested_node_config"></a>The `node_config` block supports:
 
@@ -565,6 +573,24 @@ The `web_server_network_access_control` supports:
   The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
   Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
 
+<a name="nested_master_authorized_networks_config"></a>The `master_authorized_networks_config` block supports:
+* `enabled` -
+  (Required)
+  Whether or not master authorized networks is enabled.
+ 
+* `cidr_blocks` -
+  `cidr_blocks `define up to 50 external networks that could access Kubernetes master through HTTPS. Structure is [documented below](#nested_cidr_blocks).
+
+<a name="nested_cidr_blocks"></a>The `cidr_blocks` supports:
+
+* `display_name` -
+  (Optional)
+  `display_name` is a field for users to identify CIDR blocks.
+
+* `cidr_block` -
+  (Required)
+  `cidr_block< must be specified in CIDR notation.
+
 ## Argument Reference - Cloud Composer 2
 
 The following arguments are supported:
@@ -629,6 +655,14 @@ The `config` block supports:
   Cloud Composer infrastructure that includes the Airflow database. Values for
   environment size are `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`,
   and `ENVIRONMENT_SIZE_LARGE`.
+
+* `master_authorized_networks_config` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  Configuration options for the master authorized networks feature. Enabled
+  master authorized networks will disallow all external traffic to access
+  Kubernetes master through HTTPS except traffic from the given CIDR blocks,
+  Google Compute Engine Public IPs and Google Prod IPs. Structure is
+  documented below.
 
 The `node_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add Cloud Composer support for master authorized networks.
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10748


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add support for Cloud Composer master authorized networks flag
```
