### PR TITLE
Cloud Composer: added warning to docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -70,6 +70,26 @@ resource "google_composer_environment" "test" {
 For more information, see the [Access Control](https://cloud.devsite.corp.google.com/composer/docs/how-to/access-control) page in the Cloud Composer documentation.
 You may need to assign additional roles depending on what the Airflow DAGs will be running.
 
+**NOTE** We STRONGLY recommend you read the [Cloud Composer guides](https://cloud.google.com/composer/docs/how-to) 
+as the Environment 
+resource requires a long deployment process and involves several layers of 
+Google Cloud infrastructure, including a Kubernetes Engine cluster, Cloud 
+Storage, and Compute networking resources. Composer manages most of these 
+resources fully and as a result, Terraform may not be able to automatically 
+find or manage the underlying resources. In particular:
+* It can take up to 50 minutes to create or update an environment resource and 
+some errors may be detected later in the process. Also, some error messages may 
+not be clear at first sight because they involve issues with the underlying 
+resources. If you encounter such errors, please review Composer logs and verify 
+if your configuration is valid against Cloud Composer before filing bugs 
+against the Terraform provider.
+* Environments create Google Cloud Storage buckets that contain your DAGs and 
+other work files. These buckets do not get deleted automatically on environment 
+deletion. This is by design; it ensures that DAGs source code and other 
+valuable data don’t get lost when an environment is deleted. [More about 
+Composer's use of Cloud Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage).
+* Please review the [known issues](https://cloud.google.com/composer/docs/known-issues) for Cloud Composer if you are having problems.
+
 #### GKE and Compute Resource Dependencies (Cloud Composer 1)
 
 ```hcl


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added a warning to the Cloud Composer documentation.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
cloud_composer: Added a warning to the Cloud Composer documentation.
```
