### PR TITLE
Added description of default_event_based_hold

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -321,6 +321,7 @@ func resourceStorageBucket() *schema.Resource {
 			"default_event_based_hold": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Description: `Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.`,
 			},
 
 			"logging": {

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -89,6 +89,8 @@ The following arguments are supported:
 
 * `cors` - (Optional) The bucket's [Cross-Origin Resource Sharing (CORS)](https://www.w3.org/TR/cors/) configuration. Multiple blocks of this type are permitted. Structure is [documented below](#nested_cors).
 
+* `default_event_based_hold` - (Optional) Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.
+
 * `retention_policy` - (Optional) Configuration of the bucket's data retention policy for how long objects in the bucket should be retained. Structure is [documented below](#nested_retention_policy).
 
 * `labels` - (Optional) A map of key/value label pairs to assign to the bucket.


### PR DESCRIPTION
Followup on https://github.com/GoogleCloudPlatform/magic-modules/pull/2954

Resolved https://github.com/hashicorp/terraform-provider-google/issues/11044

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
