### PR TITLE
GA several redis fields

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -351,13 +351,11 @@ objects:
           read replicas enabled is [1-5] and defaults to 2. If read replicas are not enabled
           for a Standard Tier instance, the only valid value is 1 and the default is 1. 
           The valid value for basic tier is 0 and the default is also 0.
-        min_version: beta
       - !ruby/object:Api::Type::Array
         name: nodes
         description: |
           Output only. Info per node.
         output: true
-        min_version: beta
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String
@@ -377,14 +375,12 @@ objects:
           Targets all healthy replica nodes in instance. Replication is asynchronous and replica nodes
           will exhibit some lag behind the primary. Write requests must target 'host'.
         output: true
-        min_version: beta
       - !ruby/object:Api::Type::Integer
         name: readEndpointPort
         description: |
           Output only. The port number of the exposed readonly redis endpoint. Standard tier only. 
           Write requests should target 'port'.
         output: true
-        min_version: beta
       - !ruby/object:Api::Type::Enum
         name: readReplicasMode
         description: |
@@ -398,5 +394,4 @@ objects:
           - :READ_REPLICAS_DISABLED
           - :READ_REPLICAS_ENABLED
         default_value: :READ_REPLICAS_DISABLED
-        min_version: beta
         input: true

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -61,7 +61,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "redis-test-network"
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "redis-mrr")'
-        min_version: beta
     properties:
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/templates/terraform/examples/redis_instance_mrr.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_mrr.tf.erb
@@ -1,5 +1,4 @@
 resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name           = "<%= ctx[:vars]['instance_name'] %>"
   tier           = "STANDARD_HA"
   memory_size_gb = 5
@@ -30,6 +29,5 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
 // config, add an additional network resource or change
 // this from "data"to "resource"
 data "google_compute_network" "redis-network" {
-  provider = google-beta
   name = "<%= ctx[:vars]['network_name'] %>"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: added read replica field `replicaCount `, `nodes`,  `readEndpoint`, `readEndpointPort`, `readReplicasMode` in `google_redis_instance` (GA only)
```
