### PR TITLE
Add ReadReplicasMode and secondaryIpRange support for Redis Update 

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -294,4 +294,5 @@ objects:
           add new ranges, once added ranges cannot be changed or deleted. Values in
           this list cannot overlap with the reserved_ip_range. Not supported during
           instance creation.
+        min_version: beta
         input: true

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -285,3 +285,13 @@ objects:
         default_value: :READ_REPLICAS_DISABLED
         min_version: beta
         input: true
+      - !ruby/object:Api::Type::String
+        name: secondaryIpRange
+        description: |
+          Optional. Additional ip ranges for node placement, beyond those specified
+          in reserved_ip_range. At most 1 secondary IP range is supported. The mask
+          value must not exceed /28. Not supported for BASIC tier. Updates can only
+          add new ranges, once added ranges cannot be changed or deleted. Values in
+          this list cannot overlap with the reserved_ip_range. Not supported during
+          instance creation.
+        input: true

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -88,6 +88,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       replicaCount: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      secondaryIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -90,6 +90,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       secondaryIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      readReplicasMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/third_party/terraform/tests/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_redis_instance_test.go
@@ -240,6 +240,8 @@ resource "google_redis_instance" "test" {
     notify-keyspace-events = ""
   }
   redis_version = "REDIS_5_0"
+	read_replicas_mode = "READ_REPLICAS_ENABLED"
+	secondary_ip_range = "10.1.0.0"
 }
 `, name, lifecycleBlock)
 }


### PR DESCRIPTION
Add ReadReplicasMode and secondaryIpRange support for Redis Update

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis:Added Multi read replica field `readReplicasMode` and `secondaryIpRange` in `google_redis_instance`
```
