### PR TITLE
Add validationConfig attribute to FHIR store (#11201)

### DIFF
--- a/mmv1/products/healthcare/api.yaml
+++ b/mmv1/products/healthcare/api.yaml
@@ -307,7 +307,55 @@ objects:
               project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
               Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
             required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: validationConfig
+        description: |
+          Configuration for how to validate incoming FHIR resources against configured profiles.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: disableProfileValidation
+            description: |
+              Whether to disable profile validation for this FHIR store. Set this to true to disable checking incoming
+              resources for conformance against structure definitions in this FHIR store.
+          - !ruby/object:Api::Type::Boolean
+            name: disableRequiredFieldValidation
+            description: |
+              Whether to disable required fields validation for incoming resources. Set this to true to disable checking
+              incoming resources for conformance against required fields requirement defined in the FHIR specification.
+              This property only affects resource types that do not have profiles configured for them, any rules in enabled
+              implementation guides will still be enforced.
+          - !ruby/object:Api::Type::Boolean
+            name: disableReferenceTypeValidation
+            description: |
+              Whether to disable reference type validation for incoming resources. Set this to true to disable checking
+              incoming resources for conformance against reference type requirement defined in the FHIR specification.
+              This property only affects resource types that do not have profiles configured for them, any rules in enabled
+              implementation guides will still be enforced.
+          - !ruby/object:Api::Type::Boolean
+            name: disableFhirpathValidation
+            description: |
+              Whether to disable FHIRPath validation for incoming resources. Set this to true to disable checking incoming
+              resources for conformance against FHIRPath requirement defined in the FHIR specification. This property only
+              affects resource types that do not have profiles configured for them, any rules in enabled implementation
+              guides will still be enforced.
+          - !ruby/object:Api::Type::Array
+            name: enabledImplementationGuides
+            item_type: Api::Type::String
+            description: |-
+              A list of implementation guide URLs in this FHIR store that are used to configure the profiles to use for
+              validation. For example, to use the US Core profiles for validation, set enabledImplementationGuides to
+              ["http://hl7.org/fhir/us/core/ImplementationGuide/ig"]. If enabledImplementationGuides is empty or omitted,
+              then incoming resources are only required to conform to the base FHIR profiles. Otherwise, a resource must
+              conform to at least one profile listed in the global property of one of the enabled ImplementationGuides.
 
+              The Cloud Healthcare API does not currently enforce all of the rules in a StructureDefinition.
+              The following rules are supported:
+              * min/max
+              * minValue/maxValue
+              * type
+              * fixed[x]
+              * pattern[x] on simple types
+              * slicing, when using "value" as the discriminator type
       - !ruby/object:Api::Type::Time
         name: 'creationTime'
         description: |

--- a/mmv1/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
@@ -12,6 +12,16 @@ resource "google_healthcare_fhir_store" "default" {
     pubsub_topic = google_pubsub_topic.topic.id
   }
 
+  validation_config {
+    disable_profile_validation        = false
+    disable_required_field_validation = false
+    disable_reference_type_validation = false
+    disable_fhirpath_validation       = false
+    enabled_implementation_guides = [
+      "https://some.url/to-an-implementation-guide"
+    ]
+  }
+
   labels = {
     label1 = "labelvalue1"
   }


### PR DESCRIPTION
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: Added `validation_config` in `google_healthcare_fhir_store`
```


Both `make lint` and `make test` returned errors unrelated to the changes I made.
Integration tests failed with errors related to unused imports unrelated to changes I made.