### PR TITLE
don't retry on storage bucket data source

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -673,103 +673,7 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)
 
-	// We are trying to support several different use cases for bucket. Buckets are globally
-	// unique but they are associated with projects internally, but some users want to use
-	// buckets in a project agnostic way. Thus we will check to see if the project ID has been
-	// explicitly set and use that first. However if no project is explicitly set, such as during
-	// import, we will look up the ID from the compute API using the project Number from the
-	// bucket API response.
-	// If you are working in a project-agnostic way and have not set the project ID in the provider
-	// block, or the resource or an environment variable, we use the compute API to lookup the projectID
-	// from the projectNumber which is included in the bucket API response
-	if d.Get("project") == "" {
-		project, _ := getProject(d, config)
-		if err := d.Set("project", project); err != nil {
-			return fmt.Errorf("Error setting project: %s", err)
-		}
-	}
-	if d.Get("project") == "" {
-		proj, err := config.NewComputeClient(userAgent).Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
-		if err != nil {
-			return err
-		}
-		log.Printf("[DEBUG] Bucket %v is in project number %v, which is project ID %s.\n", res.Name, res.ProjectNumber, proj.Name)
-		if err := d.Set("project", proj.Name); err != nil {
-			return fmt.Errorf("Error setting project: %s", err)
-		}
-	}
-
-	// Update the bucket ID according to the resource ID
-	if err := d.Set("self_link", res.SelfLink); err != nil {
-		return fmt.Errorf("Error setting self_link: %s", err)
-	}
-	if err := d.Set("url", fmt.Sprintf("gs://%s", bucket)); err != nil {
-		return fmt.Errorf("Error setting url: %s", err)
-	}
-	if err := d.Set("storage_class", res.StorageClass); err != nil {
-		return fmt.Errorf("Error setting storage_class: %s", err)
-	}
-	if err := d.Set("encryption", flattenBucketEncryption(res.Encryption)); err != nil {
-		return fmt.Errorf("Error setting encryption: %s", err)
-	}
-	if err := d.Set("location", res.Location); err != nil {
-		return fmt.Errorf("Error setting location: %s", err)
-	}
-	if err := d.Set("cors", flattenCors(res.Cors)); err != nil {
-		return fmt.Errorf("Error setting cors: %s", err)
-	}
-	if err := d.Set("default_event_based_hold", res.DefaultEventBasedHold); err != nil {
-		return fmt.Errorf("Error setting default_event_based_hold: %s", err)
-	}
-	if err := d.Set("logging", flattenBucketLogging(res.Logging)); err != nil {
-		return fmt.Errorf("Error setting logging: %s", err)
-	}
-	if err := d.Set("versioning", flattenBucketVersioning(res.Versioning)); err != nil {
-		return fmt.Errorf("Error setting versioning: %s", err)
-	}
-	if err := d.Set("lifecycle_rule", flattenBucketLifecycle(res.Lifecycle)); err != nil {
-		return fmt.Errorf("Error setting lifecycle_rule: %s", err)
-	}
-	if err := d.Set("labels", res.Labels); err != nil {
-		return fmt.Errorf("Error setting labels: %s", err)
-	}
-	if err := d.Set("website", flattenBucketWebsite(res.Website)); err != nil {
-		return fmt.Errorf("Error setting website: %s", err)
-	}
-	if err := d.Set("retention_policy", flattenBucketRetentionPolicy(res.RetentionPolicy)); err != nil {
-		return fmt.Errorf("Error setting retention_policy: %s", err)
-	}
-
-	if res.IamConfiguration != nil && res.IamConfiguration.UniformBucketLevelAccess != nil {
-		if err := d.Set("uniform_bucket_level_access", res.IamConfiguration.UniformBucketLevelAccess.Enabled); err != nil {
-			return fmt.Errorf("Error setting uniform_bucket_level_access: %s", err)
-		}
-	} else {
-		if err := d.Set("uniform_bucket_level_access", false); err != nil {
-			return fmt.Errorf("Error setting uniform_bucket_level_access: %s", err)
-		}
-	}
-
-<% unless version == "ga" -%>
-	if res.IamConfiguration != nil && res.IamConfiguration.PublicAccessPrevention != "" {
-		if err := d.Set("public_access_prevention", res.IamConfiguration.PublicAccessPrevention); err != nil {
-			return fmt.Errorf("Error setting public_access_prevention: %s", err)
-		}
-	}
-<% end -%>
-
-	if res.Billing == nil {
-		if err := d.Set("requester_pays", nil); err != nil {
-			return fmt.Errorf("Error setting requester_pays: %s", err)
-		}
-	} else {
-		if err := d.Set("requester_pays", res.Billing.RequesterPays); err != nil {
-			return fmt.Errorf("Error setting requester_pays: %s", err)
-		}
-	}
-
-	d.SetId(res.Id)
-	return nil
+	return setStorageBucket(d, config, res, bucket, userAgent)
 }
 
 func resourceStorageBucketDelete(d *schema.ResourceData, meta interface{}) error {
@@ -1401,4 +1305,106 @@ func detectLifecycleChange(d *schema.ResourceData) bool {
 	}
 
 	return false
+}
+
+// Resource Read and DataSource Read both need to set attributes, but Data Sources don't support Timeouts
+// so we pulled this portion out separately (https://github.com/hashicorp/terraform-provider-google/issues/11264)
+func setStorageBucket(d *schema.ResourceData, config *Config, res *storage.Bucket, bucket, userAgent string) error {
+	// We are trying to support several different use cases for bucket. Buckets are globally
+	// unique but they are associated with projects internally, but some users want to use
+	// buckets in a project agnostic way. Thus we will check to see if the project ID has been
+	// explicitly set and use that first. However if no project is explicitly set, such as during
+	// import, we will look up the ID from the compute API using the project Number from the
+	// bucket API response.
+	// If you are working in a project-agnostic way and have not set the project ID in the provider
+	// block, or the resource or an environment variable, we use the compute API to lookup the projectID
+	// from the projectNumber which is included in the bucket API response
+	if d.Get("project") == "" {
+		project, _ := getProject(d, config)
+		if err := d.Set("project", project); err != nil {
+			return fmt.Errorf("Error setting project: %s", err)
+		}
+	}
+	if d.Get("project") == "" {
+		proj, err := config.NewComputeClient(userAgent).Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Bucket %v is in project number %v, which is project ID %s.\n", res.Name, res.ProjectNumber, proj.Name)
+		if err := d.Set("project", proj.Name); err != nil {
+			return fmt.Errorf("Error setting project: %s", err)
+		}
+	}
+
+	// Update the bucket ID according to the resource ID
+	if err := d.Set("self_link", res.SelfLink); err != nil {
+		return fmt.Errorf("Error setting self_link: %s", err)
+	}
+	if err := d.Set("url", fmt.Sprintf("gs://%s", bucket)); err != nil {
+		return fmt.Errorf("Error setting url: %s", err)
+	}
+	if err := d.Set("storage_class", res.StorageClass); err != nil {
+		return fmt.Errorf("Error setting storage_class: %s", err)
+	}
+	if err := d.Set("encryption", flattenBucketEncryption(res.Encryption)); err != nil {
+		return fmt.Errorf("Error setting encryption: %s", err)
+	}
+	if err := d.Set("location", res.Location); err != nil {
+		return fmt.Errorf("Error setting location: %s", err)
+	}
+	if err := d.Set("cors", flattenCors(res.Cors)); err != nil {
+		return fmt.Errorf("Error setting cors: %s", err)
+	}
+	if err := d.Set("default_event_based_hold", res.DefaultEventBasedHold); err != nil {
+		return fmt.Errorf("Error setting default_event_based_hold: %s", err)
+	}
+	if err := d.Set("logging", flattenBucketLogging(res.Logging)); err != nil {
+		return fmt.Errorf("Error setting logging: %s", err)
+	}
+	if err := d.Set("versioning", flattenBucketVersioning(res.Versioning)); err != nil {
+		return fmt.Errorf("Error setting versioning: %s", err)
+	}
+	if err := d.Set("lifecycle_rule", flattenBucketLifecycle(res.Lifecycle)); err != nil {
+		return fmt.Errorf("Error setting lifecycle_rule: %s", err)
+	}
+	if err := d.Set("labels", res.Labels); err != nil {
+		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	if err := d.Set("website", flattenBucketWebsite(res.Website)); err != nil {
+		return fmt.Errorf("Error setting website: %s", err)
+	}
+	if err := d.Set("retention_policy", flattenBucketRetentionPolicy(res.RetentionPolicy)); err != nil {
+		return fmt.Errorf("Error setting retention_policy: %s", err)
+	}
+
+	if res.IamConfiguration != nil && res.IamConfiguration.UniformBucketLevelAccess != nil {
+		if err := d.Set("uniform_bucket_level_access", res.IamConfiguration.UniformBucketLevelAccess.Enabled); err != nil {
+			return fmt.Errorf("Error setting uniform_bucket_level_access: %s", err)
+		}
+	} else {
+		if err := d.Set("uniform_bucket_level_access", false); err != nil {
+			return fmt.Errorf("Error setting uniform_bucket_level_access: %s", err)
+		}
+	}
+
+<% unless version == "ga" -%>
+	if res.IamConfiguration != nil && res.IamConfiguration.PublicAccessPrevention != "" {
+		if err := d.Set("public_access_prevention", res.IamConfiguration.PublicAccessPrevention); err != nil {
+			return fmt.Errorf("Error setting public_access_prevention: %s", err)
+		}
+	}
+<% end -%>
+
+	if res.Billing == nil {
+		if err := d.Set("requester_pays", nil); err != nil {
+			return fmt.Errorf("Error setting requester_pays: %s", err)
+		}
+	} else {
+		if err := d.Set("requester_pays", res.Billing.RequesterPays); err != nil {
+			return fmt.Errorf("Error setting requester_pays: %s", err)
+		}
+	}
+
+	d.SetId(res.Id)
+	return nil
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11264
Datasources don't support Timeouts, so, while the read function works well for the resource to retry for eventual consistency, users can't adjust the timeout for the datasource. I've decided to remove the retry on the datasource, and rather only share the code that sets the resource data.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed a bug where `google_storage_bucket` data source would retry for 20 min when bucket was not found.
```
