### PR TITLE
Added examples for Cloud SQL instance clones

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -147,6 +147,39 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_sqlserver_instance_clone"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "root_password"
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_clone"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          deletion_protection: "true"
+        skip_test: true
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_postgres_instance_clone"
+        primary_resource_type: "google_sql_database_instance"
+        primary_resource_id: "default"
+        vars:
+          deletion_protection: "true"
+        skip_test: true
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -152,6 +152,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"
         vars:
+          sqlserver_instance_clone: "sqlserver-instance-clone"
+          sqlserver_instance_clone_source: "sqlserver-instance-clone-source"
           deletion_protection: "true"
         test_vars_overrides:
           deletion_protection: "false"
@@ -163,6 +165,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"
         vars:
+          mysql_instance_clone: "mysql-instance-clone"
+          mysql_instance_clone_source: "mysql-instance-clone-source"
           deletion_protection: "true"
         skip_test: true
         test_vars_overrides:
@@ -174,6 +178,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "default"
         vars:
+          postgres_instance_clone: " postgres-instance-clone"
+           postgres_instance_clone_source: "postgres-instance-clone-source"
           deletion_protection: "true"
         skip_test: true
         test_vars_overrides:

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_clone.tf.erb
@@ -1,10 +1,10 @@
 # [START cloud_sql_mysql_instance_clone]
 resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
-  name             = "<%= ctx[:vars]['mysql_instance'] %>"
+  name             = "<%= ctx[:vars]['mysql_instance_clone'] %>"
   region           = "us-central1"
   database_version = "MYSQL_8_0"
   clone {
-    source_instance_name = "<%= ctx[:vars]['mysql_instance'] %>"
+    source_instance_name = "<%= ctx[:vars]['mysql_instance_clone_source'] %>"
   }
   deletion_protection =  "true"
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_clone.tf.erb
@@ -1,0 +1,11 @@
+# [START cloud_sql_mysql_instance_clone]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['mysql_instance'] %>"
+  region           = "us-central1"
+  database_version = "MYSQL_8_0"
+  clone {
+    source_instance_name = "<%= ctx[:vars]['mysql_instance'] %>"
+  }
+  deletion_protection =  "true"
+}
+# [END cloud_sql_mysql_instance_clone]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.erb
@@ -4,7 +4,7 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   region           = "us-central1"
   database_version = "POSTGRES_12"
   clone {
-    source_instance_name = "<%= ctx[:vars]['mysql_instance'] %>"
+    source_instance_name = "<%= ctx[:vars]['postgres_instance'] %>"
   }
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.erb
@@ -1,0 +1,11 @@
+# [START cloud_sql_postgres_instance_clone]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['postgres_instance_clone'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_12"
+  clone {
+    source_instance_name = "<%= ctx[:vars]['mysql_instance'] %>"
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_postgres_instance_clone]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.erb
@@ -4,7 +4,7 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   region           = "us-central1"
   database_version = "POSTGRES_12"
   clone {
-    source_instance_name = "<%= ctx[:vars]['postgres_instance'] %>"
+    source_instance_name = "<%= ctx[:vars]['postgres_instance_clone_source'] %>"
   }
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.erb
@@ -5,7 +5,7 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   database_version = "SQLSERVER_2017_STANDARD"
   root_password = "INSERT-PASSWORD-HERE"
   clone {
-    source_instance_name = "<%= ctx[:vars]['mysql_instance'] %>"
+    source_instance_name = "<%= ctx[:vars]['sqlserver_instance'] %>"
   }
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.erb
@@ -5,7 +5,7 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   database_version = "SQLSERVER_2017_STANDARD"
   root_password = "INSERT-PASSWORD-HERE"
   clone {
-    source_instance_name = "<%= ctx[:vars]['sqlserver_instance'] %>"
+    source_instance_name = "<%= ctx[:vars]['sqlserver_instance_clone_source'] %>"
   }
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.erb
@@ -1,0 +1,12 @@
+# [START cloud_sql_sqlserver_instance_clone]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['sqlserver_instance_clone'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  clone {
+    source_instance_name = "<%= ctx[:vars]['mysql_instance'] %>"
+  }
+  deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_sqlserver_instance_clone]


### PR DESCRIPTION
Planning to add these samples to this section:

https://cloud.google.com/sql/docs/mysql/clone-instance
https://cloud.google.com/sql/docs/postgres/clone-instance
https://cloud.google.com/sql/docs/sqlserver/clone-instance

```release-note:none
```