### PR TITLE
ACM scoped policies

### DIFF
--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -67,6 +67,13 @@ objects:
         required: true
         description: |
           Human readable title. Does not affect behavior.
+      - !ruby/object:Api::Type::Array
+        name: scopes
+        description: |
+          Folder or project on which this policy is applicable.
+          Format: folders/{{folder_id}} or projects/{{project_id}}
+        item_type: Api::Type::String
+        max_size: 1
     properties:
       - !ruby/object:Api::Type::String
         name: name

--- a/mmv1/products/accesscontextmanager/terraform.yaml
+++ b/mmv1/products/accesscontextmanager/terraform.yaml
@@ -26,11 +26,26 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     skip_sweeper: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      parent_resource_attribute: 'name'
+      allowed_iam_role: 'roles/accesscontextmanager.policyAdmin'
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :POST
+      import_format: ["accessPolicies/{{name}}", "{{name}}"]
+      iam_conditions_request_type: null
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "access_context_manager_access_policy_basic"
         skip_test: true
         primary_resource_id: "access-policy"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "access_context_manager_access_policy_scoped"
+        skip_test: true
+        skip_import_test: true
+        primary_resource_id: "access-policy"
+        test_env_vars:
+          org_id: :ORG_ID
+          project: '"acm-tf-test-" + randString(t, 10)'
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/templates/terraform/examples/access_context_manager_access_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/access_context_manager_access_policy_basic.tf.erb
@@ -1,4 +1,4 @@
 resource "google_access_context_manager_access_policy" "<%= ctx[:primary_resource_id] %>" {
   parent = "organizations/123456789"
-  title  = "my policy"
+  title  = "Org Access Policy"
 }

--- a/mmv1/templates/terraform/examples/access_context_manager_access_policy_scoped.tf.erb
+++ b/mmv1/templates/terraform/examples/access_context_manager_access_policy_scoped.tf.erb
@@ -1,0 +1,11 @@
+resource "google_project" "project" {
+  project_id      = "<%= ctx[:test_env_vars]['project'] || 'acm-test-proj-123' %>"
+  name            = "<%= ctx[:test_env_vars]['project'] || 'acm-test-proj-123' %>"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] || 'organizations/123456789' %>"
+}
+
+resource "google_access_context_manager_access_policy" "<%= ctx[:primary_resource_id] %>" {
+  parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
+  title  = "Scoped Access Policy"
+  scopes = ["projects/${google_project.project.number}"]
+}

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_iam_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_iam_test.go
@@ -1,0 +1,147 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAccessContextManagerAccessPolicyIamBinding(t *testing.T) {
+	skipIfVcr(t)
+
+	org := getTestOrgFromEnv(t)
+	account := "tf-acm-iam-" + randString(t, 10)
+	role := "roles/accesscontextmanager.policyAdmin"
+	policy := createScopedPolicy(t, org)
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Test IAM Binding creation
+				Config: testAccAccessContextManagerAccessPolicyIamBinding_basic(policy, account, role),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_access_context_manager_access_policy_iam_binding.binding", "role", role),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAccessContextManagerAccessPolicyIamMember(t *testing.T) {
+	skipIfVcr(t)
+
+	org := getTestOrgFromEnv(t)
+	account := "tf-acm-iam-" + randString(t, 10)
+	role := "roles/accesscontextmanager.policyAdmin"
+	policy := createScopedPolicy(t, org)
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Test IAM Binding creation
+				Config: testAccAccessContextManagerAccessPolicyIamMember(policy, account, role),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_access_context_manager_access_policy_iam_member.member", "role", role),
+					resource.TestCheckResourceAttr(
+						"google_access_context_manager_access_policy_iam_member.member", "member", "serviceAccount:"+serviceAccountCanonicalEmail(account)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAccessContextManagerAccessPolicyIamPolicy(t *testing.T) {
+	skipIfVcr(t)
+
+	org := getTestOrgFromEnv(t)
+	account := "tf-acm-iam-" + randString(t, 10)
+	role := "roles/accesscontextmanager.policyAdmin"
+	policy := createScopedPolicy(t, org)
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Test IAM Binding creation
+				Config: testAccAccessContextManagerAccessPolicyIamPolicy(policy, account, role),
+			},
+		},
+	})
+}
+
+func testAccAccessContextManagerAccessPolicyIamBinding_basic(policy, account, role string) string {
+	return fmt.Sprintf(policy+`
+resource "google_service_account" "test-account1" {
+  account_id   = "%s-1"
+  display_name = "Access Context Manager IAM Testing Account"
+}
+
+resource google_access_context_manager_access_policy_iam_binding binding {
+	name = google_access_context_manager_access_policy.access-policy.name
+	role = "%s" 
+	members = [
+		"serviceAccount:${google_service_account.test-account1.email}",
+	]
+}
+`, account, role)
+}
+
+func testAccAccessContextManagerAccessPolicyIamMember(policy, account, role string) string {
+	return fmt.Sprintf(policy+`
+resource "google_service_account" "test-account" {
+  account_id   = "%s"
+  display_name = "Access Context Manager IAM Testing Account"
+}
+
+resource google_access_context_manager_access_policy_iam_member member {
+	name = google_access_context_manager_access_policy.access-policy.name
+	role = "%s" 
+    member = "serviceAccount:${google_service_account.test-account.email}"
+}
+
+`, account, role)
+}
+
+func testAccAccessContextManagerAccessPolicyIamPolicy(policy, account, role string) string {
+	return fmt.Sprintf(policy+`
+resource "google_service_account" "test-account" {
+  account_id   = "%s"
+  display_name = "Access Context Manager IAM Testing Account"
+}
+
+data google_iam_policy admin {
+	binding {
+		role = "%s"
+    	members = ["serviceAccount:${google_service_account.test-account.email}"]
+	}
+}
+   
+resource google_access_context_manager_access_policy_iam_policy policy {
+	name = google_access_context_manager_access_policy.access-policy.name
+	policy_data = data.google_iam_policy.admin.policy_data
+}
+
+`, account, role)
+}
+
+func createScopedPolicy(t *testing.T, org string) string {
+	rand := randString(t, 10)
+	return fmt.Sprintf(`
+		resource "google_project" "project" {
+		project_id      = "acm-tf-test-%s"
+		name            = "acm-tf-test-%s"
+		org_id          = "%s"
+		}
+
+		resource "google_access_context_manager_access_policy" "access-policy" {
+			parent = "organizations/%s"
+			title  = "test policy"
+			scopes = ["projects/${google_project.project.number}"]
+		}
+	`, rand, rand, org, org)
+}

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -80,6 +80,7 @@ func testSweepAccessContextManagerPolicies(region string) error {
 func TestAccAccessContextManager(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"access_policy":              testAccAccessContextManagerAccessPolicy_basicTest,
+		"access_policy_scoped":       testAccAccessContextManagerAccessPolicy_scopedTest,
 		"service_perimeter":          testAccAccessContextManagerServicePerimeter_basicTest,
 		"service_perimeter_update":   testAccAccessContextManagerServicePerimeter_updateTest,
 		"service_perimeter_resource": testAccAccessContextManagerServicePerimeterResource_basicTest,
@@ -163,4 +164,35 @@ resource "google_access_context_manager_access_policy" "test-access" {
   title  = "%s"
 }
 `, org, title)
+}
+
+func testAccAccessContextManagerAccessPolicy_scopedTest(t *testing.T) {
+	org := getTestOrgFromEnv(t)
+	project := getTestProjectFromEnv()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAccessContextManagerAccessPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerAccessPolicy_scoped(org, project, "scoped policy"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_access_policy.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAccessContextManagerAccessPolicy_scoped(org, project, title string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+  scopes = ["projects/%s"]
+}
+`, org, title, project)
 }


### PR DESCRIPTION
* Adds support for Access Context Manager (ACM) Scoped Policies (Equivalent in [gcloud](https://cloud.google.com/sdk/gcloud/reference/access-context-manager/policies/create#--scopes))
* Adds support for IAM Policies for ACM Access Policies

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
access context manager: Added support for scoped policies in `google_access_context_manager_access_policy`
```

```release-note:new-resource
`google_access_context_manager_access_policy_iam_policy`
```

```release-note:new-resource
`google_access_context_manager_access_policy_iam_binding`
```

```release-note:new-resource
`google_access_context_manager_access_policy_iam_member`
```