### PR TITLE
GCB VCR test final set up

### DIFF
--- a/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update
 RUN apt-get install -y git jq
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
+ENV PATH $PATH:/root/google-cloud-sdk/bin
 
 ADD test_terraform_vcr.sh /test_terraform_vcr.sh
 ENTRYPOINT ["/test_terraform_vcr.sh"]

--- a/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
@@ -7,5 +7,7 @@ RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
 RUN apt-get update
 RUN apt-get install -y git jq
 
+RUN curl -sSL https://sdk.cloud.google.com | bash
+
 ADD test_terraform_vcr.sh /test_terraform_vcr.sh
 ENTRYPOINT ["/test_terraform_vcr.sh"]

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -86,21 +86,21 @@ export GOOGLE_APPLICATION_CREDENTIALS=$local_path/sa_key.json
 echo "cassette copied"
 echo "VCR_PATH: $VCR_PATH"
 echo "ACCTEST_PARALLELISM: $ACCTEST_PARALLELISM" 
-echo "GOOGLE_APPLICATION_CREDENTIALS: $GOOGLE_APPLICATION_CREDENTIALS"
 
-TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run=TestAcc' -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/vers0ion.ProviderVersion=acc" > test.txt
+
+TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run=TestAcc' -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/vers0ion.ProviderVersion=acc" > test.log
 
 test_exit_code=$?
 
-FAILED_TESTS=$(grep "FAIL:" test.txt)
-PASSED_TESTS=$(grep "PASS:" test.txt)
-SKIPPED_TESTS=$(grep "SKIP:" test.txt)
+FAILED_TESTS=$(grep "FAIL: TestAcc" test.log)
+PASSED_TESTS=$(grep "PASS: TestAcc" test.log)
+SKIPPED_TESTS=$(grep "SKIP: TestAcc" test.log)
 
 FAILED_TESTS_COUNT=$(echo "$FAILED_TESTS" | wc -l)
 PASSED_TESTS_COUNT=$(echo "$PASSED_TESTS" | wc -l)
 SKIPPED_TESTS_COUNT=$(echo "$SKIPPED_TESTS" | wc -l)
 
-FAILED_TESTS_PATTERN=$(grep FAIL: test.txt | awk '{print $3}' | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+FAILED_TESTS_PATTERN=$(grep "FAIL: TestAcc" test.log | awk '{print $3}' | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
 
 comment="Tests count: ${NEWLINE}"
 comment+="Total tests: $(($FAILED_TESTS_COUNT+$PASSED_TESTS_COUNT+$SKIPPED_TESTS_COUNT)) ${NEWLINE}"
@@ -118,13 +118,15 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   comment="I have triggered VCR tests in RECORDING mode for the following tests that failed during VCR: $FAILED_TESTS_PATTERN"
   add_comment "${comment}" "${pr_number}"
 
+
   # RECORDING mode
   export VCR_MODE=RECORDING
-  TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run='$FAILED_TESTS_PATTERN -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc" > recording_test.txt
+  TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run='$FAILED_TESTS_PATTERN -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc" > recording_test.log
   test_exit_code=$?
 
-  RECORDING_FAILED_TESTS=$(grep "FAIL:" recording_test.txt | awk '{print $3}')
-  RECORDING_PASSED_TESTS=$(grep "PASS:" recording_test.txt | awk '{print $3}')
+
+  RECORDING_FAILED_TESTS=$(grep "FAIL: TestAcc" recording_test.log | awk '{print $3}')
+  RECORDING_PASSED_TESTS=$(grep "PASS: TestAcc" recording_test.log | awk '{print $3}')
 
   comment=""  
   if [[ -n $RECORDING_PASSED_TESTS ]]; then

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -88,15 +88,9 @@ echo "VCR_PATH: $VCR_PATH"
 echo "ACCTEST_PARALLELISM: $ACCTEST_PARALLELISM" 
 echo "GOOGLE_APPLICATION_CREDENTIALS: $GOOGLE_APPLICATION_CREDENTIALS"
 
-now=$(date +"%T")
-echo "Pre-replaying time: $now"
-
 TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run=TestAcc' -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/vers0ion.ProviderVersion=acc" > test.txt
 
 test_exit_code=$?
-
-now=$(date +"%T")
-echo "Post-replaying time: $now"
 
 FAILED_TESTS=$(grep "FAIL:" test.txt)
 PASSED_TESTS=$(grep "PASS:" test.txt)
@@ -123,17 +117,11 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   
   comment="I have triggered VCR tests in RECORDING mode for the following tests that failed during VCR: $FAILED_TESTS_PATTERN"
   add_comment "${comment}" "${pr_number}"
-
-  now=$(date +"%T")
-  echo "Pre-recording time: $now"
-
+  
   # RECORDING mode
   export VCR_MODE=RECORDING
   TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run='$FAILED_TESTS_PATTERN -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc" > recording_test.txt
   test_exit_code=$?
-
-  now=$(date +"%T")
-  echo "Post-recording time: $now"
 
   RECORDING_FAILED_TESTS=$(grep "FAIL:" recording_test.txt | awk '{print $3}')
   RECORDING_PASSED_TESTS=$(grep "PASS:" recording_test.txt | awk '{print $3}')
@@ -183,7 +171,5 @@ curl \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
   -d "$post_body"
 
-now=$(date +"%T")
-echo "Current time : $now"
 
 

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -65,9 +65,9 @@ curl \
 set +e
 # cassette retrieval
 mkdir fixtures
-gsutil -m cp gs://vcr-$GOOGLE_PROJECT/beta/fixtures/* fixtures/
+gsutil -m -q cp gs://vcr-$GOOGLE_PROJECT/beta/fixtures/* fixtures/
 # copy branch specific cassettes over master. This might fail but that's ok if the folder doesnt exist
-gsutil -m cp gs://vcr-$GOOGLE_PROJECT/beta/refs/heads/auto-pr-$pr_number/fixtures/* fixtures/
+gsutil -m -q cp gs://vcr-$GOOGLE_PROJECT/beta/refs/heads/auto-pr-$pr_number/fixtures/* fixtures/
 
 echo $SA_KEY > sa_key.json
 gcloud auth activate-service-account $GOOGLE_SERVICE_ACCOUNT --key-file=$local_path/sa_key.json --project=$GOOGLE_PROJECT
@@ -111,13 +111,13 @@ comment+="Failed tests: $FAILED_TESTS_COUNT"
 add_comment "${comment}" "${pr_number}"
 
 # store replaying build logs
-# gsutil -m cp $local_path/testlog/replaying/* gs://replaying/test/log/path/for/each/pr #modify to correct GCS path
+# gsutil -m -q cp $local_path/testlog/replaying/* gs://replaying/test/log/path/for/each/pr #modify to correct GCS path
 
 if [[ -n $FAILED_TESTS_PATTERN ]]; then
   
   comment="I have triggered VCR tests in RECORDING mode for the following tests that failed during VCR: $FAILED_TESTS_PATTERN"
   add_comment "${comment}" "${pr_number}"
-  
+
   # RECORDING mode
   export VCR_MODE=RECORDING
   TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel $ACCTEST_PARALLELISM -v '-run='$FAILED_TESTS_PATTERN -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc" > recording_test.txt
@@ -141,10 +141,10 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   add_comment "${comment}" ${pr_number}
 
   # store cassettes
-  gsutil -m cp fixtures/* gs://vcr-$GOOGLE_PROJECT/beta/refs/heads/auto-pr-$pr_number/fixtures/
+  gsutil -m -q cp fixtures/* gs://vcr-$GOOGLE_PROJECT/beta/refs/heads/auto-pr-$pr_number/fixtures/
 
   # store recording build logs
-  # gsutil -m cp $local_path/testlog/recording/* gs://recording/test/log/path/for/each/pr #modify to correct GCS path
+  # gsutil -m -q cp $local_path/testlog/recording/* gs://recording/test/log/path/for/each/pr #modify to correct GCS path
 
 fi
 

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -138,10 +138,11 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   if [[ -n $RECORDING_FAILED_TESTS ]]; then
     comment+="Tests failed during RECORDING mode:${NEWLINE} $RECORDING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
     comment+="Please fix these to complete your PR${NEWLINE}"
-    comment+="You can view the build log here: https://storage.cloud.google.com/vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/recording_test.log and the debug log for each test here: https://console.cloud.google.com/storage/browser/vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/recording"
   else
-    comment+="All tests passed"
+    comment+="All tests passed${NEWLINE}"
   fi
+
+  comment+="You can view the build log here: https://storage.cloud.google.com/vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/recording_test.log and the debug log for each test here: https://console.cloud.google.com/storage/browser/vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/recording"
 
   # store cassettes
   gsutil -m -q cp fixtures/* gs://vcr-$GOOGLE_PROJECT/beta/refs/heads/auto-pr-$pr_number/fixtures/
@@ -150,12 +151,13 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   gsutil -q cp recording_test.log gs://vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/
 
   # store recording test logs
-  gsutil -m -q cp testlog/recording/* gs://vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/recording/ #modify to correct GCS path
+  gsutil -m -q cp testlog/recording/* gs://vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/recording/ 
 
   add_comment "${comment}" ${pr_number}
 
 else
-  comment="All tests passed in REPLAYING mode"
+  comment="All tests passed in REPLAYING mode${NEWLINE}"
+  comment+="You can view the build log here: https://storage.cloud.google.com/vcr-test-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/replaying_test.log"
   add_comment "${comment}" ${pr_number}
 fi
 
@@ -181,5 +183,3 @@ curl \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
   -d "$post_body"
-
-

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -87,7 +87,7 @@ counter=1
 test_suffix=""
 
 while [[ -n $TESTS_TERMINATED ]]; do
-  if [[ $TESTS_RUN_COUNT -gt 3 ]]; then
+  if [[ $counter -gt 3 ]]; then
     comment="Failed to run VCR tests"
     add_comment "${comment}"
     update_status "failure"

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -3,6 +3,9 @@
 set -e
 pr_number=$1
 mm_commit_sha=$2
+build_id=$3
+project_id=$4
+build_step=$5
 echo "PR number: ${pr_number}"
 echo "Commit SHA: ${mm_commit_sha}"
 github_username=modular-magician
@@ -10,9 +13,89 @@ gh_repo=terraform-provider-google-beta
 
 # For testing only.
 echo "checking if this is the testing PR for vcr setup"
-if [ "$pr_number" == "5703"]; then
+if [ "$pr_number" == "5703" ]; then
   echo "Running tests for new VCR setup"
 else
   echo "Skipping new vcr tests: Not testing PR"
   exit 0
 fi
+
+echo "Keep running for testing PR"
+echo "Project id: ${project_id}"
+
+new_branch="auto-pr-$pr_number"
+git_remote=https://github.com/$github_username/$gh_repo
+local_path=$GOPATH/src/github.com/hashicorp/$gh_repo
+mkdir -p "$(dirname $local_path)"
+git clone $git_remote $local_path --branch $new_branch --depth 2
+pushd $local_path
+
+# # Only skip tests if we can tell for sure that no go files were changed
+# echo "Checking for modified go files"
+# # get the names of changed files and look for go files
+# # (ignoring "no matches found" errors from grep)
+# gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
+# if [[ -z $gofiles ]]; then
+#   echo "Skipping tests: No go files changed"
+#   exit 0
+# else
+#   echo "Running tests: Go files changed"
+# fi
+
+post_body=$( jq -n \
+    --arg context "VCR-test" \
+    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+    --arg state "pending" \
+    '{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+
+# cassette retrieval
+gsutil -m cp gs://vcr-$GOOGLE_PROJECT/beta/fixtures/* /fixtures/
+# # copy branch specific cassettes over master. This might fail but that's ok if the folder doesnt exist
+# gsutil -m cp gs://vcr-$GOOGLE_PROJECT/beta/%BRANCH_NAME%/fixtures/* fixtures/
+# mkdir -p $VCR_PATH
+# cp fixtures $VCR_PATH/../
+# ls $VCR_PATH
+
+export TF_LOG=DEBUG
+export GOOGLE_REGION=us-central1
+export GOOGLE_ZONE=us-central1-a
+export GOOGLE_USE_DEFAULT_CREDENTIALS=TRUE
+export VCR_PATH=/fixtures
+export VCR_MODE=REPLAYING
+
+ls $VCR_PATH
+
+make testacc TEST=./google-beta TESTARGS='-run=TestAccComputeInstanceTemplate_basic'
+
+test_exit_code=$?
+
+if [ $test_exit_code -ne 0 ]; then
+    test_state="failure"
+else
+    test_state="success"
+fi
+
+post_body=$( jq -n \
+    --arg context "VCR-test" \
+    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+    --arg state "${test_state}" \
+    '{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+
+
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This build is running against the testing PR https://github.com/GoogleCloudPlatform/magic-modules/pull/5703

Steps already work successfully:
- retrieve cassette from GCS bucket
- tests running in replaying mode
- detect pass/fail/skip tests
- trigger test in recording mode for failing tests
- store cassette back to GCS bucket (the bucket for each PR, which will later be copied to the main bucket when the PR is merged during `vcr-cassette-merger` step)
- display the result on GH, not the ideal UI though
![Screen Shot 2022-03-10 at 10 01 50 AM](https://user-images.githubusercontent.com/87669292/157726389-9a379e3f-d26e-4178-a84c-2313d39e3013.png)


Issues need to be solved:
- [x] Some tests, such as TestAccConfigLoadValidate_accessTokenImpersonated, still failed due to credentials errors.(`config_test.go:135: invalid test credentials: invalid character '/' looking for beginning of value`). More credential setup needed? (Fixed by adding `GOOGLE_CREDENTIALS`)
- [x] Test build logs are stored in test.log and recording_test.log files for each PR, which probably need to be stored in a GCS bucket for visibility (?)
- [x] The current way of detecting pass/fail/skip test would count the tests more than the actual numbers. In the following example, each sub tests will be counted instead of just one test `TestAccAccessContextManager` being counted. (could potentially be solved by adding `^---` in the match pattern, testing it now. Update: looks like this got fixed by adding `^---` in the front)
```
--- PASS: TestAccAccessContextManager (82.32s)
    --- PASS: TestAccAccessContextManager/access_policy (8.44s)
    --- PASS: TestAccAccessContextManager/service_perimeter (5.43s)
    --- SKIP: TestAccAccessContextManager/service_perimeter_resource (0.00s)
    --- PASS: TestAccAccessContextManager/access_level (8.74s)
    --- PASS: TestAccAccessContextManager/service_perimeters (12.24s)
    --- PASS: TestAccAccessContextManager/service_perimeter_update (19.22s)
    --- PASS: TestAccAccessContextManager/access_level_full (5.30s)
    --- PASS: TestAccAccessContextManager/access_level_custom (5.73s)
    --- PASS: TestAccAccessContextManager/access_levels (12.13s)
    --- PASS: TestAccAccessContextManager/access_level_condition (5.10s)
    --- SKIP: TestAccAccessContextManager/gcp_user_access_binding (0.00s)
```
- [x] Create GCS buckets to store 
  - test log in replaying mode for each PR 
  - test log in recording mode for each PR 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
