### PR TITLE
Enable usage of gcp filestore csi driver

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -64,6 +64,7 @@ var (
 		"addons_config.0.horizontal_pod_autoscaling",
 		"addons_config.0.network_policy_config",
 		"addons_config.0.cloudrun_config",
+		"addons_config.0.gcp_filestore_csi_driver_config",
 	<% unless version == 'ga' -%>
 		"addons_config.0.istio_config",
 		"addons_config.0.dns_cache_config",
@@ -253,6 +254,23 @@ func resourceContainerCluster() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"disabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"gcp_filestore_csi_driver_config": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							Computed:      true,
+							AtLeastOneOf:  addonsConfigKeys,
+							MaxItems:      1,
+							Description:   `The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes. Defaults to disabled; set enabled = true to enable.`,
+							ConflictsWith: []string{"enable_autopilot"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
 										Type:     schema.TypeBool,
 										Required: true,
 									},
@@ -3027,6 +3045,14 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 			ForceSendFields: []string{"Disabled"},
 		}
 	}
+	
+	if v, ok := config["gcp_filestore_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.GcpFilestoreCsiDriverConfig = &container.GcpFilestoreCsiDriverConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
 
 	if v, ok := config["cloudrun_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
@@ -3673,6 +3699,14 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		result["network_policy_config"] = []map[string]interface{}{
 			{
 				"disabled": c.NetworkPolicyConfig.Disabled,
+			},
+		}
+	}
+	
+	if c.GcpFilestoreCsiDriverConfig != nil {
+		result["gcp_filestore_csi_driver_config"] = []map[string]interface{}{
+			{
+				"enabled": c.GcpFilestoreCsiDriverConfig.Enabled,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -192,6 +192,15 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
+			{
+				Config: testAccContainerCluster_withGcpFilestoreCsiDriverEnabled(pid, clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
 		},
 	})
 }
@@ -2541,6 +2550,9 @@ resource "google_container_cluster" "primary" {
     network_policy_config {
       disabled = true
     }
+	gcp_filestore_csi_driver_config {
+	  enabled = false
+	}
     cloudrun_config {
       disabled = true
     }
@@ -2594,6 +2606,9 @@ resource "google_container_cluster" "primary" {
     network_policy_config {
       disabled = false
     }
+	gcp_filestore_csi_driver_config {
+	  enabled = true
+	}
     cloudrun_config {
       disabled = false
     }
@@ -2647,10 +2662,39 @@ resource "google_container_cluster" "primary" {
     network_policy_config {
       disabled = false
     }
+	gcp_filestore_csi_driver_config {
+	  enabled = true
+	}
     cloudrun_config {
 	  disabled = false
 	  load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
     }
+  }
+}
+`, projectID, clusterName)
+}
+
+func testAccContainerCluster_withGcpFilestoreCsiDriverEnabled(projectID string, clusterName string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  min_master_version = "latest"
+
+  workload_identity_config {
+    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
+  }
+
+  addons_config {
+	gcp_filestore_csi_driver_config {
+	  enabled = true
+	}
   }
 }
 `, projectID, clusterName)

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -192,15 +192,6 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
-			{
-				Config: testAccContainerCluster_withGcpFilestoreCsiDriverEnabled(pid, clusterName),
-			},
-			{
-				ResourceName:            "google_container_cluster.primary",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version"},
-			},
 		},
 	})
 }
@@ -2550,9 +2541,9 @@ resource "google_container_cluster" "primary" {
     network_policy_config {
       disabled = true
     }
-	gcp_filestore_csi_driver_config {
-	  enabled = false
-	}
+    gcp_filestore_csi_driver_config {
+      enabled = false
+    }
     cloudrun_config {
       disabled = true
     }
@@ -2606,9 +2597,9 @@ resource "google_container_cluster" "primary" {
     network_policy_config {
       disabled = false
     }
-	gcp_filestore_csi_driver_config {
-	  enabled = true
-	}
+    gcp_filestore_csi_driver_config {
+      enabled = true
+    }
     cloudrun_config {
       disabled = false
     }
@@ -2662,39 +2653,10 @@ resource "google_container_cluster" "primary" {
     network_policy_config {
       disabled = false
     }
-	gcp_filestore_csi_driver_config {
-	  enabled = true
-	}
     cloudrun_config {
 	  disabled = false
 	  load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
     }
-  }
-}
-`, projectID, clusterName)
-}
-
-func testAccContainerCluster_withGcpFilestoreCsiDriverEnabled(projectID string, clusterName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {
-  project_id = "%s"
-}
-
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  min_master_version = "latest"
-
-  workload_identity_config {
-    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
-  }
-
-  addons_config {
-	gcp_filestore_csi_driver_config {
-	  enabled = true
-	}
   }
 }
 `, projectID, clusterName)

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -367,6 +367,10 @@ subnetwork in which the cluster's instances are launched.
     It can only be disabled if the nodes already do not have network policies enabled.
     Defaults to disabled; set `disabled = false` to enable.
 
+* `gcp_filestore_csi_driver_config` - (Optional) The status of the Filestore CSI driver addon, 
+    which allows the usage of filestore instance as volumes.
+    It is disbaled by default; set `enabled = true` to enable.
+
 * `cloudrun_config` - (Optional). Structure is [documented below](#nested_cloudrun_config).
 
 * `istio_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).


### PR DESCRIPTION
This PR enables the usage of the FileStore CSI Driver addon for GKE clusters. 
closes https://github.com/hashicorp/terraform-provider-google/issues/10524 

@c2thorn asked me to create a PR in this repo instead directly in the provider repo.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added support for GCPFilestoreCSIDriver addon to `google_container_cluster` resource.
```
