### PR TITLE
Daily patchdeployment

### DIFF
--- a/mmv1/products/osconfig/api.yaml
+++ b/mmv1/products/osconfig/api.yaml
@@ -782,9 +782,6 @@ objects:
               A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
           - !ruby/object:Api::Type::NestedObject
             name: 'weekly'
-            exactly_one_of:
-              - recurring_schedule.0.weekly
-              - recurring_schedule.0.monthly
             description: |
               Schedule with weekly executions.
             properties:
@@ -803,9 +800,6 @@ objects:
                   - :SUNDAY
           - !ruby/object:Api::Type::NestedObject
             name: 'monthly'
-            exactly_one_of:
-              - recurring_schedule.0.weekly
-              - recurring_schedule.0.monthly
             description: |
               Schedule with monthly executions.
             properties:

--- a/mmv1/products/osconfig/terraform.yaml
+++ b/mmv1/products/osconfig/terraform.yaml
@@ -20,7 +20,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "os_config_patch_deployment_basic"
         primary_resource_id: "patch"
         vars:
-          instance_name: "patch-deploy-inst"
+          patch_deployment_id: "patch-deploy"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "os_config_patch_deployment_daily"
+        primary_resource_id: "patch"
+        vars:
           patch_deployment_id: "patch-deploy"
       - !ruby/object:Provider::Terraform::Examples
         name: "os_config_patch_deployment_instance"
@@ -32,7 +36,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "os_config_patch_deployment_full"
         primary_resource_id: "patch"
         vars:
-          instance_name: "patch-deploy-inst"
           patch_deployment_id: "patch-deploy"
     properties:
       patchDeploymentId: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/encoders/os_config_patch_deployment.go.erb
+++ b/mmv1/templates/terraform/encoders/os_config_patch_deployment.go.erb
@@ -4,6 +4,8 @@ if obj["recurringSchedule"] != nil {
 		obj["recurringSchedule"].(map[string]interface{})["frequency"] = "MONTHLY"
 	} else if schedule["weekly"] != nil {
 		obj["recurringSchedule"].(map[string]interface{})["frequency"] = "WEEKLY"
+	} else {
+		obj["recurringSchedule"].(map[string]interface{})["frequency"] = "DAILY"
 	}
 }
 

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_daily.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_daily.tf.erb
@@ -5,7 +5,16 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
     all = true
   }
 
-  one_time_schedule {
-    execute_time = "2999-10-10T10:10:10.045123456Z"
+  recurring_schedule {
+    time_zone {
+      id = "America/New_York"
+    }
+
+    time_of_day {
+      hours = 0
+      minutes = 30
+      seconds = 30
+      nanos = 20
+    }
   }
 }

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -1,5 +1,5 @@
 resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" {
-  patch_deployment_id = "<%= ctx[:vars]['instance_name'] %>"
+  patch_deployment_id = "<%= ctx[:vars]['patch_deployment_id'] %>"
 
   instance_filter {
     group_labels {

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_instance.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_instance.tf.erb
@@ -26,7 +26,7 @@ resource "google_compute_instance" "foobar" {
 }
 
 resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" {
-  patch_deployment_id = "<%= ctx[:vars]['instance_name'] %>"
+  patch_deployment_id = "<%= ctx[:vars]['patch_deployment_id'] %>"
 
   instance_filter {
     instances = [google_compute_instance.foobar.id]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Removes the conflict between `monthly` and `weekly` subfields of `recurring_schedule` so that a daily schedule can be specified by setting neither field.

fixes https://github.com/hashicorp/terraform-provider-google/issues/10777

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Added daily os config patch deployments
```
