### PR TITLE
Add EXTERNAL_MANAGED option to global forwarding rule and add example

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -4274,13 +4274,15 @@ objects:
           The value of INTERNAL_SELF_MANAGED means that this will be used for
           Internal Global HTTP(S) LB. The value of EXTERNAL means that this
           will be used for External Global Load Balancing (HTTP(S) LB,
-          External TCP/UDP LB, SSL Proxy)
+          External TCP/UDP LB, SSL Proxy). The value of EXTERNAL_MANAGED means
+          that this will be used for Global external HTTP(S) load balancers.
 
           ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Note: This field must be set "" if the global address is
           configured as a purpose of PRIVATE_SERVICE_CONNECT and addressType of INTERNAL.
         default_value: :EXTERNAL
         values:
           - :EXTERNAL
+          - :EXTERNAL_MANAGED
           - :INTERNAL_SELF_MANAGED
       - !ruby/object:Api::Type::Array
         name: 'metadataFilters'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1025,6 +1025,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "port_range"
           - "target"
       - !ruby/object:Provider::Terraform::Examples
+        name: "global_forwarding_rule_external_managed"
+        min_version: beta
+        primary_resource_id: "default"
+        vars:
+          forwarding_rule_name: "global-rule"
+          http_proxy_name: "target-proxy"
+          backend_service_name: "backend"
+        ignore_read_extra:
+          - "port_range"
+          - "target"
+      - !ruby/object:Provider::Terraform::Examples
         name: "private_service_connect_google_apis"
         min_version: beta
         primary_resource_id: "default"

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.erb
@@ -1,0 +1,53 @@
+resource "google_compute_global_forwarding_rule" "default" {
+  provider              = google-beta
+  name                  = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  target                = google_compute_target_http_proxy.default.id
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['http_proxy_name'] %>"
+  description = "a description"
+  url_map     = google_compute_url_map.default.id
+}
+
+resource "google_compute_url_map" "default" {
+  provider        = google-beta
+  name            = "url-map-<%= ctx[:vars]['http_proxy_name'] %>"
+  description     = "a description"
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  provider              = google-beta
+  name                  = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider           = google-beta
+  name               = "check-<%= ctx[:vars]['backend_service_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.erb
@@ -43,11 +43,3 @@ resource "google_compute_backend_service" "default" {
   timeout_sec           = 10
   load_balancing_scheme = "EXTERNAL_MANAGED"
 }
-
-resource "google_compute_http_health_check" "default" {
-  provider           = google-beta
-  name               = "check-<%= ctx[:vars]['backend_service_name'] %>"
-  request_path       = "/"
-  check_interval_sec = 1
-  timeout_sec        = 1
-}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This adds the EXTERNAL_MANAGED load balancing scheme option to the Global Forwarding Rule resource and adds an example that will generate tests.

This option was added in the DCL (the change was merged in a previous PR https://github.com/GoogleCloudPlatform/magic-modules/pull/5586), but I'm also adding it here so that it automatically generates the test and examples.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10858


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `EXTERNAL_MANAGED` as option for `load_balancing_scheme` in `google_compute_global_forwarding_rule` resource
```
