### PR TITLE
Add field `traffic.tag` and `traffic.url` to Cloud Run

### DIFF
--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -296,6 +296,10 @@ objects:
           required: true
           description: |-
             Percent specifies percent of the traffic to this Revision or Configuration.
+        - !ruby/object:Api::Type::String
+          name: tag
+          description: |-
+            Tag is optionally used to expose a dedicated url for referencing this target exclusively.
         - !ruby/object:Api::Type::Boolean
           name: latestRevision
           description: |-
@@ -303,6 +307,13 @@ objects:
             Revision of the Configuration should be used for this traffic target. When
             provided LatestRevision must be true if RevisionName is empty; it must be
             false when RevisionName is non-empty.
+        - !ruby/object:Api::Type::String
+          name: url
+          output: true
+          description: |-
+            URL displays the URL for accessing tagged traffic targets. URL is displayed in status, 
+            and is disallowed on spec. URL must contain a scheme (e.g. http://) and a hostname, 
+            but may not contain anything else (e.g. basic auth, url path, etc.)
     - !ruby/object:Api::Type::NestedObject
       name: template
       description: |-


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes for [hashicorp/terraform-provider-google#8654](https://github.com/hashicorp/terraform-provider-google/issues/8654)



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X]Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: added `traffic.tag` and `traffic.url` fields to `google_cloud_run_service`
```