### PR TITLE
Add role arn

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -370,11 +370,10 @@ func awsS3DataSchema() *schema.Resource {
 				Description: `AWS credentials block.`,
 			},
 			"role_arn": {
-				Type: schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: `The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.`,
 			},
-
 		},
 	}
 }
@@ -802,16 +801,16 @@ func expandAwsS3Data(awsS3Datas []interface{}) *storagetransfer.AwsS3Data {
 	return &storagetransfer.AwsS3Data{
 		BucketName:   awsS3Data["bucket_name"].(string),
 		AwsAccessKey: expandAwsAccessKeys(awsS3Data["aws_access_key"].([]interface{})),
-		RoleArn:      awsS3Data["role_arn"].(string)
+		RoleArn:      awsS3Data["role_arn"].(string),
 	}
 }
 
 func flattenAwsS3Data(awsS3Data *storagetransfer.AwsS3Data, d *schema.ResourceData) []map[string]interface{} {
 	data := map[string]interface{}{
-		"bucket_name":    awsS3Data.BucketName,
-		"role_arn": awsS3Data.RoleArn,
+		"bucket_name": awsS3Data.BucketName,
+		"role_arn":    awsS3Data.RoleArn,
 	}
-        if transferSpec.AwsS3DataSource != nil {
+	if transferSpec.AwsS3DataSource != nil {
 		data["aws_access_key"] = flattenAwsAccessKeys(d)
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -810,7 +810,7 @@ func flattenAwsS3Data(awsS3Data *storagetransfer.AwsS3Data, d *schema.ResourceDa
 		"bucket_name": awsS3Data.BucketName,
 		"role_arn":    awsS3Data.RoleArn,
 	}
-	if transferSpec.AwsS3DataSource != nil {
+	if awsS3Data.AwsAccessKey != nil {
 		data["aws_access_key"] = flattenAwsAccessKeys(d)
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -349,7 +349,7 @@ func awsS3DataSchema() *schema.Resource {
 			},
 			"aws_access_key": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -369,6 +369,12 @@ func awsS3DataSchema() *schema.Resource {
 				},
 				Description: `AWS credentials block.`,
 			},
+			"role_arn": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: `The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.`,
+			},
+
 		},
 	}
 }
@@ -796,13 +802,17 @@ func expandAwsS3Data(awsS3Datas []interface{}) *storagetransfer.AwsS3Data {
 	return &storagetransfer.AwsS3Data{
 		BucketName:   awsS3Data["bucket_name"].(string),
 		AwsAccessKey: expandAwsAccessKeys(awsS3Data["aws_access_key"].([]interface{})),
+		RoleArn:      awsS3Data["role_arn"].(string)
 	}
 }
 
 func flattenAwsS3Data(awsS3Data *storagetransfer.AwsS3Data, d *schema.ResourceData) []map[string]interface{} {
 	data := map[string]interface{}{
 		"bucket_name":    awsS3Data.BucketName,
-		"aws_access_key": flattenAwsAccessKeys(d),
+		"role_arn": awsS3Data.RoleArn,
+	}
+        if transferSpec.AwsS3DataSource != nil {
+		data["aws_access_key"] = flattenAwsAccessKeys(d)
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -32,6 +32,10 @@ var (
 		"transfer_spec.0.http_data_source",
 		"transfer_spec.0.azure_blob_storage_data_source",
 	}
+	awsS3AuthKeys = []string{
+		"transfer_spec.0.aws_s3_data_source.0.aws_access_key",
+		"transfer_spec.0.aws_s3_data_source.0.role_arn",
+	}
 )
 
 func resourceStorageTransferJob() *schema.Resource {
@@ -367,12 +371,14 @@ func awsS3DataSchema() *schema.Resource {
 						},
 					},
 				},
-				Description: `AWS credentials block.`,
+				ExactlyOneOf: awsS3AuthKeys,
+				Description:  `AWS credentials block.`,
 			},
 			"role_arn": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.`,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: awsS3AuthKeys,
+				Description:  `The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.`,
 			},
 		},
 	}

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -168,7 +168,9 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 
 * `bucket_name` - (Required) S3 Bucket name.
 
-* `aws_access_key` - (Required) AWS credentials block.
+* `aws_access_key` - (Optional) AWS credentials block.
+
+* `role_arn` - (Optional) The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.
 
 The `aws_access_key` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds the option to use role_arn for the transfer service resource.  Fixes https://github.com/hashicorp/terraform-provider-google/issues/10880.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
 > I did generate this and make sure it could build. `make test` and `make lint` didn't do anything because there was no rule for the make target.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
> Looks like S3 sources aren't supported in the third party tests.  Probably because it would require infrastructure to create resources in AWS S3?
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
> There aren't any relevant tests as far as I know.
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added field `transfer_spec.aws_s3_data_source.role_arn` to `google_storage_transfer_job`
```
