### PR TITLE
securitySettings is available in GA so remove beta as the min-version

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -1704,7 +1704,6 @@ objects:
           The security policy associated with this backend service.
       - !ruby/object:Api::Type::NestedObject
         name: 'securitySettings'
-        min_version: beta
         description: |
           The security settings that apply to this backend service. This field is applicable to either
           a regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2, and
@@ -1715,7 +1714,6 @@ objects:
             name: 'clientTlsPolicy'
             resource: 'Region' # TODO: 'Region' is incorrect and should be 'ClientTlsPolicy'
             imports: 'name'
-            min_version: beta
             description: |
               ClientTlsPolicy is a resource that specifies how a client should authenticate
               connections to backends of a service. This resource itself does not affect
@@ -1723,7 +1721,6 @@ objects:
             required: true
           - !ruby/object:Api::Type::Array
             name: 'subjectAltNames'
-            min_version: beta
             description: |
               A list of alternate names to verify the subject identity in the certificate.
               If specified, the client will verify that the server certificate's subject


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

securitySettings in GCP TD is now available in GA so this PR removes `min_version: beta` setting for securitySettings clientTlsPolicy and subjectAltNames.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
compute: promoted `security_settings` field of `google_compute_backend_service` to GA
```
CC @rileykarson ref #5003