### PR TITLE
Added example for creating a SQL Server instance

### DIFF
--- a/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
@@ -1,0 +1,11 @@
+# [START cloud_sql_sqlserver_instance_80_db_n1_s2]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['database_instance_name'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier = "db-custom-2-7680"
+  }
+}
+# [START cloud_sql_sqlserver_instance_80_db_n1_s2]


### PR DESCRIPTION
Intending to use this example on CGC page:

https://cloud.google.com/sql/docs/sqlserver/create-instance

Note: I didn't update https://github.com/GoogleCloudPlatform/magic-modules/blob/master/mmv1/products/sql/terraform.yaml because there doesn't seem to be a place for google_sql_database_instance examples.


```release-note:none
```
