### PR TITLE
prevent `google_container_cluster` from crashing if an empty `authenticator_groups_config` is supplied

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3306,7 +3306,7 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 
 func expandAuthenticatorGroupsConfig(configured interface{}) *container.AuthenticatorGroupsConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 && l[0] != nil {
+	if len(l) == 0 || l[0] != nil {
 		return nil
 	}
 	result := &container.AuthenticatorGroupsConfig{}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3306,7 +3306,7 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 
 func expandAuthenticatorGroupsConfig(configured interface{}) *container.AuthenticatorGroupsConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 || l[0] != nil {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	result := &container.AuthenticatorGroupsConfig{}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3052,7 +3052,7 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 			ForceSendFields: []string{"Disabled"},
 		}
 	}
-	
+
 	if v, ok := config["gcp_filestore_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.GcpFilestoreCsiDriverConfig = &container.GcpFilestoreCsiDriverConfig{
@@ -3306,7 +3306,7 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 
 func expandAuthenticatorGroupsConfig(configured interface{}) *container.AuthenticatorGroupsConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 && l[0] != nil {
 		return nil
 	}
 	result := &container.AuthenticatorGroupsConfig{}
@@ -3710,7 +3710,7 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 			},
 		}
 	}
-	
+
 	if c.GcpFilestoreCsiDriverConfig != nil {
 		result["gcp_filestore_csi_driver_config"] = []map[string]interface{}{
 			{

--- a/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
@@ -13,7 +13,7 @@ description: |-
 * Create a project in the [Google Cloud Console](https://console.cloud.google.com/)
 and set up billing on that project. Any examples in this guide will be part of
 the [GCP "always free" tier](https://cloud.google.com/free/).
-* [Install Terraform](https://www.terraform.io/downloads)
+* [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/gcp-get-started)
 and read the Terraform getting started guide that follows. This guide will
 assume basic proficiency with Terraform - it is an introduction to the Google
 provider.

--- a/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
@@ -13,7 +13,7 @@ description: |-
 * Create a project in the [Google Cloud Console](https://console.cloud.google.com/)
 and set up billing on that project. Any examples in this guide will be part of
 the [GCP "always free" tier](https://cloud.google.com/free/).
-* [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
+* [Install Terraform](https://www.terraform.io/downloads)
 and read the Terraform getting started guide that follows. This guide will
 assume basic proficiency with Terraform - it is an introduction to the Google
 provider.


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/11144

prevent resource `container_cluster` from attempting to cast nil to `map[string]interface{}`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: prevent `google_container_cluster` from crashing if an empty `authenticator_groups_config` block is supplied
```
