### PR TITLE
Add keepalive to compute router

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13184,6 +13184,15 @@ objects:
                     description: |
                       User-specified description for the IP range.
                     send_empty_value: true
+          - !ruby/object:Api::Type::Integer
+            name: keepaliveInterval
+            description: |
+              The interval in seconds between BGP keepalive messages that are sent to the peer.
+              Hold time is three times the interval at which keepalive messages are sent, and the hold time is the
+              maximum number of seconds allowed to elapse between successive keepalive messages that BGP receives from a peer.
+              BGP will use the smaller of either the local hold time value or the peer's hold time value as the hold time for
+              the BGP connection between the two peers. If set, this value must be between 20 and 60. The default is 20.
+            default_value: 20
       - !ruby/object:Api::Type::Boolean
         name: encryptedInterconnectRouter
         input: true

--- a/mmv1/third_party/terraform/tests/resource_compute_router_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_test.go
@@ -222,6 +222,7 @@ resource "google_compute_router" "foobar" {
     advertised_ip_ranges {
       range = "6.7.0.0/16"
     }
+    keepalive_interval = 25
   }
 }
 `, routerName, routerName)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/8733

The `enable` flag was already added to bgp_peer



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `keepalive_interval` to `google_compute_router.bgp`
```
