### PR TITLE
Make allAuthenticatedUsers case sensitive in iam members

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_iam_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_iam_test.go
@@ -1,0 +1,95 @@
+package google
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPrivatecaCaPoolIamMemberAllAuthenticatedUsersCasing(t *testing.T) {
+	t.Parallel()
+
+	capool := "tf-test-pool-iam-" + randString(t, 10)
+	project := getTestProjectFromEnv()
+	region := getTestRegionFromEnv()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCaPoolIamMember_allAuthenticatedUsers(capool, region, project),
+				Check: testAccCheckPrivatecaCaPoolIam(t, capool, region, project, "roles/privateca.certificateManager", []string{
+					fmt.Sprintf("group:%s.svc.id.goog:/allAuthenticatedUsers/", project),
+				}),
+			},
+		},
+	})
+}
+
+func testAccCheckPrivatecaCaPoolIam(t *testing.T, capool, region, project, role string, members []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		d := &ResourceDataMock{
+			FieldsInSchema: map[string]interface{}{
+				"ca_pool": capool,
+				"role":    role,
+				"member":  "",
+			},
+		}
+		u := &PrivatecaCaPoolIamUpdater{
+			project:  project,
+			location: region,
+			caPool:   capool,
+			d:        d,
+			Config:   googleProviderConfig(t),
+		}
+		p, err := u.GetResourceIamPolicy()
+		if err != nil {
+			return err
+		}
+
+		for _, binding := range p.Bindings {
+			if binding.Role == role {
+				sort.Strings(members)
+				sort.Strings(binding.Members)
+
+				if reflect.DeepEqual(members, binding.Members) {
+					return nil
+				}
+
+				return fmt.Errorf("Binding found but expected members is %v, got %v", members, binding.Members)
+			}
+		}
+
+		return fmt.Errorf("No binding for role %q", role)
+	}
+}
+
+func testAccPrivatecaCaPoolIamMember_allAuthenticatedUsers(capool, region, project string) string {
+	return fmt.Sprintf(`
+resource "google_privateca_ca_pool" "default" {
+  name     = "%s"
+  location = "%s"
+  tier     = "ENTERPRISE"
+  publishing_options {
+    publish_ca_cert = true
+    publish_crl     = true
+  }
+  labels = {
+    foo = "bar"
+  }
+}
+
+resource "google_privateca_ca_pool_iam_member" "member" {
+  ca_pool  = google_privateca_ca_pool.default.id
+  role     = "roles/privateca.certificateManager"
+  member   = "group:%s.svc.id.goog:/allAuthenticatedUsers/"
+}
+  
+`, capool, region, project)
+}

--- a/mmv1/third_party/terraform/utils/iam.go.erb
+++ b/mmv1/third_party/terraform/utils/iam.go.erb
@@ -245,7 +245,11 @@ func subtractFromBindings(bindings []*cloudresourcemanager.Binding, toRemove ...
 }
 
 func iamMemberIsCaseSensitive(member string) bool {
-	return strings.HasPrefix(member, "principalSet:") || strings.HasPrefix(member, "principal:") || strings.HasPrefix(member, "principalHierarchy:")
+	// allAuthenticatedUsers and allUsers are special identifiers that are case sensitive. See:
+	// https://cloud.google.com/iam/docs/overview#all-authenticated-users
+	return strings.Contains(member, "allAuthenticatedUsers") || strings.Contains(member, "allUsers") ||
+		strings.HasPrefix(member, "principalSet:") || strings.HasPrefix(member, "principal:") ||
+		strings.HasPrefix(member, "principalHierarchy:")
 }
 
 // normalizeIamMemberCasing returns the case adjusted value of an iamMember


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/10466

special identifiers should not be flattened. the added test fails without the new casing logic.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
iam: fixed an issue where special identifiers `allAuthenticatedUsers` and `allUsers` were flattened to lower case in IAM members.
```
