### PR TITLE
Use utility functions to reduce the need for strconv, validation imports

### DIFF
--- a/mmv1/templates/terraform/constants/tpu_node.erb
+++ b/mmv1/templates/terraform/constants/tpu_node.erb
@@ -32,7 +32,7 @@ func tpuNodeCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta int
 
 	if networkLinkRegex.MatchString(old.(string)) {
 		parts := networkLinkRegex.FindStringSubmatch(old.(string))
-		i, err := strconv.ParseInt(parts[1], 10, 64)
+		i, err := stringToFixed64(parts[1])
 		if err == nil {
 			if project.ProjectNumber == i {
 				if err := diff.SetNew("network", old); err != nil {

--- a/mmv1/templates/terraform/custom_flatten/default_if_empty.erb
+++ b/mmv1/templates/terraform/custom_flatten/default_if_empty.erb
@@ -19,7 +19,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 <%- if property.is_a?(Api::Type::Integer) -%>
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
+		if intVal, err := stringToFixed64(strVal); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}

--- a/mmv1/templates/terraform/decoders/avoid_meaningless_project_update.erb
+++ b/mmv1/templates/terraform/decoders/avoid_meaningless_project_update.erb
@@ -34,7 +34,7 @@
   // If it's a project ID
   var oldProjId int64
   var newProjId int64
-  if oldVal, err := strconv.ParseInt(old, 10, 64); err == nil {
+  if oldVal, err := stringToFixed64(old); err == nil {
     log.Printf("[DEBUG] The old value was a real number: %d", oldVal)
     oldProjId = oldVal
   } else {
@@ -44,7 +44,7 @@
     }
     oldProjId = pOld.ProjectNumber
   }
-  if newVal, err := strconv.ParseInt(new, 10, 64); err == nil {
+  if newVal, err := stringToFixed64(new); err == nil {
     log.Printf("[DEBUG] The new value was a real number: %d", newVal)
     newProjId = newVal
   } else {

--- a/mmv1/templates/terraform/flatten_property_method.erb
+++ b/mmv1/templates/terraform/flatten_property_method.erb
@@ -95,7 +95,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 <% elsif property.is_a?(Api::Type::Integer) -%>
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
+		if intVal, err := stringToFixed64(strVal); err == nil {
 			return intVal
 		}
 	}

--- a/mmv1/templates/terraform/schema_property.erb
+++ b/mmv1/templates/terraform/schema_property.erb
@@ -54,7 +54,7 @@
 	enum_values = property.values
 	enum_values.push "" unless property.required
 -%>
-	ValidateFunc: validation.StringInSlice([]string{"<%= enum_values.join '","' -%>"}, false),
+	ValidateFunc: validateEnum([]string{"<%= enum_values.join '","' -%>"}),
 <% end -%>
 <% if !property.diff_suppress_func.nil? -%>
   DiffSuppressFunc: <%= property.diff_suppress_func %>,
@@ -118,7 +118,7 @@
   <% elsif property.item_type.is_a?(Api::Type::Enum) -%>
       Elem: &schema.Schema{
         Type: <%= tf_types[property.item_type.class] -%>,
-        ValidateFunc: validation.StringInSlice([]string{"<%= property.item_type.values.join '","' -%>"}, false),
+        ValidateFunc: validateEnum([]string{"<%= property.item_type.values.join '","' -%>"}),
       },
   <% else # array of basic types -%>
       Elem: &schema.Schema{

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -3,7 +3,6 @@ package google
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -136,7 +136,7 @@ func flattenKmsCryptoKeyVersionVersion(v interface{}, d *schema.ResourceData) in
 	parts := strings.Split(v.(string), "/")
 	version := parts[len(parts)-1]
 	// Handles the string fixed64 format
-	if intVal, err := strconv.ParseInt(version, 10, 64); err == nil {
+	if intVal, err := stringToFixed64(version); err == nil {
 		return intVal
 	} // let terraform core handle it if we can't convert the string to an int.
 	return v

--- a/mmv1/third_party/terraform/utils/privateca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_utils.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/mmv1/third_party/terraform/utils/privateca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_utils.go
@@ -336,7 +336,7 @@ func flattenPrivatecaCertificateConfigX509ConfigCaOptionsIsCa(v interface{}, d *
 func flattenPrivatecaCertificateConfigX509ConfigCaOptionsMaxIssuerPathLength(v interface{}, d *schema.ResourceData, config *Config) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
+		if intVal, err := stringToFixed64(strVal); err == nil {
 			return intVal
 		}
 	}

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -354,7 +354,7 @@ func readSeedFromFile(fileName string) (int64, error) {
 	// Remove NULL characters from seed
 	data = bytes.Trim(data, "\x00")
 	seed := string(data)
-	return strconv.ParseInt(seed, 10, 64)
+	return stringToFixed64(seed)
 }
 
 func writeSeedToFile(seed int64, fileName string) error {

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -308,6 +309,10 @@ func mergeResourceMaps(ms ...map[string]*schema.Resource) (map[string]*schema.Re
 	}
 
 	return merged, err
+}
+
+func stringToFixed64(v string) (int64, error) {
+	return strconv.ParseInt(v, 10, 64)
 }
 
 func extractFirstMapConfig(m []interface{}) map[string]interface{} {

--- a/mmv1/third_party/terraform/utils/validation.go
+++ b/mmv1/third_party/terraform/utils/validation.go
@@ -112,6 +112,10 @@ func validateRegexp(re string) schema.SchemaValidateFunc {
 	}
 }
 
+func validateEnum(values []string) schema.SchemaValidateFunc {
+	return validation.StringInSlice(values, false)
+}
+
 func validateRFC1918Network(min, max int) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I'm playing around with how hard it would be to drop `goimports` altogether, and these two cause a moderate amount of noise so I'd like to snip them early. This reflects the strategy I believe we'd ultimately use for custom code- moving it from injected code into handwritten functions that we reference, for the most part.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
