### PR TITLE
Allow vertical pod autoscaling to be computed, auto_pilot can enable it

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1135,6 +1135,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Description: `Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -3052,7 +3053,7 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 			ForceSendFields: []string{"Disabled"},
 		}
 	}
-	
+
 	if v, ok := config["gcp_filestore_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.GcpFilestoreCsiDriverConfig = &container.GcpFilestoreCsiDriverConfig{
@@ -3710,7 +3711,7 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 			},
 		}
 	}
-	
+
 	if c.GcpFilestoreCsiDriverConfig != nil {
 		result["gcp_filestore_csi_driver_config"] = []map[string]interface{}{
 			{


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/11133

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: allowed `vertical_pod_autoscaling` to be computed as `enable_autopilot` can mutate it

```
