### PR TITLE
fix: align provider generation docs with makefile aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ In the future we will add hybrid generation with multiple generators. All the in
 pertains only to the contents of the `mmv1` directory, and commands should be executed from
 that directory.
 
-
 To get started right away, use the bootstrap script with:
 
 ```bash
@@ -104,11 +103,11 @@ OUTPUT_PATH should be set to the location of your provider repository, which is
 recommended to be inside your GOPATH.
 
 ```bash
-make terraform VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"
-make terraform VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta"
+make terraform build VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"
+make terraform build VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta"
 
 # Only generate a specific product (plus all common files)
-make terraform VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=dataproc
+make terraform build VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=dataproc
 ```
 
 It's worth noting that Magic Modules will only generate new files when run
@@ -263,13 +262,13 @@ both generators are in use. To assist with generation we have a series of `make`
 targets that will run the compilers in tandem to generate the Terraform provider.
 
 Sample Usage to compile at beta:
-`make OUTPUT_PATH=/path/to/terraform-provider-google-beta VERSION=beta`
+`make terraform build OUTPUT_PATH=/path/to/terraform-provider-google-beta VERSION=beta`
 
 Target single product:
-`make OUTPUT_PATH=/path/to/terraform-provider-google VERSION=ga PRODUCT=compute`
+`make terraform build OUTPUT_PATH=/path/to/terraform-provider-google VERSION=ga PRODUCT=compute`
 
 Target single resource
-`make OUTPUT_PATH=/path/to/terraform-provider-google VERSION=ga PRODUCT=compute RESOURCE=image`
+`make terraform build OUTPUT_PATH=/path/to/terraform-provider-google VERSION=ga PRODUCT=compute RESOURCE=image`
 
 For more advanced usage of mmv1 compiler flags, please execute the compiler directly
 from within the mmv1 directory.


### PR DESCRIPTION
This is a set of fixes to the root README file to help developers getting started with mm.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:none
```
