### PR TITLE
Cloud SQL backup location samples for cgc

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -109,6 +109,40 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_sqlserver_instance_backup_location"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          sqlserver_instance_backup_location: "sqlserver-instance-backup-location"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "root_password"
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_backup_location"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          mysql_instance_backup_location: "mysql-instance-backup-location"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_postgres_instance_backup_location"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          postgres_instance_backup_location: "postgres-instance-backup-location"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -93,6 +93,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           myinstance: "myinstance"
           sqlserver_instance_with_authorized_network: "sqlserver-instance-with-authorized-network"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -105,6 +106,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           postgres_instance_with_authorized_network: "postgres-instance-with-authorized-network"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -128,6 +130,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           mysql_instance_backup_location: "mysql-instance-backup-location"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -139,6 +142,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           postgres_instance_backup_location: "postgres-instance-backup-location"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_backup_location.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_backup_location.tf.erb
@@ -1,0 +1,15 @@
+# [START cloud_sql_mysql_instance_backup_location]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['mysql_instance_backup'] %>"
+  region           = "asia-northeast1"
+  database_version = "MYSQL_5_7"
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled                        = true
+      location                       = "asia-northeast1"
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_mysql_instance_backup_location]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_backup_location.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_backup_location.tf.erb
@@ -1,0 +1,15 @@
+# [START cloud_sql_postgres_instance_backup_location]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['postgres_instance_backup'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-7680"
+    backup_configuration {
+      enabled                        = true
+      location                       = "us-central1"
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_postgres_instance_backup_location]

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_location.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_location.tf.erb
@@ -1,0 +1,16 @@
+# [START cloud_sql_sqlserver_instance_backup_location]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['sqlserver_instance_backup'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier = "db-custom-2-7680"
+    backup_configuration {
+      enabled                        = true
+      location                       = "us-central1"
+    }
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_sqlserver_instance_backup_location]


### PR DESCRIPTION
Planning to add these samples to these sections:

https://cloud.google.com/sql/docs/sqlserver/backup-recovery/backing-up#locationbackups
https://cloud.google.com/sql/docs/mysql/backup-recovery/backing-up#locationbackups
https://cloud.google.com/sql/docs/postgres/backup-recovery/backing-up#locationbackups

```release-note:none
```