### PR TITLE
Add gc_rules to BigTable's Garbage Collection policy TF resource.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -93,7 +93,6 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Optional:      true,
 				Description:   `Serialized JSON string for garbage collection policy. Conflicts with "mode", "max_age" and "max_version".`,
 				ValidateFunc:  validation.StringIsJSON,
-				ForceNew:      false,
 				ConflictsWith: []string{"mode", "max_age", "max_version"},
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -91,7 +91,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 			"gc_rules": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed: 		true,
+				Computed:     true,
 				Description:  `Serialized JSON string for garbage collection policy. Conflicts with "mode", "max_age" and "max_version".`,
 				ValidateFunc: validation.StringIsJSON,
 				StateFunc: func(v interface{}) string {
@@ -110,11 +110,11 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				},
 			},
 			"mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Description:  `If multiple policies are set, you should choose between UNION OR INTERSECTION.`,
-				ValidateFunc: validation.StringInSlice([]string{GCPolicyModeIntersection, GCPolicyModeUnion}, false),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Description:   `If multiple policies are set, you should choose between UNION OR INTERSECTION.`,
+				ValidateFunc:  validation.StringInSlice([]string{GCPolicyModeIntersection, GCPolicyModeUnion}, false),
 				ConflictsWith: []string{"gc_rules"},
 			},
 

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -103,14 +103,8 @@ func resourceBigtableGCPolicy() *schema.Resource {
 					var oldJSON map[string]interface{}
 					var newJSON map[string]interface{}
 
-					err := json.Unmarshal([]byte(old), &oldJSON)
-					if err != nil {
-						return true
-					}
-					err = json.Unmarshal([]byte(new), &newJSON)
-					if err != nil {
-						return true
-					}
+					_ = json.Unmarshal([]byte(old), &oldJSON)
+					_ = json.Unmarshal([]byte(new), &newJSON)
 
 					return reflect.DeepEqual(oldJSON, newJSON)
 				},
@@ -337,12 +331,11 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 	}
 
 	if gok {
-		var parsedRules map[string]interface{}
-		err := json.Unmarshal([]byte(gcRules.(string)), &parsedRules)
-		if err != nil {
+		var p map[string]interface{}
+		if err := json.Unmarshal([]byte(gcRules.(string)), &p); err != nil {
 			return nil, err
 		}
-		return getGCPolicyFromJSON(parsedRules)
+		return getGCPolicyFromJSON(p)
 	}
 
 	if aok {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -362,7 +362,7 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 func getGCPolicyFromJSON(p map[string]interface{}) (bigtable.GCPolicy, error) {
 	policies := []bigtable.GCPolicy{}
 	if p["rules"] == nil {
-		return bigtable.NoGcPolicy(), nil
+		return nil, nil
 	}
 
 	for _, raw := range p["rules"].([]interface{}) {
@@ -386,7 +386,9 @@ func getGCPolicyFromJSON(p map[string]interface{}) (bigtable.GCPolicy, error) {
 			if err != nil {
 				return nil, err
 			}
-			policies = append(policies, n)
+			if n != nil {
+				policies = append(policies, n)
+			}
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -331,11 +331,11 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 	}
 
 	if gok {
-		var p map[string]interface{}
-		if err := json.Unmarshal([]byte(gcRules.(string)), &p); err != nil {
+		var j map[string]interface{}
+		if err := json.Unmarshal([]byte(gcRules.(string)), &j); err != nil {
 			return nil, err
 		}
-		return getGCPolicyFromJSON(p)
+		return getGCPolicyFromJSON(j)
 	}
 
 	if aok {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -93,6 +93,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Optional:      true,
 				Description:   `Serialized JSON string for garbage collection policy. Conflicts with "mode", "max_age" and "max_version".`,
 				ValidateFunc:  validation.StringIsJSON,
+				ForceNew:      false,
 				ConflictsWith: []string{"mode", "max_age", "max_version"},
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
@@ -358,7 +359,7 @@ func getGCPolicyFromJSON(p map[string]interface{}) (bigtable.GCPolicy, error) {
 	}
 
 	if p["mode"] == nil && len(p["rules"].([]interface{})) != 1 {
-		return nil, fmt.Errorf("`rules` needs only 1 member if `mode` is not specified")
+		return nil, fmt.Errorf("`rules` needs exactly 1 member if `mode` is not specified")
 	}
 
 	if p["mode"] != nil && len(p["rules"].([]interface{})) < 2 {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -371,7 +371,7 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 func getGCPolicyFromJSON(p map[string]interface{}) (bigtable.GCPolicy, error) {
 	policies := []bigtable.GCPolicy{}
 	if p["rules"] == nil {
-		return nil, nil
+		return bigtable.NoGcPolicy(), nil
 	}
 
 	for _, raw := range p["rules"].([]interface{}) {
@@ -390,12 +390,13 @@ func getGCPolicyFromJSON(p map[string]interface{}) (bigtable.GCPolicy, error) {
 			policies = append(policies, bigtable.MaxVersionsPolicy(int(version)))
 		}
 
-		if r["mode"] != "" {
+		if r["mode"] != nil {
 			n, err := getGCPolicyFromJSON(r)
 			if err != nil {
 				return nil, err
 			}
-			if n != nil {
+			// Don't combine NoGcPolicy with other types of policy
+			if n != nil && n != bigtable.NoGcPolicy() {
 				policies = append(policies, n)
 			}
 		}

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -103,8 +103,14 @@ func resourceBigtableGCPolicy() *schema.Resource {
 					var oldJSON map[string]interface{}
 					var newJSON map[string]interface{}
 
-					json.Unmarshal([]byte(old), &oldJSON)
-					json.Unmarshal([]byte(new), &newJSON)
+					err := json.Unmarshal([]byte(old), &oldJSON)
+					if err != nil {
+						return true
+					}
+					err = json.Unmarshal([]byte(new), &newJSON)
+					if err != nil {
+						return true
+					}
 
 					return reflect.DeepEqual(oldJSON, newJSON)
 				},
@@ -328,7 +334,10 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 
 	if gcRules != "" {
 		var parsedRules map[string]interface{}
-		json.Unmarshal([]byte(gcRules), &parsedRules)
+		err := json.Unmarshal([]byte(gcRules), &parsedRules)
+		if err != nil {
+			return nil, err
+		}
 		return getGCPolicyFromJSON(parsedRules)
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -125,9 +125,9 @@ func TestAccBigtableGCPolicy_gcRulesPolicy(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()
 
-	instanceName := fmt.Sprintf("tf-instance-%s", randString(t, 10))
-	tableName := fmt.Sprintf("tf-table-%s", randString(t, 10))
-	familyName := fmt.Sprintf("tf-family-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	tableName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	familyName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 
 	gcRulesOriginal := "{\"mode\":\"intersection\",\"rules\":[{\"max_age\":\"10h\"},{\"max_version\":2}]}"
 	gcRulesUpdate := "{\"mode\":\"intersection\",\"rules\":[{\"max_age\":\"16h\"},{\"max_version\":1}]}"
@@ -256,6 +256,11 @@ var testUnitBigtableGCPolicyRulesTestCases = []testUnitBigtableGCPolicyJSONRules
 	{
 		name:          "Invalid GC rule field: more than 2 fields in a gc rule object",
 		gcJSONString:  `{"mode": "union", "rules": [{"max_age": "10h", "max_version": 10, "something": 100}]}`,
+		errorExpected: true,
+	},
+	{
+		name:          "Invalid GC rule field: max_version or max_age is in the wrong type",
+		gcJSONString:  `{"mode": "union", "rules": [{"max_age": "10d", "max_version": 2}]}`,
 		errorExpected: true,
 	},
 	{

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -129,10 +129,10 @@ func TestAccBigtableGCPolicy_gcRulesPolicy(t *testing.T) {
 	familyName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBigtableGCPolicyDestroyProducer(t),
-		Steps: []resource.TestStep {
+		Steps: []resource.TestStep{
 			{
 				Config: testAccBigtableGCPolicy_gcRules(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -175,47 +175,47 @@ func (testcase *testUnitBigtableGCPolicyCustomizeDiffTestcase) check(t *testing.
 }
 
 type testUnitBigtableGCPolicyJSONRules struct {
-	name string
-	gcJSONString string
-	want string
+	name          string
+	gcJSONString  string
+	want          string
 	errorExpected bool
 }
 
 var testUnitBigtableGCPolicyRulesTestCases = []testUnitBigtableGCPolicyJSONRules{
 	{
-		name: "Simple policy",
-		gcJSONString: "{\"rules\":[{\"max_age\":\"10h\"}]}",
-		want: "age() > 10h",
+		name:          "Simple policy",
+		gcJSONString:  "{\"rules\":[{\"max_age\":\"10h\"}]}",
+		want:          "age() > 10h",
 		errorExpected: false,
 	},
 	{
-		name: "Simple multiple policies",
-		gcJSONString: "{\"mode\":\"union\", \"rules\":[{\"max_age\":\"10h\"},{\"max_version\":2}]}",
-		want: "(age() > 10h || versions() > 2)",
+		name:          "Simple multiple policies",
+		gcJSONString:  "{\"mode\":\"union\", \"rules\":[{\"max_age\":\"10h\"},{\"max_version\":2}]}",
+		want:          "(age() > 10h || versions() > 2)",
 		errorExpected: false,
 	},
 	{
-		name: "Nested policy",
-		gcJSONString: "{\"mode\":\"union\", \"rules\":[{\"max_age\":\"10h\"},{\"mode\": \"intersection\", \"rules\":[{\"max_age\":\"2h\"}, {\"max_version\":2}]}]}",
-		want: "(age() > 10h || (age() > 2h && versions() > 2))",
+		name:          "Nested policy",
+		gcJSONString:  "{\"mode\":\"union\", \"rules\":[{\"max_age\":\"10h\"},{\"mode\": \"intersection\", \"rules\":[{\"max_age\":\"2h\"}, {\"max_version\":2}]}]}",
+		want:          "(age() > 10h || (age() > 2h && versions() > 2))",
 		errorExpected: false,
 	},
 	{
-		name: "JSON with no `rules`",
-		gcJSONString: "{\"mode\": \"union\"}",
-		want: "",
+		name:          "JSON with no `rules`",
+		gcJSONString:  "{\"mode\": \"union\"}",
+		want:          "",
 		errorExpected: false,
 	},
 	{
-		name: "empty JSON",
-		gcJSONString: "{}",
-		want: "",
+		name:          "empty JSON",
+		gcJSONString:  "{}",
+		want:          "",
 		errorExpected: false,
 	},
 	{
-		name: "Invalid duration string",
+		name:          "Invalid duration string",
 		errorExpected: true,
-		gcJSONString: "{\"mode\":\"union\",\"rules\":[{\"max_age\":\"12o\"},{\"max_version\":2}]}",
+		gcJSONString:  "{\"mode\":\"union\",\"rules\":[{\"max_age\":\"12o\"},{\"max_version\":2}]}",
 	},
 }
 
@@ -230,7 +230,7 @@ func TestUnitBigtableGCPolicy_getGCPolicyFromJSON(t *testing.T) {
 			got, err := getGCPolicyFromJSON(j)
 			if tc.errorExpected && err == nil {
 				t.Fatal("expect error, got nil")
-			} else if !tc.errorExpected && err != nil{
+			} else if !tc.errorExpected && err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			} else {
 				if got != nil && got.String() != tc.want {

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -238,6 +238,31 @@ var testUnitBigtableGCPolicyRulesTestCases = []testUnitBigtableGCPolicyJSONRules
 		gcJSONString:  `{"mode":"union", "rules":[{"max_version":2}]}`,
 		errorExpected: true,
 	},
+	{
+		name:          "Invalid GC rule object",
+		gcJSONString:  `{"mode": "union", "rules": [{"mode": "intersection"}]}`,
+		errorExpected: true,
+	},
+	{
+		name:          "Invalid GC rule field: not max_version or max_age",
+		gcJSONString:  `{"mode": "union", "rules": [{"max_versions": 2}]}`,
+		errorExpected: true,
+	},
+	{
+		name:          "Invalid GC rule field: additional fields",
+		gcJSONString:  `{"mode": "union", "rules": [{"max_age": "10h", "something_else": 100}]}`,
+		errorExpected: true,
+	},
+	{
+		name:          "Invalid GC rule field: more than 2 fields in a gc rule object",
+		gcJSONString:  `{"mode": "union", "rules": [{"max_age": "10h", "max_version": 10, "something": 100}]}`,
+		errorExpected: true,
+	},
+	{
+		name:          "Invalid GC rule: wrong data type for child gc_rule",
+		gcJSONString:  `{"rules": {"max_version": "456"}}`,
+		errorExpected: true,
+	},
 }
 
 func TestUnitBigtableGCPolicy_getGCPolicyFromJSON(t *testing.T) {

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -489,7 +489,7 @@ func testAccBigtableGCPolicy_gcRules(instanceName, tableName, family string) str
 		table         = google_bigtable_table.table.name
 		column_family = "%s"
 
-		gc_rules = "{"mode":"intersection", "rules":[{"max_age":"10h"},{"max_version":2}]}"
+		gc_rules = "{\"mode\":\"intersection\", \"rules\":[{\"max_age\":\"10h\"},{\"max_version\":2}]}"
 	}
 `, instanceName, instanceName, tableName, family, family)
 }

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -107,10 +107,10 @@ resource "google_bigtable_gc_policy" "policy" {
       "mode": "intersection",
       "rules": [
         {
-          "max_age": "2d"
+          "max_age": "2h"
         },
         {
-          "max_version": "2"
+          "max_version": 2
         }
       ]
     }

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 * `max_version` - (Optional) GC policy that applies to all versions of a cell except for the most recent.
 
-* `gc_rules` - (Optional) Serialized JSON object to represent a more complex GC policy. Conflicts with `mode`, `max_age` and `max_version`.
+* `gc_rules` - (Optional) Serialized JSON object to represent a more complex GC policy. Conflicts with `mode`, `max_age` and `max_version`. Conflicts with `mode`, `max_age` and `max_version`.
 
 -----
 
@@ -158,6 +158,12 @@ The following arguments are supported:
 `max_version` supports the following arguments:
 
 * `number` - (Required) Number of version before applying the GC policy.
+
+-----
+`gc_rules` include 2 fields:
+- `mode`: optional, either `intersection` or `union`.
+- `rules`: an array of GC policy rule, can be specified as JSON object: `{"max_age": "16h"}` or `{"max_version": 2}`
+- If `mode` is not specified, `rules` can only contains one GC policy. If `mode` is specified, `rules` must have at least 2 policies.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -96,12 +96,7 @@ resource "google_bigtable_gc_policy" "policy" {
   table         = google_bigtable_table.table.name
   column_family = "cf1"
 
-  gc_rules = "{\"mode\":\"union\", \"rules\":[{\"max_age\":\"10h\"},{\"mode\": \"intersection\", \"rules\":[{\"max_age\":\"2d\"}, {\"max_version\":\"2\"}]}]}"
-
-}
-```
-When deserialized, the `gc_rules` JSON object looks like:
-```json
+  gc_rules = <<EOF
 {
   "mode": "union",
   "rules": [
@@ -120,6 +115,9 @@ When deserialized, the `gc_rules` JSON object looks like:
       ]
     }
   ]
+}
+EOF
+
 }
 ```
 This is equivalent to running the following `cbt` command:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added `gc_rules` to `google_bigtable_gc_policy` resource.
```
