### PR TITLE
Added MigInstancesAllowed to os_config_patch_deployment

### DIFF
--- a/mmv1/products/osconfig/api.yaml
+++ b/mmv1/products/osconfig/api.yaml
@@ -140,6 +140,10 @@ objects:
         description: |
           Patch configuration that is applied.
         properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'migInstancesAllowed'
+            description: |
+              Allows the patch job to run on Managed instance groups (MIGs).
           - !ruby/object:Api::Type::Enum
             name: 'rebootConfig'
             description: |

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -15,6 +15,8 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
   }
 
   patch_config {
+    mig_instances_allowed = true
+    
     reboot_config = "ALWAYS"
 
     apt {


### PR DESCRIPTION
Adds migInstancesAllowed field (cf. https://cloud.google.com/compute/docs/osconfig/rest/v1/PatchConfig).

If this PR is for Terraform, I acknowledge that I have:
- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written “fixes {url}” or “part of {url}” in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
```release-note:enhancement
os-config: added field `migInstancesAllowed` to resource `os_config_patch_deployment`
```