### PR TITLE
privateca sweeper

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_sweeper_test.go
@@ -1,0 +1,82 @@
+package google
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("StorageBucket", &resource.Sweeper{
+		Name: "StorageBucket",
+		F:    testSweepStorageBucket,
+	})
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepStorageBucket(region string) error {
+	resourceName := "StorageBucket"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	caPoolsUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools")
+	if err != nil {
+		return err
+	}
+
+	res, err := sendRequest(config, "GET", config.Project, caPoolsUrl, config.userAgent, nil)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", caPoolsUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["items"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	// Count items that weren't sweeped.
+	nonPrefixCount := 0
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+
+		log.Printf("%+v", obj)
+
+		// id := obj["name"].(string)
+		// // Increment count and skip if resource is not sweepable.
+		// if !isSweepableTestResource(id) {
+		// 	nonPrefixCount++
+		// 	continue
+		// }
+
+		// deleteUrl := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s", id)
+		// _, err = sendRequest(config, "DELETE", config.Project, deleteUrl, config.userAgent, nil)
+		// if err != nil {
+		// 	log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		// } else {
+		// 	log.Printf("[INFO][SWEEPER_LOG] Deleted a %s resource: %s", resourceName, id)
+		// }
+	}
+
+	if nonPrefixCount > 0 {
+		log.Printf("[INFO][SWEEPER_LOG] %d items without tf-test prefix remain.", nonPrefixCount)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
A bit abnormal since we need to loop through ca pools + disable active certificate authorities


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
