### PR TITLE
fix TestAccComputeHaVpnGateway_haVpnGatewayGcpToGcpExample test collision

### DIFF
--- a/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
@@ -24,28 +24,28 @@ resource "google_compute_network" "network2" {
 }
 
 resource "google_compute_subnetwork" "network1_subnet1" {
-  name          = "ha-vpn-subnet-1"
+  name          = "ha-vpn-subnet-1%{random_suffix}"
   ip_cidr_range = "10.0.1.0/24"
   region        = "us-central1"
   network       = google_compute_network.network1.id
 }
 
 resource "google_compute_subnetwork" "network1_subnet2" {
-  name          = "ha-vpn-subnet-2"
+  name          = "ha-vpn-subnet-2%{random_suffix}"
   ip_cidr_range = "10.0.2.0/24"
   region        = "us-west1"
   network       = google_compute_network.network1.id
 }
 
 resource "google_compute_subnetwork" "network2_subnet1" {
-  name          = "ha-vpn-subnet-3"
+  name          = "ha-vpn-subnet-3%{random_suffix}"
   ip_cidr_range = "192.168.1.0/24"
   region        = "us-central1"
   network       = google_compute_network.network2.id
 }
 
 resource "google_compute_subnetwork" "network2_subnet2" {
-  name          = "ha-vpn-subnet-4"
+  name          = "ha-vpn-subnet-4%{random_suffix}"
   ip_cidr_range = "192.168.2.0/24"
   region        = "us-east1"
   network       = google_compute_network.network2.id


### PR DESCRIPTION
ga and beta tests sometimes collide creating the same resource
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
