### PR TITLE
Added example for creating a Postgres instance

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -30,6 +30,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "deletion_protection"
           - "root_password"
       - !ruby/object:Provider::Terraform::Examples
+        name: "sql_database_instance_postgres"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "instance"
+        vars:
+          database_instance_name: "postgres-instance"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+          - "root_password"
+      - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_instance_my_sql"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -40,7 +40,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
-          - "root_password"
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_instance_my_sql"
         primary_resource_type: "google_sql_database_instance"

--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
@@ -1,0 +1,10 @@
+# [START cloud_sql_postgres_instance_80_db_n1_s2]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['database_instance_name'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-7680"
+  }
+}
+# [START cloud_sql_postgres_instance_80_db_n1_s2]

--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
@@ -6,5 +6,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   settings {
     tier = "db-custom-2-7680"
   }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
-# [START cloud_sql_postgres_instance_80_db_n1_s2]
+# [END cloud_sql_postgres_instance_80_db_n1_s2]


### PR DESCRIPTION
Intending to use this example on CGC page:

https://cloud.google.com/sql/docs/postgres/create-instance

```release-note:none
```