### PR TITLE
Add a new `network_tier` value `FIXED_STANDARD` to `google_compute_instance_template` & `google_compute_instance` resource

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -322,7 +322,7 @@ func resourceComputeInstance() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Computed:     true,
-										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD", "FIXED_STANDARD"}, false),
 										Description:  `The networking tier used for configuring this instance. One of PREMIUM or STANDARD.`,
 									},
 
@@ -379,7 +379,7 @@ func resourceComputeInstance() *schema.Resource {
 									"network_tier": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
 									},
 									"public_ptr_domain_name": {

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -378,8 +378,8 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 										Optional:     true,
 										Computed:     true,
 										ForceNew:     true,
-										Description:  `The networking tier used for configuring this instance template. This field can take the following values: PREMIUM or STANDARD. If this field is not specified, it is assumed to be PREMIUM.`,
-										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
+										Description:  `The networking tier used for configuring this instance template. This field can take the following values: PREMIUM, STANDARD, FIXED_STANDARD. If this field is not specified, it is assumed to be PREMIUM.`,
+										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD", "FIXED_STANDARD"}, false),
 									},
 									// Possibly configurable- this was added so we don't break if it's inadvertently set
 									"public_ptr_domain_name": {
@@ -438,7 +438,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 									"network_tier": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"PREMIUM","STANDARD"}, false),
 										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
 									},
 									// Possibly configurable- this was added so we don't break if it's inadvertently set

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -391,13 +391,13 @@ specified, then this instance will have no external IPv6 Internet access. Struct
     network ip. If not given, one will be generated.
 
 * `network_tier` - (Optional) The [networking tier][network-tier] used for configuring
-    this instance template. This field can take the following values: PREMIUM or
-    STANDARD. If this field is not specified, it is assumed to be PREMIUM.
+    this instance template. This field can take the following values: PREMIUM,
+    STANDARD or FIXED_STANDARD. If this field is not specified, it is assumed to be PREMIUM.
 
 <a name="nested_ipv6_access_config"></a>The `ipv6_access_config` block supports:
 
 * `network_tier` - (Optional) The service-level to be provided for IPv6 traffic when the
-    subnet has an external subnet. Only PREMIUM tier is valid for IPv6.
+    subnet has an external subnet. Only PREMIUM and STANDARD tier is valid for IPv6.
 
 <a name="nested_alias_ip_range"></a>The `alias_ip_range` block supports:
 


### PR DESCRIPTION
Fixes: [#11047](https://github.com/hashicorp/terraform-provider-google/issues/11047)

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `FIXED_STANDARD` as a valid value to the field `network_interface.0.access_configs.0.network_tier` of  `google_compute_instance_template` resource
```
```release-note:enhancement
compute: added `STANDARD` as a valid value to the field `network_interface.0.ipv6_access_configs.0.network_tier` of  `google_compute_instance_template` resource
```
```release-note:enhancement
compute: added `FIXED_STANDARD` as a valid value to the field `network_interface.0.access_configs.0.network_tier` of  `google_compute_instance` resource
```
```release-note:enhancement
compute: added `STANDARD` as a valid value to the field `network_interface.0.ipv6_access_configs.0.network_tier` of  `google_compute_instance` resource
```
