### PR TITLE
fixed a permadiff in `google_monitoring_uptime_check_config.http_check.path`

### DIFF
--- a/mmv1/products/monitoring/api.yaml
+++ b/mmv1/products/monitoring/api.yaml
@@ -1848,7 +1848,8 @@ objects:
         default_value: "/"
         description: The path to the page to run the check against. Will be combined
           with the host (specified within the MonitoredResource) and port to construct
-          the full URL. Optional (defaults to "/").
+          the full URL. If the provided path does not begin with "/", a "/" will be prepended 
+          automatically. Optional (defaults to "/").
       - !ruby/object:Api::Type::Boolean
         name: useSsl
         at_least_one_of:

--- a/mmv1/products/monitoring/terraform.yaml
+++ b/mmv1/products/monitoring/terraform.yaml
@@ -267,6 +267,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           display_name: "tcp-uptime-check"
           group_display_name: "uptime-check-group"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/monitoring_uptime_check_config.go.erb
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
     properties:
@@ -276,6 +277,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       httpCheck.authInfo.password: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
         custom_flatten: "templates/terraform/custom_flatten/uptime_check_http_password.erb"
+      httpCheck.path: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: resourceMonitoringUptimeCheckConfigHttpCheckPathDiffSuppress
       httpCheck.port: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       httpCheck.headers: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/constants/monitoring_uptime_check_config.go.erb
+++ b/mmv1/templates/terraform/constants/monitoring_uptime_check_config.go.erb
@@ -1,0 +1,3 @@
+func resourceMonitoringUptimeCheckConfigHttpCheckPathDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return old == "/"+new
+}

--- a/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
@@ -3,7 +3,7 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
   timeout      = "60s"
 
   http_check {
-    path = "/some-path"
+    path = "some-path"
     port = "8010"
     request_method = "POST"
     content_type = "URL_ENCODED"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10884

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed a permadiff when `google_monitoring_uptime_check_config.http_check.path` does not begin with "/"
```
