### PR TITLE
Change container `image_type` to be `_CONTAINERD` variant due to deprecation

### DIFF
--- a/mmv1/third_party/inspec/documentation/google_container_cluster.md
+++ b/mmv1/third_party/inspec/documentation/google_container_cluster.md
@@ -28,7 +28,7 @@
 
     describe google_container_cluster(project: 'chef-inspec-gcp', location: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
       its('node_config.disk_size_gb'){should eq 100}
-      its('node_config.image_type'){should eq "COS"}
+      its('node_config.image_type'){should eq "COS_CONTAINERD"}
       its('node_config.machine_type'){should eq "n1-standard-1"}
       its('node_ipv4_cidr_size'){should eq 24}
       its('node_pools.count'){should eq 1}

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3262,7 +3262,7 @@ resource "google_container_cluster" "with_node_config" {
     }
 
     // Updatable fields
-    image_type = "cos"
+    image_type = "COS_CONTAINERD"
   }
 }
 `, clusterName)
@@ -3311,7 +3311,7 @@ resource "google_container_cluster" "with_node_config" {
     }
 
     // Updatable fields
-    image_type = "UBUNTU"
+    image_type = "UBUNTU_CONTAINERD"
   }
 }
 `, clusterName)
@@ -3362,7 +3362,7 @@ resource "google_container_cluster" "with_node_config" {
     preemptible      = true
 
     // Updatable fields
-    image_type = "COS"
+    image_type = "COS_CONTAINERD"
 
     shielded_instance_config {
       enable_secure_boot          = true
@@ -3952,7 +3952,7 @@ resource "google_container_cluster" "with_node_pool_node_config" {
         foo                      = "bar"
         disable-legacy-endpoints = "true"
       }
-      image_type = "COS"
+      image_type = "COS_CONTAINERD"
       labels = {
         foo = "bar"
       }

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1489,7 +1489,7 @@ resource "google_container_node_pool" "np_with_node_config" {
     }
 
     // Updatable fields
-    image_type = "COS"
+    image_type = "COS_CONTAINERD"
   }
 }
 `, cluster, nodePool)
@@ -1533,7 +1533,7 @@ resource "google_container_node_pool" "np_with_node_config" {
     }
 
     // Updatable fields
-    image_type = "UBUNTU"
+    image_type = "UBUNTU_CONTAINERD"
   }
 }
 `, cluster, nodePool)
@@ -2001,7 +2001,7 @@ resource "google_container_node_pool" "np_with_gpu" {
 
     preemptible     = true
     service_account = "default"
-    image_type      = "COS"
+    image_type      = "COS_CONTAINERD"
 
     guest_accelerator {
       type  = "nvidia-tesla-a100"

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -473,7 +473,7 @@ as "Intel Haswell" or "Intel Sandy Bridge".
 
 * `service_account` - (Optional) The Google Cloud Platform Service Account to be used by the node VMs.
 
-* `image_type` - (Optional) The default image type used by NAP once a new node pool is being created. Please note that according to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning#default-image-type) the value must be one of the [COS_CONTAINERD, COS, UBUNTU_CONTAINERD, UBUNTU].
+* `image_type` - (Optional) The default image type used by NAP once a new node pool is being created. Please note that according to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning#default-image-type) the value must be one of the [COS_CONTAINERD, COS, UBUNTU_CONTAINERD, UBUNTU]. __NOTE__ : COS AND UBUNTU are deprecated as of `GKE 1.24`
 
 <a name="nested_authenticator_groups_config"></a>The `authenticator_groups_config` block supports:
 


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/10971

image types `UBUNTU` and `COS` are deprecated as of `GKE 1.24`
https://cloud.google.com/kubernetes-engine/docs/how-to/migrate-containerd

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
