### PR TITLE
Upstream fix for GCS object owner is optional

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_object_acl.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_object_acl.go
@@ -80,7 +80,10 @@ func resourceStorageObjectAclDiff(_ context.Context, diff *schema.ResourceDiff, 
 		return nil
 	}
 
-	objectOwner := sObject.Owner.Entity
+	var objectOwner string
+	if sObject.Owner != nil {
+		objectOwner = sObject.Owner.Entity
+	}
 	ownerRole := fmt.Sprintf("%s:%s", "OWNER", objectOwner)
 	oldRoleEntity, newRoleEntity := diff.GetChange("role_entity")
 
@@ -146,7 +149,10 @@ func resourceStorageObjectAclCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
 		}
 
-		objectOwner := sObject.Owner.Entity
+		var objectOwner string
+		if sObject.Owner != nil {
+			objectOwner = sObject.Owner.Entity
+		}
 		roleEntitiesUpstream, err := getRoleEntitiesAsStringsFromApi(config, bucket, object, userAgent)
 		if err != nil {
 			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
@@ -227,7 +233,10 @@ func resourceStorageObjectAclUpdate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
 		}
 
-		objectOwner := sObject.Owner.Entity
+		var objectOwner string
+		if sObject.Owner != nil {
+			objectOwner = sObject.Owner.Entity
+		}
 
 		o, n := d.GetChange("role_entity")
 		create, update, remove, err := getRoleEntityChange(

--- a/mmv1/third_party/terraform/tests/resource_storage_object_acl_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_object_acl_test.go
@@ -355,9 +355,6 @@ func TestAccStorageObjectAcl_noOwner(t *testing.T) {
 				Config:             testGoogleStorageObjectsAclBasic1(bucketName, objectName),
 				ExpectNonEmptyPlan: true,
 			},
-			/*{
-				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
-			},*/
 		},
 	})
 }

--- a/mmv1/third_party/terraform/tests/resource_storage_object_acl_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_object_acl_test.go
@@ -322,6 +322,7 @@ func (t *testRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // Test that we don't fail if there's no owner for object
 func TestAccStorageObjectAcl_noOwner(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	bucketName := testBucketName(t)

--- a/mmv1/third_party/terraform/tests/resource_storage_object_acl_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_object_acl_test.go
@@ -1,11 +1,18 @@
 package google
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -31,8 +38,7 @@ func TestAccStorageObjectAcl_basic(t *testing.T) {
 			}
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccStorageObjectAclDestroyProducer(t),
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
@@ -274,6 +280,84 @@ func TestAccStorageObjectAcl_unordered(t *testing.T) {
 			{
 				Config: testGoogleStorageObjectAclUnordered(bucketName, objectName),
 			},
+		},
+	})
+}
+
+// a round tripper that returns fake response for get object API removing `owner` attribute
+// it only modifies the response once, since otherwise resource will fail to delete.
+type testRoundTripper struct {
+	http.RoundTripper
+	bucketName, objectName string
+	done                   bool
+}
+
+func (t *testRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	response, err := t.RoundTripper.RoundTrip(r)
+	if err != nil {
+		return response, err
+	}
+	expectedPath := fmt.Sprintf("/storage/v1/b/%s/o/%s", t.bucketName, t.objectName)
+	if t.done || r.URL.Path != expectedPath || r.Host != "storage.googleapis.com" {
+		return response, err
+	}
+	t.done = true
+	responseBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return response, err
+	}
+	var responseMap map[string]json.RawMessage
+	err = json.Unmarshal(responseBytes, &responseMap)
+	if err != nil {
+		return response, err
+	}
+	delete(responseMap, "owner")
+	responseBytes, err = json.Marshal(responseMap)
+	if err != nil {
+		return response, err
+	}
+	response.Body = io.NopCloser(bytes.NewBuffer(responseBytes))
+	return response, nil
+}
+
+// Test that we don't fail if there's no owner for object
+func TestAccStorageObjectAcl_noOwner(t *testing.T) {
+	t.Parallel()
+
+	bucketName := testBucketName(t)
+	objectName := testAclObjectName(t)
+	objectData := []byte("data data data")
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
+	provider := Provider()
+	oldConfigureFunc := provider.ConfigureContextFunc
+	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		c, diagnostics := oldConfigureFunc(ctx, d)
+		config := c.(*Config)
+		roundTripper := &testRoundTripper{RoundTripper: config.client.Transport, bucketName: bucketName, objectName: objectName}
+		config.client.Transport = roundTripper
+		return c, diagnostics
+	}
+	providers := map[string]*schema.Provider{
+		"google": provider,
+	}
+	vcrTest(t, resource.TestCase{
+		PreCheck: func() {
+			if errObjectAcl != nil {
+				panic(errObjectAcl)
+			}
+			testAccPreCheck(t)
+		},
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config:             testGoogleStorageObjectsAclBasic1(bucketName, objectName),
+				ExpectNonEmptyPlan: true,
+			},
+			/*{
+				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
+			},*/
 		},
 	})
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams https://github.com/hashicorp/terraform-provider-google/pull/10902


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: Fixed bug where the provider crashes when `Object.owner` is missing when using `google_storage_object_acl`
```
