### PR TITLE
switch service networking connection to use create on create rather than update

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/resources/resource_service_networking_connection.go
@@ -90,27 +90,13 @@ func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta inte
 	project := networkFieldValue.Project
 
 	parentService := formatParentService(d.Get("service").(string))
-	// We use Patch instead of Create, because we're getting
-	//  "Error waiting for Create Service Networking Connection:
-	//   Error code 9, message: Cannot modify allocated ranges in
-	//   CreateConnection. Please use UpdateConnection."
-	// if we're creating peerings to more than one VPC (like two
-	// CloudSQL instances within one project, peered with two
-	// clusters.)
-	//
-	// This is a workaround for:
-	// https://issuetracker.google.com/issues/131908322
-	//
-	// The API docs don't specify that you can do connections/-,
-	// but that's what gcloud does, and it's easier than grabbing
-	// the connection name.
 
 	// err == nil indicates that the billing_project value was found
 	if bp, err := getBillingProject(d, config); err == nil {
 		project = bp
 	}
 
-	createCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true)
+	createCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Create(parentService, connection)
 	if config.UserProjectOverride {
 		createCall.Header().Add("X-Goog-User-Project", project)
 	}

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -667,8 +667,6 @@ func TestAccSqlDatabaseInstance_basic_with_user_labels(t *testing.T) {
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *testing.T) {
-	t.Parallel()
-
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
 	networkName := "tf-test-" + randString(t, 10)
@@ -692,8 +690,6 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testing.T) {
-	t.Parallel()
-
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
 	networkName := "tf-test-" + randString(t, 10)
@@ -728,8 +724,6 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testi
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t *testing.T) {
-	t.Parallel()
-
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
 	networkName := "tf-test-" + randString(t, 10)
@@ -759,8 +753,6 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(t *testing.T) {
-	t.Parallel()
-
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
 	networkName := "tf-test-" + randString(t, 10)

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -671,7 +671,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
-	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private")
+	networkName := "tf-test-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -696,9 +696,9 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testi
 
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
-	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private-allocated-ip-range")
+	networkName := "tf-test-" + randString(t, 10)
 	addressName_update := "tf-test-" + randString(t, 10) + "update"
-	networkName_update := BootstrapSharedTestNetwork(t, "sql-instance-private-allocated-ip-range-update")
+	networkName_update := "tf-test-" + randString(t, 10) + "update"
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -732,7 +732,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t
 
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
-	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private-replica")
+	networkName := "tf-test-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -763,7 +763,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(t *
 
 	databaseName := "tf-test-" + randString(t, 10)
 	addressName := "tf-test-" + randString(t, 10)
-	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private-clone")
+	networkName := "tf-test-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1124,8 +1124,8 @@ resource "google_sql_database_instance" "instance-failover" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-data "google_compute_network" "servicenet" {
-  name                    = "%s"
+resource "google_compute_network" "servicenet" {
+  name = "%s"
 }
 
 resource "google_compute_global_address" "foobar" {
@@ -1133,11 +1133,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
+  network       = google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
+  network                 = google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -1152,7 +1152,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = data.google_compute_network.servicenet.self_link
+      private_network    = google_compute_network.servicenet.self_link
     }
   }
 }
@@ -1161,8 +1161,8 @@ resource "google_sql_database_instance" "instance" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-data "google_compute_network" "servicenet" {
-  name                    = "%s"
+resource "google_compute_network" "servicenet" {
+  name = "%s"
 }
 
 resource "google_compute_global_address" "foobar" {
@@ -1170,11 +1170,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
+  network       = google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
+  network                 = google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -1189,7 +1189,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = data.google_compute_network.servicenet.self_link
+      private_network    = google_compute_network.servicenet.self_link
       allocated_ip_range = google_compute_global_address.foobar.name
     }
   }
@@ -1200,8 +1200,8 @@ resource "google_sql_database_instance" "instance" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-data "google_compute_network" "servicenet" {
-  name                    = "%s"
+resource "google_compute_network" "servicenet" {
+  name = "%s"
 }
 
 resource "google_compute_global_address" "foobar" {
@@ -1209,11 +1209,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
+  network       = google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
+  network                 = google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -1228,7 +1228,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = data.google_compute_network.servicenet.self_link
+      private_network    = google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true
@@ -1247,7 +1247,7 @@ resource "google_sql_database_instance" "replica1" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = data.google_compute_network.servicenet.self_link
+      private_network    = google_compute_network.servicenet.self_link
       allocated_ip_range = google_compute_global_address.foobar.name
     }
   }
@@ -1268,8 +1268,8 @@ resource "google_sql_database_instance" "replica1" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-data "google_compute_network" "servicenet" {
-  name                    = "%s"
+resource "google_compute_network" "servicenet" {
+  name = "%s"
 }
 
 resource "google_compute_global_address" "foobar" {
@@ -1277,11 +1277,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
+  network       = google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
+  network                 = google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -1296,7 +1296,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = data.google_compute_network.servicenet.self_link
+      private_network    = google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10830

I'm not sure if this is a breaking change or not? It's only on create so shouldn't break current configs? But functionality will change.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
servicenetworking: fixed bug where `google_service_networking_connection` would update if a service connection of the same type already exists.
```
