### PR TITLE
Make generation of serialization.go not depend on previous version

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -71,8 +71,9 @@ validator:
 
 serialize:
 	cd tpgtools;\
+		cp -f serialization.go.base serialization.go &&\
 		go run . $(serialize_compile) --mode "serialization" > temp.serial &&\
-		mv -f temp.serial serialization.go;\
+		mv -f temp.serial serialization.go
 
 upgrade-dcl:
 	cd tpgtools && \

--- a/tpgtools/serialization.go.base
+++ b/tpgtools/serialization.go.base
@@ -1,0 +1,17 @@
+package main
+
+import (
+        "fmt"
+)
+
+func DCLToTerraformReference(product DCLPackageName, resource miscellaneousNameSnakeCase, version string) (string, error) {
+        return "", fmt.Errorf("unimplemented - did you run `make serialize`?")
+}
+
+func ConvertSampleJSONToHCL(product DCLPackageName, resource miscellaneousNameSnakeCase, version string, hasGAEquivalent bool, b []byte) (string, error) {
+        return "", fmt.Errorf("unimplemented - did you run `make serialize`?")
+}
+
+func formatHCL(hcl string) (string, error) {
+        return "", fmt.Errorf("unimplemented - did you run `make serialize`?")
+}


### PR DESCRIPTION
`make serialize` builds a new tpgtools binary that includes (but does not make use of) the current version of `serialization.go`. If the current, checked-in version of `serialization.go` conflicts with a newer version of the DCL (because, say, a nested object type name has changed) the build fails. This works around that by building the new version of `serialization.go` by using an empty version to remove any dependencies on prior DCL versions.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
