### PR TITLE
Allow extension of default user agent in GetConfig

### DIFF
--- a/mmv1/third_party/validator/getconfig.go
+++ b/mmv1/third_party/validator/getconfig.go
@@ -2,13 +2,23 @@ package google
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
+
+	"github.com/GoogleCloudPlatform/terraform-validator/version"
 )
+
+// Return the value of the private userAgent field
+func (c *Config) UserAgent() string {
+	return c.userAgent
+}
 
 func GetConfig(ctx context.Context, project string, offline bool) (*Config, error) {
 	cfg := &Config{
-		Project: project,
+		Project:   project,
+		userAgent: fmt.Sprintf("config-validator-tf/%s", version.BuildVersion()),
 	}
 
 	// Search for default credentials
@@ -25,6 +35,12 @@ func GetConfig(ctx context.Context, project string, offline bool) (*Config, erro
 	cfg.ImpersonateServiceAccount = multiEnvSearch([]string{
 		"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 	})
+
+	// opt in extension for adding to the User-Agent header
+	if ext := os.Getenv("GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION"); ext != "" {
+		ua := cfg.userAgent
+		cfg.userAgent = fmt.Sprintf("%s %s", ua, ext)
+	}
 
 	if !offline {
 		ConfigureBasePaths(cfg)

--- a/mmv1/third_party/validator/getconfig_test.go
+++ b/mmv1/third_party/validator/getconfig_test.go
@@ -19,6 +19,9 @@ func getAccessToken(cfg *Config) string {
 func getImpersonateServiceAccount(cfg *Config) string {
 	return cfg.ImpersonateServiceAccount
 }
+func getUserAgent(cfg *Config) string {
+	return cfg.UserAgent()
+}
 
 func TestGetConfigExtractsEnvVars(t *testing.T) {
 	ctx := context.Background()
@@ -27,37 +30,50 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 		name           string
 		envKey         string
 		envValue       string
+		expected       string
 		getConfigValue configAttrGetter
 	}{
 		{
 			name:           "GOOGLE_CREDENTIALS",
 			envKey:         "GOOGLE_CREDENTIALS",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getCredentials,
 		},
 		{
 			name:           "GOOGLE_CLOUD_KEYFILE_JSON",
 			envKey:         "GOOGLE_CLOUD_KEYFILE_JSON",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getCredentials,
 		},
 		{
 			name:           "GCLOUD_KEYFILE_JSON",
 			envKey:         "GCLOUD_KEYFILE_JSON",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getCredentials,
 		},
 		{
 			name:           "GOOGLE_OAUTH_ACCESS_TOKEN",
 			envKey:         "GOOGLE_OAUTH_ACCESS_TOKEN",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getAccessToken,
 		},
 		{
 			name:           "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 			envKey:         "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getImpersonateServiceAccount,
+		},
+		{
+			name:           "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
+			envKey:         "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
+			envValue:       "whatever",
+			expected:       "config-validator-tf/dev whatever",
+			getConfigValue: getUserAgent,
 		},
 	}
 
@@ -74,7 +90,7 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 				t.Fatalf("error building converter: %s", err)
 			}
 
-			assert.EqualValues(t, c.getConfigValue(cfg), c.envValue)
+			assert.Equal(t, c.expected, c.getConfigValue(cfg))
 
 			if isSet {
 				err = os.Setenv(c.envKey, originalValue)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams the part of https://github.com/GoogleCloudPlatform/terraform-validator/pull/477 managed by mmv1. Will not pass TFV tests here until the downstream changes are merged.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
