### PR TITLE
Remove "KERBEROS" from list of accepted values for "optional_components"

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -492,7 +492,6 @@ cluster_config {
     * HBASE
     * HIVE_WEBHCAT
     * JUPYTER
-    * KERBEROS
     * PRESTO
     * RANGER
     * SOLR


### PR DESCRIPTION
If you try to add Kerberos to a Dataproc resource (`google_dataproc_cluster`) using the `google-beta` provider by including it in the `optional_components` list, you will receive the following error:

```
Error: Error creating Dataproc cluster: googleapi: Error 400: Enabling Kerberos via Optional Components and properties is no longer supported. Please configure Kerberos via KerberosConfig instead, badRequest
```

This patch reflects the information conveyed in this error by removing `KERBEROS` from the list of potential items that can be included in `optional_components`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
