### PR TITLE
Enable EXTERNAL_MANAGED resource  examples for GA

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -252,7 +252,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           neg_name: "network-endpoint"
       - !ruby/object:Provider::Terraform::Examples
         name: "backend_service_external_managed"
-        min_version: beta
         primary_resource_id: "default"
         vars:
           backend_service_name: "backend-service"
@@ -1039,7 +1038,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "target"
       - !ruby/object:Provider::Terraform::Examples
         name: "global_forwarding_rule_external_managed"
-        min_version: beta
         primary_resource_id: "default"
         vars:
           forwarding_rule_name: "global-rule"

--- a/mmv1/templates/terraform/examples/backend_service_external_managed.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_service_external_managed.tf.erb
@@ -1,12 +1,10 @@
 resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name          = "<%= ctx[:vars]['backend_service_name'] %>"
   health_checks = [google_compute_health_check.default.id]
   load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name = "<%= ctx[:vars]['health_check_name'] %>"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_global_forwarding_rule" "default" {
-  provider              = google-beta
   name                  = "<%= ctx[:vars]['forwarding_rule_name'] %>"
   target                = google_compute_target_http_proxy.default.id
   port_range            = "80"
@@ -7,14 +6,12 @@ resource "google_compute_global_forwarding_rule" "default" {
 }
 
 resource "google_compute_target_http_proxy" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['http_proxy_name'] %>"
   description = "a description"
   url_map     = google_compute_url_map.default.id
 }
 
 resource "google_compute_url_map" "default" {
-  provider        = google-beta
   name            = "url-map-<%= ctx[:vars]['http_proxy_name'] %>"
   description     = "a description"
   default_service = google_compute_backend_service.default.id
@@ -36,7 +33,6 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider              = google-beta
   name                  = "<%= ctx[:vars]['backend_service_name'] %>"
   port_name             = "http"
   protocol              = "HTTP"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

One last change for the Global External HTTP(S) Load Balancer to remove the beta-only requirement for the examples and tests. This is for the `EXTERNAL_MANAGED` `load_balancing_scheme` option for `google_compute_global_forwarding_rule` and `google_compute_backend_service`.

Really fixes https://github.com/hashicorp/terraform-provider-google/issues/10858

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted `EXTERNAL_MANAGED` value for `load_balancing_scheme` in `google_compute_backend_service ` and `google_compute_global_forwarding_rule` to GA
```
