### PR TITLE
Add EXTERNAL_MANAGED as load_balancing_scheme for google_compute_backend_service

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -1369,6 +1369,7 @@ objects:
         values:
           - :EXTERNAL
           - :INTERNAL_SELF_MANAGED
+          - :EXTERNAL_MANAGED
       - !ruby/object:Api::Type::Enum
         name: 'localityLbPolicy'
         values:
@@ -2774,7 +2775,7 @@ objects:
             name: 'idleTimeoutSec'
             description: |
               Specifies how long to keep a Connection Tracking entry while there is
-              no matching traffic (in seconds). 
+              no matching traffic (in seconds).
 
               For L4 ILB the minimum(default) is 10 minutes and maximum is 16 hours.
 
@@ -2785,7 +2786,7 @@ objects:
               Specifies the key used for connection tracking. There are two options:
               `PER_CONNECTION`: The Connection Tracking is performed as per the
               Connection Key (default Hash Method) for the specific protocol.
-              
+
               `PER_SESSION`: The Connection Tracking is performed as per the
               configured Session Affinity. It matches the configured Session Affinity.
             default_value: :PER_CONNECTION
@@ -14685,7 +14686,7 @@ objects:
         description: |
           The purpose of the resource. A subnetwork with purpose set to
           INTERNAL_HTTPS_LOAD_BALANCER is a user-created subnetwork that is
-          reserved for Internal HTTP(S) Load Balancing. 
+          reserved for Internal HTTP(S) Load Balancing.
 
           If set to INTERNAL_HTTPS_LOAD_BALANCER you must also set the `role` field.
       - !ruby/object:Api::Type::Enum

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -2775,7 +2775,7 @@ objects:
             name: 'idleTimeoutSec'
             description: |
               Specifies how long to keep a Connection Tracking entry while there is
-              no matching traffic (in seconds).
+              no matching traffic (in seconds). 
 
               For L4 ILB the minimum(default) is 10 minutes and maximum is 16 hours.
 
@@ -2786,7 +2786,7 @@ objects:
               Specifies the key used for connection tracking. There are two options:
               `PER_CONNECTION`: The Connection Tracking is performed as per the
               Connection Key (default Hash Method) for the specific protocol.
-
+              
               `PER_SESSION`: The Connection Tracking is performed as per the
               configured Session Affinity. It matches the configured Session Affinity.
             default_value: :PER_CONNECTION
@@ -14686,7 +14686,7 @@ objects:
         description: |
           The purpose of the resource. A subnetwork with purpose set to
           INTERNAL_HTTPS_LOAD_BALANCER is a user-created subnetwork that is
-          reserved for Internal HTTP(S) Load Balancing.
+          reserved for Internal HTTP(S) Load Balancing. 
 
           If set to INTERNAL_HTTPS_LOAD_BALANCER you must also set the `role` field.
       - !ruby/object:Api::Type::Enum

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -250,6 +250,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           backend_service_name: "backend-service"
           neg_name: "network-endpoint"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "backend_service_external_managed"
+        min_version: beta
+        primary_resource_id: "default"
+        vars:
+          backend_service_name: "backend-service"
+          health_check_name: "health-check"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: 'templates/terraform/constants/backend_service.go.erb'
       encoder: 'templates/terraform/encoders/backend_service.go.erb'

--- a/mmv1/templates/terraform/examples/backend_service_external_managed.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_service_external_managed.tf.erb
@@ -1,0 +1,14 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  provider = google-beta
+  name = "<%= ctx[:vars]['health_check_name'] %>"
+  http_health_check {
+    port = 80
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This adds `EXTERNAL_MANAGED` as a load_balancing_scheme option for the backend service resource. It's one of the parts needed to add support for the new Global External HTTP(S) Load Balancer (the other part will require DCL changes to the global forwarding rule).

part of https://github.com/hashicorp/terraform-provider-google/issues/10858

Tested with `make testacc TEST=./google-beta TESTARGS='-run=TestAccComputeBackendService_backendServiceExternalManagedExample'`

![image](https://user-images.githubusercontent.com/17228751/148444160-d2615dfe-fa23-4408-953d-127a88e66669.png)



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added EXTERNAL_MANAGED as option for load_balancing_scheme in google_compute_backend_service resource
```
