### PR TITLE
use rwmutex instead of mutex

### DIFF
--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -122,8 +122,8 @@ var masterBillingAccountEnvVars = []string{
 	"GOOGLE_MASTER_BILLING_ACCOUNT",
 }
 
-var configs_lock = sync.RWMutex{}
-var sources_lock = sync.RWMutex{}
+var configsLock = sync.RWMutex{}
+var sourcesLock = sync.RWMutex{}
 
 func init() {
 	configs = make(map[string]*Config)
@@ -157,9 +157,9 @@ func init() {
 // VCR requires a single HTTP client to handle all interactions so it can record and replay responses so
 // this caches HTTP clients per test by replacing ConfigureFunc
 func getCachedConfig(ctx context.Context, d *schema.ResourceData, configureFunc schema.ConfigureContextFunc, testName string) (*Config, diag.Diagnostics) {
-	configs_lock.RLock()
+	configsLock.RLock()
 	v, ok := configs[testName]
-	configs_lock.RUnlock()
+	configsLock.RUnlock()
 	if ok {
 		return v, nil
 	}
@@ -235,17 +235,17 @@ func getCachedConfig(ctx context.Context, d *schema.ResourceData, configureFunc 
 		return false
 	})
 	config.client.Transport = rec
-	configs_lock.Lock()
+	configsLock.Lock()
 	configs[testName] = config
-	configs_lock.Unlock()
+	configsLock.Unlock()
 	return config, nil
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
 func closeRecorder(t *testing.T) {
-	configs_lock.RLock()
+	configsLock.RLock()
 	config, ok := configs[t.Name()]
-	configs_lock.RUnlock()
+	configsLock.RUnlock()
 	if ok {
 		// We did not cache the config if it does not use VCR
 		if !t.Failed() && isVcrEnabled() {
@@ -256,9 +256,9 @@ func closeRecorder(t *testing.T) {
 			}
 			envPath := os.Getenv("VCR_PATH")
 
-			sources_lock.RLock()
+			sourcesLock.RLock()
 			vcrSource, ok := sources[t.Name()]
-			sources_lock.RUnlock()
+			sourcesLock.RUnlock()
 			if ok {
 				err = writeSeedToFile(vcrSource.seed, vcrSeedFile(envPath, t.Name()))
 				if err != nil {
@@ -267,20 +267,20 @@ func closeRecorder(t *testing.T) {
 			}
 		}
 		// Clean up test config
-		configs_lock.Lock()
+		configsLock.Lock()
 		delete(configs, t.Name())
-		configs_lock.Unlock()
+		configsLock.Unlock()
 
-		sources_lock.Lock()
+		sourcesLock.Lock()
 		delete(sources, t.Name())
-		sources_lock.Unlock()
+		sourcesLock.Unlock()
 	}
 }
 
 func googleProviderConfig(t *testing.T) *Config {
-	configs_lock.RLock()
+	configsLock.RLock()
 	config, ok := configs[t.Name()]
-	configs_lock.RUnlock()
+	configsLock.RUnlock()
 	if ok {
 		return config
 	}
@@ -337,9 +337,9 @@ func vcrFileName(name string) string {
 // In RECORDING mode, generates a new seed and saves it to a file, using the seed for the source
 // In REPLAYING mode, reads a seed from a file and creates a source from it
 func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
-	sources_lock.RLock()
+	sourcesLock.RLock()
 	s, ok := sources[t.Name()]
-	sources_lock.RUnlock()
+	sourcesLock.RUnlock()
 	if ok {
 		return &s, nil
 	}
@@ -348,9 +348,9 @@ func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
 		seed := rand.Int63()
 		s := rand.NewSource(seed)
 		vcrSource := VcrSource{seed: seed, source: s}
-		sources_lock.Lock()
+		sourcesLock.Lock()
 		sources[t.Name()] = vcrSource
-		sources_lock.Unlock()
+		sourcesLock.Unlock()
 		return &vcrSource, nil
 	case "REPLAYING":
 		seed, err := readSeedFromFile(vcrSeedFile(path, t.Name()))
@@ -359,9 +359,9 @@ func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
 		}
 		s := rand.NewSource(seed)
 		vcrSource := VcrSource{seed: seed, source: s}
-		sources_lock.Lock()
+		sourcesLock.Lock()
 		sources[t.Name()] = vcrSource
-		sources_lock.Unlock()
+		sourcesLock.Unlock()
 		return &vcrSource, nil
 	default:
 		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", mode)

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -122,7 +122,8 @@ var masterBillingAccountEnvVars = []string{
 	"GOOGLE_MASTER_BILLING_ACCOUNT",
 }
 
-var mutex = &sync.Mutex{}
+var configs_lock = sync.RWMutex{}
+var sources_lock = sync.RWMutex{}
 
 func init() {
 	configs = make(map[string]*Config)
@@ -156,7 +157,10 @@ func init() {
 // VCR requires a single HTTP client to handle all interactions so it can record and replay responses so
 // this caches HTTP clients per test by replacing ConfigureFunc
 func getCachedConfig(ctx context.Context, d *schema.ResourceData, configureFunc schema.ConfigureContextFunc, testName string) (*Config, diag.Diagnostics) {
-	if v, ok := configs[testName]; ok {
+	configs_lock.RLock()
+	v, ok := configs[testName]
+	configs_lock.RUnlock()
+	if ok {
 		return v, nil
 	}
 	c, diags := configureFunc(ctx, d)
@@ -231,15 +235,18 @@ func getCachedConfig(ctx context.Context, d *schema.ResourceData, configureFunc 
 		return false
 	})
 	config.client.Transport = rec
-	mutex.Lock()
+	configs_lock.Lock()
 	configs[testName] = config
-	mutex.Unlock()
+	configs_lock.Unlock()
 	return config, nil
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
 func closeRecorder(t *testing.T) {
-	if config, ok := configs[t.Name()]; ok {
+	configs_lock.RLock()
+	config, ok := configs[t.Name()]
+	configs_lock.RUnlock()
+	if ok {
 		// We did not cache the config if it does not use VCR
 		if !t.Failed() && isVcrEnabled() {
 			// If a test succeeds, write new seed/yaml to files
@@ -248,7 +255,11 @@ func closeRecorder(t *testing.T) {
 				t.Error(err)
 			}
 			envPath := os.Getenv("VCR_PATH")
-			if vcrSource, ok := sources[t.Name()]; ok {
+
+			sources_lock.RLock()
+			vcrSource, ok := sources[t.Name()]
+			sources_lock.RUnlock()
+			if ok {
 				err = writeSeedToFile(vcrSource.seed, vcrSeedFile(envPath, t.Name()))
 				if err != nil {
 					t.Error(err)
@@ -256,15 +267,20 @@ func closeRecorder(t *testing.T) {
 			}
 		}
 		// Clean up test config
-		mutex.Lock()
+		configs_lock.Lock()
 		delete(configs, t.Name())
+		configs_lock.Unlock()
+
+		sources_lock.Lock()
 		delete(sources, t.Name())
-		mutex.Unlock()
+		sources_lock.Unlock()
 	}
 }
 
 func googleProviderConfig(t *testing.T) *Config {
+	configs_lock.RLock()
 	config, ok := configs[t.Name()]
+	configs_lock.RUnlock()
 	if ok {
 		return config
 	}
@@ -321,7 +337,10 @@ func vcrFileName(name string) string {
 // In RECORDING mode, generates a new seed and saves it to a file, using the seed for the source
 // In REPLAYING mode, reads a seed from a file and creates a source from it
 func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
-	if s, ok := sources[t.Name()]; ok {
+	sources_lock.RLock()
+	s, ok := sources[t.Name()]
+	sources_lock.RUnlock()
+	if ok {
 		return &s, nil
 	}
 	switch mode {
@@ -329,9 +348,9 @@ func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
 		seed := rand.Int63()
 		s := rand.NewSource(seed)
 		vcrSource := VcrSource{seed: seed, source: s}
-		mutex.Lock()
+		sources_lock.Lock()
 		sources[t.Name()] = vcrSource
-		mutex.Unlock()
+		sources_lock.Unlock()
 		return &vcrSource, nil
 	case "REPLAYING":
 		seed, err := readSeedFromFile(vcrSeedFile(path, t.Name()))
@@ -340,9 +359,9 @@ func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
 		}
 		s := rand.NewSource(seed)
 		vcrSource := VcrSource{seed: seed, source: s}
-		mutex.Lock()
+		sources_lock.Lock()
 		sources[t.Name()] = vcrSource
-		mutex.Unlock()
+		sources_lock.Unlock()
 		return &vcrSource, nil
 	default:
 		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", mode)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`mutex` was added in https://github.com/GoogleCloudPlatform/magic-modules/pull/5722 to fix `concurrent map writes error` in new vcr test. However it still constantly ran into `concurrent map read and write` error, as the previous only add the lock when write data to the map. Therefore, in this PR
- Add the locking mechanism whenever the map is accessed (including both read-from and write-to)
- Use `rwmutex` instead of `mutex` for better efficiency (which enables concurrent read access, just not concurrent read/write or write/write access) 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
