### PR TITLE
Added examples for Cloud SQL backup retention

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -94,6 +94,40 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "deletion_protection"
           - "root_password"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_backup_retention"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "instance"
+        vars:
+          mysql_instance_backup: "mysql-instance-backup"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_postgres_instance_backup_retention"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "instance"
+        vars:
+          postgres_instance_backup: "postgres-instance-backup"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_sqlserver_instance_backup_retention"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          sqlserver_instance_backup: "sqlserver-instance-backup"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "root_password"
+          - "deletion_protection"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_backup_retention.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_backup_retention.tf.erb
@@ -1,0 +1,18 @@
+# [START cloud_sql_mysql_instance_backup_retention]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['mysql_instance_backup'] %>"
+  region           = "asia-northeast1"
+  database_version = "MYSQL_5_7"
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled                        = true
+      backup_retention_settings {
+        retained_backups               = 365
+        retention_unit                 = "COUNT"
+      }
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [START cloud_sql_mysql_instance_backup_retention]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_backup_retention.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_backup_retention.tf.erb
@@ -1,0 +1,18 @@
+# [START cloud_sql_postgres_instance_backup_retention]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['postgres_instance_backup'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-7680"
+    backup_configuration {
+      enabled                        = true
+      backup_retention_settings {
+        retained_backups               = 365
+        retention_unit                 = "COUNT"
+      }
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [START cloud_sql_postgres_instance_backup_retention]

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_retention.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_retention.tf.erb
@@ -1,0 +1,19 @@
+# [START cloud_sql_sqlserver_instance_backup_retention]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['sqlserver_instance_backup_config'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier = "db-custom-2-7680"
+    backup_configuration {
+      enabled                        = true
+      backup_retention_settings {
+        retained_backups               = 365
+        retention_unit                 = "COUNT"
+      }
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [START cloud_sql_sqlserver_instance_backup_retention]


### PR DESCRIPTION
Planning to add these samples to this section:

https://cloud.google.com/sql/docs/sqlserver/backup-recovery/backing-up#locationbackups#set-retention
https://cloud.google.com/sql/docs/mysql/backup-recovery/backing-up#locationbackups#set-retention
https://cloud.google.com/sql/docs/postgres/backup-recovery/backing-up#locationbackups#set-retention

```release-note:none
```