### PR TITLE
Added Cloud SQL mysql with authorized network example

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -86,6 +86,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "deletion_protection"
           - "root_password"
       - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_authorized_network"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "instance"
+        vars:
+          mysql_instance_with_authorized_network: "mysql-instance-with-authorized-network"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
         name: "sql_sqlserver_instance_authorized_network"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.erb
@@ -1,0 +1,18 @@
+# [START cloud_sql_mysql_instance_authorized_network]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['mysql_instance_with_authorized_network'] %>"
+  region           = "us-central1"
+  database_version = "MYSQL_5_7"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      authorized_networks {
+        name = "Network Name"
+        value = "192.0.2.0/24"
+        expiration_time = "3021-11-15T16:19:00.094Z"
+      }
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_mysql_instance_authorized_network]


### PR DESCRIPTION
Added example for inclusion on the following page:

https://cloud.google.com/sql/docs/mysql/authorize-networks

```release-note:none
```