### PR TITLE
Removed note that Cloud Build WorkerPools are not public (because they are now public)

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
@@ -11,9 +11,6 @@ description: |-
 
 Definition of custom Cloud Build WorkerPools for running jobs with custom configuration and custom networking.
 
--> This resource is not currently public, and requires allow-listing of projects prior to use.
-
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
b/218371996

GA announcement: https://cloud.google.com/build/docs/release-notes#July_27_2021

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

