### PR TITLE
Add empty string as default to `versioned_expr`

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -105,6 +105,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 									"versioned_expr": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										Default:      "",
 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
 										Description:  `Predefined rule expression. If this field is specified, config must also be specified. Available options:   SRC_IPS_V1: Must specify the corresponding src_ip_ranges field in config.`,
 									},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/9084

According to my research, this issue was caused by the `versioned_expr` being an empty string (`cty.StringVal("")`) on state, whereas it was null (`cty.NullVal(cty.String)`) on config. `match.VersionedExpr` always returns a string, but a `TypeString` marked optional is treated as a nullable string on cty.

https://github.com/hashicorp/terraform-provider-google/blob/v4.8.0/google/resource_compute_security_policy.go#L491
https://github.com/hashicorp/terraform-provider-google/blob/v4.8.0/google/resource_compute_security_policy.go#L101-L102

The following is an example of the difference of `match` value output by [`format.ResourceChange`](https://github.com/hashicorp/terraform/blob/v1.1.4/internal/command/format/diff.go#L47-L52):

**Old (state)**

```
"match":cty.ListVal([]cty.Value{
	cty.ObjectVal(map[string]cty.Value{
		"config":cty.ListValEmpty(cty.Object(map[string]cty.Type{"src_ip_ranges":cty.Set(cty.String)})),
		"expr":cty.ListVal([]cty.Value{
			cty.ObjectVal(map[string]cty.Value{
				"expression":cty.StringVal("request.path.startsWith('/admin')")
			})
		}),
		"versioned_expr":cty.StringVal("")
	})
}),
```

**New (config)**

```
"match":cty.ListVal([]cty.Value{
	cty.ObjectVal(map[string]cty.Value{
		"config":cty.ListValEmpty(cty.Object(map[string]cty.Type{"src_ip_ranges":cty.Set(cty.String)})),
		"expr":cty.ListVal([]cty.Value{
			cty.ObjectVal(map[string]cty.Value{
				"expression":cty.StringVal("request.path.startsWith('/admin')")
			})
		}),
		"versioned_expr":cty.NullVal(cty.String)})
	})
}),
```

This is the reason why it is output as a difference every time.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: suppressed changes to unchanged a match expr set in `google_compute_security_policy` rules
```
