### PR TITLE
add multi_cluster_routing_cluster_ids

### DIFF
--- a/mmv1/products/bigtable/api.yaml
+++ b/mmv1/products/bigtable/api.yaml
@@ -74,7 +74,6 @@ objects:
           If true, read/write requests are routed to the nearest cluster in the instance, and will fail over to the nearest cluster that is available
           in the event of transient errors or delays. Clusters in a region are considered equidistant. Choosing this option sacrifices read-your-writes
           consistency to improve availability.
-        input: true
       - !ruby/object:Api::Type::NestedObject
         name: 'singleClusterRouting'
         exactly_one_of:

--- a/mmv1/products/bigtable/terraform.yaml
+++ b/mmv1/products/bigtable/terraform.yaml
@@ -56,7 +56,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/bigtable_app_profile_routing.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/bigtable_app_profile.go.erb
-
+      extra_schema_entry: templates/terraform/extra_schema_entry/bigtable_app_profile.go.erb
+      pre_update: templates/terraform/pre_update/bigtable_app_profile.go.erb
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/custom_flatten/bigtable_app_profile_routing.erb
+++ b/mmv1/templates/terraform/custom_flatten/bigtable_app_profile_routing.erb
@@ -17,6 +17,10 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		return false
 	}
 
+    if v.(map[string]interface{})["clusterIds"] == nil {
+        return true
+    }
+
 	if len(v.(map[string]interface{})["clusterIds"].([]interface{})) > 0 {
 		d.Set("multi_cluster_routing_cluster_ids", v.(map[string]interface{})["clusterIds"])
 	}

--- a/mmv1/templates/terraform/custom_flatten/bigtable_app_profile_routing.erb
+++ b/mmv1/templates/terraform/custom_flatten/bigtable_app_profile_routing.erb
@@ -13,5 +13,13 @@
 	# limitations under the License.
 -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-	return v != nil
+	if v == nil {
+		return false
+	}
+
+	if len(v.(map[string]interface{})["clusterIds"].([]interface{})) > 0 {
+		d.Set("multi_cluster_routing_cluster_ids", v.(map[string]interface{})["clusterIds"])
+	}
+
+	return true
 }

--- a/mmv1/templates/terraform/custom_flatten/bigtable_app_profile_routing.erb
+++ b/mmv1/templates/terraform/custom_flatten/bigtable_app_profile_routing.erb
@@ -17,12 +17,14 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		return false
 	}
 
-    if v.(map[string]interface{})["clusterIds"] == nil {
-        return true
-    }
+	if v.(map[string]interface{})["clusterIds"] == nil {
+		return true
+	}
 
 	if len(v.(map[string]interface{})["clusterIds"].([]interface{})) > 0 {
-		d.Set("multi_cluster_routing_cluster_ids", v.(map[string]interface{})["clusterIds"])
+		if err := d.Set("multi_cluster_routing_cluster_ids", v.(map[string]interface{})["clusterIds"]); err != nil {
+			return true
+		}
 	}
 
 	return true

--- a/mmv1/templates/terraform/extra_schema_entry/bigtable_app_profile.go.erb
+++ b/mmv1/templates/terraform/extra_schema_entry/bigtable_app_profile.go.erb
@@ -1,5 +1,5 @@
-<%- # the license inside this block applies to this file
-	# Copyright 2018 Google Inc.
+<%# The license inside this block applies to this file.
+	# Copyright 2022 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,18 +12,12 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	if v == nil || !v.(bool) {
-		return nil, nil
-	}
-
-	obj := bigtableadmin.MultiClusterRoutingUseAny{}
-
-	clusterIds := d.Get("multi_cluster_routing_cluster_ids").([]interface{})
-
-	for _, id := range clusterIds {
-		obj.ClusterIds = append(obj.ClusterIds, id.(string))
-	}
-
-	return obj, nil
-}
+"multi_cluster_routing_cluster_ids": {
+	Type:        schema.TypeList,
+	Optional:    true,
+	Description: `The set of clusters to route to. The order is ignored; clusters will be tried in order of distance. If left empty, all clusters are eligible.`,
+	Elem: &schema.Schema{
+		Type: schema.TypeString,
+	},
+	ConflictsWith: []string{"single_cluster_routing"},
+},

--- a/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.erb
+++ b/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.erb
@@ -13,8 +13,24 @@
 	# limitations under the License.
 -%>
 
-if d.HasChange("multi_cluster_routing_cluster_ids") {
+if d.HasChange("multi_cluster_routing_cluster_ids") && !stringInSlice(updateMask, "multiClusterRoutingUseAny") {
 	updateMask = append(updateMask, "multiClusterRoutingUseAny")
+}
+
+// this api requires the body to define something for all values passed into
+// the update mask, however, multi-cluster routing and single-cluster routing
+// are conflicting, so we can't have them both in the update mask, despite
+// both of them registering as changing. thus, we need to remove whichever
+// one is not defined.
+newRouting, oldRouting := d.GetChange("multi_cluster_routing_use_any")
+if newRouting != oldRouting {
+	for i, val := range updateMask {
+		if val == "multiClusterRoutingUseAny" && newRouting.(bool) ||
+			val == "singleClusterRouting" && oldRouting.(bool) {
+			updateMask = append(updateMask[0:i], updateMask[i+1:]...)
+			break
+		}
+	}
 }
 // updateMask is a URL parameter but not present in the schema, so replaceVars
 // won't set it

--- a/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.erb
+++ b/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.erb
@@ -1,5 +1,5 @@
 <%- # the license inside this block applies to this file
-	# Copyright 2018 Google Inc.
+	# Copyright 2022 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,18 +12,13 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	if v == nil || !v.(bool) {
-		return nil, nil
-	}
 
-	obj := bigtableadmin.MultiClusterRoutingUseAny{}
-
-	clusterIds := d.Get("multi_cluster_routing_cluster_ids").([]interface{})
-
-	for _, id := range clusterIds {
-		obj.ClusterIds = append(obj.ClusterIds, id.(string))
-	}
-
-	return obj, nil
+if d.HasChange("multi_cluster_routing_cluster_ids") {
+	updateMask = append(updateMask, "multiClusterRoutingUseAny")
+}
+// updateMask is a URL parameter but not present in the schema, so replaceVars
+// won't set it
+url, err = addQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
 }

--- a/mmv1/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -66,15 +66,49 @@ func TestAccBigtableAppProfile_ignoreWarnings(t *testing.T) {
 	})
 }
 
+func TestAccBigtableAppProfile_multiClusterIds(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	skipIfVcr(t)
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigtableAppProfileDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableAppProfile_updateMC1(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+			{
+				Config: testAccBigtableAppProfile_updateMC2(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+		},
+	})
+}
+
 func testAccBigtableAppProfile_update1(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
   name = "%s"
   cluster {
     cluster_id   = "%s"
-    zone         = "us-central1-b"
-    num_nodes    = 3
-    storage_type = "HDD"
+      zone         = "us-central1-b"
+      num_nodes    = 3
+      storage_type = "HDD"
   }
 
   deletion_protection = false
@@ -125,64 +159,131 @@ resource "google_bigtable_app_profile" "ap" {
 
 func testAccBigtableAppProfile_warningsProduced(instanceName string) string {
 	return fmt.Sprintf(`
-  resource "google_bigtable_instance" "instance" {
-    name = "%s"
-    instance_type = "PRODUCTION"
-    cluster {
-      cluster_id   = "%s1"
-      zone         = "us-central1-b"
-      num_nodes    = 3
-    }
-
-    cluster {
-      cluster_id   = "%s2"
-      zone         = "us-west1-a"
-      num_nodes    = 3
-    }
-
-    cluster {
-      cluster_id   = "%s3"
-      zone         = "us-west1-b"
-      num_nodes    = 3
-    }
-
-    deletion_protection = false
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  instance_type = "PRODUCTION"
+  cluster {
+    cluster_id   = "%s1"
+    zone         = "us-central1-b"
+    num_nodes    = 3
   }
 
-  resource "google_bigtable_app_profile" "gae-profile1" {
-    instance       = google_bigtable_instance.instance.id
-    app_profile_id = "bigtableinstance-sample1"
-
-    single_cluster_routing {
-      cluster_id                 = "%s1"
-      allow_transactional_writes = true
-    }
-
-    ignore_warnings               = true
+  cluster {
+    cluster_id   = "%s2"
+    zone         = "us-west1-a"
+    num_nodes    = 3
   }
 
-  resource "google_bigtable_app_profile" "gae-profile2" {
-    instance       = google_bigtable_instance.instance.id
-    app_profile_id = "bigtableinstance-sample2"
-
-    single_cluster_routing {
-      cluster_id                 = "%s2"
-      allow_transactional_writes = true
-    }
-
-    ignore_warnings               = true
+  cluster {
+    cluster_id   = "%s3"
+    zone         = "us-west1-b"
+    num_nodes    = 3
   }
 
-  resource "google_bigtable_app_profile" "gae-profile3" {
-    instance       = google_bigtable_instance.instance.id
-    app_profile_id = "bigtableinstance-sample3"
+  deletion_protection = false
+}
 
-    single_cluster_routing {
-      cluster_id                 = "%s3"
-      allow_transactional_writes = true
-    }
+resource "google_bigtable_app_profile" "gae-profile1" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "bigtableinstance-sample1"
 
-    ignore_warnings               = true
+  single_cluster_routing {
+    cluster_id                 = "%s1"
+    allow_transactional_writes = true
   }
+
+  ignore_warnings               = true
+}
+
+resource "google_bigtable_app_profile" "gae-profile2" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "bigtableinstance-sample2"
+
+  single_cluster_routing {
+    cluster_id                 = "%s2"
+    allow_transactional_writes = true
+  }
+
+  ignore_warnings               = true
+}
+
+resource "google_bigtable_app_profile" "gae-profile3" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "bigtableinstance-sample3"
+
+  single_cluster_routing {
+    cluster_id                 = "%s3"
+    allow_transactional_writes = true
+  }
+
+  ignore_warnings               = true
+}
 `, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
+}
+
+func testAccBigtableAppProfile_updateMC1(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  cluster {
+    cluster_id   = "%s1"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  cluster {
+    cluster_id   = "%s2"
+    zone         = "us-central1-b"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  deletion_protection = false
+}
+
+resource "google_bigtable_app_profile" "ap" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "test"
+
+  multi_cluster_routing_use_any     = true
+  multi_cluster_routing_cluster_ids = ["%s1", "%s2"]
+
+  ignore_warnings               = true
+}
+`, instanceName, instanceName, instanceName, instanceName, instanceName)
+}
+
+func testAccBigtableAppProfile_updateMC2(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  cluster {
+    cluster_id   = "%s1"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  cluster {
+    cluster_id   = "%s2"
+    zone         = "us-central1-b"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  deletion_protection = false
+}
+
+resource "google_bigtable_app_profile" "ap" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "test"
+  description    = "add a description"
+
+  multi_cluster_routing_use_any     = true
+  multi_cluster_routing_cluster_ids = ["%s1"]
+
+  ignore_warnings               = true
+}
+`, instanceName, instanceName, instanceName, instanceName)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11005

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added `multi_cluster_routing_cluster_ids` fields to `google_bigtable_app_profile`
```
