### PR TITLE
Add repeat interval to Storage Transfer Job resource

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -172,6 +172,13 @@ func resourceStorageTransferJob() *schema.Resource {
 							DiffSuppressFunc: diffSuppressEmptyStartTimeOfDay,
 							Description:      `The time in UTC at which the transfer will be scheduled to start in a day. Transfers may start later than this time. If not specified, recurring and one-time transfers that are scheduled to run today will run immediately; recurring transfers that are scheduled to run on a future date will start at approximately midnight UTC on that date. Note that when configuring a transfer with the Cloud Platform Console, the transfer's start time in a day is specified in your local timezone.`,
 						},
+						"repeat_interval": {
+							Type:         schema.TypeString,
+							ValidateFunc: validateDuration(),
+							Optional:     true,
+							Description:  `Interval between the start of each scheduled transfer. If unspecified, the default value is 24 hours. This value may not be less than 1 hour. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".`,
+							Default:      "86400s",
+						},
 					},
 				},
 				Description: `Schedule specification defining when the Transfer Job should be scheduled to start, end and what time to run.`,
@@ -769,15 +776,16 @@ func expandTransferSchedules(transferSchedules []interface{}) *storagetransfer.S
 		ScheduleStartDate: expandDates(schedule["schedule_start_date"].([]interface{})),
 		ScheduleEndDate:   expandDates(schedule["schedule_end_date"].([]interface{})),
 		StartTimeOfDay:    expandTimeOfDays(schedule["start_time_of_day"].([]interface{})),
+		RepeatInterval:    schedule["repeat_interval"].(string),
 	}
 }
 
-func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string][]map[string]interface{} {
+func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string]interface{} {
 	if reflect.DeepEqual(transferSchedule, &storagetransfer.Schedule{}) {
 		return nil
 	}
 
-	data := map[string][]map[string]interface{}{
+	data := map[string]interface{}{
 		"schedule_start_date": flattenDate(transferSchedule.ScheduleStartDate),
 	}
 
@@ -789,7 +797,11 @@ func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[s
 		data["start_time_of_day"] = flattenTimeOfDay(transferSchedule.StartTimeOfDay)
 	}
 
-	return []map[string][]map[string]interface{}{data}
+	if transferSchedule.RepeatInterval != "" {
+		data["repeat_interval"] = transferSchedule.RepeatInterval
+	}
+
+	return []map[string]interface{}{data}
 }
 
 func expandGcsData(gcsDatas []interface{}) *storagetransfer.GcsData {

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -289,6 +289,7 @@ resource "google_storage_transfer_job" "transfer_job" {
       seconds = 0
       nanos   = 0
     }
+	repeat_interval = "604800s"
   }
 
   depends_on = [

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -85,6 +85,7 @@ resource "google_storage_transfer_job" "s3-bucket-nightly-backup" {
       seconds = 0
       nanos   = 0
     }
+    repeat_interval = "604800s"
   }
 
   depends_on = [google_storage_bucket_iam_member.s3-backup-bucket]
@@ -135,6 +136,8 @@ The following arguments are supported:
 * `schedule_end_date` - (Optional) The last day the recurring transfer will be run. If `schedule_end_date` is the same as `schedule_start_date`, the transfer will be executed only once. Structure [documented below](#nested_schedule_start_end_date).
 
 * `start_time_of_day` - (Optional) The time in UTC at which the transfer will be scheduled to start in a day. Transfers may start later than this time. If not specified, recurring and one-time transfers that are scheduled to run today will run immediately; recurring transfers that are scheduled to run on a future date will start at approximately midnight UTC on that date. Note that when configuring a transfer with the Cloud Platform Console, the transfer's start time in a day is specified in your local timezone. Structure [documented below](#nested_start_time_of_day).
+
+* `repeat_interval` - (Optional) Interval between the start of each scheduled transfer. If unspecified, the default value is 24 hours. This value may not be less than 1 hour. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
 
 <a name="nested_object_conditions"></a>The `object_conditions` block supports:
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/8578

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storagetransfer: added `repeat_interval` field to `google_storage_transfer_job` resource
```
