### PR TITLE
Added Cloud SQL postgres + authorized network example

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -52,19 +52,22 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
-<<<<<<< HEAD
         name: "sql_sqlserver_instance_authorized_network"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"
         vars:
           myinstance: "myinstance"
+          sqlserver_instance_with_authorized_network: "sqlserver-instance-with-authorized-network"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
           - "root_password"
-=======
+      - !ruby/object:Provider::Terraform::Examples
         name: "sql_postgres_instance_authorized_network"
         primary_resource_type: "google_sql_database_instance"
-        primary_resource_id: "instance"
+        primary_resource_id: "default"
         vars:
           postgres_instance_with_authorized_network: "postgres-instance-with-authorized-network"
           deletion_protection: "true"
@@ -72,7 +75,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
->>>>>>> 16a6d21d0 (Added Cloud SQL postgres with authorized network example for inclusion in CGC docs)
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -63,6 +63,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "root_password"
 =======
         name: "sql_postgres_instance_authorized_network"
+        primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
         vars:
           postgres_instance_with_authorized_network: "postgres-instance-with-authorized-network"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -52,6 +52,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
+<<<<<<< HEAD
         name: "sql_sqlserver_instance_authorized_network"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"
@@ -60,6 +61,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "deletion_protection"
           - "root_password"
+=======
+        name: "sql_postgres_instance_authorized_network"
+        primary_resource_id: "instance"
+        vars:
+          postgres_instance_with_authorized_network: "postgres-instance-with-authorized-network"
+        ignore_read_extra:
+          - "deletion_protection"
+>>>>>>> 16a6d21d0 (Added Cloud SQL postgres with authorized network example for inclusion in CGC docs)
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -67,6 +67,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           postgres_instance_with_authorized_network: "postgres-instance-with-authorized-network"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
 >>>>>>> 16a6d21d0 (Added Cloud SQL postgres with authorized network example for inclusion in CGC docs)

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_authorized_network.tf.erb
@@ -13,6 +13,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
-  deletion_protection =  "false"
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_postgres_instance_authorized_network]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_authorized_network.tf.erb
@@ -1,0 +1,18 @@
+# [START cloud_sql_postgres_instance_authorized_network]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['postgres_instance_with_authorized_network'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-7680"
+    ip_configuration {
+      authorized_networks {
+        name = "Network Name"
+        value = "192.0.2.0/24"
+        expiration_time = "3021-11-15T16:19:00.094Z"
+      }
+    }
+  }
+  deletion_protection =  "false"
+}
+# [END cloud_sql_postgres_instance_authorized_network]


### PR DESCRIPTION
Added example for inclusion on the following pages:

https://cloud.google.com/sql/docs/postgres/authorize-networks

```release-note:none
```