### PR TITLE
Allow setting source_location in google_compute_image

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7701,7 +7701,6 @@ objects:
         description: |
           The regional or multi-regional Cloud Storage bucket location where the machine image is stored.
         item_type: Api::Type::String
-        default_from_api: true
       - !ruby/object:Api::Type::Boolean
         name: guestFlush
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7700,8 +7700,8 @@ objects:
         name: 'storageLocations'
         description: |
           The regional or multi-regional Cloud Storage bucket location where the machine image is stored.
-        default_from_api: true
         item_type: Api::Type::String
+        default_from_api: true
       - !ruby/object:Api::Type::Boolean
         name: guestFlush
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7700,6 +7700,7 @@ objects:
         name: 'storageLocations'
         description: |
           The regional or multi-regional Cloud Storage bucket location where the machine image is stored.
+        default_from_api: true
         item_type: Api::Type::String
       - !ruby/object:Api::Type::Boolean
         name: guestFlush

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7701,7 +7701,6 @@ objects:
         description: |
           The regional or multi-regional Cloud Storage bucket location where the machine image is stored.
         item_type: Api::Type::String
-        output: true
       - !ruby/object:Api::Type::Boolean
         name: guestFlush
         description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1386,6 +1386,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       machineImageEncryptionKey.kmsKeyName: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: compareCryptoKeyVersions
+      storageLocations: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       allowed_iam_role: 'roles/compute.admin'
       parent_resource_attribute: 'machine_image'

--- a/mmv1/third_party/terraform/tests/resource_compute_image_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_image_test.go.erb
@@ -3,6 +3,7 @@ package google
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -162,6 +163,27 @@ func TestAccComputeImage_sourceSnapshot(t *testing.T) {
 	})
 }
 
+func TestAccComputeImage_withStorageLocations(t *testing.T) {
+	t.Parallel()
+
+	var image compute.Image
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeImageDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeImage_storageLocations("image-test-" + randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeImageExists(
+						t, "google_compute_image.foobar", &image),
+					testAccCheckComputeImageHasStorageLocation(&image, "eu"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeImageExists(t *testing.T, n string, image *compute.Image) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -297,6 +319,15 @@ func testAccCheckComputeImageDoesNotContainLabel(image *compute.Image, key strin
 			return fmt.Errorf("Expected no label for key '%s' but found one with value '%s'", key, v)
 		}
 
+		return nil
+	}
+}
+
+func testAccCheckComputeImageHasStorageLocation(image *compute.Image, locations ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !reflect.DeepEqual(locations, image.StorageLocations) {
+			return fmt.Errorf("Expected source locations to be %q, but found %q", locations, image.StorageLocations)
+		}
 		return nil
 	}
 }
@@ -454,4 +485,19 @@ resource "google_compute_image" "foobar" {
   source_snapshot = google_compute_snapshot.foobar.self_link
 }
 `, diskName, snapshotName, imageName)
+}
+
+func testAccComputeImage_storageLocations(name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_image" "foobar" {
+  name        = "%s"
+  raw_disk {
+	# Would create an image in 'us' if 'storage_locations' was not defined.
+    source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+  }
+  storage_locations = [
+	  "eu",
+  ]
+}
+`, name)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/11148

```release-note:enhancement
Allow setting source_location in google_compute_image
```
