### PR TITLE
Added new examples for Cloud SQL DB backup

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -51,6 +51,23 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_backup"
+        primary_resource_id: "instance"
+        vars:
+          mysql_instance_backup: "mysql-instance-backup"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_postgres_instance_backup"
+        primary_resource_id: "instance"
+        vars:
+          postgres_instance_backup: "postgres-instance-backup"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_sqlserver_instance_backup"
+        primary_resource_id: "default"
+        vars:
+          sqlserver_instance_backup: "sqlserver-instance-backup"
+        # ignore_read_extra:
+        #   - "root_password"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_backup.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_backup.tf.erb
@@ -1,0 +1,22 @@
+# [START cloud_sql_mysql_instance_backup]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['mysql_instance_backup'] %>"
+  region           = "asia-northeast1"
+  database_version = "MYSQL_5_7"
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled                        = true
+      binary_log_enabled             = true
+      start_time                     = "20:55"
+      location                       = null
+      transaction_log_retention_days = null
+      backup_retention_settings {
+        retained_backups               = 365
+        retention_unit                 = "COUNT"
+      }
+    }
+  }
+  deletion_protection  = "false"
+}
+# [END cloud_sql_mysql_instance_backup]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_backup.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_backup.tf.erb
@@ -1,0 +1,25 @@
+provider "google" {
+ credentials = file("CREDENTIALS_FILE.json")
+ project     = "load-balancer-https"
+}
+# [START cloud_sql_postgres_instance_backup]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['postgres_instance_backup'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-7680"
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "20:55"
+      location                       = null
+      transaction_log_retention_days = null
+      backup_retention_settings {
+        retained_backups               = 365
+        retention_unit                 = "COUNT"
+      }
+    }
+  }
+  deletion_protection =  "false"
+}
+# [END cloud_sql_postgres_instance_backup]

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup.tf.erb
@@ -1,0 +1,22 @@
+# [START cloud_sql_sqlserver_instance_backup]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['sqlserver_instance_backup'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier = "db-custom-2-7680"
+    backup_configuration {
+      enabled                        = true
+      binary_log_enabled             = true
+      start_time                     = "20:55"
+      location                       = null
+      transaction_log_retention_days = null
+      backup_retention_settings {
+        retained_backups               = 365
+        retention_unit                 = "COUNT"
+      }
+    }
+  }
+}
+# [START cloud_sql_sqlserver_instance_backup]


### PR DESCRIPTION
Added examples for inclusion on the following pages:

https://cloud.google.com/sql/docs/sqlserver/backup-recovery/backing-up
https://cloud.google.com/sql/docs/postgres/backup-recovery/backing-up
https://cloud.google.com/sql/docs/mysql/backup-recovery/backing-up

```release-note:none
```