### PR TITLE
Added Cloud SQL Server with authorized network example

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -51,6 +51,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_sqlserver_instance_authorized_network"
+        primary_resource_id: "default"
+        vars:
+          myinstance: "myinstance"
+        ignore_read_extra:
+          - "deletion_protection"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -59,6 +59,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           myinstance: "myinstance"
         ignore_read_extra:
           - "deletion_protection"
+          - "root_password"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -53,6 +53,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_sqlserver_instance_authorized_network"
+        primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"
         vars:
           myinstance: "myinstance"

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_authorized_network.tf.erb
@@ -14,5 +14,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
+  deletion_protection = false
 }
 # [END cloud_sql_sqlserver_instance_authorized_network]

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_authorized_network.tf.erb
@@ -1,0 +1,18 @@
+# [START cloud_sql_sqlserver_instance_authorized_network]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['myinstance'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier = "db-custom-2-7680"
+    ip_configuration {
+      authorized_networks {
+        name = "Network Name"
+        value = "192.0.2.0/24"
+        expiration_time = "3021-11-15T16:19:00.094Z"
+      }
+    }
+  }
+}
+# [END cloud_sql_sqlserver_instance_authorized_network]


### PR DESCRIPTION
Added example for inclusion on the following page:

https://cloud.google.com/sql/docs/sqlserver/authorize-networks


```release-note:none
```