### PR TITLE
Return identity missing error when project not found for project iam

### DIFF
--- a/mmv1/third_party/validator/project_iam.go
+++ b/mmv1/third_party/validator/project_iam.go
@@ -90,6 +90,10 @@ func newProjectIamAsset(
 }
 
 func FetchProjectIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
+	if _, ok := d.GetOk("project"); !ok {
+		return Asset{}, ErrEmptyIdentityField
+	}
+
 	// We use project_id in the asset name template to be consistent with newProjectIamAsset.
 	return fetchIamPolicy(
 		NewProjectIamUpdater,

--- a/mmv1/third_party/validator/tests/data/example_project_iam_member_empty_project.json
+++ b/mmv1/third_party/validator/tests/data/example_project_iam_member_empty_project.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+    "asset_type": "cloudresourcemanager.googleapis.com/Project",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "iam_policy": {
+      "bindings": [
+        {
+          "role": "roles/editor",
+          "members": [
+            "user:jane@example.com"
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/mmv1/third_party/validator/tests/data/example_project_iam_member_empty_project.tf
+++ b/mmv1/third_party/validator/tests/data/example_project_iam_member_empty_project.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+
+resource "google_project_iam_member" "project" {
+  project = ""
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
+}

--- a/mmv1/third_party/validator/tests/data/example_project_iam_member_empty_project.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/example_project_iam_member_empty_project.tfplan.json
@@ -1,0 +1,82 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.10",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_project_iam_member.project",
+          "mode": "managed",
+          "type": "google_project_iam_member",
+          "name": "project",
+          "provider_name": "google",
+          "schema_version": 0,
+          "values": {
+            "member": "user:jane@example.com",
+            "project": "",
+            "role": "roles/editor"
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_project_iam_member.project",
+      "mode": "managed",
+      "type": "google_project_iam_member",
+      "name": "project",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "member": "user:jane@example.com",
+          "project": "",
+          "role": "roles/editor"
+        },
+        "after_unknown": {
+          "etag": true,
+          "id": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "expressions": {
+          "project": {
+            "constant_value": ""
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_project_iam_member.project",
+          "mode": "managed",
+          "type": "google_project_iam_member",
+          "name": "project",
+          "provider_config_key": "google",
+          "expressions": {
+            "member": {
+              "constant_value": "user:jane@example.com"
+            },
+            "project": {
+              "constant_value": ""
+            },
+            "role": {
+              "constant_value": "roles/editor"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

b/218368396 
https://github.com/GoogleCloudPlatform/terraform-validator/issues/511

In user's tf file, project is referencing a variable, in this case the project field is an empty string, and fetching iam policy returns a 404 error. 

The fix:
- when it detects project is empty, it return an error before it tries to fetch the iam policy. 
- In this scenario, users have to specify --project command line flag to specify the default project, in order for ancestry manager to construct the ancestry and parent using the default project. 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
