### PR TITLE
Add support for Compact Placement feature for GKE nodes

### DIFF
--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -1395,6 +1395,7 @@ google.golang.org/genproto v0.0.0-20211206160659-862468c7d6e0/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211221195035-429b39de9b1c/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 h1:Et6SkiuvnBn+SgrSYXs/BrUpGB4mbdwt4R3vaPIlicA=
 google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220111164026-67b88f271998 h1:g/x+MYjJYDEP3OBCYYmwIbt4x6k3gryb+ohyOR7PXfI=
 google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=

--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -104,6 +104,25 @@ var schemaNodePool = map[string]*schema.Schema{
 		},
 	},
 
+<% unless version == 'ga' -%>
+	"placement_policy": {
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: `Specifies the node placement policy`,
+		ForceNew:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					Description:  `Type defines the type of placement policy`,
+				},
+			},
+		},
+	},
+<% end -%>
+
 	"max_pods_per_node": &schema.Schema{
 		Type:        schema.TypeInt,
 		Optional:    true,
@@ -747,6 +766,15 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 		}
 	}
 
+ <% unless version == 'ga' -%>
+	if v, ok := d.GetOk(prefix + "placement_policy"); ok {
+		placement_policy := v.([]interface{})[0].(map[string]interface{})
+		np.PlacementPolicy = &container.PlacementPolicy{
+			Type: placement_policy["type"].(string),
+		}
+	}
+<% end -%>
+
 	if v, ok := d.GetOk(prefix + "max_pods_per_node"); ok {
 		np.MaxPodsConstraint = &container.MaxPodsConstraint{
 			MaxPodsPerNode: int64(v.(int)),
@@ -843,6 +871,16 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodeP
 			nodePool["autoscaling"] = []map[string]interface{}{}
 		}
 	}
+
+<% unless version == 'ga' -%>
+	if np.PlacementPolicy != nil {
+		nodePool["placement_policy"] = []map[string]interface{}{
+			{
+				"type": np.PlacementPolicy.Type,
+			},
+		}
+	}
+<% end -%>
 
 	if np.MaxPodsConstraint != nil {
 		nodePool["max_pods_per_node"] = np.MaxPodsConstraint.MaxPodsPerNode

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -978,6 +978,55 @@ resource "google_container_node_pool" "np" {
 `, cluster, np)
 }
 
+<% unless version == 'ga' -%>
+func TestAccContainerNodePool_compactPlacement(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_compactPlacement(cluster, np, "COMPACT"),
+			},
+			{
+				ResourceName:      "google_container_cluster.cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_compactPlacement(cluster, np, placementType string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 2
+
+  node_config {
+    machine_type = "c2-standard-4"
+  }
+  placement_policy {
+    type = "%s"
+  }
+}
+`, cluster, np, placementType)
+}
+<% end -%>
+
 func testAccCheckContainerNodePoolDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -170,6 +170,9 @@ cluster.
     when fuzzy versions are used. See the `google_container_engine_versions` data source's
     `version_prefix` field to approximate fuzzy versions in a Terraform-compatible way.
 
+* `placement_policy` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Specifies a custom placement policy for the
+  nodes.
+
 <a name="nested_autoscaling"></a>The `autoscaling` block supports:
 
 * `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=0 and
@@ -194,6 +197,12 @@ cluster.
     parallel. Can be set to 0 or greater.
 
 `max_surge` and `max_unavailable` must not be negative and at least one of them must be greater than zero.
+
+<a name="nested_placement_policy"></a>The `placement_policy` block supports:
+
+* `type` - (Required) The type of the policy. Supports a single value: COMPACT.
+  Specifying COMPACT placement policy type places node pool's nodes in a closer
+  physical proximity in order to reduce network latency between nodes.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
[Compact Placement](https://cloud.google.com/kubernetes-engine/docs/how-to/compact-placement) is a GKE node pool feature that allows to locate nodes in a close physical proximity to each other and achieve lower communication within the node pool. Compact Placement is currently in preview (beta).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Add support for GKE Compact Placement
```

**Note** I was able to test my code end-to-end with terraform, but I wasn't able to run the acceptance tests. The acceptance tests seem to be always using the GA provider.