### PR TITLE
Add disable_http2 to google_network_services_edge_cache_service resource

### DIFF
--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -313,6 +313,14 @@ objects:
         description: |
           HTTP/3 (IETF QUIC) and Google QUIC are enabled by default.
       - !ruby/object:Api::Type::Boolean
+        name: disableHttp2 # default from api
+        description: |
+          Disables HTTP/2.
+
+          HTTP/2 (h2) is enabled by default and recommended for performance. HTTP/2 improves connection re-use and reduces connection setup overhead by sending multiple streams over the same connection.
+
+          Some legacy HTTP clients may have issues with HTTP/2 connections due to broken HTTP/2 implementations. Setting this to true will prevent HTTP/2 from being advertised and negotiated.
+      - !ruby/object:Api::Type::Boolean
         name: requireTls # default from api
         description: |
           Require TLS (HTTPS) for all clients connecting to this service.

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_advanced.tf.erb
@@ -28,6 +28,7 @@ resource "google_network_services_edge_cache_service" "<%= ctx[:primary_resource
   name                 = "<%= ctx[:vars]['service_name'] %>"
   description          = "some description"
   disable_quic         = true
+  disable_http2        = true
   labels = {
     a = "b"
   }


### PR DESCRIPTION
The GCP EdgeCacheService resource now has the ability disable the HTTP/2 protocol.  This commit updates the
`google_network_services_edge_cache_service` resource with an option to disable the HTTP/2 protocol.

I tested this with:
```
make testacc TEST=./google TESTARGS='-run=TestAccNetworkServicesEdgeCacheService_.*AdvancedExample'
```

This is part of [hashicorp/terraform-provider-google/#10722](/hashicorp/terraform-provider-google/issues/10722).

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkservices: added `disable_http2` property to `google_network_services_edge_cache_service` resource
```
