### PR TITLE
Added maintenancePolicy attribute to redis instance

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -143,6 +143,125 @@ objects:
           The ID of the instance or a fully qualified identifier for the instance.
         required: true
         input: true
+      - !ruby/object:Api::Type::NestedObject
+        name: maintenancePolicy
+        description: Maintenance policy for an instance.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'createTime'
+            output: true
+            description: |
+              Output only. The time when the policy was created.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+              resolution and up to nine fractional digits.
+          - !ruby/object:Api::Type::String
+            name: 'updateTime'
+            output: true
+            description: |
+              Output only. The time when the policy was last updated.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+              resolution and up to nine fractional digits.
+          - !ruby/object:Api::Type::String
+            name: 'description'
+            description: |
+              Optional. Description of what this policy is for.
+              Create/Update methods return INVALID_ARGUMENT if the
+              length is greater than 512.
+          - !ruby/object:Api::Type::Array
+            name: 'weeklyMaintenanceWindow'
+            description: |
+              Optional. Maintenance window that is applied to resources covered by this policy.
+              Minimum 1. For the current version, the maximum number
+              of weekly_window is expected to be one.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: 'day'
+                  required: true
+                  description: |
+                    Required. The day of week that maintenance updates occur.
+
+                    - DAY_OF_WEEK_UNSPECIFIED: The day of the week is unspecified.
+                    - MONDAY: Monday
+                    - TUESDAY: Tuesday
+                    - WEDNESDAY: Wednesday
+                    - THURSDAY: Thursday
+                    - FRIDAY: Friday
+                    - SATURDAY: Saturday
+                    - SUNDAY: Sunday
+                  values:
+                    - :DAY_OF_WEEK_UNSPECIFIED
+                    - :MONDAY
+                    - :TUESDAY
+                    - :WEDNESDAY
+                    - :THURSDAY
+                    - :FRIDAY
+                    - :SATURDAY
+                    - :SUNDAY
+                - !ruby/object:Api::Type::String
+                  name: 'duration'
+                  output: true
+                  description: |
+                    Output only. Duration of the maintenance window.
+                    The current window is fixed at 1 hour.
+                    A duration in seconds with up to nine fractional digits,
+                    terminated by 's'. Example: "3.5s".
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'startTime'
+                  required: true
+                  allow_empty_object: true
+                  send_empty_value: true
+                  description: |
+                    Required. Start time of the window in UTC time.
+                  properties:
+                    - !ruby/object:Api::Type::Integer
+                      name: 'hours'
+                      default_value: 0
+                      description: |
+                        Hours of day in 24 hour format. Should be from 0 to 23.
+                        An API may choose to allow the value "24:00:00" for scenarios like business closing time.
+                    - !ruby/object:Api::Type::Integer
+                      name: 'minutes'
+                      default_value: 0
+                      description: |
+                        Minutes of hour of day. Must be from 0 to 59.
+                    - !ruby/object:Api::Type::Integer
+                      name: 'seconds'
+                      default_value: 0
+                      description: |
+                        Seconds of minutes of the time. Must normally be from 0 to 59.
+                        An API may allow the value 60 if it allows leap-seconds.
+                    - !ruby/object:Api::Type::Integer
+                      name: 'nanos'
+                      default_value: 0
+                      description: |
+                        Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999.
+      - !ruby/object:Api::Type::NestedObject
+        name: maintenanceSchedule
+        description: Upcoming maintenance schedule.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'startTime'
+            output: true
+            description: |
+              Output only. The start time of any upcoming scheduled maintenance for this instance.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+              resolution and up to nine fractional digits.
+          - !ruby/object:Api::Type::String
+            name: 'endTime'
+            output: true
+            description: |
+              Output only. The end time of any upcoming scheduled maintenance for this instance.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+              resolution and up to nine fractional digits.
+          - !ruby/object:Api::Type::String
+            name: 'scheduleDeadlineTime'
+            output: true
+            description: |
+              Output only. The deadline that the maintenance schedule start time
+              can not go beyond, including reschedule.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+              resolution and up to nine fractional digits.
       - !ruby/object:Api::Type::Integer
         name: memorySizeGb
         description: Redis memory size in GiB.

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -216,24 +216,20 @@ objects:
                   properties:
                     - !ruby/object:Api::Type::Integer
                       name: 'hours'
-                      default_value: 0
                       description: |
                         Hours of day in 24 hour format. Should be from 0 to 23.
                         An API may choose to allow the value "24:00:00" for scenarios like business closing time.
                     - !ruby/object:Api::Type::Integer
                       name: 'minutes'
-                      default_value: 0
                       description: |
                         Minutes of hour of day. Must be from 0 to 59.
                     - !ruby/object:Api::Type::Integer
                       name: 'seconds'
-                      default_value: 0
                       description: |
                         Seconds of minutes of the time. Must normally be from 0 to 59.
                         An API may allow the value 60 if it allows leap-seconds.
                     - !ruby/object:Api::Type::Integer
                       name: 'nanos'
-                      default_value: 0
                       description: |
                         Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999.
       - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -76,6 +76,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^[a-z][a-z0-9-]{0,39}[a-z0-9]$'
+      maintenancePolicy.weeklyMaintenanceWindow.startTime.hours: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0,23)'
+      maintenancePolicy.weeklyMaintenanceWindow.startTime.minutes: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0,59)'
+      maintenancePolicy.weeklyMaintenanceWindow.startTime.seconds: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0,60)'
+      maintenancePolicy.weeklyMaintenanceWindow.startTime.nanos: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0,999999999)'
       redisVersion: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         update_url: 'projects/{{project}}/locations/{{region}}/instances/{{name}}:upgrade'

--- a/mmv1/templates/terraform/examples/redis_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_full.tf.erb
@@ -16,6 +16,18 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
     my_key    = "my_val"
     other_key = "other_val"
   }
+
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = "TUESDAY"
+      start_time {
+        hours = 0
+        minutes = 30
+        seconds = 0
+        nanos = 0
+      }
+    }
+  }
 }
 
 // This example assumes this network already exists.


### PR DESCRIPTION
Signed-off-by: Jacek Kikiewicz <public@kikiewicz.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds maintenance_policy as well as maintenance_schedule to redis instance.
Resolves: https://github.com/hashicorp/terraform-provider-google/issues/9727


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


```release-note:enhancement
redis: added `maintenance_policy` and `maintenance_schedule` to `google_redis_instance`
```
    


