### PR TITLE
Remove an outdated note on cloudsql regions

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -163,12 +163,8 @@ provider "google-beta" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region the instance will sit in. Note, Cloud SQL is not
-    available in all regions - choose from one of the options listed [here](https://cloud.google.com/sql/docs/mysql/instance-locations).
-    A valid region must be provided to use this resource. If a region is not provided in the resource definition,
-    the provider region will be used instead, but this will be an apply-time error for instances if the provider
-    region is not supported with Cloud SQL. If you choose not to provide the `region` argument for this resource,
-    make sure you understand this.
+* `region` - (Optional) The region the instance will sit in. If a region is not provided in the resource definition,
+    the provider region will be used instead.
 
 - - -
 


### PR DESCRIPTION
From the linked doc https://cloud.google.com/sql/docs/mysql/instance-locations

> Cloud SQL is currently available in all Google Cloud regions and will be offered in upcoming regional launches at the time of launch.

If this PR is for Terraform, I acknowledge that I have […snip…] It's for docs, not terraform.

I went with no release notes, because this does not seem significant enough to land in them. Let me know if I should add some (I guess `release-note:note` then?).

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: none

```
