### PR TITLE
Update EdgeCacheOrigin resources to reflect current API

### DIFF
--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -153,9 +153,9 @@ objects:
         description: |
           A fully qualified domain name (FQDN) or IP address reachable over the public Internet, or the address of a Google Cloud Storage bucket.
 
-          This address will be used as the origin for cache requests - e.g. FQDN: media-backend.example.com IPv4:35.218.1.1 IPv6:[2607:f8b0:4012:809::200e] Cloud Storage: gs://bucketname
+          This address will be used as the origin for cache requests - e.g. FQDN: media-backend.example.com, IPv4: 35.218.1.1, IPv6: 2607:f8b0:4012:809::200e, Cloud Storage: gs://bucketname
 
-          When providing an FQDN (hostname), it must be publicly resolvable (e.g. via Google public DNS) and IP addresses must be publicly routable.
+          When providing an FQDN (hostname), it must be publicly resolvable (e.g. via Google public DNS) and IP addresses must be publicly routable.  It must not contain a protocol (e.g., https://) and it must not contain any slashes.
           If a Cloud Storage bucket is provided, it must be in the canonical "gs://bucketname" format. Other forms, such as "storage.googleapis.com", will be rejected.
       - !ruby/object:Api::Type::Enum
         name: 'protocol' # default http2 from api
@@ -183,8 +183,8 @@ objects:
           The total number of allowed attempts to cache fill across this and failover origins is limited to four.
           The total time allowed for cache fill attempts across this and failover origins can be controlled with maxAttemptsTimeout.
 
-          The last valid response from an origin will be returned to the client.
-          If no origin returns a valid response, an HTTP 503 will be returned to the client.
+          The last valid, non-retried response from all origins will be returned to the client.
+          If no origin returns a valid response, an HTTP 502 will be returned to the client.
 
           Defaults to 1. Must be a value greater than 0 and less than 4.
       - !ruby/object:Api::Type::String
@@ -215,6 +215,7 @@ objects:
           - GATEWAY_ERROR: Similar to 5xx, but only applies to response codes 502, 503 or 504.
           - RETRIABLE_4XX: Retry for retriable 4xx response codes, which include HTTP 409 (Conflict) and HTTP 429 (Too Many Requests)
           - NOT_FOUND: Retry if the origin returns a HTTP 404 (Not Found). This can be useful when generating video content, and the segment is not available yet.
+          - FORBIDDEN: Retry if the origin returns a HTTP 403 (Forbidden).
         item_type: !ruby/object:Api::Type::Enum
           name: 'undefined'
           description: |
@@ -226,6 +227,7 @@ objects:
             - :GATEWAY_ERROR
             - :RETRIABLE_4XX
             - :NOT_FOUND
+            - :FORBIDDEN
       - !ruby/object:Api::Type::NestedObject
         name: 'timeout'
         description: |
@@ -234,33 +236,62 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'connectTimeout'
             description: |
-              The maximum duration to wait for the origin connection to be established, including DNS lookup, TLS handshake and TCP/QUIC connection establishment.
+              The maximum duration to wait for a single origin connection to be established, including DNS lookup, TLS handshake and TCP/QUIC connection establishment.
 
               Defaults to 5 seconds. The timeout must be a value between 1s and 15s.
+
+              The connectTimeout capped by the deadline set by the request's maxAttemptsTimeout.  The last connection attempt may have a smaller connectTimeout in order to adhere to the overall maxAttemptsTimeout.
+
             at_least_one_of:
               - timeout.0.connect_timeout
               - timeout.0.max_attempts_timeout
               - timeout.0.response_timeout
+              - timeout.0.read_timeout
           - !ruby/object:Api::Type::String
             name: 'maxAttemptsTimeout'
             description: |
-              The maximum time across all connection attempts to the origin, including failover origins, before returning an error to the client. A HTTP 503 will be returned if the timeout is reached before a response is returned.
+              The maximum time across all connection attempts to the origin, including failover origins, before returning an error to the client. A HTTP 504 will be returned if the timeout is reached before a response is returned.
 
-              Defaults to 5 seconds. The timeout must be a value between 1s and 15s.
+              Defaults to 15 seconds. The timeout must be a value between 1s and 30s.
+
+              If a failoverOrigin is specified, the maxAttemptsTimeout of the first configured origin sets the deadline for all connection attempts across all failoverOrigins.
             at_least_one_of:
               - timeout.0.connect_timeout
               - timeout.0.max_attempts_timeout
               - timeout.0.response_timeout
+              - timeout.0.read_timeout
           - !ruby/object:Api::Type::String
             name: 'responseTimeout'
             description: |
-              The maximum duration to wait for data to arrive when reading from the HTTP connection/stream.
+              The maximum duration to wait for the last byte of a response to arrive when reading from the HTTP connection/stream.
 
-              Defaults to 5 seconds. The timeout must be a value between 1s and 30s.
+              Defaults to 30 seconds. The timeout must be a value between 1s and 120s.
+
+              The responseTimeout starts after the connection has been established.
+
+              This also applies to HTTP Chunked Transfer Encoding responses, and/or when an open-ended Range request is made to the origin. Origins that take longer to write additional bytes to the response than the configured responseTimeout will result in an error being returned to the client.
+
+              If the response headers have already been written to the connection, the response will be truncated and logged.
             at_least_one_of:
               - timeout.0.connect_timeout
               - timeout.0.max_attempts_timeout
               - timeout.0.response_timeout
+              - timeout.0.read_timeout
+          - !ruby/object:Api::Type::String
+            name: 'readTimeout'
+            description: |
+              The maximum duration to wait between reads of a single HTTP connection/stream.
+
+              Defaults to 15 seconds.  The timeout must be a value between 1s and 30s.
+
+              The readTimeout is capped by the responseTimeout.  All reads of the HTTP connection/stream must be completed by the deadline set by the responseTimeout.
+
+              If the response headers have already been written to the connection, the response will be truncated and logged.
+            at_least_one_of:
+              - timeout.0.connect_timeout
+              - timeout.0.max_attempts_timeout
+              - timeout.0.response_timeout
+              - timeout.0.read_timeout
   - !ruby/object:Api::Resource
     name: 'EdgeCacheService'
     base_url: 'projects/{{project}}/locations/global/edgeCacheServices'

--- a/mmv1/products/networkservices/terraform.yaml
+++ b/mmv1/products/networkservices/terraform.yaml
@@ -58,8 +58,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       retryConditions: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       timeout: !ruby/object:Overrides::Terraform::PropertyOverride
-        # We don't support ignore_read on nested fields
-        ignore_read: true # b/192698242
         custom_flatten: "templates/terraform/custom_flatten/network_services_timeout_mirror.go.erb"
   EdgeCacheService: !ruby/object:Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs #

--- a/mmv1/templates/terraform/custom_flatten/network_services_timeout_mirror.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/network_services_timeout_mirror.go.erb
@@ -13,9 +13,22 @@
 	# limitations under the License.
 -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-	out := make(map[string]interface{})
-	out["connect_timeout"] = d.Get("timeout.0.connect_timeout")
-	out["max_attempts_timeout"] = d.Get("timeout.0.max_attempts_timeout")
-	out["responseTimeout"] = d.Get("timeout.0.responseTimeout")
+	out := make(map[string]string)
+
+	if v == nil {
+		return nil
+	}
+
+	in := v.(map[string]interface{})
+	for _, names := range []struct{ in, out string }{
+		{"connectTimeout", "connect_timeout"},
+		{"maxAttemptsTimeout", "max_attempts_timeout"},
+		{"responseTimeout", "response_timeout"},
+		{"readTimeout", "read_timeout"},
+	} {
+		if e, ok := in[names.in]; ok {
+			out[names.out] = e.(string)
+		}
+	}
 	return []interface{}{out}
 }

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_advanced.tf.erb
@@ -10,12 +10,14 @@ resource "google_network_services_edge_cache_origin" "fallback" {
   retry_conditions = [
     "CONNECT_FAILURE",
     "NOT_FOUND",
-    "HTTP_5XX"
+    "HTTP_5XX",
+    "FORBIDDEN",
   ]
   timeout {
     connect_timeout = "10s"
-    max_attempts_timeout = "10s"
-    response_timeout = "10s"
+    max_attempts_timeout = "20s"
+    response_timeout = "60s"
+    read_timeout = "5s"
   }
 }
 

--- a/mmv1/third_party/terraform/tests/resource_network_services_edge_cache_origin_test.go
+++ b/mmv1/third_party/terraform/tests/resource_network_services_edge_cache_origin_test.go
@@ -22,7 +22,7 @@ func TestAccNetworkServicesEdgeCacheOrigin_updateAndImport(t *testing.T) {
 				ResourceName:            "google_network_services_edge_cache_origin.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "timeout"},
+				ImportStateVerifyIgnore: []string{"name"},
 			},
 			{
 				Config: testAccNetworkServicesEdgeCacheOrigin_update_1(name),
@@ -31,7 +31,7 @@ func TestAccNetworkServicesEdgeCacheOrigin_updateAndImport(t *testing.T) {
 				ResourceName:            "google_network_services_edge_cache_origin.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "timeout"},
+				ImportStateVerifyIgnore: []string{"name"},
 			},
 		},
 	})
@@ -46,6 +46,7 @@ func testAccNetworkServicesEdgeCacheOrigin_update_0(name string) string {
 		labels = {
 			a = "b"
 		}
+		retry_conditions = ["NOT_FOUND"]
 		timeout {
 			connect_timeout = "10s"
 		}
@@ -59,8 +60,12 @@ func testAccNetworkServicesEdgeCacheOrigin_update_1(name string) string {
 		origin_address       = "gs://media-edge-fallback"
 		description          = "The default bucket for media edge test"
 		max_attempts         = 3
+		retry_conditions     = ["FORBIDDEN"]
 		timeout {
 			connect_timeout = "9s"
+			max_attempts_timeout = "14s"
+			response_timeout = "29s"
+			read_timeout = "13s"
 		}
 	}
 `, name)


### PR DESCRIPTION
The google_network_services_edge_cache_origin resource is stale
compared to the current GCP Network Services API.  This commit updates
the resources to keep them in sync.

* Add the missing `FORBIDDEN` retry condition

* Properly read and write the `timeout` property, including the
  previously missing `read_timeout` field.

* Update field documentation to represent the documentation of the
  resource’s REST API.

I tested my changes with:
```
$ make testacc TEST=./google TESTARGS='-run=TestAccNetworkServicesEdgeCacheOrigin'
```

This is part of [hashicorp/terraform-provider-google/#10722](/hashicorp/terraform-provider-google/issues/10722).

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkservices: updated EdgeCacheOrigin to retry_conditions to include `FORBIDDEN`
```
```release-note:enhancement
networkservices: updated EdgeCacheOrigin resource to read and write the `timeout` property, including a new `read_timeout` field.
```
