### PR TITLE
Add google_dns_record_set data source

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_dns_record_set.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_record_set.go
@@ -1,0 +1,86 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDnsRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsRecordSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"managed_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"rrdatas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"ttl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	zone := d.Get("managed_zone").(string)
+	name := d.Get("name").(string)
+	dnsType := d.Get("type").(string)
+	d.SetId(fmt.Sprintf("projects/%s/managedZones/%s/rrsets/%s/%s", project, zone, name, dnsType))
+
+	resp, err := config.NewDnsClient(userAgent).ResourceRecordSets.List(project, zone).Name(name).Type(dnsType).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("dataSourceDnsRecordSet %q", name))
+	}
+	if len(resp.Rrsets) != 1 {
+		return fmt.Errorf("Only expected 1 record set, got %d", len(resp.Rrsets))
+	}
+
+	if err := d.Set("rrdatas", resp.Rrsets[0].Rrdatas); err != nil {
+		return fmt.Errorf("Error setting rrdatas: %s", err)
+	}
+	if err := d.Set("ttl", resp.Rrsets[0].Ttl); err != nil {
+		return fmt.Errorf("Error setting ttl: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go
@@ -1,0 +1,51 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAcccDataSourceDnsRecordSet_basic(t *testing.T) {
+	t.Parallel()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordSetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDnsRecordSet_basic(randString(t, 10), randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_dns_record_set.rs", "google_dns_record_set.rs"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDnsRecordSet_basic(zoneName, recordSetName string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "zone" {
+  name     = "test-zone"
+  dns_name = "%s.hashicorptest.com."
+}
+
+resource "google_dns_record_set" "rs" {
+  managed_zone = google_dns_managed_zone.zone.name
+  name         = "%s.${google_dns_managed_zone.zone.dns_name}"
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [
+	"192.168.1.0",
+  ]
+}
+
+data "google_dns_record_set" "rs" {
+  managed_zone = google_dns_record_set.rs.managed_zone
+  name         = google_dns_record_set.rs.name
+  type         = google_dns_record_set.rs.type
+}
+`, zoneName, recordSetName)
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -254,6 +254,7 @@ func Provider() *schema.Provider {
 			"google_container_registry_repository":             dataSourceGoogleContainerRepo(),
 			"google_dns_keys":                                  dataSourceDNSKeys(),
 			"google_dns_managed_zone":                          dataSourceDnsManagedZone(),
+			"google_dns_record_set":                            dataSourceDnsRecordSet(),
 			"google_game_services_game_server_deployment_rollout":  dataSourceGameServicesGameServerDeploymentRollout(),
 			"google_iam_policy":                                dataSourceGoogleIamPolicy(),
 			"google_iam_role":                                  dataSourceGoogleIamRole(),

--- a/mmv1/third_party/terraform/website/docs/d/dns_record_set.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_record_set.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Cloud DNS"
+layout: "google"
+page_title: "Google: google_dns_record_set"
+sidebar_current: "docs-google-datasource-dns-record-set"
+description: |-
+  Get a DNS record set within Google Cloud DNS
+---
+
+# google\_dns\_record\_set
+
+Get a DNS record set within Google Cloud DNS
+For more information see
+[the official documentation](https://cloud.google.com/dns/docs/records)
+and
+[API](https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets)
+
+## Example Usage
+
+```tf
+data "google_dns_managed_zone" "sample" {
+  name = "sample-zone"
+}
+
+data "google_dns_record_set" "rs" {
+  managed_zone = data.google_dns_managed_zone.sample.name
+  name = "my-record.${data.google_dns_managed_zone.sample.dns_name}"
+  type = "A"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `managed_zone` - (Required) The Name of the zone.
+
+* `name` - (Required) The DNS name for the resource.
+
+* `project` - (Optional) The ID of the project for the Google Cloud.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `rrdatas` - The string data for the records in this record set.
+
+* `ttl` - The time-to-live of this record set (seconds).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

ref https://github.com/hashicorp/terraform-provider-google/issues/10906

Added `google_dns_record_set` data sources.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_dns_record_set`
```
