### PR TITLE
Update EdgeCacheService documentation

### DIFF
--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -371,11 +371,23 @@ objects:
                   max_size: 10
                   description: |
                     The list of host patterns to match.
+  
+                    Host patterns must be valid hostnames. Ports are not allowed. Wildcard hosts are supported in the suffix or prefix form. * matches any string of ([a-z0-9-.]*). It does not match the empty string.
+  
+                    When multiple hosts are specified, hosts are matched in the following priority:
+  
+                      1. Exact domain names: ``www.foo.com``.
+                      2. Suffix domain wildcards: ``*.foo.com`` or ``*-bar.foo.com``.
+                      3. Prefix domain wildcards: ``foo.*`` or ``foo-*``.
+                      4. Special wildcard ``*`` matching any domain.
+  
+                      Notes:
+  
+                        The wildcard will not match the empty string. e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``. The longest wildcards match first. Only a single host in the entire service can match on ``*``. A domain must be unique across all configured hosts within a service.
 
-                    Host patterns must be valid hostnames with optional port numbers in the format host:port. * matches any string of ([a-z0-9-.]*).
-                    The only accepted ports are :80 and :443.
-
-                    Hosts are matched against the HTTP Host header, or for HTTP/2 and HTTP/3, the ":authority" header, from the incoming request.
+                        Hosts are matched against the HTTP Host header, or for HTTP/2 and HTTP/3, the ":authority" header, from the incoming request.
+  
+                        You may specify up to 10 hosts.
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::String
                   name: pathMatcher
@@ -623,10 +635,11 @@ objects:
                                   - The TTL must be > 0 and <= 86400s (1 day)
                                   - The clientTtl cannot be larger than the defaultTtl (if set)
                                   - Fractions of a second are not allowed.
-                                  - Omit this field to use the defaultTtl, or the max-age set by the origin, as the client-facing TTL.
+
+                                  Omit this field to use the defaultTtl, or the max-age set by the origin, as the client-facing TTL.
 
                                   When the cache mode is set to "USE_ORIGIN_HEADERS" or "BYPASS_CACHE", you must omit this field.
-                                  A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+                                  A duration in seconds terminated by 's'. Example: "3s".
                               - !ruby/object:Api::Type::String
                                 name: 'defaultTtl' # defalt from api
                                 description: |
@@ -634,7 +647,7 @@ objects:
 
                                   Defaults to 3600s (1 hour).
 
-                                  - The TTL must be >= 0 and <= 2592000s (1 month)
+                                  - The TTL must be >= 0 and <= 31,536,000 seconds (1 year)
                                   - Setting a TTL of "0" means "always revalidate" (equivalent to must-revalidate)
                                   - The value of defaultTTL cannot be set to a value greater than that of maxTTL.
                                   - Fractions of a second are not allowed.
@@ -644,7 +657,7 @@ objects:
 
                                   When the cache mode is set to "USE_ORIGIN_HEADERS" or "BYPASS_CACHE", you must omit this field.
 
-                                  A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+                                  A duration in seconds terminated by 's'. Example: "3s".
                               - !ruby/object:Api::Type::String
                                 name: 'maxTtl' # defalt from api
                                 description: |
@@ -654,13 +667,14 @@ objects:
 
                                   Cache directives that attempt to set a max-age or s-maxage higher than this, or an Expires header more than maxTtl seconds in the future will be capped at the value of maxTTL, as if it were the value of an s-maxage Cache-Control directive.
 
-                                  - The TTL must be >= 0 and <= 2592000s (1 month)
+                                  - The TTL must be >= 0 and <= 31,536,000 seconds (1 year)
                                   - Setting a TTL of "0" means "always revalidate"
                                   - The value of maxTtl must be equal to or greater than defaultTtl.
                                   - Fractions of a second are not allowed.
-                                  - When the cache mode is set to "USE_ORIGIN_HEADERS", "FORCE_CACHE_ALL", or "BYPASS_CACHE", you must omit this field.
 
-                                  A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+                                  When the cache mode is set to "USE_ORIGIN_HEADERS", "FORCE_CACHE_ALL", or "BYPASS_CACHE", you must omit this field.
+
+                                  A duration in seconds terminated by 's'. Example: "3s".
                               - !ruby/object:Api::Type::NestedObject
                                 name: 'cacheKeyPolicy'
                                 description: |
@@ -685,7 +699,7 @@ objects:
                                     description: |
                                       If true, requests to different hosts will be cached separately.
 
-                                      Note: this should only be enabled if hosts share the same origin and content Removing the host from the cache key may inadvertently result in different objects being cached than intended, depending on which route the first user matched.
+                                      Note: this should only be enabled if hosts share the same origin and content. Removing the host from the cache key may inadvertently result in different objects being cached than intended, depending on which route the first user matched.
                                   - !ruby/object:Api::Type::Array
                                     name: includedQueryParameters
                                     description: |


### PR DESCRIPTION
The documenation for the `google_network_services_edge_cache_service` resource is out of date compared to the API’s documentation.

Despite this being a documentation-only change, I tested this with:
```
make testacc TEST=./google TESTARGS='-run=TestAccNetworkServicesEdgeCacheService_.*AdvancedExample'
```

This is part of [hashicorp/terraform-provider-google/#10722](/hashicorp/terraform-provider-google/issues/10722).

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkservices: update edge cache service documentation
```
