### PR TITLE
fixed scenario where `region_instance_group_manager` would not start update

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -615,13 +615,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	if d.Get("wait_for_instances").(bool) {
-		err := computeRIGMWaitForInstanceStatus(d, meta)
-		if err != nil {
-			return err
-		}
-	}
-
 	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
 		return err


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/10648 and https://github.com/hashicorp/terraform-provider-google/issues/10792

duplicate pr of https://github.com/GoogleCloudPlatform/magic-modules/pull/5506 just against RIGM

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed scenario where `region_instance_group_manager` would not start update if `wait_for_instances` was set and initial status was not `STABLE`
```
