### PR TITLE
add version to guard `public_access_prevention` from tpg

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -743,11 +743,13 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+<% unless version == "ga" -%>
 	if res.IamConfiguration != nil && res.IamConfiguration.PublicAccessPrevention != "" {
 		if err := d.Set("public_access_prevention", res.IamConfiguration.PublicAccessPrevention); err != nil {
 			return fmt.Errorf("Error setting public_access_prevention: %s", err)
 		}
 	}
+<% end -%>
 
 	if res.Billing == nil {
 		if err := d.Set("requester_pays", nil); err != nil {
@@ -1140,8 +1142,8 @@ func expandIamConfiguration(d *schema.ResourceData) *storage.BucketIamConfigurat
 			ForceSendFields: []string{"Enabled"},
 		},
 	}
-<% unless version == "ga" -%>
 
+<% unless version == "ga" -%>
 	if v, ok := d.GetOk("public_access_prevention"); ok {
 		cfg.PublicAccessPrevention = v.(string)
 	}


### PR DESCRIPTION
This code mistakenly allows this field in GA provider... adding protection

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
