### PR TITLE
Allow network tags to be updated for GKE Nodepools

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -1078,6 +1078,53 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 
 <% unless version == 'ga' -%>
+		if d.HasChange(prefix + "node_config.0.tags") {
+			req := &container.UpdateNodePoolRequest{
+				NodePoolId: name,
+			}
+			if v, ok := d.GetOk(prefix + "node_config.0.tags"); ok {
+				tagsList := v.([]interface{})
+				tags := []string{}
+				for _, v := range tagsList {
+					if v != nil {
+						tags = append(tags, v.(string))
+					}
+				}
+				ntags := &container.NetworkTags{
+					Tags: tags,
+				}
+				req.Tags = ntags
+			}	
+			if req.Tags.Tags == nil {
+				req.Tags.ForceSendFields = []string{"Tags"}
+			}
+	
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return containerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool tags", userAgent,
+					timeout)
+			}
+
+			// Call update serially.
+			if err := lockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] Updated tags for node pool %s", name)
+		}
+
 		if d.HasChange(prefix + "node_config.0.kubelet_config") {
 			req := &container.UpdateNodePoolRequest{
 				NodePoolId: name,

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1443,7 +1443,7 @@ resource "google_container_node_pool" "np_with_management" {
   %s
 
   node_config {
-    machine_type = "g1-small"
+    machine_type = "e2-medium"
     disk_size_gb = 10
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }
@@ -1475,7 +1475,9 @@ resource "google_container_node_pool" "np_with_node_config" {
     ]
     preemptible      = true
     min_cpu_platform = "Intel Broadwell"
-
+<% unless  version == 'ga' -%>
+    tags = ["beta"]
+<% end -%>
     taint {
       key    = "taint_key"
       value  = "taint_value"
@@ -1519,7 +1521,9 @@ resource "google_container_node_pool" "np_with_node_config" {
     ]
     preemptible      = true
     min_cpu_platform = "Intel Broadwell"
-
+<% unless  version == 'ga' -%>
+    tags = ["ga"]
+<% end -%>
     taint {
       key    = "taint_key"
       value  = "taint_value"
@@ -2027,7 +2031,7 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {
-    machine_type = "g1-small"
+    machine_type = "e2-medium"
     disk_size_gb = 10
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -243,7 +243,9 @@ func schemaNodeConfig() *schema.Schema {
 				"tags": {
 					Type:     schema.TypeList,
 					Optional: true,
+					<% unless version == 'beta' -%>
 					ForceNew: true,
+					<% end -%>
 					Elem:     &schema.Schema{Type: schema.TypeString},
 					Description: `The list of instance tags applied to all nodes.`,
 				},


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10995

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: `node_config.0.tags` field of `google_container_node_pool` is updateable now. (beta)
```
