### PR TITLE
Allow composer_environment region to be computed

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -151,6 +151,7 @@ func resourceComposerEnvironment() *schema.Resource {
 			},
 			"region": {
 				Type:        schema.TypeString,
+				Computed:    true
 				Optional:    true,
 				ForceNew:    true,
 				Description: `The location or Compute Engine region for the environment.`,


### PR DESCRIPTION
If region is not defined it is inferred from the configuration

closes https://github.com/hashicorp/terraform-provider-google/issues/11165

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
composer: allow region to be undefined in configuration for `google_composer_environment`
```
