### PR TITLE
Add attribute reference to google_service_networking_connection

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-    peering - (Computed) The name of the created peering.
+* `peering` - (Computed) The name of the VPC Network Peering connection that was created by the service producer.
 
 
 ## Import

--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -50,6 +50,13 @@ The following arguments are supported:
   this service provider. Note that invoking this method with a different range when connection
   is already established will not reallocate already provisioned service producer subnetworks.
 
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+    peering - (Computed) The name of the created peering.
+
+
 ## Import
 ServiceNetworkingConnection can be imported using any of these accepted formats
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The `google_service_networking_connection` resource doesn't have an Attributes reference section. The resource currently exposes a `peering` field that should be documented.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
```release-note:none
```
