### PR TITLE
Added examples for Cloud SQL user

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -23,6 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           database_instance_name: "sqlserver-instance"
+          users_name: "users-name"
           deletion_protection: "true"
         test_vars_overrides:
           deletion_protection: "false"
@@ -35,6 +36,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           database_instance_name: "postgres-instance"
+          users_name: "users-name"
           deletion_protection: "true"
         test_vars_overrides:
           deletion_protection: "false"
@@ -46,6 +48,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           database_instance_name: "mysql-instance"
+          users_name: "users-name"
           deletion_protection: "true"
         test_vars_overrides:
           deletion_protection: "false"

--- a/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
@@ -9,3 +9,12 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_mysql_instance_80_db_n1_s2]
+
+# [START cloud_sql_mysql_instance_user]
+resource "google_sql_user" "default" {
+  name     = "<%= ctx[:vars]['users_name'] %>"
+  instance = google_sql_database_instance.instance.name
+  host     = "example.com"
+  password = "changeme"
+}
+# [END cloud_sql_mysql_instance_user]

--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
@@ -14,7 +14,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
 resource "google_sql_user" "default" {
   name     = "<%= ctx[:vars]['users_name'] %>"
   instance = google_sql_database_instance.instance.name
-  host     = "example.com"
   password = "changeme"
 }
 # [END cloud_sql_postgres_instance_user]

--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
@@ -9,3 +9,12 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_postgres_instance_80_db_n1_s2]
+
+# [START cloud_sql_postgres_instance_user]
+resource "google_sql_user" "default" {
+  name     = "<%= ctx[:vars]['users_name'] %>"
+  instance = google_sql_database_instance.instance.name
+  host     = "example.com"
+  password = "changeme"
+}
+# [END cloud_sql_postgres_instance_user]

--- a/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
@@ -10,3 +10,12 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_sqlserver_instance_80_db_n1_s2]
+
+# [START cloud_sql_sqlserver_instance_user]
+resource "google_sql_user" "default" {
+  name     = "<%= ctx[:vars]['users_name'] %>"
+  instance = google_sql_database_instance.instance.name
+  host     = "example.com"
+  password = "changeme"
+}
+# [END cloud_sql_sqlserver_instance_user]


### PR DESCRIPTION
Planning to add these samples to this section:

https://cloud.google.com/sql/docs/mysql/create-manage-users
https://cloud.google.com/sql/docs/postgres/create-manage-users
https://cloud.google.com/sql/docs/sqlserver/create-manage-users

```release-note:none
```