### PR TITLE
Add dialect to spanner database

### DIFF
--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -209,3 +209,16 @@ objects:
             description: |
               Fully qualified name of the KMS key to use to encrypt this database. This key must exist
               in the same location as the Spanner Database.
+      - !ruby/object:Api::Type::Enum
+        name: 'databaseDialect'
+        description: |
+          The dialect of the Cloud Spanner Database.
+          If it is not provided, "DATABASE_DIALECT_UNSPECIFIED" will be used, 
+          which will create a Google Standard SQL database.
+          Note: Databases that are created with POSTGRESQL dialect do not support 
+          extra DDL statements in the `CreateDatabase` call. We must therefore re-apply 
+          terraform with ddl on the same database after creation.
+        values:
+          - :DATABASE_DIALECT_UNSPECIFIED
+          - :GOOGLE_STANDARD_SQL
+          - :POSTGRESQL

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -213,12 +213,10 @@ objects:
         name: 'databaseDialect'
         description: |
           The dialect of the Cloud Spanner Database.
-          If it is not provided, "DATABASE_DIALECT_UNSPECIFIED" will be used, 
-          which will create a Google Standard SQL database.
+          If it is not provided, "GOOGLE_STANDARD_SQL" will be used. 
           Note: Databases that are created with POSTGRESQL dialect do not support 
-          extra DDL statements in the `CreateDatabase` call. We must therefore re-apply 
+          extra DDL statements in the `CreateDatabase` call. You must therefore re-apply 
           terraform with ddl on the same database after creation.
         values:
-          - :DATABASE_DIALECT_UNSPECIFIED
           - :GOOGLE_STANDARD_SQL
           - :POSTGRESQL

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -63,6 +63,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
       state: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: false
+      databaseDialect: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: 'templates/terraform/constants/spanner_database.go.erb'
       encoder: templates/terraform/encoders/spanner_database.go.erb

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -33,7 +33,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         for more information on lifecycle parameters.
         
         Note: Databases that are created with POSTGRESQL dialect do not support 
-        extra DDL statements in the `CreateDatabase` call. We must therefore re-apply 
+        extra DDL statements in the `CreateDatabase` call. You must therefore re-apply 
         terraform with ddl on the same database after creation.
 
     examples:

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -31,6 +31,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         On older versions, it is strongly recommended to set `lifecycle { prevent_destroy = true }`
         on databases in order to prevent accidental data loss. See [Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
         for more information on lifecycle parameters.
+        
+        Note: Databases that are created with POSTGRESQL dialect do not support 
+        extra DDL statements in the `CreateDatabase` call. We must therefore re-apply 
+        terraform with ddl on the same database after creation.
+
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_database_basic"

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -1,4 +1,7 @@
 obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
+if dialect, ok := obj["databaseDialect"]; ok && dialect == "POSTGRESQL" {
+    obj["createStatement"] = fmt.Sprintf("CREATE DATABASE %s", obj["name"])
+}
 delete(obj, "name")
 delete(obj, "instance")
 return obj, nil

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -95,6 +95,7 @@ resource "google_spanner_database" "basic" {
 resource "google_spanner_database" "basic" {
 	instance = google_spanner_instance.basic.name
 	name     = "%s_spangres"
+	database_dialect = "POSTGRESQL"
 	deletion_protection = false
 }
 `, instanceName, instanceName, databaseName, databaseName)
@@ -124,6 +125,7 @@ resource "google_spanner_database" "basic" {
 resource "google_spanner_database" "basic" {
 	instance = google_spanner_instance.basic.name
 	name     = "%s_spangres"
+	database_dialect = "POSTGRESQL"
 	ddl = [
 	"CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
 	"CREATE TABLE t2 (t2 bigint NOT NULL PRIMARY KEY)",

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -117,7 +117,7 @@ resource "google_spanner_database" "basic" {
 `, instanceName, instanceName, databaseName)
 }
 
-func TestAccSpannerPGDatabase_basic(t *testing.T) {
+func TestAccSpannerDatabase_postgres(t *testing.T) {
 	t.Parallel()
 
 	project := getTestProjectFromEnv()
@@ -131,7 +131,7 @@ func TestAccSpannerPGDatabase_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSpannerDatabaseDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpannerPGDatabase_basic(instanceName, databaseName),
+				Config: testAccSpannerDatabase_postgres(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_database.basic_spangres", "state"),
 				),
@@ -144,7 +144,7 @@ func TestAccSpannerPGDatabase_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
 			},
 			{
-				Config: testAccSpannerPGDatabase_basicUpdate(instanceName, databaseName),
+				Config: testAccSpannerDatabase_postgresUpdate(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_database.basic_spangres", "state"),
 				),
@@ -152,27 +152,6 @@ func TestAccSpannerPGDatabase_basic(t *testing.T) {
 			{
 				// Test import with default Terraform ID
 				ResourceName:            "google_spanner_database.basic_spangres",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
-			},
-			{
-				ResourceName:            "google_spanner_database.basic_spangres",
-				ImportStateId:           fmt.Sprintf("projects/%s/instances/%s/databases/%s_spangres", project, instanceName, databaseName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
-			},
-			{
-				ResourceName:            "google_spanner_database.basic_spangres",
-				ImportStateId:           fmt.Sprintf("instances/%s/databases/%s_spangres", instanceName, databaseName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
-			},
-			{
-				ResourceName:            "google_spanner_database.basic_spangres",
-				ImportStateId:           fmt.Sprintf("%s/%s_spangres", instanceName, databaseName),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
@@ -181,7 +160,7 @@ func TestAccSpannerPGDatabase_basic(t *testing.T) {
 	})
 }
 
-func testAccSpannerPGDatabase_basic(instanceName, databaseName string) string {
+func testAccSpannerDatabase_postgres(instanceName, databaseName string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {
   name         = "%s"
@@ -199,7 +178,7 @@ resource "google_spanner_database" "basic_spangres" {
 `, instanceName, instanceName, databaseName)
 }
 
-func testAccSpannerPGDatabase_basicUpdate(instanceName, databaseName string) string {
+func testAccSpannerDatabase_postgresUpdate(instanceName, databaseName string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {
   name         = "%s"

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -133,7 +133,7 @@ func TestAccSpannerPGDatabase_basic(t *testing.T) {
 			{
 				Config: testAccSpannerPGDatabase_basic(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic_spangres", "state"),
 				),
 			},
 			{
@@ -146,7 +146,7 @@ func TestAccSpannerPGDatabase_basic(t *testing.T) {
 			{
 				Config: testAccSpannerPGDatabase_basicUpdate(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic_spangres", "state"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -120,7 +120,6 @@ resource "google_spanner_database" "basic" {
 func TestAccSpannerDatabase_postgres(t *testing.T) {
 	t.Parallel()
 
-	project := getTestProjectFromEnv()
 	rnd := randString(t, 10)
 	instanceName := fmt.Sprintf("tf-test-%s", rnd)
 	databaseName := fmt.Sprintf("tfgen_%s", rnd)

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -36,12 +36,6 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
 			},
 			{
-				ResourceName:            "google_spanner_database.basic_spangres",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
-			},
-			{
 				Config: testAccSpannerDatabase_basicUpdate(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
@@ -75,7 +69,88 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
 			},
+		},
+	})
+}
+
+func testAccSpannerDatabase_basic(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  ddl = [
+	"CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+	"CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName)
+}
+
+func testAccSpannerDatabase_basicUpdate(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  ddl = [
+	"CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+	"CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
+	"CREATE TABLE t3 (t3 INT64 NOT NULL,) PRIMARY KEY(t3)",
+	"CREATE TABLE t4 (t4 INT64 NOT NULL,) PRIMARY KEY(t4)",
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName)
+}
+
+func TestAccSpannerPGDatabase_basic(t *testing.T) {
+	t.Parallel()
+
+	project := getTestProjectFromEnv()
+	rnd := randString(t, 10)
+	instanceName := fmt.Sprintf("tf-test-%s", rnd)
+	databaseName := fmt.Sprintf("tfgen_%s", rnd)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpannerDatabaseDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
+				Config: testAccSpannerPGDatabase_basic(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+				),
+			},
+			{
+				// Test import with default Terraform ID
+				ResourceName:            "google_spanner_database.basic_spangres",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
+			},
+			{
+				Config: testAccSpannerPGDatabase_basicUpdate(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+				),
+			},
+			{
+				// Test import with default Terraform ID
 				ResourceName:            "google_spanner_database.basic_spangres",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -106,7 +181,7 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 	})
 }
 
-func testAccSpannerDatabase_basic(instanceName, databaseName string) string {
+func testAccSpannerPGDatabase_basic(instanceName, databaseName string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {
   name         = "%s"
@@ -115,26 +190,16 @@ resource "google_spanner_instance" "basic" {
   num_nodes    = 1
 }
 
-resource "google_spanner_database" "basic" {
+resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
-  name     = "%s"
-  ddl = [
-	"CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
-	"CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
-  ]
+  name     = "%s_spangres"
+  database_dialect = "POSTGRESQL"
   deletion_protection = false
 }
-
-resource "google_spanner_database" "basic_spangres" {
-	instance = google_spanner_instance.basic.name
-	name     = "%s_spangres"
-	database_dialect = "POSTGRESQL"
-	deletion_protection = false
-}
-`, instanceName, instanceName, databaseName, databaseName)
+`, instanceName, instanceName, databaseName)
 }
 
-func testAccSpannerDatabase_basicUpdate(instanceName, databaseName string) string {
+func testAccSpannerPGDatabase_basicUpdate(instanceName, databaseName string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {
   name         = "%s"
@@ -143,31 +208,19 @@ resource "google_spanner_instance" "basic" {
   num_nodes    = 1
 }
 
-resource "google_spanner_database" "basic" {
+resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
-  name     = "%s"
+  name     = "%s_spangres"
+  database_dialect = "POSTGRESQL"
   ddl = [
-	"CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
-	"CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
-	"CREATE TABLE t3 (t3 INT64 NOT NULL,) PRIMARY KEY(t3)",
-	"CREATE TABLE t4 (t4 INT64 NOT NULL,) PRIMARY KEY(t4)",
+     "CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
+     "CREATE TABLE t2 (t2 bigint NOT NULL PRIMARY KEY)",
+     "CREATE TABLE t3 (t3 bigint NOT NULL PRIMARY KEY)",
+     "CREATE TABLE t4 (t4 bigint NOT NULL PRIMARY KEY)",
   ]
   deletion_protection = false
 }
-
-resource "google_spanner_database" "basic_spangres" {
-	instance = google_spanner_instance.basic.name
-	name     = "%s_spangres"
-	database_dialect = "POSTGRESQL"
-	ddl = [
-	"CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
-	"CREATE TABLE t2 (t2 bigint NOT NULL PRIMARY KEY)",
-	"CREATE TABLE t3 (t3 bigint NOT NULL PRIMARY KEY)",
-	"CREATE TABLE t4 (t4 bigint NOT NULL PRIMARY KEY)",
-	]
-	deletion_protection = false
-}
-`, instanceName, instanceName, databaseName, databaseName)
+`, instanceName, instanceName, databaseName)
 }
 
 // Unit Tests for type spannerDatabaseId

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -91,7 +91,13 @@ resource "google_spanner_database" "basic" {
   ]
   deletion_protection = false
 }
-`, instanceName, instanceName, databaseName)
+
+resource "google_spanner_database" "basic" {
+	instance = google_spanner_instance.basic.name
+	name     = "%s_spangres"
+	deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName)
 }
 
 func testAccSpannerDatabase_basicUpdate(instanceName, databaseName string) string {
@@ -114,7 +120,19 @@ resource "google_spanner_database" "basic" {
   ]
   deletion_protection = false
 }
-`, instanceName, instanceName, databaseName)
+
+resource "google_spanner_database" "basic" {
+	instance = google_spanner_instance.basic.name
+	name     = "%s_spangres"
+	ddl = [
+	"CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
+	"CREATE TABLE t2 (t2 bigint NOT NULL PRIMARY KEY)",
+	"CREATE TABLE t3 (t3 bigint NOT NULL PRIMARY KEY)",
+	"CREATE TABLE t4 (t4 bigint NOT NULL PRIMARY KEY)",
+	]
+	deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName)
 }
 
 // Unit Tests for type spannerDatabaseId

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -36,6 +36,12 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
 			},
 			{
+				ResourceName:            "google_spanner_database.basic_spangres",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
+			},
+			{
 				Config: testAccSpannerDatabase_basicUpdate(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
@@ -69,6 +75,33 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
 			},
+			{
+				ResourceName:            "google_spanner_database.basic_spangres",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
+			},
+			{
+				ResourceName:            "google_spanner_database.basic_spangres",
+				ImportStateId:           fmt.Sprintf("projects/%s/instances/%s/databases/%s_spangres", project, instanceName, databaseName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
+			},
+			{
+				ResourceName:            "google_spanner_database.basic_spangres",
+				ImportStateId:           fmt.Sprintf("instances/%s/databases/%s_spangres", instanceName, databaseName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
+			},
+			{
+				ResourceName:            "google_spanner_database.basic_spangres",
+				ImportStateId:           fmt.Sprintf("%s/%s_spangres", instanceName, databaseName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ddl", "deletion_protection"},
+			},
 		},
 	})
 }
@@ -92,7 +125,7 @@ resource "google_spanner_database" "basic" {
   deletion_protection = false
 }
 
-resource "google_spanner_database" "basic" {
+resource "google_spanner_database" "basic_spangres" {
 	instance = google_spanner_instance.basic.name
 	name     = "%s_spangres"
 	database_dialect = "POSTGRESQL"
@@ -122,7 +155,7 @@ resource "google_spanner_database" "basic" {
   deletion_protection = false
 }
 
-resource "google_spanner_database" "basic" {
+resource "google_spanner_database" "basic_spangres" {
 	instance = google_spanner_instance.basic.name
 	name     = "%s_spangres"
 	database_dialect = "POSTGRESQL"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for setting database_dialect on google_spanner_database
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
spanner: added support for setting database_dialect on `google_spanner_database`
```
