### PR TITLE
docs(samples): added region tags for PrivateCa samples for inclusion in cgc

### DIFF
--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_ca_pool_all_fields]
 resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["name"] %>"
   location = "us-central1"
@@ -75,3 +76,4 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 }
+# [END privateca_create_ca_pool_all_fields]

--- a/mmv1/templates/terraform/examples/privateca_capool_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_basic.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_ca_pool]
 resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["name"] %>"
   location = "us-central1"
@@ -10,3 +11,4 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
     foo = "bar"
   }
 }
+# [END privateca_create_ca_pool]

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_ca]
 resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
   // This example assumes this pool already exists.
   // Pools cannot be deleted in normal test circumstances, so we depend on static pools
@@ -45,3 +46,4 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     algorithm = "RSA_PKCS1_4096_SHA256"
   }
 }
+# [END privateca_create_ca]

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_ca_byo_key]
 resource "google_project_service_identity" "privateca_sa" {
   service = "privateca.googleapis.com"
 }
@@ -60,3 +61,4 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     google_kms_crypto_key_iam_binding.privateca_sa_keyuser_viewer,
   ]
 }
+# [END privateca_create_ca_byo_key]

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_subordinateca]
 resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
   // This example assumes this pool already exists.
   // Pools cannot be deleted in normal test circumstances, so we depend on static pools
@@ -18,7 +19,6 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
       ca_options {
         is_ca = true
         # Force the sub CA to only issue leaf certs
-        zero_max_issuer_path_length = true
         max_issuer_path_length = 0
       }
       key_usage {
@@ -48,3 +48,4 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   }
   type = "SUBORDINATE"
 }
+# [END privateca_create_subordinateca]

--- a/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_certificate_config]
 resource "google_privateca_certificate_authority" "test-ca" {
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "us-central1"
@@ -49,7 +50,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
         locality = "mountain view"
         province = "california"
         street_address = "1600 amphitheatre parkway"
-      }
+      } 
       subject_alt_name {
         email_addresses = ["email@example.com"]
         ip_addresses = ["127.0.0.1"]
@@ -58,7 +59,6 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
-        non_ca = true
         is_ca = false
       }
       key_usage {
@@ -77,3 +77,4 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 }
+# [END privateca_create_certificate_config]

--- a/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_certificate_csr]
 resource "google_privateca_certificate_authority" "test-ca" {
   pool = "<%= ctx[:vars]["pool"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
@@ -43,3 +44,4 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["certificate_name"] %>"
   pem_csr = file("test-fixtures/rsa_csr.pem")
 }
+# [END privateca_create_certificate_csr]

--- a/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_certificate]
 resource "google_privateca_certificate_authority" "authority" {
   // This example assumes this pool already exists.
   // Pools cannot be deleted in normal test circumstances, so we depend on static pools
@@ -57,7 +58,6 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
-        non_ca = true
         is_ca = false
       }
       key_usage {
@@ -78,3 +78,4 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
   // need to be explicitly connected to it
   depends_on = [google_privateca_certificate_authority.authority]
 }
+# [END privateca_create_certificate]

--- a/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_create_certificate_template]
 resource "google_privateca_certificate_template" "template" {
   location    = "us-central1"
   name = "<%= ctx[:vars]["certificate_template_name"] %>"
@@ -36,8 +37,8 @@ resource "google_privateca_certificate_template" "template" {
     aia_ocsp_servers = ["string"]
 
     ca_options {
-      is_ca                          = false
-      max_issuer_path_length         = 6
+      is_ca                  = false
+      max_issuer_path_length = 6
     }
 
     key_usage {
@@ -119,3 +120,4 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
   pem_csr = file("test-fixtures/rsa_csr.pem")
   certificate_template = google_privateca_certificate_template.template.id
 }
+# [END privateca_create_certificate_template]

--- a/mmv1/templates/terraform/examples/privateca_quickstart.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_quickstart.tf.erb
@@ -1,3 +1,4 @@
+# [START privateca_quickstart]
 provider google{}
 provider tls{}
 
@@ -93,3 +94,4 @@ resource "google_privateca_certificate" "default" {
   name = "<%= ctx[:vars]['my_certificate'] %>"
   pem_csr = tls_cert_request.example.cert_request_pem
 }
+# [END privateca_quickstart]


### PR DESCRIPTION
Adding region tags to PrivateCA Samples for inclusion into cgc

I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
