### PR TITLE
Added region tags for inclusion on cgc cloud SQL docs

### DIFF
--- a/mmv1/templates/terraform/examples/sql_database_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_basic.tf.erb
@@ -1,8 +1,11 @@
+# [START cloud_sql_database_create]
 resource "google_sql_database" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['database_name'] %>"
   instance = google_sql_database_instance.instance.name
 }
+# [END cloud_sql_database_create]
 
+# See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
 resource "google_sql_database_instance" "instance" {
   name             = "<%= ctx[:vars]['database_instance_name'] %>"
   region           = "us-central1"


### PR DESCRIPTION
Added region tags for inclusion on the following pages:

https://cloud.google.com/sql/docs/sqlserver/create-manage-databases#create https://cloud.google.com/sql/docs/postgres/create-manage-databases#create https://cloud.google.com/sql/docs/mysql/create-manage-databases#create

```release-note:none
```