### PR TITLE
Added Cloud SQL mysql with authorized network example

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -53,6 +53,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_mysql_instance_authorized_network"
+        primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
         vars:
           mysql_instance_with_authorized_network: "mysql-instance-with-authorized-network"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -55,7 +55,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "sql_mysql_instance_authorized_network"
         primary_resource_id: "instance"
         vars:
-          mysql_instance_with_authorized_network: "mysql-instance-with-authoriz$
+          mysql_instance_with_authorized_network: "mysql-instance-with-authorized-network"
         ignore_read_extra:
           - "deletion_protection"
     # Storage

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -51,6 +51,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_authorized_network"
+        primary_resource_id: "instance"
+        vars:
+          mysql_instance_with_authorized_network: "mysql-instance-with-authoriz$
+        ignore_read_extra:
+          - "deletion_protection"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -57,6 +57,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           mysql_instance_with_authorized_network: "mysql-instance-with-authorized-network"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
     # Storage

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.erb
@@ -1,0 +1,18 @@
+# [START cloud_sql_mysql_instance_authorized_network]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['mysql_instance_with_authorized_network'] %>"
+  region           = "us-central1"
+  database_version = "MYSQL_5_7"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      authorized_networks {
+        name = "Network Name"
+        value = "192.0.2.0/24"
+        expiration_time = "3021-11-15T16:19:00.094Z"
+      }
+    }
+  }
+  deletion_protection  = "false"
+}
+# [END cloud_sql_mysql_instance_authorized_network]

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.erb
@@ -13,6 +13,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
-  deletion_protection  = "false"
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_mysql_instance_authorized_network]


### PR DESCRIPTION
Added example for inclusion on the following page:

https://cloud.google.com/sql/docs/mysql/authorize-networks

```release-note:none
```