### PR TITLE
Allow errors during downstream build

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -134,7 +134,6 @@ if [ "$REPO" == "terraform-validator" ] || [ "$REPO" == "tf-conversion" ]; then
       set +e
     fi
 
-    mkdir -p ./testdata/generatedconvert/
     make build
     export TFV_CREATE_GENERATED_FILES=true
     go test ./test -run "TestAcc.*_generated_offline"

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -127,9 +127,16 @@ if [ "$REPO" == "terraform-validator" ] || [ "$REPO" == "tf-conversion" ]; then
 
     go mod tidy
 
-    make build
-    export TFV_CREATE_GENERATED_FILES=true
-    go test ./test -run "TestAcc.*_generated_offline"
+    # generate converted assets if we are not building the downstream
+    # this allows for a diff of the converted output to be presented to,
+    # and approved by, the developer
+    if [ "$COMMAND" != "downstream" ]; then
+      mkdir -p ./testdata/generatedconvert/
+      make build
+      export TFV_CREATE_GENERATED_FILES=true
+      go test ./test -run "TestAcc.*_generated_offline"
+    fi
+
     popd
 elif [ "$REPO" == "tf-oics" ]; then
     # use terraform generator with oics override

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -127,9 +127,9 @@ if [ "$REPO" == "terraform-validator" ] || [ "$REPO" == "tf-conversion" ]; then
 
     go mod tidy
 
-    # the downstream build can fail to build which results in a subsequent failure to push
+    # the following build can fail which results in a subsequent failure to push to tfv repository.
     # due to the uncertainty of tpg being able to build we will ignore errors here
-    # as these files are not critical to operation of tfv
+    # as these files are not critical to operation of tfv and not worth blocking the GA pipeline
     if [ "$COMMAND" == "downstream" ]; then
       set +e
     fi


### PR DESCRIPTION
Due to the recent failure of the magician we are switching the builder to allow errors during build stage... This is okay as the generated assets are only presented to allow for a diff of the previous asset to the newest version. They are not needed, as of right now, and will never be needed for pure operation of tfv.

As this behavior is an exception in the mm build process, we are modifying it to align with prior behavior.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
