### PR TITLE
Add `enable_exactly_once_delivery` to `google_pubsub_subscription`

### DIFF
--- a/mmv1/products/pubsub/api.yaml
+++ b/mmv1/products/pubsub/api.yaml
@@ -238,7 +238,7 @@ objects:
         description: |
           How long to retain unacknowledged messages in the subscription's
           backlog, from the moment a message is published. If
-          retainAckedMessages is true, then this also configures the retention
+          retain_acked_messages is true, then this also configures the retention
           of acknowledged messages, and thus configures how far back in time a
           subscriptions.seek can be done. Defaults to 7 days. Cannot be more
           than 7 days (`"604800s"`) or less than 10 minutes (`"600s"`).
@@ -350,6 +350,19 @@ objects:
           If `true`, messages published with the same orderingKey in PubsubMessage will be delivered to
           the subscribers in the order in which they are received by the Pub/Sub system. Otherwise, they
           may be delivered in any order.
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableExactlyOnceDelivery'
+        input: true
+        description: |
+          If `true`, Pub/Sub provides the following guarantees for the delivery
+          of a message with a given value of messageId on this Subscriptions':
+
+          - The message sent to a subscriber is guaranteed not to be resent before the message's acknowledgement deadline expires.
+ 
+          - An acknowledged message will not be resent to a subscriber.
+
+          Note that subscribers may still receive multiple copies of a message when `enable_exactly_once_delivery`
+          is true if the message was published multiple times by a publisher client. These copies are considered distinct by Pub/Sub and have distinct messageId values
   - !ruby/object:Api::Resource
     name: 'Schema'
     input: true

--- a/mmv1/third_party/terraform/tests/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_subscription_test.go
@@ -44,7 +44,7 @@ func TestAccPubsubSubscription_basic(t *testing.T) {
 		CheckDestroy: testAccCheckPubsubSubscriptionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPubsubSubscription_basic(topic, subscription, "bar", 20),
+				Config: testAccPubsubSubscription_basic(topic, subscription, "bar", 20, false),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -68,7 +68,7 @@ func TestAccPubsubSubscription_update(t *testing.T) {
 		CheckDestroy: testAccCheckPubsubSubscriptionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPubsubSubscription_basic(topic, subscriptionShort, "bar", 20),
+				Config: testAccPubsubSubscription_basic(topic, subscriptionShort, "bar", 20, false),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -77,7 +77,7 @@ func TestAccPubsubSubscription_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPubsubSubscription_basic(topic, subscriptionShort, "baz", 30),
+				Config: testAccPubsubSubscription_basic(topic, subscriptionShort, "baz", 30, true),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -209,7 +209,7 @@ resource "google_pubsub_subscription" "foo" {
 `, saAccount, topicFoo, subscription)
 }
 
-func testAccPubsubSubscription_basic(topic, subscription, label string, deadline int) string {
+func testAccPubsubSubscription_basic(topic, subscription, label string, deadline int, exactlyOnceDelivery bool) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foo" {
   name = "%s"
@@ -226,8 +226,9 @@ resource "google_pubsub_subscription" "foo" {
     minimum_backoff = "60.0s"
   }
   ack_deadline_seconds = %d
+  enable_exactly_once_delivery = %t
 }
-`, topic, subscription, label, deadline)
+`, topic, subscription, label, deadline, exactlyOnceDelivery)
 }
 
 func testAccPubsubSubscription_topicOnly(topic string) string {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/11286

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: added `enable_exactly_once_delivery` to `google_pubsub_subscription`
```
