### PR TITLE
add `subject_id` to transfer job project SA

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
@@ -48,7 +48,7 @@ func dataSourceGoogleStorageTransferProjectServiceAccountRead(d *schema.Resource
 	if err := d.Set("email", serviceAccount.AccountEmail); err != nil {
 		return fmt.Errorf("Error setting email: %s", err)
 	}
-	if err := d.Set("subject_id", serviceAccount.subjectId); err != nil {
+	if err := d.Set("subject_id", serviceAccount.SubjectId); err != nil {
 		return fmt.Errorf("Error setting subject_id: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -16,6 +17,10 @@ func dataSourceGoogleStorageTransferProjectServiceAccount() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"subject_id": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -42,6 +47,9 @@ func dataSourceGoogleStorageTransferProjectServiceAccountRead(d *schema.Resource
 	d.SetId(serviceAccount.AccountEmail)
 	if err := d.Set("email", serviceAccount.AccountEmail); err != nil {
 		return fmt.Errorf("Error setting email: %s", err)
+	}
+	if err := d.Set("subject_id", serviceAccount.subjectId); err != nil {
+		return fmt.Errorf("Error setting subject_id: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)

--- a/mmv1/third_party/terraform/tests/data_source_google_storage_transfer_project_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_storage_transfer_project_service_account_test.go
@@ -20,6 +20,7 @@ func TestAccDataSourceGoogleStorageTransferProjectServiceAccount_basic(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "email"),
+					resource.TestCheckResourceAttrSet(resourceName, "subject_id"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
@@ -33,4 +33,5 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `email` - Email address of the default service account used by Storage Transfer Jobs running in this project
+* `email` - Email address of the default service account used by Storage Transfer Jobs running in this project.
+* `subject_id` - Unique identifier for the service account.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add `subject_id` attribute to the transfer job project SA data source, this will allow getting the subject id to create aws iam role assumable by google SA and reduce the need to static IAM keys on AWS side.

Closes https://github.com/hashicorp/terraform-provider-google/issues/11149

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
transfer: added attribute `subject_id` to data source `google_storage_transfer_project_service_account`
```

