### PR TITLE
Allow instance disks to be deleted so resources are cleared in test infra

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -983,7 +983,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -1041,7 +1041,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -1103,7 +1103,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -1307,7 +1307,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -1364,7 +1364,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -1650,7 +1650,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -755,7 +755,7 @@ resource "google_compute_instance_template" "template" {
 
 resource "google_compute_instance_group_manager" "manager" {
   name               = "%s"
-  base_instance_name = "disk-igm"
+  base_instance_name = "tf-test-disk-igm"
   version {
     instance_template = google_compute_instance_template.template.self_link
     name              = "primary"

--- a/mmv1/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
@@ -471,7 +471,7 @@ resource "google_compute_instance_group_manager" "igm" {
     instance_template = google_compute_instance_template.instance_template.self_link
     name              = "primary"
   }
-  base_instance_name = "internal-igm"
+  base_instance_name = "tf-test-internal-igm"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -590,7 +590,7 @@ resource "google_compute_instance_group_manager" "igm" {
     instance_template = google_compute_instance_template.instance_template.self_link
     name              = "primary"
   }
-  base_instance_name = "internal-igm"
+  base_instance_name = "tf-test-internal-igm"
   zone               = "us-central1-f"
   target_size        = 1
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -494,7 +494,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   }
 
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
 }
@@ -508,7 +508,7 @@ resource "google_compute_instance_group_manager" "igm-no-tp" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "igm-no-tp"
+  base_instance_name = "tf-test-igm-no-tp"
   zone               = "us-central1-c"
   target_size        = 2
 }
@@ -552,7 +552,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
 }
 `, template, igm)
@@ -602,7 +602,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
   }
 
   target_pools       = [google_compute_target_pool.igm-update.self_link]
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   zone               = "us-central1-c"
   target_size        = 2
   named_port {
@@ -688,7 +688,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
     google_compute_target_pool.igm-update.self_link,
     google_compute_target_pool.igm-update2.self_link,
   ]
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   zone               = "us-central1-c"
   target_size        = 3
   named_port {
@@ -774,7 +774,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
     instance_template = google_compute_instance_template.igm-update2.self_link
   }
 
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   zone               = "us-central1-c"
   target_size        = 3
   named_port {
@@ -829,7 +829,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
     instance_template = google_compute_instance_template.igm-update.self_link
   }
 
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   zone               = "us-central1-c"
   target_size        = 2
   named_port {
@@ -878,7 +878,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     name              = "prod"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name = "igm-rolling-update-policy"
+  base_instance_name = "tf-test-igm-rolling-update-policy"
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
@@ -929,7 +929,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     name              = "prod2"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name = "igm-rolling-update-policy"
+  base_instance_name = "tf-test-igm-rolling-update-policy"
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
@@ -977,7 +977,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     name              = "prod2"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name = "igm-rolling-update-policy"
+  base_instance_name = "tf-test-igm-rolling-update-policy"
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
@@ -1028,7 +1028,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     name              = "prod2"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name = "igm-rolling-update-policy"
+  base_instance_name = "tf-test-igm-rolling-update-policy"
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
@@ -1076,7 +1076,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     name              = "prod2"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name = "igm-rolling-update-policy"
+  base_instance_name = "tf-test-igm-rolling-update-policy"
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
@@ -1130,7 +1130,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
 
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
 }
@@ -1144,7 +1144,7 @@ resource "google_compute_instance_group_manager" "igm-basic-2" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "igm-basic-2"
+  base_instance_name = "tf-test-igm-basic-2"
   zone               = "us-west1-b"
   target_size        = 2
 }
@@ -1191,7 +1191,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
   auto_healing_policies {
@@ -1249,7 +1249,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
 }
@@ -1311,7 +1311,7 @@ resource "google_compute_instance_template" "igm-canary" {
 resource "google_compute_instance_group_manager" "igm-basic" {
   description        = "Terraform test instance group manager"
   name               = "%s"
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
 
@@ -1385,7 +1385,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
   stateful_disk {
@@ -1457,7 +1457,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
   stateful_disk {
@@ -1522,7 +1522,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   wait_for_instances = true
   wait_for_instances_status = "STABLE"
@@ -1584,7 +1584,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     name              = "prod"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   wait_for_instances = true
   wait_for_instances_status = "UPDATED"

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -1390,7 +1390,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   target_size        = 2
   stateful_disk {
     device_name = "my-stateful-disk"
-    delete_rule = "NEVER"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
   }
 }
 
@@ -1462,7 +1462,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   target_size        = 2
   stateful_disk {
     device_name = "my-stateful-disk"
-    delete_rule = "NEVER"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
   }
 
   stateful_disk {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -1462,7 +1462,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   target_size        = 2
   stateful_disk {
     device_name = "my-stateful-disk"
-    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
+    delete_rule = "NEVER"
   }
 
   stateful_disk {

--- a/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -290,7 +290,7 @@ resource "google_compute_instance_group_manager" "igm" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "igm-no-tp"
+  base_instance_name = "tf-test-igm-no-tp"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -156,7 +156,7 @@ resource "google_compute_region_instance_group_manager" "foobar" {
     name              = "primary"
   }
   target_pools       = [google_compute_target_pool.foobar.self_link]
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   region             = "us-central1"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -553,7 +553,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -650,7 +650,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template  = google_compute_instance_template.foobar.self_link
     name               = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -715,7 +715,7 @@ resource "google_compute_instance_group_manager" "foobar" {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
   }
-  base_instance_name = "foobar"
+  base_instance_name = "tf-test-foobar"
   zone               = "us-central1-f"
   target_size        = 1
 }
@@ -784,7 +784,7 @@ resource "google_compute_region_instance_group_manager" "rigm1" {
     instance_template = google_compute_instance_template.instance_template.self_link
     name              = "primary"
   }
-  base_instance_name = "internal-glb"
+  base_instance_name = "tf-test-internal-glb"
   target_size        = 1
 }
 
@@ -795,7 +795,7 @@ resource "google_compute_region_instance_group_manager" "rigm2" {
     instance_template = google_compute_instance_template.instance_template.self_link
     name              = "primary"
   }
-  base_instance_name = "internal-glb"
+  base_instance_name = "tf-test-internal-glb"
   target_size        = 1
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -464,7 +464,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
   }
 
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   target_size        = 2
 }
 
@@ -477,7 +477,7 @@ resource "google_compute_region_instance_group_manager" "igm-no-tp" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "igm-no-tp"
+  base_instance_name = "tf-test-igm-no-tp"
   region             = "us-central1"
   target_size        = 2
 }
@@ -521,7 +521,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   region             = "us-central1"
 }
 `, template, igm)
@@ -571,7 +571,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
   }
 
   target_pools       = [google_compute_target_pool.igm-update.self_link]
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   region             = "us-central1"
   target_size        = 2
   named_port {
@@ -657,7 +657,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
     google_compute_target_pool.igm-update.self_link,
     google_compute_target_pool.igm-update2.self_link,
   ]
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   region             = "us-central1"
   target_size        = 3
   named_port {
@@ -743,7 +743,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
     name              = "primary"
   }
 
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   region             = "us-central1"
   target_size        = 3
   named_port {
@@ -798,7 +798,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
     name              = "primary"
   }
 
-  base_instance_name = "igm-update"
+  base_instance_name = "tf-test-igm-update"
   region             = "us-central1"
   target_size        = 2
   named_port {
@@ -845,7 +845,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     name              = "primary"
   }
 
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   region             = "us-central1"
   target_size        = 2
 }
@@ -859,7 +859,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic-2" {
     name              = "primary"
   }
 
-  base_instance_name = "igm-basic-2"
+  base_instance_name = "tf-test-igm-basic-2"
   region             = "us-west1"
   target_size        = 2
 }
@@ -906,7 +906,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     name              = "primary"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   region             = "us-central1"
   target_size        = 2
   auto_healing_policies {
@@ -964,7 +964,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     name              = "primary"
   }
   target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   region             = "us-central1"
   target_size        = 2
 }
@@ -1026,7 +1026,7 @@ resource "google_compute_instance_template" "igm-canary" {
 resource "google_compute_region_instance_group_manager" "igm-basic" {
   description        = "Terraform test region instance group manager"
   name               = "%s"
-  base_instance_name = "igm-basic"
+  base_instance_name = "tf-test-igm-basic"
   region             = "us-central1"
   target_size        = 2
 
@@ -1077,7 +1077,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     name              = "primary"
   }
 
-  base_instance_name               = "igm-basic"
+  base_instance_name               = "tf-test-igm-basic"
   region                           = "us-central1"
   target_size                      = 2
   distribution_policy_zones        = ["%s"]
@@ -1124,7 +1124,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
     name              = "primary"
   }
-  base_instance_name        = "igm-rolling-update-policy"
+  base_instance_name        = "tf-test-igm-rolling-update"
   region                    = "us-central1"
   target_size               = 4
   distribution_policy_zones = ["us-central1-a", "us-central1-f"]
@@ -1182,7 +1182,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
     name              = "primary"
   }
-  base_instance_name        = "igm-rolling-update-policy"
+  base_instance_name        = "tf-test-igm-rolling-update"
   region                    = "us-central1"
   target_size               = 4
   distribution_policy_zones = ["us-central1-a", "us-central1-f"]
@@ -1237,7 +1237,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
     name              = "primary"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name        = "igm-rolling-update-policy"
+  base_instance_name        = "tf-test-igm-rolling-update"
   region                    = "us-central1"
   distribution_policy_zones = ["us-central1-a", "us-central1-f"]
   target_size               = 3
@@ -1290,7 +1290,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
     name              = "primary"
     instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
   }
-  base_instance_name        = "igm-rolling-update-policy"
+  base_instance_name        = "tf-test-igm-rolling-update"
   region                    = "us-central1"
   distribution_policy_zones = ["us-central1-a", "us-central1-f"]
   target_size               = 3
@@ -1350,7 +1350,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     name              = "primary"
   }
 
-  base_instance_name        = "igm-basic"
+  base_instance_name        = "tf-test-igm-basic"
   region                    = "us-central1"
   target_size               = 2
   update_policy {
@@ -1405,7 +1405,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     name              = "primary"
   }
 
-  base_instance_name        = "igm-basic"
+  base_instance_name        = "tf-test-igm-basic"
   region                    = "us-central1"
   target_size               = 2
 

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -1422,7 +1422,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
   }
   stateful_disk {
     device_name = "stateful-disk2"
-    delete_rule = "NEVER"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
   }
 }
 `, template, igm)

--- a/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -290,7 +290,7 @@ resource "google_compute_region_instance_group_manager" "rigm" {
     instance_template = google_compute_instance_template.rigm-basic.self_link
   }
 
-  base_instance_name = "rigm-no-tp"
+  base_instance_name = "tf-test-rigm-no-tp"
 
   update_policy {
     instance_redistribution_type = "NONE"


### PR DESCRIPTION
https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs#configuring_stateful_disks_on_mig_creation

<img width="752" alt="Screen Shot 2021-12-22 at 11 48 10 AM" src="https://user-images.githubusercontent.com/9483464/147147319-77526523-3381-4847-ae9a-65298b438267.png">


```release-note:none

```
