### PR TITLE
upgrade ACM version in test

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
@@ -103,7 +103,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -120,7 +120,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -153,7 +153,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -170,7 +170,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -209,7 +209,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       source_format = "unstructured"
       git {
@@ -237,7 +237,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -281,7 +281,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     policy_controller {
       enabled = true
       audit_interval_seconds = "100"
@@ -388,7 +388,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       git {
         sync_repo = "https://github.com/hashicorp/terraform"
@@ -460,7 +460,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.7.0"
+    version = "1.9.0"
     config_sync {
       git {
         sync_repo = "https://github.com/hashicorp/terraform"

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
@@ -103,7 +103,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -120,7 +120,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.6.1"
+    version = "1.7.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -153,7 +153,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -170,7 +170,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.6.1"
+    version = "1.7.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -209,7 +209,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     config_sync {
       source_format = "unstructured"
       git {
@@ -237,7 +237,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -281,7 +281,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     policy_controller {
       enabled = true
       audit_interval_seconds = "100"
@@ -388,7 +388,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     config_sync {
       git {
         sync_repo = "https://github.com/hashicorp/terraform"
@@ -460,7 +460,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.6.2"
+    version = "1.7.0"
     config_sync {
       git {
         sync_repo = "https://github.com/hashicorp/terraform"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

It appears that [ACM versions < 1.7.0 are deprecated through acm hub controller](https://cloud.google.com/anthos/docs/version-and-upgrade-support), so upgrade the version to 1.7.0 in tests.
This fixes https://github.com/hashicorp/terraform-provider-google/issues/10304.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
gke_hub: Only ACM versions >= 1.7.0 are supported and should be used in `version` field in `google_gke_hub_feature_membership`.
```
