### PR TITLE
Add `NON_GCP_PRIVATE_IP_PORT` as networkEndpointType for NetworkEndpointGroup

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8066,7 +8066,6 @@ objects:
           The name for a specific VM instance that the IP address belongs to.
           This is required for network endpoints of type GCE_VM_IP_PORT.
           The instance must be in the same zone of network endpoint group.
-        required: true
       - !ruby/object:Api::Type::Integer
         name: 'port'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8160,7 +8160,7 @@ objects:
           endpoint groups (see https://cloud.google.com/load-balancing/docs/hybrid).
           Note that NON_GCP_PRIVATE_IP_PORT can only be used with Backend Services
           that 1) have the following load balancing schemes: EXTERNAL, EXTERNAL_MANAGED,
-          INTERNAL_MANAGED, and INTERNAL_SELF_MANAGED and 2) to support the RATE or 
+          INTERNAL_MANAGED, and INTERNAL_SELF_MANAGED and 2) support the RATE or
           CONNECTION balancing modes.
         values:
           - :GCE_VM_IP_PORT

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8155,9 +8155,16 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'networkEndpointType'
         description: |
-          Type of network endpoints in this network endpoint group.
+          Type of network endpoints in this network endpoint group. 
+          NON_GCP_PRIVATE_IP_PORT is used for hybrid connectivity network 
+          endpoint groups (see https://cloud.google.com/load-balancing/docs/hybrid).
+          Note that NON_GCP_PRIVATE_IP_PORT can only be used with Backend Services
+          that 1) have the following load balancing schemes: EXTERNAL, EXTERNAL_MANAGED,
+          INTERNAL_MANAGED, and INTERNAL_SELF_MANAGED and 2) to support the RATE or 
+          CONNECTION balancing modes.
         values:
           - :GCE_VM_IP_PORT
+          - :NON_GCP_PRIVATE_IP_PORT
         default_value: :GCE_VM_IP_PORT
       - !ruby/object:Api::Type::Integer
         name: 'size'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1054,6 +1054,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "port_range"
           - "target"
       - !ruby/object:Provider::Terraform::Examples
+        name: "global_forwarding_rule_hybrid"
+        primary_resource_id: "default"
+        vars:
+          forwarding_rule_name: "global-rule"
+          http_proxy_name: "target-proxy"
+          network_name: "my-network"
+          default_backend_service_name: "backend-default"
+          hybrid_backend_service_name: "backend-hybrid"
+          default_neg_name: "default-neg"
+          hybrid_neg_name: "hybrid-neg"
+          health_check_name: "health-check"
+        ignore_read_extra:
+          - "port_range"
+          - "target"
+      - !ruby/object:Provider::Terraform::Examples
         name: "private_service_connect_google_apis"
         min_version: beta
         primary_resource_id: "default"
@@ -1498,6 +1513,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           neg_name: "my-lb-neg"
           network_name: "neg-network"
           subnetwork_name: "neg-subnetwork"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "network_endpoint_group_non_gcp"
+        primary_resource_id: "neg"
+        vars:
+          neg_name: "my-lb-neg"
+          network_name: "neg-network"
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1502,6 +1502,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/compute_network_endpoint.go.erb
+      custom_import: templates/terraform/custom_import/compute_network_endpoint.go.erb
       decoder: templates/terraform/decoders/unwrap_resource.go.erb
       encoder: templates/terraform/encoders/compute_network_endpoint.go.erb
   NetworkEndpointGroup: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/templates/terraform/custom_import/compute_network_endpoint.go.erb
+++ b/mmv1/templates/terraform/custom_import/compute_network_endpoint.go.erb
@@ -1,0 +1,19 @@
+config := meta.(*Config)
+// instance is optional, so use * instead of + when reading the import id
+if err := parseImportId([]string{
+    "projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/networkEndpointGroups/(?P<network_endpoint_group>[^/]+)/(?P<instance>[^/]*)/(?P<ip_address>[^/]+)/(?P<port>[^/]+)",
+    "(?P<project>[^/]+)/(?P<zone>[^/]+)/(?P<network_endpoint_group>[^/]+)/(?P<instance>[^/]*)/(?P<ip_address>[^/]+)/(?P<port>[^/]+)",
+    "(?P<zone>[^/]+)/(?P<network_endpoint_group>[^/]+)/(?P<instance>[^/]*)/(?P<ip_address>[^/]+)/(?P<port>[^/]+)",
+    "(?P<network_endpoint_group>[^/]+)/(?P<instance>[^/]*)/(?P<ip_address>[^/]+)/(?P<port>[^/]+)",
+}, d, config); err != nil {
+	return nil, err
+}
+
+// Replace import id for the resource id
+id, err := replaceVars(d, config, "{{project}}/{{zone}}/{{network_endpoint_group}}/{{instance}}/{{ip_address}}/{{port}}")
+if err != nil {
+  return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_hybrid.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_hybrid.tf.erb
@@ -1,0 +1,99 @@
+// Roughly mirrors https://cloud.google.com/load-balancing/docs/https/setting-up-ext-https-hybrid
+
+resource "google_compute_network" "default" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+}
+
+// Zonal NEG with GCE_VM_IP_PORT
+resource "google_compute_network_endpoint_group" "default" {
+  name                  = "<%= ctx[:vars]['default_neg_name'] %>"
+  network               = google_compute_network.default.id
+  default_port          = "90"
+  zone                  = "us-central1-a"
+  network_endpoint_type = "GCE_VM_IP_PORT"
+}
+
+// Hybrid connectivity NEG
+resource "google_compute_network_endpoint_group" "hybrid" {
+  name                  = "<%= ctx[:vars]['hybrid_neg_name'] %>"
+  network               = google_compute_network.default.id
+  default_port          = "90"
+  zone                  = "us-central1-a"
+  network_endpoint_type = "NON_GCP_PRIVATE_IP_PORT"
+}
+
+// Backend service for Zonal NEG
+resource "google_compute_backend_service" "default" {
+  name                  = "<%= ctx[:vars]['default_backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  backend {
+    group = google_compute_network_endpoint_group.default.id
+    balancing_mode               = "RATE"
+    max_rate_per_endpoint        = 10
+  }
+  health_checks = [google_compute_health_check.default.id]
+}
+
+// Backgend service for Hybrid NEG
+resource "google_compute_backend_service" "hybrid" {
+  name                  = "<%= ctx[:vars]['hybrid_backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  backend {
+    group                        = google_compute_network_endpoint_group.hybrid.id
+    balancing_mode               = "RATE"
+    max_rate_per_endpoint = 10
+  }
+  health_checks = [google_compute_health_check.default.id]
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "<%= ctx[:vars]['health_check_name'] %>"
+  timeout_sec        = 1
+  check_interval_sec = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "url-map-<%= ctx[:vars]['http_proxy_name'] %>"
+  description     = "a description"
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+
+    path_rule {
+      paths   = ["/hybrid"]
+      service = google_compute_backend_service.hybrid.id
+    }
+  }
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  name        = "<%= ctx[:vars]['http_proxy_name'] %>"
+  description = "a description"
+  url_map     = google_compute_url_map.default.id
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  name       = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  target     = google_compute_target_http_proxy.default.id
+  port_range = "80"
+}

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_hybrid.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_hybrid.tf.erb
@@ -13,6 +13,12 @@ resource "google_compute_network_endpoint_group" "default" {
   network_endpoint_type = "GCE_VM_IP_PORT"
 }
 
+resource "google_compute_network_endpoint" "default-endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.default.name
+  port       = google_compute_network_endpoint_group.default.default_port
+  ip_address = "127.0.0.1"
+}
+
 // Hybrid connectivity NEG
 resource "google_compute_network_endpoint_group" "hybrid" {
   name                  = "<%= ctx[:vars]['hybrid_neg_name'] %>"

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_hybrid.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_hybrid.tf.erb
@@ -13,12 +13,6 @@ resource "google_compute_network_endpoint_group" "default" {
   network_endpoint_type = "GCE_VM_IP_PORT"
 }
 
-resource "google_compute_network_endpoint" "default-endpoint" {
-  network_endpoint_group = google_compute_network_endpoint_group.default.name
-  port       = google_compute_network_endpoint_group.default.default_port
-  ip_address = "127.0.0.1"
-}
-
 // Hybrid connectivity NEG
 resource "google_compute_network_endpoint_group" "hybrid" {
   name                  = "<%= ctx[:vars]['hybrid_neg_name'] %>"
@@ -26,6 +20,12 @@ resource "google_compute_network_endpoint_group" "hybrid" {
   default_port          = "90"
   zone                  = "us-central1-a"
   network_endpoint_type = "NON_GCP_PRIVATE_IP_PORT"
+}
+
+resource "google_compute_network_endpoint" "hybrid-endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.hybrid.name
+  port       = google_compute_network_endpoint_group.hybrid.default_port
+  ip_address = "127.0.0.1"
 }
 
 // Backend service for Zonal NEG

--- a/mmv1/templates/terraform/examples/network_endpoint_group_non_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/network_endpoint_group_non_gcp.tf.erb
@@ -1,7 +1,6 @@
 resource "google_compute_network_endpoint_group" "<%= ctx[:primary_resource_id] %>" {
   name                  = "<%= ctx[:vars]['neg_name'] %>"
   network               = google_compute_network.default.id
-  subnetwork            = google_compute_subnetwork.default.id
   default_port          = "90"
   zone                  = "us-central1-a"
   network_endpoint_type = "NON_GCP_PRIVATE_IP_PORT"
@@ -9,12 +8,4 @@ resource "google_compute_network_endpoint_group" "<%= ctx[:primary_resource_id] 
 
 resource "google_compute_network" "default" {
   name                    = "<%= ctx[:vars]['network_name'] %>"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.default.id
 }

--- a/mmv1/templates/terraform/examples/network_endpoint_group_non_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/network_endpoint_group_non_gcp.tf.erb
@@ -6,6 +6,12 @@ resource "google_compute_network_endpoint_group" "<%= ctx[:primary_resource_id] 
   network_endpoint_type = "NON_GCP_PRIVATE_IP_PORT"
 }
 
+resource "google_compute_network_endpoint" "default-endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.<%= ctx[:primary_resource_id] %>.name
+  port = google_compute_network_endpoint_group.<%= ctx[:primary_resource_id] %>.default_port
+  ip_address = "127.0.0.1"
+}
+
 resource "google_compute_network" "default" {
-  name                    = "<%= ctx[:vars]['network_name'] %>"
+  name = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/mmv1/templates/terraform/examples/network_endpoint_group_non_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/network_endpoint_group_non_gcp.tf.erb
@@ -1,0 +1,20 @@
+resource "google_compute_network_endpoint_group" "<%= ctx[:primary_resource_id] %>" {
+  name                  = "<%= ctx[:vars]['neg_name'] %>"
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  default_port          = "90"
+  zone                  = "us-central1-a"
+  network_endpoint_type = "NON_GCP_PRIVATE_IP_PORT"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}

--- a/mmv1/templates/terraform/pre_delete/compute_network_endpoint.go.erb
+++ b/mmv1/templates/terraform/pre_delete/compute_network_endpoint.go.erb
@@ -3,7 +3,9 @@ instanceProp, err := expandNestedComputeNetworkEndpointInstance(d.Get("instance"
 if err != nil {
 	return err
 }
-toDelete["instance"] = instanceProp
+if instanceProp != "" {
+	toDelete["instance"] = instanceProp
+}
 
 portProp, err := expandNestedComputeNetworkEndpointPort(d.Get("port"), d, config)
 if err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This change adds `NON_GCP_PRIVATE_IP_PORT` as a `network_endpoint_type` option for the `google_compute_network_endpoint_group` resource.  This is in support for Hybrid Load Balancing.

I added two examples: one with a basic `google_compute_network_endpoint_group` with the new type, and one with a global external managed load balancer with hybrid connectivity (roughly following the configuration at https://cloud.google.com/load-balancing/docs/https/setting-up-ext-https-hybrid). I also added documentation about the valid combination of this new type and backend service load balancing scheme/balancing modes.

Part of https://github.com/hashicorp/terraform-provider-google/issues/10040

For posterity, this change also sets the `instance` attribute on the `google_compute_network_endpoint` resource to be optional, as Hybrid connectivity NEGs use endpoints with just IP and PORT (without an instance). See https://cloud.google.com/load-balancing/docs/negs#hybrid-neg and https://cloud.google.com/load-balancing/docs/https/setting-up-ext-global-https-hybrid#set_up_the_hybrid_connectivity_neg for more details.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: add `NON_GCP_PRIVATE_IP_PORT` value for `network_endpoint_type` in the `google_compute_network_endpoint_group` resource
```

```release-note:enhancement
compute: Update `instance` attribute for `google_compute_network_endpoint` to be optional, as Hybrid connectivity NEGs use network endpoints with just IP and Port.
```
