### PR TITLE
Add back self_link to vpc access and healthcare

### DIFF
--- a/mmv1/products/kms/terraform.yaml
+++ b/mmv1/products/kms/terraform.yaml
@@ -40,7 +40,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
+      decoder: templates/terraform/decoders/kms.go.erb
       encoder: templates/terraform/encoders/send_nil_body.go.erb
   CryptoKey: !ruby/object:Overrides::Terraform::ResourceOverride
     description: |
@@ -95,7 +95,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_delete: templates/terraform/custom_delete/kms_crypto_key.erb
       custom_import: templates/terraform/custom_import/kms_crypto_key.go.erb
-      decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
+      decoder: templates/terraform/decoders/kms.go.erb
       encoder: templates/terraform/encoders/kms_crypto_key.go.erb
       update_encoder: templates/terraform/update_encoder/kms_crypto_key.go.erb
   KeyRingImportJob: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/templates/terraform/decoders/kms.go.erb
+++ b/mmv1/templates/terraform/decoders/kms.go.erb
@@ -12,13 +12,9 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-	// Take the returned long form of the name and use it as `self_link`.
-	// Then modify the name to be the user specified form.
+	// Modify the name to be the user specified form.
 	// We can't just ignore_read on `name` as the linter will
 	// complain that the returned `res` is never used afterwards.
 	// Some field needs to be actually set, and we chose `name`.
-	if err := d.Set("self_link", res["name"].(string)); err != nil {
-		return nil, fmt.Errorf("Error setting self_link: %s", err)
-	}
 	res["name"] = d.Get("name").(string)
 return res, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`self_link` functionality for `healthcare` and `vpcaccess` was accidentally removed in PR https://github.com/GoogleCloudPlatform/magic-modules/pull/5314, and now add them back.

This also fixes https://github.com/hashicorp/terraform-provider-google/issues/10584


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
healthcare: Added back `self_link` functionality which was accidentally removed in `4.0.0` release. 
```

```release-note:bug
vpcaccess: Added back `self_link` functionality which was accidentally removed in `4.0.0` release.
```
