### PR TITLE
Add `skip_wait_on_job_termination` option for dataflow job resources

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -84,6 +84,13 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+     "skip_wait_on_job_termination": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `If true, treat DRAINING and CANCELLING as terminal job states and do not wait for further changes before removing from terraform state and moving on. WARNING: this will lead to job name conflicts if you do not ensure that the job names are different, e.g. by embedding a release ID or by using a random_id.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -167,7 +174,7 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
 
-	if _, ok := dataflowTerminalStatesMap[job.CurrentState]; ok {
+  if ok := shouldStopDataflowJobDeleteQuery(job.CurrentState, d.Get("skip_wait_on_job_termination").(bool)); ok {
 		log.Printf("[DEBUG] Removing resource '%s' because it is in state %s.\n", job.Name, job.CurrentState)
 		d.SetId("")
 		return nil
@@ -333,9 +340,11 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	// Wait for state to reach terminal state (canceled/drained/done)
-	_, ok := dataflowTerminalStatesMap[d.Get("state").(string)]
-	for !ok {
+	// Wait for state to reach terminal state (canceled/drained/done plus cancelling/draining if skipWait)
+  skipWait := d.Get("skip_wait_on_job_termination").(bool)
+  var ok bool
+  ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
+  for !ok {
 		log.Printf("[DEBUG] Waiting for job with job state %q to terminate...", d.Get("state").(string))
 		time.Sleep(5 * time.Second)
 
@@ -343,11 +352,11 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return fmt.Errorf("Error while reading job to see if it was properly terminated: %v", err)
 		}
-		_, ok = dataflowTerminalStatesMap[d.Get("state").(string)]
+    ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
 	}
 
-	// Only remove the job from state if it's actually successfully canceled.
-	if _, ok := dataflowTerminalStatesMap[d.Get("state").(string)]; ok {
+	// Only remove the job from state if it's actually successfully hit a final state.
+	if ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait); ok {
 		log.Printf("[DEBUG] Removing dataflow job with final state %q", d.Get("state").(string))
 		d.SetId("")
 		return nil

--- a/mmv1/third_party/terraform/resources/resource_dataflow_job.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_job.go.erb
@@ -19,12 +19,10 @@ import (
 
 const resourceDataflowJobGoogleProvidedLabelPrefix = "labels.goog-dataflow-provided"
 
-<% unless version == "ga" -%>
 var dataflowTerminatingStatesMap = map[string]struct{}{
 	"JOB_STATE_CANCELLING": {},
 	"JOB_STATE_DRAINING":   {},
 }
-<% end -%>
 
 var dataflowTerminalStatesMap = map[string]struct{}{
 	"JOB_STATE_DONE":      {},
@@ -212,6 +210,13 @@ func resourceDataflowJob() *schema.Resource {
 				Optional:    true,
 				Description: `Indicates if the job should use the streaming engine feature.`,
 			},
+
+			"skip_wait_on_job_termination": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `If true, treat DRAINING and CANCELLING as terminal job states and do not wait for further changes before removing from terraform state and moving on. WARNING: this will lead to job name conflicts if you do not ensure that the job names are different, e.g. by embedding a release ID or by using a random_id.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -239,6 +244,16 @@ func resourceDataflowJobTypeCustomizeDiff(_ context.Context, d *schema.ResourceD
 	}
 
 	return nil
+}
+
+// return true if a job is in a terminal state, OR if a job is in a
+// terminating state and skipWait is true
+func shouldStopDataflowJobDeleteQuery(state string, skipWait bool) bool {
+	_, stopQuery := dataflowTerminalStatesMap[state]
+	if !stopQuery && skipWait {
+		_, stopQuery = dataflowTerminatingStatesMap[state]
+	}
+	return stopQuery
 }
 
 func resourceDataflowJobCreate(d *schema.ResourceData, meta interface{}) error {
@@ -351,7 +366,7 @@ func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting additional_experiments: %s", err)
 	}
 
-	if _, ok := dataflowTerminalStatesMap[job.CurrentState]; ok {
+	if ok := shouldStopDataflowJobDeleteQuery(job.CurrentState, d.Get("skip_wait_on_job_termination").(bool)); ok {
 		log.Printf("[DEBUG] Removing resource '%s' because it is in state %s.\n", job.Name, job.CurrentState)
 		d.SetId("")
 		return nil
@@ -477,8 +492,9 @@ func resourceDataflowJobDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// Wait for state to reach terminal state (canceled/drained/done)
-	_, ok := dataflowTerminalStatesMap[d.Get("state").(string)]
+	// Wait for state to reach terminal state (canceled/drained/done plus cancelling/draining if skipWait)
+  skipWait := d.Get("skip_wait_on_job_termination").(bool)
+	ok := shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
 	for !ok {
 		log.Printf("[DEBUG] Waiting for job with job state %q to terminate...", d.Get("state").(string))
 		time.Sleep(5 * time.Second)
@@ -487,11 +503,11 @@ func resourceDataflowJobDelete(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error while reading job to see if it was properly terminated: %v", err)
 		}
-		_, ok = dataflowTerminalStatesMap[d.Get("state").(string)]
+		ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
 	}
 
-	// Only remove the job from state if it's actually successfully canceled.
-	if _, ok := dataflowTerminalStatesMap[d.Get("state").(string)]; ok {
+	// Only remove the job from state if it's actually successfully hit a final state.
+	if ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait); ok {
 		log.Printf("[DEBUG] Removing dataflow job with final state %q", d.Get("state").(string))
 		d.SetId("")
 		return nil

--- a/mmv1/third_party/terraform/tests/resource_dataflow_job_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataflow_job_test.go.erb
@@ -3,6 +3,7 @@ package google
 
 import (
 	"fmt"
+  "strconv"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +42,32 @@ func TestAccDataflowJob_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataflowJob_zone(bucket, job, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataflowJobSkipWait_basic(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
+	skipIfVcr(t)
+	t.Parallel()
+
+	randStr := randString(t, 10)
+	bucket := "tf-test-dataflow-gcs-" + randStr
+	job := "tf-test-dataflow-job-" + randStr
+	zone := "us-central1-f"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataflowJobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataflowJobSkipWait_zone(bucket, job, zone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
 				),
@@ -334,9 +361,18 @@ func testAccCheckDataflowJobDestroyProducer(t *testing.T) func(s *terraform.Stat
 			config := googleProviderConfig(t)
 			job, err := config.NewDataflowClient(config.userAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
 			if job != nil {
-				if _, ok := dataflowTerminalStatesMap[job.CurrentState]; !ok {
-					return fmt.Errorf("Job still present")
-				}
+        var ok bool
+        skipWait, err := strconv.ParseBool(rs.Primary.Attributes["skip_wait_on_job_termination"])
+        if err != nil {
+          return fmt.Errorf("could not parse attribute: %v", err)
+        }
+				_, ok = dataflowTerminalStatesMap[job.CurrentState]
+        if !ok && skipWait {
+				  _, ok = dataflowTerminatingStatesMap[job.CurrentState]
+        }
+        if !ok {
+          return fmt.Errorf("Job still present")
+        }
 			} else if err != nil {
 				return err
 			}
@@ -356,9 +392,18 @@ func testAccCheckDataflowJobRegionDestroyProducer(t *testing.T) func(s *terrafor
 			config := googleProviderConfig(t)
 			job, err := config.NewDataflowClient(config.userAgent).Projects.Locations.Jobs.Get(config.Project, "us-central1", rs.Primary.ID).Do()
 			if job != nil {
-				if _, ok := dataflowTerminalStatesMap[job.CurrentState]; !ok {
-					return fmt.Errorf("Job still present")
-				}
+        var ok bool
+        skipWait, err := strconv.ParseBool(rs.Primary.Attributes["skip_wait_on_job_termination"])
+        if err != nil {
+          return fmt.Errorf("could not parse attribute: %v", err)
+        }
+				_, ok = dataflowTerminalStatesMap[job.CurrentState]
+        if !ok && skipWait {
+				  _, ok = dataflowTerminatingStatesMap[job.CurrentState]
+        }
+        if !ok {
+          return fmt.Errorf("Job still present")
+        }
 			} else if err != nil {
 				return err
 			}
@@ -636,6 +681,32 @@ resource "google_dataflow_job" "big_data" {
     output    = "${google_storage_bucket.temp.url}/output"
   }
   on_delete = "cancel"
+}
+`, bucket, job, zone, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+}
+
+func testAccDataflowJobSkipWait_zone(bucket, job, zone string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "temp" {
+  name          = "%s"
+  location      = "US"
+  force_destroy = true
+}
+
+resource "google_dataflow_job" "big_data" {
+  name = "%s"
+ 
+  zone    = "%s"
+
+  machine_type      = "e2-standard-2"
+  template_gcs_path = "%s"
+  temp_gcs_location = google_storage_bucket.temp.url
+  parameters = {
+    inputFile = "%s"
+    output    = "${google_storage_bucket.temp.url}/output"
+  }
+  on_delete                    = "cancel"
+  skip_wait_on_job_termination = true
 }
 `, bucket, job, zone, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }


### PR DESCRIPTION
This addresses #10559

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataflow: added `skip_wait_on_job_termination` attribute to `google_dataflow_job` and `google_dataflow_flex_template_job` resources (issue #10559)
```
