### PR TITLE
Update Cloud Run Resource to make containerPort be optional

### DIFF
--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -11,8 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-!ruby/object:Api::Product
+--- !ruby/object:Api::Product
 name: CloudRun
 display_name: Cloud Run
 versions:
@@ -27,822 +26,824 @@ versions:
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:
-  # Cloud Run DomainMappings
-  - !ruby/object:Api::Resource
-    name: DomainMapping
-    kind: DomainMapping
-    base_url: apis/domains.cloudrun.com/v1/namespaces/{{project}}/domainmappings
-    cai_base_url: projects/{{project}}/locations/{{location}}/DomainMappings
-    references: !ruby/object:Api::Resource::ReferenceLinks
+# Cloud Run DomainMappings
+- !ruby/object:Api::Resource
+  name: DomainMapping
+  kind: DomainMapping
+  base_url: apis/domains.cloudrun.com/v1/namespaces/{{project}}/domainmappings
+  cai_base_url: projects/{{project}}/locations/{{location}}/DomainMappings
+  references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
-        'Official Documentation': 'https://cloud.google.com/run/docs/mapping-custom-domains'
+        'Official Documentation':
+          'https://cloud.google.com/run/docs/mapping-custom-domains'
       api: 'https://cloud.google.com/run/docs/reference/rest/v1/projects.locations.domainmappings'
-    description: |-
-      Resource to hold the state and status of a user's domain mapping.
+  description: |-
+    Resource to hold the state and status of a user's domain mapping.
+  input: true
+  parameters:
+  - !ruby/object:Api::Type::String
+    name: location
+    description: The location of the cloud run instance. eg us-central1
+    url_param_only: true
+    required: true
+  properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    url_param_only: true
     input: true
-    parameters:
-      - !ruby/object:Api::Type::String
-        name: location
-        description: The location of the cloud run instance. eg us-central1
-        url_param_only: true
-        required: true
+    # This is a convenience field handled by terraform encoder/decoders
+    exclude: true
+    description: |-
+      Name should be a [verified](https://support.google.com/webmasters/answer/9008080) domain
+  - !ruby/object:Api::Type::String
+    name: kind
+    description: This is always set to DomainMapping
+  - !ruby/object:Api::Type::NestedObject
+    name: status
+    description: The current status of the DomainMapping.
+    output: true
     properties:
-      - !ruby/object:Api::Type::String
-        name: name
-        url_param_only: true
-        input: true
-        # This is a convenience field handled by terraform encoder/decoders
-        exclude: true
-        description: |-
-          Name should be a [verified](https://support.google.com/webmasters/answer/9008080) domain
-      - !ruby/object:Api::Type::String
-        name: kind
-        description: This is always set to DomainMapping
-      - !ruby/object:Api::Type::NestedObject
-        name: status
-        description: The current status of the DomainMapping.
-        output: true
+    - !ruby/object:Api::Type::Array
+      name: conditions
+      description: |-
+        Array of observed DomainMappingConditions, indicating the current state
+        of the DomainMapping.
+      output: true
+      item_type: !ruby/object:Api::Type::NestedObject
         properties:
-          - !ruby/object:Api::Type::Array
-            name: conditions
-            description: |-
-              Array of observed DomainMappingConditions, indicating the current state
-              of the DomainMapping.
-            output: true
-            item_type: !ruby/object:Api::Type::NestedObject
-              properties:
-                - !ruby/object:Api::Type::String
-                  name: message
-                  output: true
-                  description: |-
-                    Human readable message indicating details about the current status.
-                - !ruby/object:Api::Type::String
-                  name: status
-                  output: true
-                  description: Status of the condition, one of True, False, Unknown.
-                - !ruby/object:Api::Type::String
-                  name: reason
-                  output: true
-                  description: |-
-                    One-word CamelCase reason for the condition's current status.
-                - !ruby/object:Api::Type::String
-                  name: type
-                  output: true
-                  description: Type of domain mapping condition.
-          - !ruby/object:Api::Type::Integer
-            name: observedGeneration
-            description: |-
-              ObservedGeneration is the 'Generation' of the DomainMapping that
-              was last processed by the controller.
-            output: true
-          - !ruby/object:Api::Type::Array
-            name: resourceRecords
-            description: |-
-              The resource records required to configure this domain mapping. These
-              records must be added to the domain's DNS configuration in order to
-              serve the application via this domain mapping.
-            item_type: !ruby/object:Api::Type::NestedObject
-              properties:
-                - !ruby/object:Api::Type::Enum
-                  name: type
-                  description: 'Resource record type. Example: `AAAA`.'
-                  values:
-                    - :A
-                    - :AAAA
-                    - :CNAME
-                - !ruby/object:Api::Type::String
-                  name: rrdata
-                  output: true
-                  description: |-
-                    Data for this record. Values vary by record type, as defined in RFC 1035
-                    (section 5) and RFC 1034 (section 3.6.1).
-                - !ruby/object:Api::Type::String
-                  name: name
-                  output: true
-                  description: |-
-                    Relative name of the object affected by this record. Only applicable for
-                    `CNAME` records. Example: 'www'.
-          - !ruby/object:Api::Type::String
-            name: mappedRouteName
-            output: true
-            description: The name of the route that the mapping currently points to.
-      - !ruby/object:Api::Type::String
-        name: apiVersion
-        description: The API version for this call such as "serving.knative.dev/v1alpha1".
-      - !ruby/object:Api::Type::NestedObject
-        name: spec
-        description: The spec for this DomainMapping.
-        required: true
+        - !ruby/object:Api::Type::String
+          name: message
+          output: true
+          description: |-
+            Human readable message indicating details about the current status.
+        - !ruby/object:Api::Type::String
+          name: status
+          output: true
+          description: Status of the condition, one of True, False, Unknown.
+        - !ruby/object:Api::Type::String
+          name: reason
+          output: true
+          description: |-
+            One-word CamelCase reason for the condition's current status.
+        - !ruby/object:Api::Type::String
+          name: type
+          output: true
+          description: Type of domain mapping condition.
+    - !ruby/object:Api::Type::Integer
+      name: observedGeneration
+      description: |-
+        ObservedGeneration is the 'Generation' of the DomainMapping that
+        was last processed by the controller.
+      output: true
+    - !ruby/object:Api::Type::Array
+      name: resourceRecords
+      description: |-
+        The resource records required to configure this domain mapping. These
+        records must be added to the domain's DNS configuration in order to
+        serve the application via this domain mapping.
+      item_type: !ruby/object:Api::Type::NestedObject
         properties:
-          - !ruby/object:Api::Type::Boolean
-            name: forceOverride
-            description: |-
-              If set, the mapping will override any mapping set before this spec was set.
-              It is recommended that the user leaves this empty to receive an error
-              warning about a potential conflict and only set it once the respective UI
-              has given such a warning.
-          - !ruby/object:Api::Type::String
-            name: routeName
-            required: true
-            description: |-
-              The name of the Cloud Run Service that this DomainMapping applies to.
-              The route must exist.
-          - !ruby/object:Api::Type::Enum
-            name: certificateMode
-            description: The mode of the certificate.
-            values:
-              - :NONE
-              - :AUTOMATIC
-            default_value: :AUTOMATIC
+        - !ruby/object:Api::Type::Enum
+          name: type
+          description: 'Resource record type. Example: `AAAA`.'
+          values:
+          - :A
+          - :AAAA
+          - :CNAME
+        - !ruby/object:Api::Type::String
+          name: rrdata
+          output: true
+          description: |-
+            Data for this record. Values vary by record type, as defined in RFC 1035
+            (section 5) and RFC 1034 (section 3.6.1).
+        - !ruby/object:Api::Type::String
+          name: name
+          output: true
+          description: |-
+            Relative name of the object affected by this record. Only applicable for
+            `CNAME` records. Example: 'www'.
+    - !ruby/object:Api::Type::String
+      name: mappedRouteName
+      output: true
+      description: The name of the route that the mapping currently points to.
+  - !ruby/object:Api::Type::String
+    name: apiVersion
+    description: The API version for this call such as "serving.knative.dev/v1alpha1".
+  - !ruby/object:Api::Type::NestedObject
+    name: spec
+    description: The spec for this DomainMapping.
+    required: true
+    properties:
+    - !ruby/object:Api::Type::Boolean
+      name: forceOverride
+      description: |-
+        If set, the mapping will override any mapping set before this spec was set.
+        It is recommended that the user leaves this empty to receive an error
+        warning about a potential conflict and only set it once the respective UI
+        has given such a warning.
+    - !ruby/object:Api::Type::String
+      name: routeName
+      required: true
+      description: |-
+        The name of the Cloud Run Service that this DomainMapping applies to.
+        The route must exist.
+    - !ruby/object:Api::Type::Enum
+      name: certificateMode
+      description: The mode of the certificate.
+      values:
+      - :NONE
+      - :AUTOMATIC
+      default_value: :AUTOMATIC
+  - !ruby/object:Api::Type::NestedObject
+    name: metadata
+    required: true
+    description: Metadata associated with this DomainMapping.
+    properties:
+    - !ruby/object:Api::Type::KeyValuePairs
+      name: labels
+      description: |-
+        Map of string keys and values that can be used to organize and categorize
+        (scope and select) objects. May match selectors of replication controllers
+        and routes.
+        More info: http://kubernetes.io/docs/user-guide/labels
+    - !ruby/object:Api::Type::Integer
+      name: generation
+      description: |-
+        A sequence number representing a specific generation of the desired state.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: resourceVersion
+      description: |-
+        An opaque value that represents the internal version of this object that
+        can be used by clients to determine when objects have changed. May be used
+        for optimistic concurrency, change detection, and the watch operation on a
+        resource or set of resources. They may only be valid for a
+        particular resource or set of resources.
+
+        More info:
+        https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+      output: true
+    - !ruby/object:Api::Type::String
+      name: selfLink
+      description: |-
+        SelfLink is a URL representing this object.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: uid
+      description: |-
+        UID is a unique id generated by the server on successful creation of a resource and is not
+        allowed to change on PUT operations.
+
+        More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+      output: true
+    - !ruby/object:Api::Type::String
+      name: namespace
+      required: true
+      description: |-
+        In Cloud Run the namespace must be equal to either the
+        project ID or project number.
+    - !ruby/object:Api::Type::KeyValuePairs
+      name: annotations
+      description: |-
+        Annotations is a key value map stored with a resource that
+        may be set by external tools to store and retrieve arbitrary metadata. More
+        info: http://kubernetes.io/docs/user-guide/annotations
+
+        **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+        If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
+        or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+    - !ruby/object:Api::Type::String
+      name: name
+      required: true
+      input: true
+      description: |-
+        Name must be unique within a namespace, within a Cloud Run region.
+        Is required when creating resources. Name is primarily intended
+        for creation idempotence and configuration definition. Cannot be updated.
+        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+# Cloud Run Service
+- !ruby/object:Api::Resource
+  name: Service
+  kind: Service
+  base_url: apis/serving.knative.dev/v1/namespaces/{{project}}/services
+  cai_base_url: projects/{{project}}/locations/{{location}}/services
+  references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/run/docs/'
+      api: 'https://cloud.google.com/run/docs/reference/rest/v1/namespaces.services'
+  description: |-
+    Service acts as a top-level container that manages a set of Routes and
+    Configurations which implement a network service. Service exists to provide a
+    singular abstraction which can be access controlled, reasoned about, and
+    which encapsulates software lifecycle decisions such as rollout policy and
+    team resource ownership. Service acts only as an orchestrator of the
+    underlying Routes and Configurations (much as a kubernetes Deployment
+    orchestrates ReplicaSets).
+
+    The Service's controller will track the statuses of its owned Configuration
+    and Route, reflecting their statuses and conditions as its own.
+
+    See also:
+    https://github.com/knative/specs/blob/main/specs/serving/overview.md
+  iam_policy: !ruby/object:Api::Resource::IamPolicy
+    method_name_separator: ':'
+    parent_resource_attribute: 'service'
+    base_url: v1/projects/{{project}}/locations/{{location}}/services/{{service}}
+    import_format: ["projects/{{project}}/locations/{{location}}/services/{{service}}", "{{service}}"]
+  parameters:
+  - !ruby/object:Api::Type::String
+    name: location
+    description: The location of the cloud run instance. eg us-central1
+    url_param_only: true
+    required: true
+    input: true
+  properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    # This is a convenience field as terraform expects `name` to be a top level property
+    url_param_only: true
+    input: true
+    description: |-
+      Name must be unique within a namespace, within a Cloud Run region.
+      Is required when creating resources. Name is primarily intended
+      for creation idempotence and configuration definition. Cannot be updated.
+      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+  - !ruby/object:Api::Type::String
+    name: apiVersion
+    description: The API version for this call such as "serving.knative.dev/v1alpha1".
+  - !ruby/object:Api::Type::String
+    name: kind
+    description: This is always set to Service
+  - !ruby/object:Api::Type::NestedObject
+    name: spec
+    required: true
+    description: Spec holds the desired state of the Service (from the client).
+    properties:
+    - !ruby/object:Api::Type::Array
+      name: traffic
+      description: |-
+        Traffic specifies how to distribute traffic over a collection of Knative Revisions
+        and Configurations
+      item_type: !ruby/object:Api::Type::NestedObject
+        properties:
+        - !ruby/object:Api::Type::String
+          name: revisionName
+          description: |-
+            RevisionName of a specific revision to which to send this portion of traffic.
+        - !ruby/object:Api::Type::Integer
+          name: percent
+          required: true
+          description: |-
+            Percent specifies percent of the traffic to this Revision or Configuration.
+        - !ruby/object:Api::Type::Boolean
+          name: latestRevision
+          description: |-
+            LatestRevision may be optionally provided to indicate that the latest ready
+            Revision of the Configuration should be used for this traffic target. When
+            provided LatestRevision must be true if RevisionName is empty; it must be
+            false when RevisionName is non-empty.
+    - !ruby/object:Api::Type::NestedObject
+      name: template
+      description: |-
+        template holds the latest specification for the Revision to
+        be stamped out. The template references the container image, and may also
+        include labels and annotations that should be attached to the Revision.
+        To correlate a Revision, and/or to force a Revision to be created when the
+        spec doesn't otherwise change, a nonce label may be provided in the
+        template metadata. For more details, see:
+        https://github.com/knative/serving/blob/master/docs/client-conventions.md#associate-modifications-with-revisions
+
+        Cloud Run does not currently support referencing a build that is
+        responsible for materializing the container image from source.
+      properties:
       - !ruby/object:Api::Type::NestedObject
         name: metadata
-        required: true
-        description: Metadata associated with this DomainMapping.
-        properties:
-          - !ruby/object:Api::Type::KeyValuePairs
-            name: labels
-            description: |-
-              Map of string keys and values that can be used to organize and categorize
-              (scope and select) objects. May match selectors of replication controllers
-              and routes.
-              More info: http://kubernetes.io/docs/user-guide/labels
-          - !ruby/object:Api::Type::Integer
-            name: generation
-            description: |-
-              A sequence number representing a specific generation of the desired state.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: resourceVersion
-            description: |-
-              An opaque value that represents the internal version of this object that
-              can be used by clients to determine when objects have changed. May be used
-              for optimistic concurrency, change detection, and the watch operation on a
-              resource or set of resources. They may only be valid for a
-              particular resource or set of resources.
-
-              More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
-            output: true
-          - !ruby/object:Api::Type::String
-            name: selfLink
-            description: |-
-              SelfLink is a URL representing this object.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: uid
-            description: |-
-              UID is a unique id generated by the server on successful creation of a resource and is not
-              allowed to change on PUT operations.
-
-              More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-            output: true
-          - !ruby/object:Api::Type::String
-            name: namespace
-            required: true
-            description: |-
-              In Cloud Run the namespace must be equal to either the
-              project ID or project number.
-          - !ruby/object:Api::Type::KeyValuePairs
-            name: annotations
-            description: |-
-              Annotations is a key value map stored with a resource that
-              may be set by external tools to store and retrieve arbitrary metadata. More
-              info: http://kubernetes.io/docs/user-guide/annotations
-
-              **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
-              If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
-              or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
-          - !ruby/object:Api::Type::String
-            name: name
-            required: true
-            input: true
-            description: |-
-              Name must be unique within a namespace, within a Cloud Run region.
-              Is required when creating resources. Name is primarily intended
-              for creation idempotence and configuration definition. Cannot be updated.
-              More info: http://kubernetes.io/docs/user-guide/identifiers#names
-
-  # Cloud Run Service
-  - !ruby/object:Api::Resource
-    name: Service
-    kind: Service
-    base_url: apis/serving.knative.dev/v1/namespaces/{{project}}/services
-    cai_base_url: projects/{{project}}/locations/{{location}}/services
-    references: !ruby/object:Api::Resource::ReferenceLinks
-      guides:
-        'Official Documentation': 'https://cloud.google.com/run/docs/'
-      api: 'https://cloud.google.com/run/docs/reference/rest/v1/namespaces.services'
-    description: |-
-      Service acts as a top-level container that manages a set of Routes and
-      Configurations which implement a network service. Service exists to provide a
-      singular abstraction which can be access controlled, reasoned about, and
-      which encapsulates software lifecycle decisions such as rollout policy and
-      team resource ownership. Service acts only as an orchestrator of the
-      underlying Routes and Configurations (much as a kubernetes Deployment
-      orchestrates ReplicaSets).
-
-      The Service's controller will track the statuses of its owned Configuration
-      and Route, reflecting their statuses and conditions as its own.
-
-      See also:
-      https://github.com/knative/specs/blob/main/specs/serving/overview.md
-    iam_policy: !ruby/object:Api::Resource::IamPolicy
-      method_name_separator: ':'
-      parent_resource_attribute: 'service'
-      base_url: v1/projects/{{project}}/locations/{{location}}/services/{{service}}
-      import_format: ['projects/{{project}}/locations/{{location}}/services/{{service}}', '{{service}}']
-    parameters:
-      - !ruby/object:Api::Type::String
-        name: location
-        description: The location of the cloud run instance. eg us-central1
-        url_param_only: true
-        required: true
-        input: true
-    properties:
-      - !ruby/object:Api::Type::String
-        name: name
-        # This is a convenience field as terraform expects `name` to be a top level property
-        url_param_only: true
-        input: true
         description: |-
-          Name must be unique within a namespace, within a Cloud Run region.
-          Is required when creating resources. Name is primarily intended
-          for creation idempotence and configuration definition. Cannot be updated.
-          More info: http://kubernetes.io/docs/user-guide/identifiers#names
-      - !ruby/object:Api::Type::String
-        name: apiVersion
-        description: The API version for this call such as "serving.knative.dev/v1alpha1".
-      - !ruby/object:Api::Type::String
-        name: kind
-        description: This is always set to Service
+          Optional metadata for this Revision, including labels and annotations.
+          Name will be generated by the Configuration. To set minimum instances
+          for this revision, use the "autoscaling.knative.dev/minScale" annotation
+          key. To set maximum instances for this revision, use the
+          "autoscaling.knative.dev/maxScale" annotation key. To set Cloud SQL
+          connections for the revision, use the "run.googleapis.com/cloudsql-instances"
+          annotation key.
+        properties:
+        - !ruby/object:Api::Type::KeyValuePairs
+          name: labels
+          description: |-
+            Map of string keys and values that can be used to organize and categorize
+            (scope and select) objects. May match selectors of replication controllers
+            and routes.
+            More info: http://kubernetes.io/docs/user-guide/labels
+        - !ruby/object:Api::Type::Integer
+          name: generation
+          description: |-
+            A sequence number representing a specific generation of the desired state.
+          output: true
+        - !ruby/object:Api::Type::String
+          name: resourceVersion
+          description: |-
+            An opaque value that represents the internal version of this object that
+            can be used by clients to determine when objects have changed. May be used
+            for optimistic concurrency, change detection, and the watch operation on a
+            resource or set of resources. They may only be valid for a
+            particular resource or set of resources.
+
+            More info:
+            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+          output: true
+        - !ruby/object:Api::Type::String
+          name: selfLink
+          description: |-
+            SelfLink is a URL representing this object.
+          output: true
+        - !ruby/object:Api::Type::String
+          name: uid
+          description: |-
+            UID is a unique id generated by the server on successful creation of a resource and is not
+            allowed to change on PUT operations.
+
+            More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+          output: true
+        - !ruby/object:Api::Type::String
+          name: namespace
+          description: |-
+            In Cloud Run the namespace must be equal to either the
+            project ID or project number. It will default to the resource's project.
+        - !ruby/object:Api::Type::KeyValuePairs
+          name: annotations
+          description: |-
+            Annotations is a key value map stored with a resource that
+            may be set by external tools to store and retrieve arbitrary metadata. More
+            info: http://kubernetes.io/docs/user-guide/annotations
+
+            **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+            If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
+            or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+        - !ruby/object:Api::Type::String
+          name: name
+          description: |-
+            Name must be unique within a namespace, within a Cloud Run region.
+            Is required when creating resources. Name is primarily intended
+            for creation idempotence and configuration definition. Cannot be updated.
+            More info: http://kubernetes.io/docs/user-guide/identifiers#names
       - !ruby/object:Api::Type::NestedObject
         name: spec
         required: true
-        description: Spec holds the desired state of the Service (from the client).
+        description: RevisionSpec holds the desired state of the Revision (from
+          the client).
         properties:
-          - !ruby/object:Api::Type::Array
-            name: traffic
-            description: |-
-              Traffic specifies how to distribute traffic over a collection of Knative Revisions
-              and Configurations
-            item_type: !ruby/object:Api::Type::NestedObject
-              properties:
-                - !ruby/object:Api::Type::String
-                  name: revisionName
-                  description: |-
-                    RevisionName of a specific revision to which to send this portion of traffic.
-                - !ruby/object:Api::Type::Integer
-                  name: percent
-                  required: true
-                  description: |-
-                    Percent specifies percent of the traffic to this Revision or Configuration.
-                - !ruby/object:Api::Type::Boolean
-                  name: latestRevision
-                  description: |-
-                    LatestRevision may be optionally provided to indicate that the latest ready
-                    Revision of the Configuration should be used for this traffic target. When
-                    provided LatestRevision must be true if RevisionName is empty; it must be
-                    false when RevisionName is non-empty.
-          - !ruby/object:Api::Type::NestedObject
-            name: template
-            description: |-
-              template holds the latest specification for the Revision to
-              be stamped out. The template references the container image, and may also
-              include labels and annotations that should be attached to the Revision.
-              To correlate a Revision, and/or to force a Revision to be created when the
-              spec doesn't otherwise change, a nonce label may be provided in the
-              template metadata. For more details, see:
-              https://github.com/knative/serving/blob/master/docs/client-conventions.md#associate-modifications-with-revisions
-
-              Cloud Run does not currently support referencing a build that is
-              responsible for materializing the container image from source.
+        - !ruby/object:Api::Type::Array
+          name: containers
+          update_verb: :PUT
+          required: true
+          description: |-
+            Container defines the unit of execution for this Revision.
+            In the context of a Revision, we disallow a number of the fields of
+            this Container, including: name, ports, and volumeMounts.
+            The runtime contract is documented here:
+            https://github.com/knative/serving/blob/master/docs/runtime-contract.md
+          item_type: !ruby/object:Api::Type::NestedObject
             properties:
-              - !ruby/object:Api::Type::NestedObject
-                name: metadata
-                description: |-
-                  Optional metadata for this Revision, including labels and annotations.
-                  Name will be generated by the Configuration. To set minimum instances
-                  for this revision, use the "autoscaling.knative.dev/minScale" annotation
-                  key. To set maximum instances for this revision, use the
-                  "autoscaling.knative.dev/maxScale" annotation key. To set Cloud SQL
-                  connections for the revision, use the "run.googleapis.com/cloudsql-instances"
-                  annotation key.
+            - !ruby/object:Api::Type::String
+              deprecation_message: "Not supported by Cloud Run fully managed"
+              name: workingDir
+              input: true
+              description: |-
+                Container's working directory.
+                If not specified, the container runtime's default will be used, which
+                might be configured in the container image.
+            - !ruby/object:Api::Type::Array
+              name: args
+              description: |-
+                Arguments to the entrypoint.
+                The docker image's CMD is used if this is not provided.
+                Variable references $(VAR_NAME) are expanded using the container's
+                environment. If a variable cannot be resolved, the reference in the input
+                string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                regardless of whether the variable exists or not.
+                More info:
+                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: envFrom
+              deprecation_message: "Not supported by Cloud Run fully managed"
+              input: true
+              description: |-
+                List of sources to populate environment variables in the container.
+                All invalid keys will be reported as an event when the container is starting.
+                When a key exists in multiple sources, the value associated with the last source will
+                take precedence. Values defined by an Env with a duplicate key will take
+                precedence.
+              item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object:Api::Type::KeyValuePairs
-                    name: labels
+                - !ruby/object:Api::Type::String
+                  name: prefix
+                  description: |-
+                    An optional identifier to prepend to each key in the ConfigMap.
+                - !ruby/object:Api::Type::NestedObject
+                  name: configMapRef
+                  description: |-
+                    The ConfigMap to select from.
+                  properties:
+                  - !ruby/object:Api::Type::Boolean
+                    name: optional
                     description: |-
-                      Map of string keys and values that can be used to organize and categorize
-                      (scope and select) objects. May match selectors of replication controllers
-                      and routes.
-                      More info: http://kubernetes.io/docs/user-guide/labels
-                  - !ruby/object:Api::Type::Integer
-                    name: generation
+                      Specify whether the ConfigMap must be defined
+                  - !ruby/object:Api::Type::NestedObject
+                    name: localObjectReference
+                    description: The ConfigMap to select from.
+                    properties:
+                    - !ruby/object:Api::Type::String
+                      name: name
+                      required: true
+                      description: |-
+                        Name of the referent.
+                        More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                - !ruby/object:Api::Type::NestedObject
+                  name: secretRef
+                  description: |-
+                    The Secret to select from.
+                  properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: localObjectReference
+                    description: The Secret to select from.
+                    properties:
+                    - !ruby/object:Api::Type::String
+                      name: name
+                      required: true
+                      description: |-
+                        Name of the referent.
+                        More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                  - !ruby/object:Api::Type::Boolean
+                    name: optional
                     description: |-
-                      A sequence number representing a specific generation of the desired state.
-                    output: true
-                  - !ruby/object:Api::Type::String
-                    name: resourceVersion
-                    description: |-
-                      An opaque value that represents the internal version of this object that
-                      can be used by clients to determine when objects have changed. May be used
-                      for optimistic concurrency, change detection, and the watch operation on a
-                      resource or set of resources. They may only be valid for a
-                      particular resource or set of resources.
-
-                      More info:
-                      https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
-                    output: true
-                  - !ruby/object:Api::Type::String
-                    name: selfLink
-                    description: |-
-                      SelfLink is a URL representing this object.
-                    output: true
-                  - !ruby/object:Api::Type::String
-                    name: uid
-                    description: |-
-                      UID is a unique id generated by the server on successful creation of a resource and is not
-                      allowed to change on PUT operations.
-
-                      More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-                    output: true
-                  - !ruby/object:Api::Type::String
-                    name: namespace
-                    description: |-
-                      In Cloud Run the namespace must be equal to either the
-                      project ID or project number. It will default to the resource's project.
-                  - !ruby/object:Api::Type::KeyValuePairs
-                    name: annotations
-                    description: |-
-                      Annotations is a key value map stored with a resource that
-                      may be set by external tools to store and retrieve arbitrary metadata. More
-                      info: http://kubernetes.io/docs/user-guide/annotations
-
-                      **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
-                      If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
-                      or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
-                  - !ruby/object:Api::Type::String
-                    name: name
-                    description: |-
-                      Name must be unique within a namespace, within a Cloud Run region.
-                      Is required when creating resources. Name is primarily intended
-                      for creation idempotence and configuration definition. Cannot be updated.
-                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
-              - !ruby/object:Api::Type::NestedObject
-                name: spec
-                required: true
-                description: RevisionSpec holds the desired state of the Revision (from
-                  the client).
+                      Specify whether the Secret must be defined
+            - !ruby/object:Api::Type::String
+              name: image
+              required: true
+              description: |-
+                Docker image name. This is most often a reference to a container located
+                in the container registry, such as gcr.io/cloudrun/hello
+                More info: https://kubernetes.io/docs/concepts/containers/images
+            - !ruby/object:Api::Type::Array
+              name: command
+              description: |-
+                Entrypoint array. Not executed within a shell.
+                The docker image's ENTRYPOINT is used if this is not provided.
+                Variable references $(VAR_NAME) are expanded using the container's
+                environment. If a variable cannot be resolved, the reference in the input
+                string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                regardless of whether the variable exists or not.
+                More info:
+                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: env
+              description: |-
+                List of environment variables to set in the container.
+              item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object:Api::Type::Array
-                    name: containers
-                    update_verb: :PUT
-                    required: true
-                    description: |-
-                      Container defines the unit of execution for this Revision.
-                      In the context of a Revision, we disallow a number of the fields of
-                      this Container, including: name, ports, and volumeMounts.
-                      The runtime contract is documented here:
-                      https://github.com/knative/serving/blob/master/docs/runtime-contract.md
-                    item_type: !ruby/object:Api::Type::NestedObject
+                - !ruby/object:Api::Type::String
+                  name: name
+                  description: Name of the environment variable.
+                - !ruby/object:Api::Type::String
+                  name: value
+                  description: |-
+                    Variable references $(VAR_NAME) are expanded
+                    using the previous defined environment variables in the container and
+                    any route environment variables. If a variable cannot be resolved,
+                    the reference in the input string will be unchanged. The $(VAR_NAME)
+                    syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                    references will never be expanded, regardless of whether the variable
+                    exists or not.
+                    Defaults to "".
+                - !ruby/object:Api::Type::NestedObject
+                  name: valueFrom
+                  description: |-
+                    Source for the environment variable's value. Only supports secret_key_ref.
+                  properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: secretKeyRef
+                      required: true
+                      description: |-
+                        Selects a key (version) of a secret in Secret Manager.
                       properties:
                         - !ruby/object:Api::Type::String
-                          deprecation_message: 'Not supported by Cloud Run fully managed'
-                          name: workingDir
-                          input: true
-                          description: |-
-                            Container's working directory.
-                            If not specified, the container runtime's default will be used, which
-                            might be configured in the container image.
-                        - !ruby/object:Api::Type::Array
-                          name: args
-                          description: |-
-                            Arguments to the entrypoint.
-                            The docker image's CMD is used if this is not provided.
-                            Variable references $(VAR_NAME) are expanded using the container's
-                            environment. If a variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
-                            double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                            regardless of whether the variable exists or not.
-                            More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-                          item_type: Api::Type::String
-                        - !ruby/object:Api::Type::Array
-                          name: envFrom
-                          deprecation_message: 'Not supported by Cloud Run fully managed'
-                          input: true
-                          description: |-
-                            List of sources to populate environment variables in the container.
-                            All invalid keys will be reported as an event when the container is starting.
-                            When a key exists in multiple sources, the value associated with the last source will
-                            take precedence. Values defined by an Env with a duplicate key will take
-                            precedence.
-                          item_type: !ruby/object:Api::Type::NestedObject
-                            properties:
-                              - !ruby/object:Api::Type::String
-                                name: prefix
-                                description: |-
-                                  An optional identifier to prepend to each key in the ConfigMap.
-                              - !ruby/object:Api::Type::NestedObject
-                                name: configMapRef
-                                description: |-
-                                  The ConfigMap to select from.
-                                properties:
-                                  - !ruby/object:Api::Type::Boolean
-                                    name: optional
-                                    description: |-
-                                      Specify whether the ConfigMap must be defined
-                                  - !ruby/object:Api::Type::NestedObject
-                                    name: localObjectReference
-                                    description: The ConfigMap to select from.
-                                    properties:
-                                      - !ruby/object:Api::Type::String
-                                        name: name
-                                        required: true
-                                        description: |-
-                                          Name of the referent.
-                                          More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              - !ruby/object:Api::Type::NestedObject
-                                name: secretRef
-                                description: |-
-                                  The Secret to select from.
-                                properties:
-                                  - !ruby/object:Api::Type::NestedObject
-                                    name: localObjectReference
-                                    description: The Secret to select from.
-                                    properties:
-                                      - !ruby/object:Api::Type::String
-                                        name: name
-                                        required: true
-                                        description: |-
-                                          Name of the referent.
-                                          More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  - !ruby/object:Api::Type::Boolean
-                                    name: optional
-                                    description: |-
-                                      Specify whether the Secret must be defined
-                        - !ruby/object:Api::Type::String
-                          name: image
+                          name: key
                           required: true
                           description: |-
-                            Docker image name. This is most often a reference to a container located
-                            in the container registry, such as gcr.io/cloudrun/hello
-                            More info: https://kubernetes.io/docs/concepts/containers/images
-                        - !ruby/object:Api::Type::Array
-                          name: command
-                          description: |-
-                            Entrypoint array. Not executed within a shell.
-                            The docker image's ENTRYPOINT is used if this is not provided.
-                            Variable references $(VAR_NAME) are expanded using the container's
-                            environment. If a variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
-                            double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                            regardless of whether the variable exists or not.
-                            More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-                          item_type: Api::Type::String
-                        - !ruby/object:Api::Type::Array
-                          name: env
-                          description: |-
-                            List of environment variables to set in the container.
-                          item_type: !ruby/object:Api::Type::NestedObject
-                            properties:
-                              - !ruby/object:Api::Type::String
-                                name: name
-                                description: Name of the environment variable.
-                              - !ruby/object:Api::Type::String
-                                name: value
-                                description: |-
-                                  Variable references $(VAR_NAME) are expanded
-                                  using the previous defined environment variables in the container and
-                                  any route environment variables. If a variable cannot be resolved,
-                                  the reference in the input string will be unchanged. The $(VAR_NAME)
-                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                                  references will never be expanded, regardless of whether the variable
-                                  exists or not.
-                                  Defaults to "".
-                              - !ruby/object:Api::Type::NestedObject
-                                name: valueFrom
-                                description: |-
-                                  Source for the environment variable's value. Only supports secret_key_ref.
-                                properties:
-                                  - !ruby/object:Api::Type::NestedObject
-                                    name: secretKeyRef
-                                    required: true
-                                    description: |-
-                                      Selects a key (version) of a secret in Secret Manager.
-                                    properties:
-                                      - !ruby/object:Api::Type::String
-                                        name: key
-                                        required: true
-                                        description: |-
-                                          A Cloud Secret Manager secret version. Must be 'latest' for the latest
-                                          version or an integer for a specific version.
-                                      - !ruby/object:Api::Type::String
-                                        name: name
-                                        required: true
-                                        description: |-
-                                          The name of the secret in Cloud Secret Manager. By default, the secret
-                                          is assumed to be in the same project.
-                                          If the secret is in another project, you must define an alias.
-                                          You set the <alias> in this field, and create an annotation with the
-                                          following structure
-                                          "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
-                                          If multiple alias definitions are needed, they must be separated by
-                                          commas in the annotation field.
-                        - !ruby/object:Api::Type::Array
-                          name: ports
-                          description: |-
-                            List of open ports in the container.
-                            More Info:
-                            https://cloud.google.com/run/docs/reference/rest/v1/Container#ContainerPort
-                          item_type: !ruby/object:Api::Type::NestedObject
-                            properties:
-                              - !ruby/object:Api::Type::String
-                                name: name
-                                description: If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c".
-                              - !ruby/object:Api::Type::String
-                                name: protocol
-                                description: Protocol for port. Must be "TCP". Defaults to "TCP".
-                              - !ruby/object:Api::Type::Integer
-                                name: containerPort
-                                description: Port number the container listens on. This must be a valid port number, 0 < x < 65536.
-                        - !ruby/object:Api::Type::NestedObject
-                          name: resources
-                          description: |-
-                            Compute Resources required by this container. Used to set values such as max memory
-                            More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
-                          properties:
-                            - !ruby/object:Api::Type::KeyValuePairs
-                              name: limits
-                              description: |-
-                                Limits describes the maximum amount of compute resources allowed.
-                                The values of the map is string form of the 'quantity' k8s type:
-                                https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
-                            - !ruby/object:Api::Type::KeyValuePairs
-                              name: requests
-                              description: |-
-                                Requests describes the minimum amount of compute resources required.
-                                If Requests is omitted for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined value.
-                                The values of the map is string form of the 'quantity' k8s type:
-                                https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
-                        - !ruby/object:Api::Type::Array
-                          name: volumeMounts
-                          description: |-
-                            Volume to mount into the container's filesystem.
-                            Only supports SecretVolumeSources.
-                          item_type: !ruby/object:Api::Type::NestedObject
-                            properties:
-                              - !ruby/object:Api::Type::String
-                                name: mountPath
-                                required: true
-                                description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
-                              - !ruby/object:Api::Type::String
-                                name: name
-                                required: true
-                                description: |-
-                                  This must match the Name of a Volume.
-
-                  - !ruby/object:Api::Type::Integer
-                    name: containerConcurrency
-                    description: |-
-                      ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
-                      requests per container of the Revision. Values are:
-                      - `0` thread-safe, the system should manage the max concurrency. This is
-                          the default value.
-                      - `1` not-thread-safe. Single concurrency
-                      - `2-N` thread-safe, max concurrency of N
-                  - !ruby/object:Api::Type::Integer
-                    name: timeoutSeconds
-                    description: |-
-                      TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
-                  - !ruby/object:Api::Type::String
-                    name: serviceAccountName
-                    description: |-
-                      Email address of the IAM service account associated with the revision of the
-                      service. The service account represents the identity of the running revision,
-                      and determines what permissions the revision has. If not provided, the revision
-                      will use the project's default service account.
-                  - !ruby/object:Api::Type::Array
-                    name: volumes
-                    description: |-
-                      Volume represents a named volume in a container.
-                    item_type: !ruby/object:Api::Type::NestedObject
-                      properties:
+                            A Cloud Secret Manager secret version. Must be 'latest' for the latest
+                            version or an integer for a specific version.
                         - !ruby/object:Api::Type::String
                           name: name
                           required: true
                           description: |-
-                            Volume's name.
-                        - !ruby/object:Api::Type::NestedObject
-                          name: secret
+                            The name of the secret in Cloud Secret Manager. By default, the secret
+                            is assumed to be in the same project.
+                            If the secret is in another project, you must define an alias.
+                            You set the <alias> in this field, and create an annotation with the
+                            following structure
+                            "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
+                            If multiple alias definitions are needed, they must be separated by
+                            commas in the annotation field.
+            - !ruby/object:Api::Type::Array
+              name: ports
+              description: |-
+                List of open ports in the container.
+                More Info:
+                https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                - !ruby/object:Api::Type::String
+                  name: name
+                  description: If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c".
+                - !ruby/object:Api::Type::String
+                  name: protocol
+                  description: Protocol for port. Must be "TCP". Defaults to "TCP".
+                - !ruby/object:Api::Type::Integer
+                  name: containerPort
+                  description: Port number the container listens on. This must be a valid port number, 0 < x < 65536.
+            - !ruby/object:Api::Type::NestedObject
+              name: resources
+              description: |-
+                Compute Resources required by this container. Used to set values such as max memory
+                More info:
+                https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+              properties:
+              - !ruby/object:Api::Type::KeyValuePairs
+                name: limits
+                description: |-
+                  Limits describes the maximum amount of compute resources allowed.
+                  The values of the map is string form of the 'quantity' k8s type:
+                  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+              - !ruby/object:Api::Type::KeyValuePairs
+                name: requests
+                description: |-
+                  Requests describes the minimum amount of compute resources required.
+                  If Requests is omitted for a container, it defaults to Limits if that is
+                  explicitly specified, otherwise to an implementation-defined value.
+                  The values of the map is string form of the 'quantity' k8s type:
+                  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+            - !ruby/object:Api::Type::Array
+              name: volumeMounts
+              description: |-
+                Volume to mount into the container's filesystem.
+                Only supports SecretVolumeSources.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: mountPath
+                    required: true
+                    description: |-
+                      Path within the container at which the volume should be mounted.  Must
+                      not contain ':'.
+                  - !ruby/object:Api::Type::String
+                    name: name
+                    required: true
+                    description: |-
+                      This must match the Name of a Volume.
+
+        - !ruby/object:Api::Type::Integer
+          name: containerConcurrency
+          description: |-
+            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+            requests per container of the Revision. Values are:
+            - `0` thread-safe, the system should manage the max concurrency. This is
+                the default value.
+            - `1` not-thread-safe. Single concurrency
+            - `2-N` thread-safe, max concurrency of N
+        - !ruby/object:Api::Type::Integer
+          name: timeoutSeconds
+          description: |-
+            TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
+        - !ruby/object:Api::Type::String
+          name: serviceAccountName
+          description:  |-
+            Email address of the IAM service account associated with the revision of the
+            service. The service account represents the identity of the running revision,
+            and determines what permissions the revision has. If not provided, the revision
+            will use the project's default service account.
+        - !ruby/object:Api::Type::Array
+          name: volumes
+          description: |-
+            Volume represents a named volume in a container.
+          item_type: !ruby/object:Api::Type::NestedObject
+            properties:
+              - !ruby/object:Api::Type::String
+                name: name
+                required: true
+                description: |-
+                  Volume's name.
+              - !ruby/object:Api::Type::NestedObject
+                name: secret
+                required: true
+                description: |-
+                  The secret's value will be presented as the content of a file whose
+                  name is defined in the item path. If no items are defined, the name of
+                  the file is the secret_name.
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: secretName
+                    required: true
+                    description: |-
+                      The name of the secret in Cloud Secret Manager. By default, the secret
+                      is assumed to be in the same project.
+                      If the secret is in another project, you must define an alias.
+                      An alias definition has the form:
+                      <alias>:projects/<project-id|project-number>/secrets/<secret-name>.
+                      If multiple alias definitions are needed, they must be separated by
+                      commas.
+                      The alias definitions must be set on the run.googleapis.com/secrets
+                      annotation.
+                  - !ruby/object:Api::Type::Integer
+                    name: defaultMode
+                    description: |-
+                      Mode bits to use on created files by default. Must be a value between 0000
+                      and 0777. Defaults to 0644. Directories within the path are not affected by
+                      this setting. This might be in conflict with other options that affect the
+                      file mode, like fsGroup, and the result can be other mode bits set.
+                  - !ruby/object:Api::Type::Array
+                    name: items
+                    description: |-
+                      If unspecified, the volume will expose a file whose name is the
+                      secret_name.
+                      If specified, the key will be used as the version to fetch from Cloud
+                      Secret Manager and the path will be the name of the file exposed in the
+                      volume. When items are defined, they must specify a key and a path.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: key
                           required: true
                           description: |-
-                            The secret's value will be presented as the content of a file whose
-                            name is defined in the item path. If no items are defined, the name of
-                            the file is the secret_name.
-                          properties:
-                            - !ruby/object:Api::Type::String
-                              name: secretName
-                              required: true
-                              description: |-
-                                The name of the secret in Cloud Secret Manager. By default, the secret
-                                is assumed to be in the same project.
-                                If the secret is in another project, you must define an alias.
-                                An alias definition has the form:
-                                <alias>:projects/<project-id|project-number>/secrets/<secret-name>.
-                                If multiple alias definitions are needed, they must be separated by
-                                commas.
-                                The alias definitions must be set on the run.googleapis.com/secrets
-                                annotation.
-                            - !ruby/object:Api::Type::Integer
-                              name: defaultMode
-                              description: |-
-                                Mode bits to use on created files by default. Must be a value between 0000
-                                and 0777. Defaults to 0644. Directories within the path are not affected by
-                                this setting. This might be in conflict with other options that affect the
-                                file mode, like fsGroup, and the result can be other mode bits set.
-                            - !ruby/object:Api::Type::Array
-                              name: items
-                              description: |-
-                                If unspecified, the volume will expose a file whose name is the
-                                secret_name.
-                                If specified, the key will be used as the version to fetch from Cloud
-                                Secret Manager and the path will be the name of the file exposed in the
-                                volume. When items are defined, they must specify a key and a path.
-                              item_type: !ruby/object:Api::Type::NestedObject
-                                properties:
-                                  - !ruby/object:Api::Type::String
-                                    name: key
-                                    required: true
-                                    description: |-
-                                      The Cloud Secret Manager secret version.
-                                      Can be 'latest' for the latest value or an integer for a specific version.
-                                  - !ruby/object:Api::Type::String
-                                    name: path
-                                    required: true
-                                    description: |-
-                                      The relative path of the file to map the key to.
-                                      May not be an absolute path.
-                                      May not contain the path element '..'.
-                                      May not start with the string '..'.
-                                  - !ruby/object:Api::Type::Integer
-                                    name: mode
-                                    description: |-
-                                      Mode bits to use on this file, must be a value between 0000 and 0777. If
-                                      not specified, the volume defaultMode will be used. This might be in
-                                      conflict with other options that affect the file mode, like fsGroup, and
-                                      the result can be other mode bits set.
-                  - !ruby/object:Api::Type::Enum
-                    name: servingState
-                    deprecation_message: 'Not supported by Cloud Run fully managed'
-                    description: |-
-                      ServingState holds a value describing the state the resources
-                      are in for this Revision.
-                      It is expected
-                      that the system will manipulate this based on routability and load.
-                    output: true
-                    values:
-                      - :ACTIVE
-                      - :RESERVE
-                      - :RETIRED
+                            The Cloud Secret Manager secret version.
+                            Can be 'latest' for the latest value or an integer for a specific version.
+                        - !ruby/object:Api::Type::String
+                          name: path
+                          required: true
+                          description: |-
+                            The relative path of the file to map the key to.
+                            May not be an absolute path.
+                            May not contain the path element '..'.
+                            May not start with the string '..'.
+                        - !ruby/object:Api::Type::Integer
+                          name: mode
+                          description: |-
+                            Mode bits to use on this file, must be a value between 0000 and 0777. If
+                            not specified, the volume defaultMode will be used. This might be in
+                            conflict with other options that affect the file mode, like fsGroup, and
+                            the result can be other mode bits set.
+        - !ruby/object:Api::Type::Enum
+          name: servingState
+          deprecation_message: "Not supported by Cloud Run fully managed"
+          description: |-
+            ServingState holds a value describing the state the resources
+            are in for this Revision.
+            It is expected
+            that the system will manipulate this based on routability and load.
+          output: true
+          values:
+          - :ACTIVE
+          - :RESERVE
+          - :RETIRED
 
-      - !ruby/object:Api::Type::NestedObject
-        name: status
-        description: The current status of the Service.
-        output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: status
+    description: The current status of the Service.
+    output: true
+    properties:
+    - !ruby/object:Api::Type::Array
+      name: conditions
+      description: |-
+        Array of observed Service Conditions, indicating the current ready state of the service.
+      output: true
+      item_type: !ruby/object:Api::Type::NestedObject
         properties:
-          - !ruby/object:Api::Type::Array
-            name: conditions
-            description: |-
-              Array of observed Service Conditions, indicating the current ready state of the service.
-            output: true
-            item_type: !ruby/object:Api::Type::NestedObject
-              properties:
-                - !ruby/object:Api::Type::String
-                  name: message
-                  output: true
-                  description: |-
-                    Human readable message indicating details about the current status.
-                - !ruby/object:Api::Type::String
-                  name: status
-                  output: true
-                  description: Status of the condition, one of True, False, Unknown.
-                - !ruby/object:Api::Type::String
-                  name: reason
-                  output: true
-                  description: |-
-                    One-word CamelCase reason for the condition's current status.
-                - !ruby/object:Api::Type::String
-                  name: type
-                  output: true
-                  description: Type of domain mapping condition.
-          - !ruby/object:Api::Type::String
-            name: url
-            description: |-
-              From RouteStatus. URL holds the url that will distribute traffic over the provided traffic
-              targets. It generally has the form
-              https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app
-            output: true
-          - !ruby/object:Api::Type::Integer
-            name: observedGeneration
-            description: |-
-              ObservedGeneration is the 'Generation' of the Route that was last processed by the
-              controller.
+        - !ruby/object:Api::Type::String
+          name: message
+          output: true
+          description: |-
+            Human readable message indicating details about the current status.
+        - !ruby/object:Api::Type::String
+          name: status
+          output: true
+          description: Status of the condition, one of True, False, Unknown.
+        - !ruby/object:Api::Type::String
+          name: reason
+          output: true
+          description: |-
+            One-word CamelCase reason for the condition's current status.
+        - !ruby/object:Api::Type::String
+          name: type
+          output: true
+          description: Type of domain mapping condition.
+    - !ruby/object:Api::Type::String
+      name: url
+      description: |-
+        From RouteStatus. URL holds the url that will distribute traffic over the provided traffic
+        targets. It generally has the form
+        https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app
+      output: true
+    - !ruby/object:Api::Type::Integer
+      name: observedGeneration
+      description: |-
+        ObservedGeneration is the 'Generation' of the Route that was last processed by the
+        controller.
 
-              Clients polling for completed reconciliation should poll until observedGeneration =
-              metadata.generation and the Ready condition's status is True or False.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: latestCreatedRevisionName
-            description: |-
-              From ConfigurationStatus. LatestCreatedRevisionName is the last revision that was created
-              from this Service's Configuration. It might not be ready yet, for that use
-              LatestReadyRevisionName.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: latestReadyRevisionName
-            description: |-
-              From ConfigurationStatus. LatestReadyRevisionName holds the name of the latest Revision
-              stamped out from this Service's Configuration that has had its "Ready" condition become
-              "True".
-            output: true
+        Clients polling for completed reconciliation should poll until observedGeneration =
+        metadata.generation and the Ready condition's status is True or False.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: latestCreatedRevisionName
+      description: |-
+        From ConfigurationStatus. LatestCreatedRevisionName is the last revision that was created
+        from this Service's Configuration. It might not be ready yet, for that use
+        LatestReadyRevisionName.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: latestReadyRevisionName
+      description: |-
+        From ConfigurationStatus. LatestReadyRevisionName holds the name of the latest Revision
+        stamped out from this Service's Configuration that has had its "Ready" condition become
+        "True".
+      output: true
 
-      - !ruby/object:Api::Type::NestedObject
-        name: metadata
-        required: true
-        description: |-
-          Metadata associated with this Service, including name, namespace, labels,
-          and annotations.
-        properties:
-          - !ruby/object:Api::Type::KeyValuePairs
-            name: labels
-            description: |-
-              Map of string keys and values that can be used to organize and categorize
-              (scope and select) objects. May match selectors of replication controllers
-              and routes.
-              More info: http://kubernetes.io/docs/user-guide/labels
-          - !ruby/object:Api::Type::Integer
-            name: generation
-            description: |-
-              A sequence number representing a specific generation of the desired state.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: resourceVersion
-            description: |-
-              An opaque value that represents the internal version of this object that
-              can be used by clients to determine when objects have changed. May be used
-              for optimistic concurrency, change detection, and the watch operation on a
-              resource or set of resources. They may only be valid for a
-              particular resource or set of resources.
+  - !ruby/object:Api::Type::NestedObject
+    name: metadata
+    required: true
+    description: |-
+      Metadata associated with this Service, including name, namespace, labels,
+      and annotations.
+    properties:
+    - !ruby/object:Api::Type::KeyValuePairs
+      name: labels
+      description: |-
+        Map of string keys and values that can be used to organize and categorize
+        (scope and select) objects. May match selectors of replication controllers
+        and routes.
+        More info: http://kubernetes.io/docs/user-guide/labels
+    - !ruby/object:Api::Type::Integer
+      name: generation
+      description: |-
+        A sequence number representing a specific generation of the desired state.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: resourceVersion
+      description: |-
+        An opaque value that represents the internal version of this object that
+        can be used by clients to determine when objects have changed. May be used
+        for optimistic concurrency, change detection, and the watch operation on a
+        resource or set of resources. They may only be valid for a
+        particular resource or set of resources.
 
-              More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
-            output: true
-          - !ruby/object:Api::Type::String
-            name: selfLink
-            description: |-
-              SelfLink is a URL representing this object.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: uid
-            description: |-
-              UID is a unique id generated by the server on successful creation of a resource and is not
-              allowed to change on PUT operations.
+        More info:
+        https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+      output: true
+    - !ruby/object:Api::Type::String
+      name: selfLink
+      description: |-
+        SelfLink is a URL representing this object.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: uid
+      description: |-
+        UID is a unique id generated by the server on successful creation of a resource and is not
+        allowed to change on PUT operations.
 
-              More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-            output: true
-          - !ruby/object:Api::Type::String
-            name: namespace
-            required: true
-            description: |-
-              In Cloud Run the namespace must be equal to either the
-              project ID or project number.
-          - !ruby/object:Api::Type::KeyValuePairs
-            name: annotations
-            description: |-
-              Annotations is a key value map stored with a resource that
-              may be set by external tools to store and retrieve arbitrary metadata. More
-              info: http://kubernetes.io/docs/user-guide/annotations
+        More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+      output: true
+    - !ruby/object:Api::Type::String
+      name: namespace
+      required: true
+      description: |-
+        In Cloud Run the namespace must be equal to either the
+        project ID or project number.
+    - !ruby/object:Api::Type::KeyValuePairs
+      name: annotations
+      description: |-
+        Annotations is a key value map stored with a resource that
+        may be set by external tools to store and retrieve arbitrary metadata. More
+        info: http://kubernetes.io/docs/user-guide/annotations
 
-              **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
-              If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
-              or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+        **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+        If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
+        or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
 
-              Cloud Run (fully managed) uses the following annotation keys to configure features on a Service:
+        Cloud Run (fully managed) uses the following annotation keys to configure features on a Service:
 
-              - `run.googleapis.com/ingress` sets the [ingress settings](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--ingress)
-                for the Service. For example, `"run.googleapis.com/ingress" = "all"`.
-          - !ruby/object:Api::Type::String
-            name: name
-            required: true
-            description: |-
-              Name must be unique within a namespace, within a Cloud Run region.
-              Is required when creating resources. Name is primarily intended
-              for creation idempotence and configuration definition. Cannot be updated.
-              More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        - `run.googleapis.com/ingress` sets the [ingress settings](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--ingress)
+          for the Service. For example, `"run.googleapis.com/ingress" = "all"`.
+    - !ruby/object:Api::Type::String
+      name: name
+      required: true
+      description: |-
+        Name must be unique within a namespace, within a Cloud Run region.
+        Is required when creating resources. Name is primarily intended
+        for creation idempotence and configuration definition. Cannot be updated.
+        More info: http://kubernetes.io/docs/user-guide/identifiers#names

--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
---- !ruby/object:Api::Product
+---
+!ruby/object:Api::Product
 name: CloudRun
 display_name: Cloud Run
 versions:
@@ -26,825 +27,822 @@ versions:
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:
-# Cloud Run DomainMappings
-- !ruby/object:Api::Resource
-  name: DomainMapping
-  kind: DomainMapping
-  base_url: apis/domains.cloudrun.com/v1/namespaces/{{project}}/domainmappings
-  cai_base_url: projects/{{project}}/locations/{{location}}/DomainMappings
-  references: !ruby/object:Api::Resource::ReferenceLinks
+  # Cloud Run DomainMappings
+  - !ruby/object:Api::Resource
+    name: DomainMapping
+    kind: DomainMapping
+    base_url: apis/domains.cloudrun.com/v1/namespaces/{{project}}/domainmappings
+    cai_base_url: projects/{{project}}/locations/{{location}}/DomainMappings
+    references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
-        'Official Documentation':
-          'https://cloud.google.com/run/docs/mapping-custom-domains'
+        'Official Documentation': 'https://cloud.google.com/run/docs/mapping-custom-domains'
       api: 'https://cloud.google.com/run/docs/reference/rest/v1/projects.locations.domainmappings'
-  description: |-
-    Resource to hold the state and status of a user's domain mapping.
-  input: true
-  parameters:
-  - !ruby/object:Api::Type::String
-    name: location
-    description: The location of the cloud run instance. eg us-central1
-    url_param_only: true
-    required: true
-  properties:
-  - !ruby/object:Api::Type::String
-    name: name
-    url_param_only: true
-    input: true
-    # This is a convenience field handled by terraform encoder/decoders
-    exclude: true
     description: |-
-      Name should be a [verified](https://support.google.com/webmasters/answer/9008080) domain
-  - !ruby/object:Api::Type::String
-    name: kind
-    description: This is always set to DomainMapping
-  - !ruby/object:Api::Type::NestedObject
-    name: status
-    description: The current status of the DomainMapping.
-    output: true
-    properties:
-    - !ruby/object:Api::Type::Array
-      name: conditions
-      description: |-
-        Array of observed DomainMappingConditions, indicating the current state
-        of the DomainMapping.
-      output: true
-      item_type: !ruby/object:Api::Type::NestedObject
-        properties:
-        - !ruby/object:Api::Type::String
-          name: message
-          output: true
-          description: |-
-            Human readable message indicating details about the current status.
-        - !ruby/object:Api::Type::String
-          name: status
-          output: true
-          description: Status of the condition, one of True, False, Unknown.
-        - !ruby/object:Api::Type::String
-          name: reason
-          output: true
-          description: |-
-            One-word CamelCase reason for the condition's current status.
-        - !ruby/object:Api::Type::String
-          name: type
-          output: true
-          description: Type of domain mapping condition.
-    - !ruby/object:Api::Type::Integer
-      name: observedGeneration
-      description: |-
-        ObservedGeneration is the 'Generation' of the DomainMapping that
-        was last processed by the controller.
-      output: true
-    - !ruby/object:Api::Type::Array
-      name: resourceRecords
-      description: |-
-        The resource records required to configure this domain mapping. These
-        records must be added to the domain's DNS configuration in order to
-        serve the application via this domain mapping.
-      item_type: !ruby/object:Api::Type::NestedObject
-        properties:
-        - !ruby/object:Api::Type::Enum
-          name: type
-          description: 'Resource record type. Example: `AAAA`.'
-          values:
-          - :A
-          - :AAAA
-          - :CNAME
-        - !ruby/object:Api::Type::String
-          name: rrdata
-          output: true
-          description: |-
-            Data for this record. Values vary by record type, as defined in RFC 1035
-            (section 5) and RFC 1034 (section 3.6.1).
-        - !ruby/object:Api::Type::String
-          name: name
-          output: true
-          description: |-
-            Relative name of the object affected by this record. Only applicable for
-            `CNAME` records. Example: 'www'.
-    - !ruby/object:Api::Type::String
-      name: mappedRouteName
-      output: true
-      description: The name of the route that the mapping currently points to.
-  - !ruby/object:Api::Type::String
-    name: apiVersion
-    description: The API version for this call such as "serving.knative.dev/v1alpha1".
-  - !ruby/object:Api::Type::NestedObject
-    name: spec
-    description: The spec for this DomainMapping.
-    required: true
-    properties:
-    - !ruby/object:Api::Type::Boolean
-      name: forceOverride
-      description: |-
-        If set, the mapping will override any mapping set before this spec was set.
-        It is recommended that the user leaves this empty to receive an error
-        warning about a potential conflict and only set it once the respective UI
-        has given such a warning.
-    - !ruby/object:Api::Type::String
-      name: routeName
-      required: true
-      description: |-
-        The name of the Cloud Run Service that this DomainMapping applies to.
-        The route must exist.
-    - !ruby/object:Api::Type::Enum
-      name: certificateMode
-      description: The mode of the certificate.
-      values:
-      - :NONE
-      - :AUTOMATIC
-      default_value: :AUTOMATIC
-  - !ruby/object:Api::Type::NestedObject
-    name: metadata
-    required: true
-    description: Metadata associated with this DomainMapping.
-    properties:
-    - !ruby/object:Api::Type::KeyValuePairs
-      name: labels
-      description: |-
-        Map of string keys and values that can be used to organize and categorize
-        (scope and select) objects. May match selectors of replication controllers
-        and routes.
-        More info: http://kubernetes.io/docs/user-guide/labels
-    - !ruby/object:Api::Type::Integer
-      name: generation
-      description: |-
-        A sequence number representing a specific generation of the desired state.
-      output: true
-    - !ruby/object:Api::Type::String
-      name: resourceVersion
-      description: |-
-        An opaque value that represents the internal version of this object that
-        can be used by clients to determine when objects have changed. May be used
-        for optimistic concurrency, change detection, and the watch operation on a
-        resource or set of resources. They may only be valid for a
-        particular resource or set of resources.
-
-        More info:
-        https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
-      output: true
-    - !ruby/object:Api::Type::String
-      name: selfLink
-      description: |-
-        SelfLink is a URL representing this object.
-      output: true
-    - !ruby/object:Api::Type::String
-      name: uid
-      description: |-
-        UID is a unique id generated by the server on successful creation of a resource and is not
-        allowed to change on PUT operations.
-
-        More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-      output: true
-    - !ruby/object:Api::Type::String
-      name: namespace
-      required: true
-      description: |-
-        In Cloud Run the namespace must be equal to either the
-        project ID or project number.
-    - !ruby/object:Api::Type::KeyValuePairs
-      name: annotations
-      description: |-
-        Annotations is a key value map stored with a resource that
-        may be set by external tools to store and retrieve arbitrary metadata. More
-        info: http://kubernetes.io/docs/user-guide/annotations
-
-        **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
-        If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
-        or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
-    - !ruby/object:Api::Type::String
-      name: name
-      required: true
-      input: true
-      description: |-
-        Name must be unique within a namespace, within a Cloud Run region.
-        Is required when creating resources. Name is primarily intended
-        for creation idempotence and configuration definition. Cannot be updated.
-        More info: http://kubernetes.io/docs/user-guide/identifiers#names
-
-# Cloud Run Service
-- !ruby/object:Api::Resource
-  name: Service
-  kind: Service
-  base_url: apis/serving.knative.dev/v1/namespaces/{{project}}/services
-  cai_base_url: projects/{{project}}/locations/{{location}}/services
-  references: !ruby/object:Api::Resource::ReferenceLinks
-      guides:
-        'Official Documentation':
-          'https://cloud.google.com/run/docs/'
-      api: 'https://cloud.google.com/run/docs/reference/rest/v1/namespaces.services'
-  description: |-
-    Service acts as a top-level container that manages a set of Routes and
-    Configurations which implement a network service. Service exists to provide a
-    singular abstraction which can be access controlled, reasoned about, and
-    which encapsulates software lifecycle decisions such as rollout policy and
-    team resource ownership. Service acts only as an orchestrator of the
-    underlying Routes and Configurations (much as a kubernetes Deployment
-    orchestrates ReplicaSets).
-
-    The Service's controller will track the statuses of its owned Configuration
-    and Route, reflecting their statuses and conditions as its own.
-
-    See also:
-    https://github.com/knative/specs/blob/main/specs/serving/overview.md
-  iam_policy: !ruby/object:Api::Resource::IamPolicy
-    method_name_separator: ':'
-    parent_resource_attribute: 'service'
-    base_url: v1/projects/{{project}}/locations/{{location}}/services/{{service}}
-    import_format: ["projects/{{project}}/locations/{{location}}/services/{{service}}", "{{service}}"]
-  parameters:
-  - !ruby/object:Api::Type::String
-    name: location
-    description: The location of the cloud run instance. eg us-central1
-    url_param_only: true
-    required: true
+      Resource to hold the state and status of a user's domain mapping.
     input: true
-  properties:
-  - !ruby/object:Api::Type::String
-    name: name
-    # This is a convenience field as terraform expects `name` to be a top level property
-    url_param_only: true
-    input: true
-    description: |-
-      Name must be unique within a namespace, within a Cloud Run region.
-      Is required when creating resources. Name is primarily intended
-      for creation idempotence and configuration definition. Cannot be updated.
-      More info: http://kubernetes.io/docs/user-guide/identifiers#names
-  - !ruby/object:Api::Type::String
-    name: apiVersion
-    description: The API version for this call such as "serving.knative.dev/v1alpha1".
-  - !ruby/object:Api::Type::String
-    name: kind
-    description: This is always set to Service
-  - !ruby/object:Api::Type::NestedObject
-    name: spec
-    required: true
-    description: Spec holds the desired state of the Service (from the client).
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: location
+        description: The location of the cloud run instance. eg us-central1
+        url_param_only: true
+        required: true
     properties:
-    - !ruby/object:Api::Type::Array
-      name: traffic
-      description: |-
-        Traffic specifies how to distribute traffic over a collection of Knative Revisions
-        and Configurations
-      item_type: !ruby/object:Api::Type::NestedObject
+      - !ruby/object:Api::Type::String
+        name: name
+        url_param_only: true
+        input: true
+        # This is a convenience field handled by terraform encoder/decoders
+        exclude: true
+        description: |-
+          Name should be a [verified](https://support.google.com/webmasters/answer/9008080) domain
+      - !ruby/object:Api::Type::String
+        name: kind
+        description: This is always set to DomainMapping
+      - !ruby/object:Api::Type::NestedObject
+        name: status
+        description: The current status of the DomainMapping.
+        output: true
         properties:
-        - !ruby/object:Api::Type::String
-          name: revisionName
-          description: |-
-            RevisionName of a specific revision to which to send this portion of traffic.
-        - !ruby/object:Api::Type::Integer
-          name: percent
-          required: true
-          description: |-
-            Percent specifies percent of the traffic to this Revision or Configuration.
-        - !ruby/object:Api::Type::Boolean
-          name: latestRevision
-          description: |-
-            LatestRevision may be optionally provided to indicate that the latest ready
-            Revision of the Configuration should be used for this traffic target. When
-            provided LatestRevision must be true if RevisionName is empty; it must be
-            false when RevisionName is non-empty.
-    - !ruby/object:Api::Type::NestedObject
-      name: template
-      description: |-
-        template holds the latest specification for the Revision to
-        be stamped out. The template references the container image, and may also
-        include labels and annotations that should be attached to the Revision.
-        To correlate a Revision, and/or to force a Revision to be created when the
-        spec doesn't otherwise change, a nonce label may be provided in the
-        template metadata. For more details, see:
-        https://github.com/knative/serving/blob/master/docs/client-conventions.md#associate-modifications-with-revisions
-
-        Cloud Run does not currently support referencing a build that is
-        responsible for materializing the container image from source.
-      properties:
+          - !ruby/object:Api::Type::Array
+            name: conditions
+            description: |-
+              Array of observed DomainMappingConditions, indicating the current state
+              of the DomainMapping.
+            output: true
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: message
+                  output: true
+                  description: |-
+                    Human readable message indicating details about the current status.
+                - !ruby/object:Api::Type::String
+                  name: status
+                  output: true
+                  description: Status of the condition, one of True, False, Unknown.
+                - !ruby/object:Api::Type::String
+                  name: reason
+                  output: true
+                  description: |-
+                    One-word CamelCase reason for the condition's current status.
+                - !ruby/object:Api::Type::String
+                  name: type
+                  output: true
+                  description: Type of domain mapping condition.
+          - !ruby/object:Api::Type::Integer
+            name: observedGeneration
+            description: |-
+              ObservedGeneration is the 'Generation' of the DomainMapping that
+              was last processed by the controller.
+            output: true
+          - !ruby/object:Api::Type::Array
+            name: resourceRecords
+            description: |-
+              The resource records required to configure this domain mapping. These
+              records must be added to the domain's DNS configuration in order to
+              serve the application via this domain mapping.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: type
+                  description: 'Resource record type. Example: `AAAA`.'
+                  values:
+                    - :A
+                    - :AAAA
+                    - :CNAME
+                - !ruby/object:Api::Type::String
+                  name: rrdata
+                  output: true
+                  description: |-
+                    Data for this record. Values vary by record type, as defined in RFC 1035
+                    (section 5) and RFC 1034 (section 3.6.1).
+                - !ruby/object:Api::Type::String
+                  name: name
+                  output: true
+                  description: |-
+                    Relative name of the object affected by this record. Only applicable for
+                    `CNAME` records. Example: 'www'.
+          - !ruby/object:Api::Type::String
+            name: mappedRouteName
+            output: true
+            description: The name of the route that the mapping currently points to.
+      - !ruby/object:Api::Type::String
+        name: apiVersion
+        description: The API version for this call such as "serving.knative.dev/v1alpha1".
+      - !ruby/object:Api::Type::NestedObject
+        name: spec
+        description: The spec for this DomainMapping.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: forceOverride
+            description: |-
+              If set, the mapping will override any mapping set before this spec was set.
+              It is recommended that the user leaves this empty to receive an error
+              warning about a potential conflict and only set it once the respective UI
+              has given such a warning.
+          - !ruby/object:Api::Type::String
+            name: routeName
+            required: true
+            description: |-
+              The name of the Cloud Run Service that this DomainMapping applies to.
+              The route must exist.
+          - !ruby/object:Api::Type::Enum
+            name: certificateMode
+            description: The mode of the certificate.
+            values:
+              - :NONE
+              - :AUTOMATIC
+            default_value: :AUTOMATIC
       - !ruby/object:Api::Type::NestedObject
         name: metadata
-        description: |-
-          Optional metadata for this Revision, including labels and annotations.
-          Name will be generated by the Configuration. To set minimum instances
-          for this revision, use the "autoscaling.knative.dev/minScale" annotation
-          key. To set maximum instances for this revision, use the
-          "autoscaling.knative.dev/maxScale" annotation key. To set Cloud SQL
-          connections for the revision, use the "run.googleapis.com/cloudsql-instances"
-          annotation key.
+        required: true
+        description: Metadata associated with this DomainMapping.
         properties:
-        - !ruby/object:Api::Type::KeyValuePairs
-          name: labels
-          description: |-
-            Map of string keys and values that can be used to organize and categorize
-            (scope and select) objects. May match selectors of replication controllers
-            and routes.
-            More info: http://kubernetes.io/docs/user-guide/labels
-        - !ruby/object:Api::Type::Integer
-          name: generation
-          description: |-
-            A sequence number representing a specific generation of the desired state.
-          output: true
-        - !ruby/object:Api::Type::String
-          name: resourceVersion
-          description: |-
-            An opaque value that represents the internal version of this object that
-            can be used by clients to determine when objects have changed. May be used
-            for optimistic concurrency, change detection, and the watch operation on a
-            resource or set of resources. They may only be valid for a
-            particular resource or set of resources.
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: labels
+            description: |-
+              Map of string keys and values that can be used to organize and categorize
+              (scope and select) objects. May match selectors of replication controllers
+              and routes.
+              More info: http://kubernetes.io/docs/user-guide/labels
+          - !ruby/object:Api::Type::Integer
+            name: generation
+            description: |-
+              A sequence number representing a specific generation of the desired state.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: resourceVersion
+            description: |-
+              An opaque value that represents the internal version of this object that
+              can be used by clients to determine when objects have changed. May be used
+              for optimistic concurrency, change detection, and the watch operation on a
+              resource or set of resources. They may only be valid for a
+              particular resource or set of resources.
 
-            More info:
-            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
-          output: true
-        - !ruby/object:Api::Type::String
-          name: selfLink
-          description: |-
-            SelfLink is a URL representing this object.
-          output: true
-        - !ruby/object:Api::Type::String
-          name: uid
-          description: |-
-            UID is a unique id generated by the server on successful creation of a resource and is not
-            allowed to change on PUT operations.
+              More info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+            output: true
+          - !ruby/object:Api::Type::String
+            name: selfLink
+            description: |-
+              SelfLink is a URL representing this object.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: uid
+            description: |-
+              UID is a unique id generated by the server on successful creation of a resource and is not
+              allowed to change on PUT operations.
 
-            More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-          output: true
-        - !ruby/object:Api::Type::String
-          name: namespace
-          description: |-
-            In Cloud Run the namespace must be equal to either the
-            project ID or project number. It will default to the resource's project.
-        - !ruby/object:Api::Type::KeyValuePairs
-          name: annotations
-          description: |-
-            Annotations is a key value map stored with a resource that
-            may be set by external tools to store and retrieve arbitrary metadata. More
-            info: http://kubernetes.io/docs/user-guide/annotations
+              More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+            output: true
+          - !ruby/object:Api::Type::String
+            name: namespace
+            required: true
+            description: |-
+              In Cloud Run the namespace must be equal to either the
+              project ID or project number.
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: annotations
+            description: |-
+              Annotations is a key value map stored with a resource that
+              may be set by external tools to store and retrieve arbitrary metadata. More
+              info: http://kubernetes.io/docs/user-guide/annotations
 
-            **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
-            If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
-            or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
-        - !ruby/object:Api::Type::String
-          name: name
-          description: |-
-            Name must be unique within a namespace, within a Cloud Run region.
-            Is required when creating resources. Name is primarily intended
-            for creation idempotence and configuration definition. Cannot be updated.
-            More info: http://kubernetes.io/docs/user-guide/identifiers#names
+              **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+              If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
+              or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+          - !ruby/object:Api::Type::String
+            name: name
+            required: true
+            input: true
+            description: |-
+              Name must be unique within a namespace, within a Cloud Run region.
+              Is required when creating resources. Name is primarily intended
+              for creation idempotence and configuration definition. Cannot be updated.
+              More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+  # Cloud Run Service
+  - !ruby/object:Api::Resource
+    name: Service
+    kind: Service
+    base_url: apis/serving.knative.dev/v1/namespaces/{{project}}/services
+    cai_base_url: projects/{{project}}/locations/{{location}}/services
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/run/docs/'
+      api: 'https://cloud.google.com/run/docs/reference/rest/v1/namespaces.services'
+    description: |-
+      Service acts as a top-level container that manages a set of Routes and
+      Configurations which implement a network service. Service exists to provide a
+      singular abstraction which can be access controlled, reasoned about, and
+      which encapsulates software lifecycle decisions such as rollout policy and
+      team resource ownership. Service acts only as an orchestrator of the
+      underlying Routes and Configurations (much as a kubernetes Deployment
+      orchestrates ReplicaSets).
+
+      The Service's controller will track the statuses of its owned Configuration
+      and Route, reflecting their statuses and conditions as its own.
+
+      See also:
+      https://github.com/knative/specs/blob/main/specs/serving/overview.md
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      method_name_separator: ':'
+      parent_resource_attribute: 'service'
+      base_url: v1/projects/{{project}}/locations/{{location}}/services/{{service}}
+      import_format: ['projects/{{project}}/locations/{{location}}/services/{{service}}', '{{service}}']
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: location
+        description: The location of the cloud run instance. eg us-central1
+        url_param_only: true
+        required: true
+        input: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        # This is a convenience field as terraform expects `name` to be a top level property
+        url_param_only: true
+        input: true
+        description: |-
+          Name must be unique within a namespace, within a Cloud Run region.
+          Is required when creating resources. Name is primarily intended
+          for creation idempotence and configuration definition. Cannot be updated.
+          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+      - !ruby/object:Api::Type::String
+        name: apiVersion
+        description: The API version for this call such as "serving.knative.dev/v1alpha1".
+      - !ruby/object:Api::Type::String
+        name: kind
+        description: This is always set to Service
       - !ruby/object:Api::Type::NestedObject
         name: spec
         required: true
-        description: RevisionSpec holds the desired state of the Revision (from
-          the client).
+        description: Spec holds the desired state of the Service (from the client).
         properties:
-        - !ruby/object:Api::Type::Array
-          name: containers
-          update_verb: :PUT
-          required: true
-          description: |-
-            Container defines the unit of execution for this Revision.
-            In the context of a Revision, we disallow a number of the fields of
-            this Container, including: name, ports, and volumeMounts.
-            The runtime contract is documented here:
-            https://github.com/knative/serving/blob/master/docs/runtime-contract.md
-          item_type: !ruby/object:Api::Type::NestedObject
+          - !ruby/object:Api::Type::Array
+            name: traffic
+            description: |-
+              Traffic specifies how to distribute traffic over a collection of Knative Revisions
+              and Configurations
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: revisionName
+                  description: |-
+                    RevisionName of a specific revision to which to send this portion of traffic.
+                - !ruby/object:Api::Type::Integer
+                  name: percent
+                  required: true
+                  description: |-
+                    Percent specifies percent of the traffic to this Revision or Configuration.
+                - !ruby/object:Api::Type::Boolean
+                  name: latestRevision
+                  description: |-
+                    LatestRevision may be optionally provided to indicate that the latest ready
+                    Revision of the Configuration should be used for this traffic target. When
+                    provided LatestRevision must be true if RevisionName is empty; it must be
+                    false when RevisionName is non-empty.
+          - !ruby/object:Api::Type::NestedObject
+            name: template
+            description: |-
+              template holds the latest specification for the Revision to
+              be stamped out. The template references the container image, and may also
+              include labels and annotations that should be attached to the Revision.
+              To correlate a Revision, and/or to force a Revision to be created when the
+              spec doesn't otherwise change, a nonce label may be provided in the
+              template metadata. For more details, see:
+              https://github.com/knative/serving/blob/master/docs/client-conventions.md#associate-modifications-with-revisions
+
+              Cloud Run does not currently support referencing a build that is
+              responsible for materializing the container image from source.
             properties:
-            - !ruby/object:Api::Type::String
-              deprecation_message: "Not supported by Cloud Run fully managed"
-              name: workingDir
-              input: true
-              description: |-
-                Container's working directory.
-                If not specified, the container runtime's default will be used, which
-                might be configured in the container image.
-            - !ruby/object:Api::Type::Array
-              name: args
-              description: |-
-                Arguments to the entrypoint.
-                The docker image's CMD is used if this is not provided.
-                Variable references $(VAR_NAME) are expanded using the container's
-                environment. If a variable cannot be resolved, the reference in the input
-                string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
-                double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                regardless of whether the variable exists or not.
-                More info:
-                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-              item_type: Api::Type::String
-            - !ruby/object:Api::Type::Array
-              name: envFrom
-              deprecation_message: "Not supported by Cloud Run fully managed"
-              input: true
-              description: |-
-                List of sources to populate environment variables in the container.
-                All invalid keys will be reported as an event when the container is starting.
-                When a key exists in multiple sources, the value associated with the last source will
-                take precedence. Values defined by an Env with a duplicate key will take
-                precedence.
-              item_type: !ruby/object:Api::Type::NestedObject
+              - !ruby/object:Api::Type::NestedObject
+                name: metadata
+                description: |-
+                  Optional metadata for this Revision, including labels and annotations.
+                  Name will be generated by the Configuration. To set minimum instances
+                  for this revision, use the "autoscaling.knative.dev/minScale" annotation
+                  key. To set maximum instances for this revision, use the
+                  "autoscaling.knative.dev/maxScale" annotation key. To set Cloud SQL
+                  connections for the revision, use the "run.googleapis.com/cloudsql-instances"
+                  annotation key.
                 properties:
-                - !ruby/object:Api::Type::String
-                  name: prefix
-                  description: |-
-                    An optional identifier to prepend to each key in the ConfigMap.
-                - !ruby/object:Api::Type::NestedObject
-                  name: configMapRef
-                  description: |-
-                    The ConfigMap to select from.
-                  properties:
-                  - !ruby/object:Api::Type::Boolean
-                    name: optional
+                  - !ruby/object:Api::Type::KeyValuePairs
+                    name: labels
                     description: |-
-                      Specify whether the ConfigMap must be defined
-                  - !ruby/object:Api::Type::NestedObject
-                    name: localObjectReference
-                    description: The ConfigMap to select from.
-                    properties:
-                    - !ruby/object:Api::Type::String
-                      name: name
-                      required: true
-                      description: |-
-                        Name of the referent.
-                        More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                - !ruby/object:Api::Type::NestedObject
-                  name: secretRef
-                  description: |-
-                    The Secret to select from.
-                  properties:
-                  - !ruby/object:Api::Type::NestedObject
-                    name: localObjectReference
-                    description: The Secret to select from.
-                    properties:
-                    - !ruby/object:Api::Type::String
-                      name: name
-                      required: true
-                      description: |-
-                        Name of the referent.
-                        More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                  - !ruby/object:Api::Type::Boolean
-                    name: optional
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication controllers
+                      and routes.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                  - !ruby/object:Api::Type::Integer
+                    name: generation
                     description: |-
-                      Specify whether the Secret must be defined
-            - !ruby/object:Api::Type::String
-              name: image
-              required: true
-              description: |-
-                Docker image name. This is most often a reference to a container located
-                in the container registry, such as gcr.io/cloudrun/hello
-                More info: https://kubernetes.io/docs/concepts/containers/images
-            - !ruby/object:Api::Type::Array
-              name: command
-              description: |-
-                Entrypoint array. Not executed within a shell.
-                The docker image's ENTRYPOINT is used if this is not provided.
-                Variable references $(VAR_NAME) are expanded using the container's
-                environment. If a variable cannot be resolved, the reference in the input
-                string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
-                double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                regardless of whether the variable exists or not.
-                More info:
-                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-              item_type: Api::Type::String
-            - !ruby/object:Api::Type::Array
-              name: env
-              description: |-
-                List of environment variables to set in the container.
-              item_type: !ruby/object:Api::Type::NestedObject
+                      A sequence number representing a specific generation of the desired state.
+                    output: true
+                  - !ruby/object:Api::Type::String
+                    name: resourceVersion
+                    description: |-
+                      An opaque value that represents the internal version of this object that
+                      can be used by clients to determine when objects have changed. May be used
+                      for optimistic concurrency, change detection, and the watch operation on a
+                      resource or set of resources. They may only be valid for a
+                      particular resource or set of resources.
+
+                      More info:
+                      https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                    output: true
+                  - !ruby/object:Api::Type::String
+                    name: selfLink
+                    description: |-
+                      SelfLink is a URL representing this object.
+                    output: true
+                  - !ruby/object:Api::Type::String
+                    name: uid
+                    description: |-
+                      UID is a unique id generated by the server on successful creation of a resource and is not
+                      allowed to change on PUT operations.
+
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                    output: true
+                  - !ruby/object:Api::Type::String
+                    name: namespace
+                    description: |-
+                      In Cloud Run the namespace must be equal to either the
+                      project ID or project number. It will default to the resource's project.
+                  - !ruby/object:Api::Type::KeyValuePairs
+                    name: annotations
+                    description: |-
+                      Annotations is a key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata. More
+                      info: http://kubernetes.io/docs/user-guide/annotations
+
+                      **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+                      If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
+                      or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+                  - !ruby/object:Api::Type::String
+                    name: name
+                    description: |-
+                      Name must be unique within a namespace, within a Cloud Run region.
+                      Is required when creating resources. Name is primarily intended
+                      for creation idempotence and configuration definition. Cannot be updated.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+              - !ruby/object:Api::Type::NestedObject
+                name: spec
+                required: true
+                description: RevisionSpec holds the desired state of the Revision (from
+                  the client).
                 properties:
-                - !ruby/object:Api::Type::String
-                  name: name
-                  description: Name of the environment variable.
-                - !ruby/object:Api::Type::String
-                  name: value
-                  description: |-
-                    Variable references $(VAR_NAME) are expanded
-                    using the previous defined environment variables in the container and
-                    any route environment variables. If a variable cannot be resolved,
-                    the reference in the input string will be unchanged. The $(VAR_NAME)
-                    syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                    references will never be expanded, regardless of whether the variable
-                    exists or not.
-                    Defaults to "".
-                - !ruby/object:Api::Type::NestedObject
-                  name: valueFrom
-                  description: |-
-                    Source for the environment variable's value. Only supports secret_key_ref.
-                  properties:
-                    - !ruby/object:Api::Type::NestedObject
-                      name: secretKeyRef
-                      required: true
-                      description: |-
-                        Selects a key (version) of a secret in Secret Manager.
+                  - !ruby/object:Api::Type::Array
+                    name: containers
+                    update_verb: :PUT
+                    required: true
+                    description: |-
+                      Container defines the unit of execution for this Revision.
+                      In the context of a Revision, we disallow a number of the fields of
+                      this Container, including: name, ports, and volumeMounts.
+                      The runtime contract is documented here:
+                      https://github.com/knative/serving/blob/master/docs/runtime-contract.md
+                    item_type: !ruby/object:Api::Type::NestedObject
                       properties:
                         - !ruby/object:Api::Type::String
-                          name: key
+                          deprecation_message: 'Not supported by Cloud Run fully managed'
+                          name: workingDir
+                          input: true
+                          description: |-
+                            Container's working directory.
+                            If not specified, the container runtime's default will be used, which
+                            might be configured in the container image.
+                        - !ruby/object:Api::Type::Array
+                          name: args
+                          description: |-
+                            Arguments to the entrypoint.
+                            The docker image's CMD is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's
+                            environment. If a variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                            double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                            regardless of whether the variable exists or not.
+                            More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::Array
+                          name: envFrom
+                          deprecation_message: 'Not supported by Cloud Run fully managed'
+                          input: true
+                          description: |-
+                            List of sources to populate environment variables in the container.
+                            All invalid keys will be reported as an event when the container is starting.
+                            When a key exists in multiple sources, the value associated with the last source will
+                            take precedence. Values defined by an Env with a duplicate key will take
+                            precedence.
+                          item_type: !ruby/object:Api::Type::NestedObject
+                            properties:
+                              - !ruby/object:Api::Type::String
+                                name: prefix
+                                description: |-
+                                  An optional identifier to prepend to each key in the ConfigMap.
+                              - !ruby/object:Api::Type::NestedObject
+                                name: configMapRef
+                                description: |-
+                                  The ConfigMap to select from.
+                                properties:
+                                  - !ruby/object:Api::Type::Boolean
+                                    name: optional
+                                    description: |-
+                                      Specify whether the ConfigMap must be defined
+                                  - !ruby/object:Api::Type::NestedObject
+                                    name: localObjectReference
+                                    description: The ConfigMap to select from.
+                                    properties:
+                                      - !ruby/object:Api::Type::String
+                                        name: name
+                                        required: true
+                                        description: |-
+                                          Name of the referent.
+                                          More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              - !ruby/object:Api::Type::NestedObject
+                                name: secretRef
+                                description: |-
+                                  The Secret to select from.
+                                properties:
+                                  - !ruby/object:Api::Type::NestedObject
+                                    name: localObjectReference
+                                    description: The Secret to select from.
+                                    properties:
+                                      - !ruby/object:Api::Type::String
+                                        name: name
+                                        required: true
+                                        description: |-
+                                          Name of the referent.
+                                          More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  - !ruby/object:Api::Type::Boolean
+                                    name: optional
+                                    description: |-
+                                      Specify whether the Secret must be defined
+                        - !ruby/object:Api::Type::String
+                          name: image
                           required: true
                           description: |-
-                            A Cloud Secret Manager secret version. Must be 'latest' for the latest
-                            version or an integer for a specific version.
+                            Docker image name. This is most often a reference to a container located
+                            in the container registry, such as gcr.io/cloudrun/hello
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                        - !ruby/object:Api::Type::Array
+                          name: command
+                          description: |-
+                            Entrypoint array. Not executed within a shell.
+                            The docker image's ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's
+                            environment. If a variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                            double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                            regardless of whether the variable exists or not.
+                            More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::Array
+                          name: env
+                          description: |-
+                            List of environment variables to set in the container.
+                          item_type: !ruby/object:Api::Type::NestedObject
+                            properties:
+                              - !ruby/object:Api::Type::String
+                                name: name
+                                description: Name of the environment variable.
+                              - !ruby/object:Api::Type::String
+                                name: value
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in the container and
+                                  any route environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                  references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                              - !ruby/object:Api::Type::NestedObject
+                                name: valueFrom
+                                description: |-
+                                  Source for the environment variable's value. Only supports secret_key_ref.
+                                properties:
+                                  - !ruby/object:Api::Type::NestedObject
+                                    name: secretKeyRef
+                                    required: true
+                                    description: |-
+                                      Selects a key (version) of a secret in Secret Manager.
+                                    properties:
+                                      - !ruby/object:Api::Type::String
+                                        name: key
+                                        required: true
+                                        description: |-
+                                          A Cloud Secret Manager secret version. Must be 'latest' for the latest
+                                          version or an integer for a specific version.
+                                      - !ruby/object:Api::Type::String
+                                        name: name
+                                        required: true
+                                        description: |-
+                                          The name of the secret in Cloud Secret Manager. By default, the secret
+                                          is assumed to be in the same project.
+                                          If the secret is in another project, you must define an alias.
+                                          You set the <alias> in this field, and create an annotation with the
+                                          following structure
+                                          "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
+                                          If multiple alias definitions are needed, they must be separated by
+                                          commas in the annotation field.
+                        - !ruby/object:Api::Type::Array
+                          name: ports
+                          description: |-
+                            List of open ports in the container.
+                            More Info:
+                            https://cloud.google.com/run/docs/reference/rest/v1/Container#ContainerPort
+                          item_type: !ruby/object:Api::Type::NestedObject
+                            properties:
+                              - !ruby/object:Api::Type::String
+                                name: name
+                                description: If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c".
+                              - !ruby/object:Api::Type::String
+                                name: protocol
+                                description: Protocol for port. Must be "TCP". Defaults to "TCP".
+                              - !ruby/object:Api::Type::Integer
+                                name: containerPort
+                                description: Port number the container listens on. This must be a valid port number, 0 < x < 65536.
+                        - !ruby/object:Api::Type::NestedObject
+                          name: resources
+                          description: |-
+                            Compute Resources required by this container. Used to set values such as max memory
+                            More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+                          properties:
+                            - !ruby/object:Api::Type::KeyValuePairs
+                              name: limits
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                The values of the map is string form of the 'quantity' k8s type:
+                                https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+                            - !ruby/object:Api::Type::KeyValuePairs
+                              name: requests
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined value.
+                                The values of the map is string form of the 'quantity' k8s type:
+                                https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+                        - !ruby/object:Api::Type::Array
+                          name: volumeMounts
+                          description: |-
+                            Volume to mount into the container's filesystem.
+                            Only supports SecretVolumeSources.
+                          item_type: !ruby/object:Api::Type::NestedObject
+                            properties:
+                              - !ruby/object:Api::Type::String
+                                name: mountPath
+                                required: true
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
+                              - !ruby/object:Api::Type::String
+                                name: name
+                                required: true
+                                description: |-
+                                  This must match the Name of a Volume.
+
+                  - !ruby/object:Api::Type::Integer
+                    name: containerConcurrency
+                    description: |-
+                      ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                      requests per container of the Revision. Values are:
+                      - `0` thread-safe, the system should manage the max concurrency. This is
+                          the default value.
+                      - `1` not-thread-safe. Single concurrency
+                      - `2-N` thread-safe, max concurrency of N
+                  - !ruby/object:Api::Type::Integer
+                    name: timeoutSeconds
+                    description: |-
+                      TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
+                  - !ruby/object:Api::Type::String
+                    name: serviceAccountName
+                    description: |-
+                      Email address of the IAM service account associated with the revision of the
+                      service. The service account represents the identity of the running revision,
+                      and determines what permissions the revision has. If not provided, the revision
+                      will use the project's default service account.
+                  - !ruby/object:Api::Type::Array
+                    name: volumes
+                    description: |-
+                      Volume represents a named volume in a container.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
                         - !ruby/object:Api::Type::String
                           name: name
                           required: true
                           description: |-
-                            The name of the secret in Cloud Secret Manager. By default, the secret
-                            is assumed to be in the same project.
-                            If the secret is in another project, you must define an alias.
-                            You set the <alias> in this field, and create an annotation with the
-                            following structure
-                            "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
-                            If multiple alias definitions are needed, they must be separated by
-                            commas in the annotation field.
-            - !ruby/object:Api::Type::Array
-              name: ports
-              description: |-
-                List of open ports in the container.
-                More Info:
-                https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort
-              item_type: !ruby/object:Api::Type::NestedObject
-                properties:
-                - !ruby/object:Api::Type::String
-                  name: name
-                  description: Name of the port.
-                - !ruby/object:Api::Type::String
-                  name: protocol
-                  description: Protocol used on port. Defaults to TCP.
-                - !ruby/object:Api::Type::Integer
-                  name: containerPort
-                  description: Port number.
-                  required: true
-            - !ruby/object:Api::Type::NestedObject
-              name: resources
-              description: |-
-                Compute Resources required by this container. Used to set values such as max memory
-                More info:
-                https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
-              properties:
-              - !ruby/object:Api::Type::KeyValuePairs
-                name: limits
-                description: |-
-                  Limits describes the maximum amount of compute resources allowed.
-                  The values of the map is string form of the 'quantity' k8s type:
-                  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
-              - !ruby/object:Api::Type::KeyValuePairs
-                name: requests
-                description: |-
-                  Requests describes the minimum amount of compute resources required.
-                  If Requests is omitted for a container, it defaults to Limits if that is
-                  explicitly specified, otherwise to an implementation-defined value.
-                  The values of the map is string form of the 'quantity' k8s type:
-                  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
-            - !ruby/object:Api::Type::Array
-              name: volumeMounts
-              description: |-
-                Volume to mount into the container's filesystem.
-                Only supports SecretVolumeSources.
-              item_type: !ruby/object:Api::Type::NestedObject
-                properties:
-                  - !ruby/object:Api::Type::String
-                    name: mountPath
-                    required: true
-                    description: |-
-                      Path within the container at which the volume should be mounted.  Must
-                      not contain ':'.
-                  - !ruby/object:Api::Type::String
-                    name: name
-                    required: true
-                    description: |-
-                      This must match the Name of a Volume.
-
-        - !ruby/object:Api::Type::Integer
-          name: containerConcurrency
-          description: |-
-            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
-            requests per container of the Revision. Values are:
-            - `0` thread-safe, the system should manage the max concurrency. This is
-                the default value.
-            - `1` not-thread-safe. Single concurrency
-            - `2-N` thread-safe, max concurrency of N
-        - !ruby/object:Api::Type::Integer
-          name: timeoutSeconds
-          description: |-
-            TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
-        - !ruby/object:Api::Type::String
-          name: serviceAccountName
-          description:  |-
-            Email address of the IAM service account associated with the revision of the
-            service. The service account represents the identity of the running revision,
-            and determines what permissions the revision has. If not provided, the revision
-            will use the project's default service account.
-        - !ruby/object:Api::Type::Array
-          name: volumes
-          description: |-
-            Volume represents a named volume in a container.
-          item_type: !ruby/object:Api::Type::NestedObject
-            properties:
-              - !ruby/object:Api::Type::String
-                name: name
-                required: true
-                description: |-
-                  Volume's name.
-              - !ruby/object:Api::Type::NestedObject
-                name: secret
-                required: true
-                description: |-
-                  The secret's value will be presented as the content of a file whose
-                  name is defined in the item path. If no items are defined, the name of
-                  the file is the secret_name.
-                properties:
-                  - !ruby/object:Api::Type::String
-                    name: secretName
-                    required: true
-                    description: |-
-                      The name of the secret in Cloud Secret Manager. By default, the secret
-                      is assumed to be in the same project.
-                      If the secret is in another project, you must define an alias.
-                      An alias definition has the form:
-                      <alias>:projects/<project-id|project-number>/secrets/<secret-name>.
-                      If multiple alias definitions are needed, they must be separated by
-                      commas.
-                      The alias definitions must be set on the run.googleapis.com/secrets
-                      annotation.
-                  - !ruby/object:Api::Type::Integer
-                    name: defaultMode
-                    description: |-
-                      Mode bits to use on created files by default. Must be a value between 0000
-                      and 0777. Defaults to 0644. Directories within the path are not affected by
-                      this setting. This might be in conflict with other options that affect the
-                      file mode, like fsGroup, and the result can be other mode bits set.
-                  - !ruby/object:Api::Type::Array
-                    name: items
-                    description: |-
-                      If unspecified, the volume will expose a file whose name is the
-                      secret_name.
-                      If specified, the key will be used as the version to fetch from Cloud
-                      Secret Manager and the path will be the name of the file exposed in the
-                      volume. When items are defined, they must specify a key and a path.
-                    item_type: !ruby/object:Api::Type::NestedObject
-                      properties:
-                        - !ruby/object:Api::Type::String
-                          name: key
+                            Volume's name.
+                        - !ruby/object:Api::Type::NestedObject
+                          name: secret
                           required: true
                           description: |-
-                            The Cloud Secret Manager secret version.
-                            Can be 'latest' for the latest value or an integer for a specific version.
-                        - !ruby/object:Api::Type::String
-                          name: path
-                          required: true
-                          description: |-
-                            The relative path of the file to map the key to.
-                            May not be an absolute path.
-                            May not contain the path element '..'.
-                            May not start with the string '..'.
-                        - !ruby/object:Api::Type::Integer
-                          name: mode
-                          description: |-
-                            Mode bits to use on this file, must be a value between 0000 and 0777. If
-                            not specified, the volume defaultMode will be used. This might be in
-                            conflict with other options that affect the file mode, like fsGroup, and
-                            the result can be other mode bits set.
-        - !ruby/object:Api::Type::Enum
-          name: servingState
-          deprecation_message: "Not supported by Cloud Run fully managed"
-          description: |-
-            ServingState holds a value describing the state the resources
-            are in for this Revision.
-            It is expected
-            that the system will manipulate this based on routability and load.
-          output: true
-          values:
-          - :ACTIVE
-          - :RESERVE
-          - :RETIRED
+                            The secret's value will be presented as the content of a file whose
+                            name is defined in the item path. If no items are defined, the name of
+                            the file is the secret_name.
+                          properties:
+                            - !ruby/object:Api::Type::String
+                              name: secretName
+                              required: true
+                              description: |-
+                                The name of the secret in Cloud Secret Manager. By default, the secret
+                                is assumed to be in the same project.
+                                If the secret is in another project, you must define an alias.
+                                An alias definition has the form:
+                                <alias>:projects/<project-id|project-number>/secrets/<secret-name>.
+                                If multiple alias definitions are needed, they must be separated by
+                                commas.
+                                The alias definitions must be set on the run.googleapis.com/secrets
+                                annotation.
+                            - !ruby/object:Api::Type::Integer
+                              name: defaultMode
+                              description: |-
+                                Mode bits to use on created files by default. Must be a value between 0000
+                                and 0777. Defaults to 0644. Directories within the path are not affected by
+                                this setting. This might be in conflict with other options that affect the
+                                file mode, like fsGroup, and the result can be other mode bits set.
+                            - !ruby/object:Api::Type::Array
+                              name: items
+                              description: |-
+                                If unspecified, the volume will expose a file whose name is the
+                                secret_name.
+                                If specified, the key will be used as the version to fetch from Cloud
+                                Secret Manager and the path will be the name of the file exposed in the
+                                volume. When items are defined, they must specify a key and a path.
+                              item_type: !ruby/object:Api::Type::NestedObject
+                                properties:
+                                  - !ruby/object:Api::Type::String
+                                    name: key
+                                    required: true
+                                    description: |-
+                                      The Cloud Secret Manager secret version.
+                                      Can be 'latest' for the latest value or an integer for a specific version.
+                                  - !ruby/object:Api::Type::String
+                                    name: path
+                                    required: true
+                                    description: |-
+                                      The relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                  - !ruby/object:Api::Type::Integer
+                                    name: mode
+                                    description: |-
+                                      Mode bits to use on this file, must be a value between 0000 and 0777. If
+                                      not specified, the volume defaultMode will be used. This might be in
+                                      conflict with other options that affect the file mode, like fsGroup, and
+                                      the result can be other mode bits set.
+                  - !ruby/object:Api::Type::Enum
+                    name: servingState
+                    deprecation_message: 'Not supported by Cloud Run fully managed'
+                    description: |-
+                      ServingState holds a value describing the state the resources
+                      are in for this Revision.
+                      It is expected
+                      that the system will manipulate this based on routability and load.
+                    output: true
+                    values:
+                      - :ACTIVE
+                      - :RESERVE
+                      - :RETIRED
 
-  - !ruby/object:Api::Type::NestedObject
-    name: status
-    description: The current status of the Service.
-    output: true
-    properties:
-    - !ruby/object:Api::Type::Array
-      name: conditions
-      description: |-
-        Array of observed Service Conditions, indicating the current ready state of the service.
-      output: true
-      item_type: !ruby/object:Api::Type::NestedObject
+      - !ruby/object:Api::Type::NestedObject
+        name: status
+        description: The current status of the Service.
+        output: true
         properties:
-        - !ruby/object:Api::Type::String
-          name: message
-          output: true
-          description: |-
-            Human readable message indicating details about the current status.
-        - !ruby/object:Api::Type::String
-          name: status
-          output: true
-          description: Status of the condition, one of True, False, Unknown.
-        - !ruby/object:Api::Type::String
-          name: reason
-          output: true
-          description: |-
-            One-word CamelCase reason for the condition's current status.
-        - !ruby/object:Api::Type::String
-          name: type
-          output: true
-          description: Type of domain mapping condition.
-    - !ruby/object:Api::Type::String
-      name: url
-      description: |-
-        From RouteStatus. URL holds the url that will distribute traffic over the provided traffic
-        targets. It generally has the form
-        https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app
-      output: true
-    - !ruby/object:Api::Type::Integer
-      name: observedGeneration
-      description: |-
-        ObservedGeneration is the 'Generation' of the Route that was last processed by the
-        controller.
+          - !ruby/object:Api::Type::Array
+            name: conditions
+            description: |-
+              Array of observed Service Conditions, indicating the current ready state of the service.
+            output: true
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: message
+                  output: true
+                  description: |-
+                    Human readable message indicating details about the current status.
+                - !ruby/object:Api::Type::String
+                  name: status
+                  output: true
+                  description: Status of the condition, one of True, False, Unknown.
+                - !ruby/object:Api::Type::String
+                  name: reason
+                  output: true
+                  description: |-
+                    One-word CamelCase reason for the condition's current status.
+                - !ruby/object:Api::Type::String
+                  name: type
+                  output: true
+                  description: Type of domain mapping condition.
+          - !ruby/object:Api::Type::String
+            name: url
+            description: |-
+              From RouteStatus. URL holds the url that will distribute traffic over the provided traffic
+              targets. It generally has the form
+              https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app
+            output: true
+          - !ruby/object:Api::Type::Integer
+            name: observedGeneration
+            description: |-
+              ObservedGeneration is the 'Generation' of the Route that was last processed by the
+              controller.
 
-        Clients polling for completed reconciliation should poll until observedGeneration =
-        metadata.generation and the Ready condition's status is True or False.
-      output: true
-    - !ruby/object:Api::Type::String
-      name: latestCreatedRevisionName
-      description: |-
-        From ConfigurationStatus. LatestCreatedRevisionName is the last revision that was created
-        from this Service's Configuration. It might not be ready yet, for that use
-        LatestReadyRevisionName.
-      output: true
-    - !ruby/object:Api::Type::String
-      name: latestReadyRevisionName
-      description: |-
-        From ConfigurationStatus. LatestReadyRevisionName holds the name of the latest Revision
-        stamped out from this Service's Configuration that has had its "Ready" condition become
-        "True".
-      output: true
+              Clients polling for completed reconciliation should poll until observedGeneration =
+              metadata.generation and the Ready condition's status is True or False.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: latestCreatedRevisionName
+            description: |-
+              From ConfigurationStatus. LatestCreatedRevisionName is the last revision that was created
+              from this Service's Configuration. It might not be ready yet, for that use
+              LatestReadyRevisionName.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: latestReadyRevisionName
+            description: |-
+              From ConfigurationStatus. LatestReadyRevisionName holds the name of the latest Revision
+              stamped out from this Service's Configuration that has had its "Ready" condition become
+              "True".
+            output: true
 
-  - !ruby/object:Api::Type::NestedObject
-    name: metadata
-    required: true
-    description: |-
-      Metadata associated with this Service, including name, namespace, labels,
-      and annotations.
-    properties:
-    - !ruby/object:Api::Type::KeyValuePairs
-      name: labels
-      description: |-
-        Map of string keys and values that can be used to organize and categorize
-        (scope and select) objects. May match selectors of replication controllers
-        and routes.
-        More info: http://kubernetes.io/docs/user-guide/labels
-    - !ruby/object:Api::Type::Integer
-      name: generation
-      description: |-
-        A sequence number representing a specific generation of the desired state.
-      output: true
-    - !ruby/object:Api::Type::String
-      name: resourceVersion
-      description: |-
-        An opaque value that represents the internal version of this object that
-        can be used by clients to determine when objects have changed. May be used
-        for optimistic concurrency, change detection, and the watch operation on a
-        resource or set of resources. They may only be valid for a
-        particular resource or set of resources.
+      - !ruby/object:Api::Type::NestedObject
+        name: metadata
+        required: true
+        description: |-
+          Metadata associated with this Service, including name, namespace, labels,
+          and annotations.
+        properties:
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: labels
+            description: |-
+              Map of string keys and values that can be used to organize and categorize
+              (scope and select) objects. May match selectors of replication controllers
+              and routes.
+              More info: http://kubernetes.io/docs/user-guide/labels
+          - !ruby/object:Api::Type::Integer
+            name: generation
+            description: |-
+              A sequence number representing a specific generation of the desired state.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: resourceVersion
+            description: |-
+              An opaque value that represents the internal version of this object that
+              can be used by clients to determine when objects have changed. May be used
+              for optimistic concurrency, change detection, and the watch operation on a
+              resource or set of resources. They may only be valid for a
+              particular resource or set of resources.
 
-        More info:
-        https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
-      output: true
-    - !ruby/object:Api::Type::String
-      name: selfLink
-      description: |-
-        SelfLink is a URL representing this object.
-      output: true
-    - !ruby/object:Api::Type::String
-      name: uid
-      description: |-
-        UID is a unique id generated by the server on successful creation of a resource and is not
-        allowed to change on PUT operations.
+              More info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+            output: true
+          - !ruby/object:Api::Type::String
+            name: selfLink
+            description: |-
+              SelfLink is a URL representing this object.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: uid
+            description: |-
+              UID is a unique id generated by the server on successful creation of a resource and is not
+              allowed to change on PUT operations.
 
-        More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-      output: true
-    - !ruby/object:Api::Type::String
-      name: namespace
-      required: true
-      description: |-
-        In Cloud Run the namespace must be equal to either the
-        project ID or project number.
-    - !ruby/object:Api::Type::KeyValuePairs
-      name: annotations
-      description: |-
-        Annotations is a key value map stored with a resource that
-        may be set by external tools to store and retrieve arbitrary metadata. More
-        info: http://kubernetes.io/docs/user-guide/annotations
+              More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+            output: true
+          - !ruby/object:Api::Type::String
+            name: namespace
+            required: true
+            description: |-
+              In Cloud Run the namespace must be equal to either the
+              project ID or project number.
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: annotations
+            description: |-
+              Annotations is a key value map stored with a resource that
+              may be set by external tools to store and retrieve arbitrary metadata. More
+              info: http://kubernetes.io/docs/user-guide/annotations
 
-        **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
-        If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
-        or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+              **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+              If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
+              or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
 
-        Cloud Run (fully managed) uses the following annotation keys to configure features on a Service:
+              Cloud Run (fully managed) uses the following annotation keys to configure features on a Service:
 
-        - `run.googleapis.com/ingress` sets the [ingress settings](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--ingress)
-          for the Service. For example, `"run.googleapis.com/ingress" = "all"`.
-    - !ruby/object:Api::Type::String
-      name: name
-      required: true
-      description: |-
-        Name must be unique within a namespace, within a Cloud Run region.
-        Is required when creating resources. Name is primarily intended
-        for creation idempotence and configuration definition. Cannot be updated.
-        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+              - `run.googleapis.com/ingress` sets the [ingress settings](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--ingress)
+                for the Service. For example, `"run.googleapis.com/ingress" = "all"`.
+          - !ruby/object:Api::Type::String
+            name: name
+            required: true
+            description: |-
+              Name must be unique within a namespace, within a Cloud Run region.
+              Is required when creating resources. Name is primarily intended
+              for creation idempotence and configuration definition. Cannot be updated.
+              More info: http://kubernetes.io/docs/user-guide/identifiers#names


### PR DESCRIPTION
Updating Cloud Run resource to mark containerPort as optional.   Discovered this when I tried to specify h2c only and let GCP tell my app which port to use.

See documentation here - https://cloud.google.com/run/docs/reference/rest/v1/Container#ContainerPort


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrun: updated `containers.ports.container_port` to be optional instead of required on `google_cloud_run_service`
```
