### PR TITLE
Enable CGC Samples for handwritten resources

### DIFF
--- a/mmv1/api/product.rb
+++ b/mmv1/api/product.rb
@@ -58,6 +58,10 @@ module Api
 
     attr_reader :async
 
+    # A flag that signals when a product should be intended for testing and documentation
+    # generation only.
+    attr_reader :cgc_only
+
     def validate
       super
       set_variables @objects, :__product
@@ -70,6 +74,7 @@ module Api
       check :async, type: Api::Async
 
       check :versions, type: Array, item_type: Api::Product::Version, required: true
+      check :cgc_only, type: :boolean, default: false
     end
 
     # ====================

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -247,7 +247,7 @@ if generate_code
   provider&.compile_common_files(
     output_path,
     products_for_version.reject { |product| product[:definitions].cgc_only }
-        .sort_by { |p| p[:definitions].name.downcase },
+                        .sort_by { |p| p[:definitions].name.downcase },
     common_compile_file
   )
 
@@ -257,7 +257,7 @@ if generate_code
     provider&.compile_common_files(
       output_path,
       products_for_version.reject { |product| product[:definitions].cgc_only }
-          .sort_by { |p| p[:definitions].name.downcase },
+                          .sort_by { |p| p[:definitions].name.downcase },
       common_compile_file,
       override_dir
     )

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -246,7 +246,8 @@ common_compile_file = "provider/#{provider_name}/common~compile.yaml"
 if generate_code
   provider&.compile_common_files(
     output_path,
-    products_for_version.sort_by { |p| p[:definitions].name.downcase },
+    products_for_version.reject { |product| product[:definitions].cgc_only }
+        .sort_by { |p| p[:definitions].name.downcase },
     common_compile_file
   )
 
@@ -255,7 +256,8 @@ if generate_code
     common_compile_file = "#{override_dir}/common~compile.yaml"
     provider&.compile_common_files(
       output_path,
-      products_for_version.sort_by { |p| p[:definitions].name.downcase },
+      products_for_version.reject { |product| product[:definitions].cgc_only }
+          .sort_by { |p| p[:definitions].name.downcase },
       common_compile_file,
       override_dir
     )

--- a/mmv1/overrides/terraform/resource_override.rb
+++ b/mmv1/overrides/terraform/resource_override.rb
@@ -89,7 +89,6 @@ module Overrides
           # an error and returns one.
           :read_error_transform,
 
-
           # If true, only generate tests and cgc samples
           :cgc_only
         ]

--- a/mmv1/overrides/terraform/resource_override.rb
+++ b/mmv1/overrides/terraform/resource_override.rb
@@ -87,7 +87,11 @@ module Overrides
           # Function to transform a read error so that handleNotFound recognises
           # it as a 404. This should be added as a handwritten fn that takes in
           # an error and returns one.
-          :read_error_transform
+          :read_error_transform,
+
+
+          # If true, only generate tests and cgc samples
+          :cgc_only
         ]
       end
 
@@ -122,6 +126,7 @@ module Overrides
         check :skip_delete, type: :boolean, default: false
         check :supports_indirect_user_project_override, type: :boolean, default: false
         check :read_error_transform, type: String
+        check :cgc_only, type: :boolean, default: false
       end
 
       def apply(resource)

--- a/mmv1/products/cgc/api.yaml
+++ b/mmv1/products/cgc/api.yaml
@@ -1,0 +1,42 @@
+# Copyright 2022 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Product
+name: CGC
+display_name: CGC
+cgc_only: true
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: na
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: placeholder
+    url: placeholder
+objects:
+  - !ruby/object:Api::Resource
+    name: Snippet
+    base_url: placeholder
+    description: |
+      Empty resource to serve as a base for handwritten CGC Snippets
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'placeholder'
+      api: 'placeholder'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: |
+          placeholder

--- a/mmv1/products/cgc/api.yaml
+++ b/mmv1/products/cgc/api.yaml
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 --- !ruby/object:Api::Product
 name: CGC
 display_name: CGC

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -1,0 +1,43 @@
+# Copyright 2022 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Snippet: !ruby/object:Overrides::Terraform::ResourceOverride
+    cgc_only: true
+    examples:
+    # SQL
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_database_instance_sqlserver"
+        primary_resource_id: "instance"
+        vars:
+          database_instance_name: "sqlserver-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_database_instance_my_sql"
+        primary_resource_id: "instance"
+        vars:
+          database_instance_name: "mysql-instance"
+    # Storage
+      - !ruby/object:Provider::Terraform::Examples
+        name: "storage_new_bucket"
+        primary_resource_id: "static"
+        vars:
+          new_bucket: "new-bucket"
+    properties:
+
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -26,6 +26,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "true"
         test_vars_overrides:
           deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_instance_my_sql"
         primary_resource_type: "google_sql_database_instance"
@@ -35,6 +37,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "true"
         test_vars_overrides:
           deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -28,6 +28,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+          - "root_password"
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_instance_my_sql"
         primary_resource_type: "google_sql_database_instance"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -19,17 +19,26 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # SQL
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_instance_sqlserver"
+        primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
         vars:
           database_instance_name: "sqlserver-instance"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_instance_my_sql"
+        primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
         vars:
           database_instance_name: "mysql-instance"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"
+        primary_resource_type: "google_storage_bucket"
         primary_resource_id: "static"
         vars:
           new_bucket: "new-bucket"

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -200,6 +200,7 @@ module Provider
 
     def generate_documentation(pwd, data)
       return if data.object.cgc_only
+
       target_folder = data.output_folder
       target_folder = File.join(target_folder, 'website', 'docs', 'r')
       FileUtils.mkpath target_folder

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -185,7 +185,7 @@ module Provider
     # per resource. The resource.erb template forms the basis of a single
     # GCP Resource on Terraform.
     def generate_resource(pwd, data, generate_code, generate_docs)
-      if generate_code
+      if generate_code && !data.object.cgc_only
         FileUtils.mkpath folder_name(data.version) unless Dir.exist?(folder_name(data.version))
         data.generate(pwd,
                       '/templates/terraform/resource.erb',
@@ -199,6 +199,7 @@ module Provider
     end
 
     def generate_documentation(pwd, data)
+      return if data.object.cgc_only
       target_folder = data.output_folder
       target_folder = File.join(target_folder, 'website', 'docs', 'r')
       FileUtils.mkpath target_folder
@@ -229,7 +230,8 @@ module Provider
                 data.object.custom_code.custom_delete ||
                 data.object.custom_code.pre_delete ||
                 data.object.custom_code.post_delete ||
-                data.object.skip_delete
+                data.object.skip_delete ||
+                data.object.cgc_only
 
       file_name =
         "#{folder_name(data.version)}/resource_#{full_resource_name(data)}_sweeper_test.go"
@@ -247,6 +249,9 @@ module Provider
       data = build_object_data(pwd, @api.objects.first, output_folder, @target_version_name)
 
       data.object = @api.objects.select(&:autogen_async).first
+
+      return if data.object.cgc_only
+
       data.async = data.object.async
       FileUtils.mkpath folder_name(data.version) unless Dir.exist?(folder_name(data.version))
       data.generate(pwd,

--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -39,7 +39,7 @@ module Provider
       attr_reader :primary_resource_id
 
       # Optional resource type of the "primary" resource. Used in import tests.
-      # If set, this will override the default resource type implied from the 
+      # If set, this will override the default resource type implied from the
       # object parent
       attr_reader :primary_resource_type
 

--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -38,6 +38,11 @@ module Provider
       # }
       attr_reader :primary_resource_id
 
+      # Optional resource type of the "primary" resource. Used in import tests.
+      # If set, this will override the default resource type implied from the 
+      # object parent
+      attr_reader :primary_resource_type
+
       # vars is a Hash from template variable names to output variable names.
       # It will use the provided value as a prefix for generated tests, and
       # insert it into the docs verbatim.
@@ -255,7 +260,8 @@ module Provider
                        {
                          vars: rand_vars.merge(overrides),
                          test_env_vars: test_env_vars.map { |k, _| [k, "%{#{k}}"] }.to_h,
-                         primary_resource_id: primary_resource_id
+                         primary_resource_id: primary_resource_id,
+                         primary_resource_type: primary_resource_type
                        },
                        pwd + '/' + config_path
                      ))

--- a/mmv1/provider/terraform_oics.rb
+++ b/mmv1/provider/terraform_oics.rb
@@ -30,7 +30,7 @@ module Provider
 
     # Create a directory of examples per resource
     def generate_resource(pwd, data, _generate_code, generate_docs)
-      return unless generate_docs
+      return unless generate_docs && !data.object.cgc_only
 
       examples = data.object.examples
                      .reject(&:skip_test)

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -34,7 +34,7 @@ module Provider
     end
 
     def generate_object(object, output_folder, version_name, generate_code, generate_docs)
-      if object.exclude_validator
+      if object.exclude_validator || object.cgc_only
         Google::LOGGER.info "Skipping fine-grained resource #{object.name}"
         return
       end

--- a/mmv1/spec/copyright.rb
+++ b/mmv1/spec/copyright.rb
@@ -19,8 +19,8 @@ module Google
     def initialize(files)
       @input_files = files
       @copyrightable_files = {
-        /.*\.yaml$/ => /^# Copyright 20(17|18|19|20|21)/,
-        /.*\.rb$/ => /^# Copyright 20(17|18|19|20|21)/
+        /.*\.yaml$/ => /^# Copyright 20(17|18|19|20|21|22)/,
+        /.*\.rb$/ => /^# Copyright 20(17|18|19|20|21|22)/
       }
     end
 

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -18,7 +18,7 @@ terraform_name = object.legacy_name || "google_#{tf_product}_#{tf_resource}"
 -%>
 <%
 # @api.version_obj_or_closest(version) is slightly wrong; we want the _object_ version or the generation version.
-# Ultimately this won't matter though, since the API default should always be less than the object default.
+# Ultimately this will not matter though, since the API default should always be less than the object default.
 object.examples
   .reject(&:skip_test)
   .reject { |e| @api.version_obj_or_closest(version) < @api.version_obj_or_closest(e.min_version) }
@@ -35,6 +35,9 @@ object.examples
     # Use explicit version for the example if given.
     # Otherwise, use object version.
     example_version = example.min_version || object.min_version.name
+
+	# Use explicit resource type if given
+	resource_type = example.primary_resource_type || terraform_name
 -%>
 
 func TestAcc<%= test_slug -%>(t *testing.T) {
@@ -67,7 +70,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 			"time": {},
 		},
 		<% end -%>
-		<% unless object.skip_delete -%>
+		<% unless object.skip_delete || object.cgc_only -%>
 		CheckDestroy: testAccCheck<%= "#{resource_name}" -%>DestroyProducer(t),
 		<% end -%>
 		Steps: []resource.TestStep{
@@ -76,7 +79,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 			},
 		<% unless example.skip_import_test -%>
 			{
-				ResourceName:      "<%= terraform_name -%>.<%= example.primary_resource_id -%>",
+				ResourceName:      "<%= resource_type -%>.<%= example.primary_resource_id -%>",
 				ImportState:       true,
 				ImportStateVerify: true,
 		<%- unless ignore_read.empty? -%>
@@ -93,7 +96,7 @@ func testAcc<%= test_slug -%>(context map[string]interface{}) string {
 }
 <%- end %>
 
-<% unless object.skip_delete -%>
+<% unless object.skip_delete || object.cgc_only -%>
 func testAccCheck<%= resource_name -%>DestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for name, rs := range s.RootModule().Resources {

--- a/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
@@ -1,0 +1,10 @@
+# [START cloud_sql_mysql_instance_80_db_n1_s2]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['database_instance_name'] %>"
+  region           = "us-central1"
+  database_version = "MYSQL_8_0"
+  settings {
+    tier = "db-n1-standard-2"
+  }
+}
+# [END cloud_sql_mysql_instance_80_db_n1_s2]

--- a/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
@@ -6,5 +6,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   settings {
     tier = "db-n1-standard-2"
   }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_mysql_instance_80_db_n1_s2]

--- a/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
@@ -7,5 +7,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   settings {
     tier = "db-custom-2-7680"
   }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_sqlserver_instance_80_db_n1_s2]

--- a/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
@@ -1,0 +1,11 @@
+# [START cloud_sql_sqlserver_instance_80_db_n1_s2]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['database_instance_name'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier = "db-custom-2-7680"
+  }
+}
+# [END cloud_sql_sqlserver_instance_80_db_n1_s2]

--- a/mmv1/templates/terraform/examples/storage_new_bucket.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_new_bucket.tf.erb
@@ -1,0 +1,13 @@
+# [START storage_create_new_bucket_tf]
+
+# Create new storage bucket in the US region
+# with coldline storage
+resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
+  name          = "<%= ctx[:vars]['new_bucket'] %>"
+  location      = "US"
+  storage_class = "COLDLINE"
+
+  uniform_bucket_level_access = true
+}
+
+# [END storage_create_new_bucket_tf]

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -354,7 +354,7 @@ products.each do |product|
   product_definition = product[:definitions]
   config = product[:overrides]
   product_definition.objects.each do |object|
-	next if object.exclude || object.not_in_version?(product_definition.version_obj_or_closest(version))
+	next if object.exclude || object.not_in_version?(product_definition.version_obj_or_closest(version)) || object.cgc_only
 	tf_product = (config.legacy_name || product_definition.name).underscore
 	terraform_name = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
 -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes https://github.com/hashicorp/terraform-provider-google/issues/10651

Adds `cgc_only` variable to make a sort of mock resource that only generates CGC samples and tests.
Also `primary_resource_type` since for import tests, the resource type is usually implied from the resource object. We needed a way to specify the type since CGC samples will be a mix of resources.

Includes the samples from the following PRs:

- https://github.com/GoogleCloudPlatform/magic-modules/pull/5544
- https://github.com/GoogleCloudPlatform/magic-modules/pull/5577
- https://github.com/GoogleCloudPlatform/magic-modules/pull/5579


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
