### PR TITLE
Add support to verify data loss in Cloud Bigtable tests

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cloud.google.com/go/bigtable"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -53,6 +54,9 @@ func TestAccBigtableGCPolicy_swapOffDeprecated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
 						t, "google_bigtable_gc_policy.policy"),
+					// Verify can write some data.
+					testAccBigtableCanWriteData(
+						t, "google_bigtable_gc_policy.policy", 10),
 				),
 			},
 			{
@@ -60,6 +64,9 @@ func TestAccBigtableGCPolicy_swapOffDeprecated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
 						t, "google_bigtable_gc_policy.policy"),
+					// Verify no data loss after the GC policy update.
+					testAccBigtableCanReadData(
+						t, "google_bigtable_gc_policy.policy", 10),
 				),
 			},
 		},
@@ -263,6 +270,84 @@ func testAccBigtableGCPolicyExists(t *testing.T, n string) resource.TestCheckFun
 		}
 
 		return fmt.Errorf("Error retrieving gc policy. Could not find policy in family %s", rs.Primary.Attributes["column_family"])
+	}
+}
+
+func testAccBigtableCanWriteData(t *testing.T, n string, numberOfRows int) resource.TestCheckFunc {
+	var ctx = context.Background()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := googleProviderConfig(t)
+		c, err := config.BigTableClientFactory(config.userAgent).NewClient(config.Project, rs.Primary.Attributes["instance_name"])
+		if err != nil {
+			return fmt.Errorf("Error starting client. %s", err)
+		}
+
+		defer c.Close()
+
+		table := c.Open(rs.Primary.Attributes["table"])
+		rowKeys := make([]string, numberOfRows)
+		mutations := make([]*bigtable.Mutation, numberOfRows)
+		columnFamily := rs.Primary.Attributes["column_family"]
+		for i := 0; i < 10; i++ {
+			rowKeys[i] = fmt.Sprintf("row%d", i)
+			mutations[i] = bigtable.NewMutation()
+			mutations[i].Set(columnFamily, "column", bigtable.Now(), []byte(fmt.Sprintf("value%d", i)))
+		}
+
+		rowErrs, err := table.ApplyBulk(ctx, rowKeys, mutations)
+		if err != nil {
+			return fmt.Errorf("could not write elements to bigtable: %v", err)
+		} else if rowErrs != nil {
+			for _, rowErr := range rowErrs {
+				return fmt.Errorf("could not write element to bigtable: %v", rowErr)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccBigtableCanReadData(t *testing.T, n string, numberOfRows int) resource.TestCheckFunc {
+	var ctx = context.Background()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := googleProviderConfig(t)
+		c, err := config.BigTableClientFactory(config.userAgent).NewClient(config.Project, rs.Primary.Attributes["instance_name"])
+		if err != nil {
+			return fmt.Errorf("Error starting client. %s", err)
+		}
+
+		defer c.Close()
+
+		table := c.Open(rs.Primary.Attributes["table"])
+		var rows []bigtable.Row
+		if err := table.ReadRows(ctx, bigtable.InfiniteRange(""), func(row bigtable.Row) bool {
+			rows = append(rows, row)
+			return true
+		}); err != nil {
+			return fmt.Errorf("Could not read elements from bigtable: %v", err)
+		}
+
+		if len(rows) != numberOfRows {
+			return fmt.Errorf("Expecting %d rows but got: %d", numberOfRows, len(rows))
+		}
+
+		return nil
 	}
 }
 

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -308,7 +308,7 @@ func testAccBigtableCanWriteData(t *testing.T, n string, numberOfRows int) resou
 		}
 		for _, rowErr := range rowErrs {
 			return fmt.Errorf("could not write element to bigtable: %v", rowErr)
-                }
+		}
 		return nil
 	}
 }

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -305,12 +305,10 @@ func testAccBigtableCanWriteData(t *testing.T, n string, numberOfRows int) resou
 		rowErrs, err := table.ApplyBulk(ctx, rowKeys, mutations)
 		if err != nil {
 			return fmt.Errorf("could not write elements to bigtable: %v", err)
-		} else if rowErrs != nil {
-			for _, rowErr := range rowErrs {
-				return fmt.Errorf("could not write element to bigtable: %v", rowErr)
-			}
 		}
-
+		for _, rowErr := range rowErrs {
+			return fmt.Errorf("could not write element to bigtable: %v", rowErr)
+                }
 		return nil
 	}
 }

--- a/mmv1/third_party/terraform/utils/bigtable_client_factory.go
+++ b/mmv1/third_party/terraform/utils/bigtable_client_factory.go
@@ -48,3 +48,19 @@ func (s BigtableClientFactory) NewAdminClient(project, instance string) (*bigtab
 
 	return bigtable.NewAdminClient(context.Background(), project, instance, opts...)
 }
+
+func (s BigtableClientFactory) NewClient(project, instance string) (*bigtable.Client, error) {
+	var opts []option.ClientOption
+	if requestReason := os.Getenv("CLOUDSDK_CORE_REQUEST_REASON"); requestReason != "" {
+		opts = append(opts, option.WithRequestReason(requestReason))
+	}
+
+	if s.UserProjectOverride && s.BillingProject != "" {
+		opts = append(opts, option.WithQuotaProject(s.BillingProject))
+	}
+
+	opts = append(opts, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
+	opts = append(opts, s.gRPCLoggingOptions...)
+
+	return bigtable.NewClient(context.Background(), project, instance, opts...)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support to verify data loss in Cloud Bigtable tests. The step for making sure no data loss issue are:

1. Verify can write some data
2. update something.
3. Verify that we can read the same data back (# of rows for now) to ensure no data loss.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
bigtable: Add support to verify data loss in Cloud Bigtable tests
```
