### PR TITLE
vcr test initial setup

### DIFF
--- a/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
@@ -1,0 +1,11 @@
+from golang:1.16-stretch as resource
+SHELL ["/bin/bash", "-c"]
+# Set up Github SSH cloning.
+RUN ssh-keyscan github.com >> /known_hosts
+RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
+
+RUN apt-get update
+RUN apt-get install -y git jq
+
+ADD test_terraform_vcr.sh /test_terraform_vcr.sh
+ENTRYPOINT ["/test_terraform_vcr.sh"]

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+pr_number=$1
+mm_commit_sha=$2
+echo "PR number: ${pr_number}"
+echo "Commit SHA: ${mm_commit_sha}"
+github_username=modular-magician
+gh_repo=terraform-provider-google-beta
+
+# For testing only.
+echo "checking if this is the testing PR for vcr setup"
+if [ "$pr_number" == "5703"]; then
+  echo "Running tests for new VCR setup"
+else
+  echo "Skipping new vcr tests: Not testing PR"
+  exit 0
+fi

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -243,6 +243,8 @@ steps:
       args:
           - $_PR_NUMBER
           - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
           - "25"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-vcr-tester'

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -236,6 +236,15 @@ steps:
           - GoogleCloudPlatform/magic-modules
           - "24"  # Build step
 
+    - name: 'gcr.io/graphite-docker-images/gcb-terraform-vcr-tester'
+      id: gcb-tpg-vcr-test
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["diff"]
+      args:
+          - $_PR_NUMBER
+          - $COMMIT_SHA
+          - "25"  # Build step
+
     - name: 'gcr.io/graphite-docker-images/terraform-vcr-tester'
       id: tpg-vcr-test
       secretEnv: ["TEAMCITY_TOKEN", "GITHUB_TOKEN"]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

GCB vcr test setup to kick off the run 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
