### PR TITLE
Added example for creating a Postgres instance

### DIFF
--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
@@ -1,0 +1,10 @@
+# [START cloud_sql_postgres_instance_80_db_n1_s2]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['database_instance_name'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-n1-standard-2"
+  }
+}
+# [START cloud_sql_postgres_instance_80_db_n1_s2]


### PR DESCRIPTION
Intending to use this example on CGC page:

https://cloud.google.com/sql/docs/postgres/create-instance

Note: I didn't update https://github.com/GoogleCloudPlatform/magic-modules/blob/master/mmv1/products/sql/terraform.yaml because there doesn't seem to be a place for google_sql_database_instance examples.


```release-note:none
```
