### PR TITLE
Add the ability to create a big query view with schema

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -1040,15 +1040,40 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	datasetID := d.Get("dataset_id").(string)
 
-	log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
+	if table.View != nil && table.Schema != nil {
 
-	res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
-	if err != nil {
-		return err
+		log.Printf("[INFO] Removing schema from table definition because big query don't support setting schema on view creation")
+		schemaBack := table.Schema
+		table.Schema = nil
+
+		log.Printf("[INFO] Creating BigQuery table: %s without schema", table.TableReference.TableId)
+
+		res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been created", res.Id)
+		d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
+
+		table.Schema = schemaBack
+		log.Printf("[INFO] Updating BigQuery table: %s with schema", table.TableReference.TableId)
+		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, res.TableReference.TableId, table).Do(); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been update with schema", res.Id)
+	} else {
+		log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
+
+		res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been created", res.Id)
+		d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 	}
-
-	log.Printf("[INFO] BigQuery table %s has been created", res.Id)
-	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 
 	return resourceBigQueryTableRead(d, meta)
 }
@@ -1216,8 +1241,6 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	log.Printf("[INFO] Updating BigQuery table: %s", d.Id())
-
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
@@ -1226,8 +1249,31 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 	datasetID := d.Get("dataset_id").(string)
 	tableID := d.Get("table_id").(string)
 
-	if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
-		return err
+	if table.View != nil && table.Schema != nil {
+
+		log.Printf("[INFO] Removing schema from table definition")
+		schemaBack := table.Schema
+		table.Schema = nil
+
+		log.Printf("[INFO] Updating BigQuery table: %s without schema", d.Id())
+
+		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been updated whithout schema", d.Id())
+
+		table.Schema = schemaBack
+		log.Printf("[INFO] Updating BigQuery table: %s with schema", table.TableReference.TableId)
+		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been updated with schema", d.Id())
+	} else {
+		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
+			return err
+		}
 	}
 
 	return resourceBigQueryTableRead(d, meta)

--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -1042,7 +1042,7 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	if table.View != nil && table.Schema != nil {
 
-		log.Printf("[INFO] Removing schema from table definition because big query don't support setting schema on view creation")
+		log.Printf("[INFO] Removing schema from table definition because big query does not support setting schema on view creation")
 		schemaBack := table.Schema
 		table.Schema = nil
 
@@ -1241,6 +1241,8 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	log.Printf("[INFO] Updating BigQuery table: %s", d.Id())
+
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
@@ -1249,31 +1251,8 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 	datasetID := d.Get("dataset_id").(string)
 	tableID := d.Get("table_id").(string)
 
-	if table.View != nil && table.Schema != nil {
-
-		log.Printf("[INFO] Removing schema from table definition")
-		schemaBack := table.Schema
-		table.Schema = nil
-
-		log.Printf("[INFO] Updating BigQuery table: %s without schema", d.Id())
-
-		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] BigQuery table %s has been updated whithout schema", d.Id())
-
-		table.Schema = schemaBack
-		log.Printf("[INFO] Updating BigQuery table: %s with schema", table.TableReference.TableId)
-		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] BigQuery table %s has been updated with schema", d.Id())
-	} else {
-		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
-			return err
-		}
+	if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
+		return err
 	}
 
 	return resourceBigQueryTableRead(d, meta)


### PR DESCRIPTION
Co-authored-by: Adrien Vercoutere <avercoutere@users.noreply.github.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams and modifies https://github.com/hashicorp/terraform-provider-google/pull/9101

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9096

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added ability to create a table with both a schema and view simultaneously to `google_bigquery_table`
```
