### PR TITLE
Add support for image type configuration on the GKE NAP

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -439,6 +439,7 @@ func resourceContainerCluster() *schema.Resource {
 										Default:     "default",
 										Description: `The Google Cloud Platform Service Account to be used by the node VMs.`,
 									},
+									<% unless version == 'ga' -%>
 									"image_type": {
 										Type:        schema.TypeString,
 										Optional:    true,
@@ -452,6 +453,7 @@ func resourceContainerCluster() *schema.Resource {
 										   return
 										 },
 									},
+									<% end -%>
 									<% unless version == 'ga' -%>
 									"min_cpu_platform": {
 										Type:             schema.TypeString,
@@ -3270,7 +3272,9 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 	npd := &container.AutoprovisioningNodePoolDefaults{
 		OauthScopes:    convertStringArr(config["oauth_scopes"].([]interface{})),
 		ServiceAccount: config["service_account"].(string),
+		<% unless version == 'ga' -%>
 		ImageType: config["image_type"].(string),
+		<% end -%>
 	}
 
 <% unless version == 'ga' -%>
@@ -4003,7 +4007,9 @@ func flattenAutoProvisioningDefaults(a *container.AutoprovisioningNodePoolDefaul
 	r := make(map[string]interface{})
 	r["oauth_scopes"] = a.OauthScopes
 	r["service_account"] = a.ServiceAccount
+	<% unless version == 'ga' -%>
 	r["image_type"] = a.ImageType
+	<% end -%>
 	<% unless version == 'ga' -%>
 	r["min_cpu_platform"] = a.MinCpuPlatform
 	<% end -%>

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -439,6 +439,19 @@ func resourceContainerCluster() *schema.Resource {
 										Default:     "default",
 										Description: `The Google Cloud Platform Service Account to be used by the node VMs.`,
 									},
+									"image_type": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Default:     "cos",
+										Description: `The default image type used by NAP once a new node pool is being created.`,
+										ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+										   v := val.(string)
+										   if v != "cos_containerd" || v != "cos" || v != "ubuntu_containerd" || v != "ubuntu" {
+										     errs = append(errs, fmt.Errorf("%q must be one of the [cos_containerd, cos, ubuntu_containerd, ubuntu], got: %d", key, v))
+										   }
+										   return
+										 },
+									},
 									<% unless version == 'ga' -%>
 									"min_cpu_platform": {
 										Type:             schema.TypeString,
@@ -3257,6 +3270,7 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 	npd := &container.AutoprovisioningNodePoolDefaults{
 		OauthScopes:    convertStringArr(config["oauth_scopes"].([]interface{})),
 		ServiceAccount: config["service_account"].(string),
+		ImageType: config["image_type"].(string),
 	}
 
 <% unless version == 'ga' -%>
@@ -3989,6 +4003,7 @@ func flattenAutoProvisioningDefaults(a *container.AutoprovisioningNodePoolDefaul
 	r := make(map[string]interface{})
 	r["oauth_scopes"] = a.OauthScopes
 	r["service_account"] = a.ServiceAccount
+	r["image_type"] = a.ImageType
 	<% unless version == 'ga' -%>
 	r["min_cpu_platform"] = a.MinCpuPlatform
 	<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2037,6 +2037,39 @@ func TestAccContainerCluster_withFlexiblePodCIDR(t *testing.T) {
 }
 <% end -%>
 
+func TestAccContainerCluster_nodeAutoprovisioningDefaultsImageType(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	includeImageType := true
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autoprovisioningDefaultsImageType(clusterName, includeImageType),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autoprovisioning",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_autoprovisioningDefaultsImageType(clusterName, !includeImageType),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autoprovisioning",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_errorCleanDanglingCluster(t *testing.T) {
 	t.Parallel()
 
@@ -3772,6 +3805,38 @@ resource "google_container_cluster" "with_autoprovisioning" {
 }`, cluster, minCpuPlatformCfg)
 }
 <% end -%>
+
+func testAccContainerCluster_autoprovisioningDefaultsImageType(cluster string, includeImageType bool) string {
+	imageTypeCfg := ""
+	if includeImageType {
+		imageTypeCfg = `image_type = "cos_containerd"`
+	}
+
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+resource "google_container_cluster" "with_autoprovisioning" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+  cluster_autoscaling {
+    enabled = true
+    resource_limits {
+      resource_type = "cpu"
+      maximum       = 2
+    }
+    resource_limits {
+      resource_type = "memory"
+      maximum       = 2048
+    }
+    auto_provisioning_defaults {
+      %s
+    }
+  }
+}`, cluster, imageTypeCfg)
+}
 
 func testAccContainerCluster_withNodePoolAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2037,6 +2037,7 @@ func TestAccContainerCluster_withFlexiblePodCIDR(t *testing.T) {
 }
 <% end -%>
 
+<% unless version == 'ga' -%>
 func TestAccContainerCluster_nodeAutoprovisioningDefaultsImageType(t *testing.T) {
 	t.Parallel()
 
@@ -2069,7 +2070,7 @@ func TestAccContainerCluster_nodeAutoprovisioningDefaultsImageType(t *testing.T)
 		},
 	})
 }
-
+<% end -%>
 func TestAccContainerCluster_errorCleanDanglingCluster(t *testing.T) {
 	t.Parallel()
 
@@ -3806,6 +3807,7 @@ resource "google_container_cluster" "with_autoprovisioning" {
 }
 <% end -%>
 
+<% unless version == 'ga' -%>
 func testAccContainerCluster_autoprovisioningDefaultsImageType(cluster string, includeImageType bool) string {
 	imageTypeCfg := ""
 	if includeImageType {
@@ -3837,6 +3839,7 @@ resource "google_container_cluster" "with_autoprovisioning" {
   }
 }`, cluster, imageTypeCfg)
 }
+<% end -%>
 
 func testAccContainerCluster_withNodePoolAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -469,7 +469,7 @@ as "Intel Haswell" or "Intel Sandy Bridge".
 
 * `service_account` - (Optional) The Google Cloud Platform Service Account to be used by the node VMs.
 
-* `image_type` - (Optional) The default image type used by NAP once a new node pool is being created. Please note that according to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning#default-image-type) the value must be one of the [cos_containerd, cos, ubuntu_containerd, ubuntu].
+* `image_type` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The default image type used by NAP once a new node pool is being created. Please note that according to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning#default-image-type) the value must be one of the [cos_containerd, cos, ubuntu_containerd, ubuntu].
 
 <a name="nested_authenticator_groups_config"></a>The `authenticator_groups_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -197,7 +197,7 @@ and requires the `ip_allocation_policy` block to be defined. By default when thi
 * `master_auth` - (Optional) The authentication information for accessing the
 Kubernetes master. Some values in this block are only returned by the API if
 your service account has permission to get credentials for your GKE cluster. If
-you see an unexpected diff unsetting your client cert, ensure you have the 
+you see an unexpected diff unsetting your client cert, ensure you have the
 `container.clusters.getCredentials` permission.
 Structure is [documented below](#nested_master_auth).
 
@@ -469,6 +469,8 @@ as "Intel Haswell" or "Intel Sandy Bridge".
 
 * `service_account` - (Optional) The Google Cloud Platform Service Account to be used by the node VMs.
 
+* `image_type` - (Optional) The default image type used by NAP once a new node pool is being created. Please note that according to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning#default-image-type) the value must be one of the [cos_containerd, cos, ubuntu_containerd, ubuntu].
+
 <a name="nested_authenticator_groups_config"></a>The `authenticator_groups_config` block supports:
 
 * `security_group` - (Required) The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format `gke-security-groups@yourdomain.com`.
@@ -683,7 +685,7 @@ gcfs_config {
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
-* `spot` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) A boolean 
+* `spot` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) A boolean
     that represents whether the underlying node VMs are spot. See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
     for more information. Defaults to false.
 


### PR DESCRIPTION
Since one of the [image streaming requirements](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#requirements) is having Container-Optimized OS with containers as node image and on the other side, if we use the [Node Auto Provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning), there's not any possibility to config `auto_provisioning_defaults` to set up the [default image type to cos_containerd](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning#default-image-type). 
In this PR I added this feature to pass the `image_type` value on the NAP configuration. 

Related issue: https://github.com/hashicorp/terraform-provider-google/issues/10957 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Add support for image type configuration on the GKE Node Auto-provisioning
```
