### PR TITLE
#9883 Add fields sourceToBuild and GitFileSource to google_cloudbuild…

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -73,16 +73,17 @@ objects:
         description: |
           The service account used for all user-controlled operations including
           triggers.patch, triggers.run, builds.create, and builds.cancel.
-          
+
           If no service account is set, then the standard Cloud Build service account
           ([PROJECT_NUM]@system.gserviceaccount.com) will be used instead.
-          
+
           Format: projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT_ID_OR_EMAIL}
       - !ruby/object:Api::Type::String
         name: 'filename'
         exactly_one_of:
           - filename
           - build
+          - git_file_source
         description: |
           Path, from the source root, to a file whose contents is used for the template. Either a filename or build template must be provided.
       - !ruby/object:Api::Type::Array
@@ -113,6 +114,64 @@ objects:
           and includedFiles is not empty, then we make sure that at least one of
           those files matches a includedFiles glob. If not, then we do not trigger
           a build.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'sourceToBuild'
+        description: |
+          The repo and ref of the repository from which to build.
+          This field is used only for those triggers that do not respond to SCM events.
+          Triggers that respond to such events build source at whatever commit caused the event.
+          This field is currently only used by Webhook, Pub/Sub, Manual, and Cron triggers.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'uri'
+            description: |
+              The URI of the repo (required).
+          - !ruby/object:Api::Type::String
+            name: 'ref'
+            description: |
+              The branch or tag to use. Must start with "refs/" (required).
+          - !ruby/object:Api::Type::Enum
+                name: 'repoType'
+                description: |
+                    The type of the repo, since it may not be explicit from the repo field (e.g from a URL).
+                values:
+                  - :UNKNOWN
+                  - :CLOUD_SOURCE_REPOSITORIES
+                  - :GITHUB
+                default_value: :UNKNOWN
+      - !ruby/object:Api::Type::NestedObject
+        name: 'gitFileSource'
+        exactly_one_of:
+          - filename
+          - build
+          - git_file_source
+        description: |
+          The file source describing the local or remote Build template.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'path'
+            description: |
+              The path of the file, with the repo root as the root of the path.
+          - !ruby/object:Api::Type::String
+            name: 'uri'
+            description: |
+              The URI of the repo (optional).
+              If unspecified, the repo from which the trigger invocation originated is assumed to be the repo from which to read the specified path.
+          - !ruby/object:Api::Type::Enum
+                name: 'repoType'
+                description: |
+                    The type of the repo, since it may not be explicit from the repo field (e.g from a URL).
+                values:
+                  - :UNKNOWN
+                  - :CLOUD_SOURCE_REPOSITORIES
+                  - :GITHUB
+                default_value: :UNKNOWN
+          - !ruby/object:Api::Type::String
+            name: 'revision'
+            description: |
+              The branch, tag, arbitrary ref, or SHA version of the repo to use when resolving the filename (optional).
+              This field respects the same syntax/resolution as described here: https://git-scm.com/docs/gitrevisions
+              If unspecified, the revision from which the trigger invocation originated is assumed to be the revision from which to read the specified path.
       - !ruby/object:Api::Type::NestedObject
         name: 'triggerTemplate'
         description: |
@@ -250,7 +309,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'pubsubConfig'
         description: |
-          PubsubConfig describes the configuration of a trigger that creates 
+          PubsubConfig describes the configuration of a trigger that creates
           a build whenever a Pub/Sub message is published.
         exactly_one_of:
           - trigger_template
@@ -281,7 +340,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'webhookConfig'
         description: |
-          WebhookConfig describes the configuration of a trigger that creates 
+          WebhookConfig describes the configuration of a trigger that creates
           a build whenever a webhook is sent to a trigger's webhook URL.
         exactly_one_of:
           - trigger_template
@@ -305,6 +364,7 @@ objects:
         exactly_one_of:
           - filename
           - build
+          - git_file_source
         description: |
           Contents of the build template. Either a filename or build template must be provided.
         properties:
@@ -332,7 +392,7 @@ objects:
                   - !ruby/object:Api::Type::String
                     name: 'generation'
                     description: |
-                      Google Cloud Storage generation for the object. 
+                      Google Cloud Storage generation for the object.
                       If the generation is omitted, the latest generation will be used
               - !ruby/object:Api::Type::NestedObject
                 name: 'repoSource'
@@ -342,7 +402,7 @@ objects:
                   - !ruby/object:Api::Type::String
                     name: 'projectId'
                     description: |
-                      ID of the project that owns the Cloud Source Repository. 
+                      ID of the project that owns the Cloud Source Repository.
                       If omitted, the project ID requesting the build is assumed.
                   - !ruby/object:Api::Type::String
                     name: 'repoName'
@@ -353,7 +413,7 @@ objects:
                     name: 'dir'
                     description: |
                       Directory, relative to the source root, in which to run the build.
-                      This must be a relative path. If a step's dir is specified and is an absolute path, 
+                      This must be a relative path. If a step's dir is specified and is an absolute path,
                       this value is ignored for that step's execution.
                   - !ruby/object:Api::Type::Boolean
                     name: 'invertRegex'
@@ -367,7 +427,7 @@ objects:
                     name: 'branchName'
                     description: |
                       Regex matching branches to build. Exactly one a of branch name, tag, or commit SHA must be provided.
-                      The syntax of the regular expressions accepted is the syntax accepted by RE2 and 
+                      The syntax of the regular expressions accepted is the syntax accepted by RE2 and
                       described at https://github.com/google/re2/wiki/Syntax
                     exactly_one_of:
                       - build.0.source.0.repo_source.0.branch_name
@@ -377,7 +437,7 @@ objects:
                     name: 'tagName'
                     description: |
                       Regex matching tags to build. Exactly one a of branch name, tag, or commit SHA must be provided.
-                      The syntax of the regular expressions accepted is the syntax accepted by RE2 and 
+                      The syntax of the regular expressions accepted is the syntax accepted by RE2 and
                       described at https://github.com/google/re2/wiki/Syntax
                     exactly_one_of:
                       - build.0.source.0.repo_source.0.branch_name
@@ -411,14 +471,14 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'queueTtl'
             description: |
-              TTL in queue for this build. If provided and the build is enqueued longer than this value, 
+              TTL in queue for this build. If provided and the build is enqueued longer than this value,
               the build will expire and the build status will be EXPIRED.
               The TTL starts ticking from createTime.
               A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
           - !ruby/object:Api::Type::String
             name: 'logsBucket'
             description: |
-              Google Cloud Storage bucket where logs should be written. 
+              Google Cloud Storage bucket where logs should be written.
               Logs file names will be of the format ${logsBucket}/log-${build_id}.txt.
           - !ruby/object:Api::Type::String
             name: 'timeout'
@@ -444,8 +504,8 @@ objects:
                   name: 'secretEnv'
                   description: |
                     Map of environment variable name to its encrypted value.
-                    Secret environment variables must be unique across all of a build's secrets, 
-                    and must be used by at least one build step. Values can be at most 64 KB in size. 
+                    Secret environment variables must be unique across all of a build's secrets,
+                    and must be used by at least one build step. Values can be at most 64 KB in size.
                     There can be at most 100 secret values across all of a build's secrets.
           - !ruby/object:Api::Type::NestedObject
             name: 'availableSecrets'
@@ -489,7 +549,7 @@ objects:
                     the builder service account's credentials if necessary.
 
                     The Docker daemon's cache will already have the latest versions of all of
-                    the officially supported build steps (see https://github.com/GoogleCloudPlatform/cloud-builders 
+                    the officially supported build steps (see https://github.com/GoogleCloudPlatform/cloud-builders
                     for images and examples).
                     The Docker daemon will also have cached many of the layers for some popular
                     images, like "ubuntu", "debian", but they will be refreshed at the time

--- a/mmv1/products/cloudbuild/terraform.yaml
+++ b/mmv1/products/cloudbuild/terraform.yaml
@@ -32,6 +32,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "cloudbuild_trigger_service_account"
         primary_resource_id: "service-account-trigger"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloudbuild_trigger_webhook"
+        primary_resource_id: "webhook-trigger"
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'trigger_id'

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_webhook.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_webhook.tf.erb
@@ -1,0 +1,41 @@
+data "google_project" "project" {
+}
+
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  git_file_source {
+    path = "someuri.com/cloudbuild.yaml"
+    repo_type = "GITHUB"
+    revision = "revision-tag"
+  }
+  webhook_config {
+    secret = google_secret_manager_secret_version.secret-version-basic.name
+  }
+  source_to_build {
+    uri = "someuri.com"
+    repo_type = "GITHUB"
+  }
+}
+
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "secret-version"
+
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.id
+  secret_data = "secret-data"
+}
+
+resource "google_secret_manager_secret_iam_member" "member" {
+  project = google_secret_manager_secret.secret-basic.project
+  secret_id = google_secret_manager_secret.secret-basic.secret_id
+  role = "roles/secretmanager.secretAccessor"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
…_trigger

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added fields sourceToBuild and GitFileSource to google_cloudbuild_trigger

fixes https://github.com/hashicorp/terraform-provider-google/issues/9883


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: Added fields sourceToBuild and GitFileSource to `google_cloudbuild_trigger`
```
