### PR TITLE
Migrate cloud resource manager v2 to v3 API

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
+	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
 )
 
 func dataSourceGoogleActiveFolder() *schema.Resource {
@@ -35,19 +35,19 @@ func dataSourceGoogleActiveFolderRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	var folderMatch *resourceManagerV2.Folder
+	var folderMatch *resourceManagerV3.Folder
 	parent := d.Get("parent").(string)
 	displayName := d.Get("display_name").(string)
 	token := ""
 
 	for paginate := true; paginate; {
-		resp, err := config.NewResourceManagerV2Client(userAgent).Folders.List().Parent(parent).PageSize(300).PageToken(token).Do()
+		resp, err := config.NewResourceManagerV3Client(userAgent).Folders.List().Parent(parent).PageSize(300).PageToken(token).Do()
 		if err != nil {
 			return fmt.Errorf("error reading folder list: %s", err)
 		}
 
 		for _, folder := range resp.Folders {
-			if folder.DisplayName == displayName && folder.LifecycleState == "ACTIVE" {
+			if folder.DisplayName == displayName && folder.State == "ACTIVE" {
 				if folderMatch != nil {
 					return fmt.Errorf("more than one matching folder found")
 				}

--- a/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"
-	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
+	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
 )
 
 // Test that an IAM binding can be applied to a folder
@@ -254,11 +254,11 @@ func testAccCheckGoogleFolderIamBindingExists(t *testing.T, expected *cloudresou
 }
 
 func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config *Config) (*cloudresourcemanager.Policy, error) {
-	var folderMatch *resourceManagerV2.Folder
+	var folderMatch *resourceManagerV3.Folder
 	token := ""
 
 	for paginate := true; paginate; {
-		resp, err := config.NewResourceManagerV2Client(config.userAgent).Folders.List().Parent(parent).PageSize(300).PageToken(token).Do()
+		resp, err := config.NewResourceManagerV3Client(config.userAgent).Folders.List().Parent(parent).PageSize(300).PageToken(token).Do()
 		if err != nil {
 			return nil, fmt.Errorf("Error reading folder list: %s", err)
 		}

--- a/mmv1/third_party/terraform/tests/resource_google_folder_iam_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_folder_iam_policy_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
+	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
 )
 
 func TestAccFolderIamPolicy_basic(t *testing.T) {
@@ -75,7 +75,7 @@ func testAccCheckGoogleFolderIamPolicyDestroyProducer(t *testing.T) func(s *terr
 			}
 
 			folder := rs.Primary.Attributes["folder"]
-			policy, err := config.NewResourceManagerV2Client(config.userAgent).Folders.GetIamPolicy(folder, &resourceManagerV2.GetIamPolicyRequest{}).Do()
+			policy, err := config.NewResourceManagerV3Client(config.userAgent).Folders.GetIamPolicy(folder, &resourceManagerV3.GetIamPolicyRequest{}).Do()
 
 			if err != nil && len(policy.Bindings) > 0 {
 				return fmt.Errorf("Folder '%s' policy hasn't been deleted.", folder)

--- a/mmv1/third_party/terraform/tests/resource_google_folder_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_folder_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
+	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
 )
 
 func TestAccFolder_rename(t *testing.T) {
@@ -17,7 +17,7 @@ func TestAccFolder_rename(t *testing.T) {
 	newFolderDisplayName := "tf-test-renamed-" + randString(t, 10)
 	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
-	folder := resourceManagerV2.Folder{}
+	folder := resourceManagerV3.Folder{}
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -55,8 +55,8 @@ func TestAccFolder_moveParent(t *testing.T) {
 	folder2DisplayName := "tf-test-" + randString(t, 10)
 	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
-	folder1 := resourceManagerV2.Folder{}
-	folder2 := resourceManagerV2.Folder{}
+	folder1 := resourceManagerV3.Folder{}
+	folder2 := resourceManagerV3.Folder{}
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -94,8 +94,8 @@ func testAccCheckGoogleFolderDestroyProducer(t *testing.T) func(s *terraform.Sta
 				continue
 			}
 
-			folder, err := config.NewResourceManagerV2Client(config.userAgent).Folders.Get(rs.Primary.ID).Do()
-			if err != nil || folder.LifecycleState != "DELETE_REQUESTED" {
+			folder, err := config.NewResourceManagerV3Client(config.userAgent).Folders.Get(rs.Primary.ID).Do()
+			if err != nil || folder.State != "DELETE_REQUESTED" {
 				return fmt.Errorf("Folder '%s' hasn't been marked for deletion", rs.Primary.Attributes["display_name"])
 			}
 		}
@@ -104,7 +104,7 @@ func testAccCheckGoogleFolderDestroyProducer(t *testing.T) func(s *terraform.Sta
 	}
 }
 
-func testAccCheckGoogleFolderExists(t *testing.T, n string, folder *resourceManagerV2.Folder) resource.TestCheckFunc {
+func testAccCheckGoogleFolderExists(t *testing.T, n string, folder *resourceManagerV3.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -117,7 +117,7 @@ func testAccCheckGoogleFolderExists(t *testing.T, n string, folder *resourceMana
 
 		config := googleProviderConfig(t)
 
-		found, err := config.NewResourceManagerV2Client(config.userAgent).Folders.Get(rs.Primary.ID).Do()
+		found, err := config.NewResourceManagerV3Client(config.userAgent).Folders.Get(rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func testAccCheckGoogleFolderExists(t *testing.T, n string, folder *resourceMana
 	}
 }
 
-func testAccCheckGoogleFolderDisplayName(folder *resourceManagerV2.Folder, displayName string) resource.TestCheckFunc {
+func testAccCheckGoogleFolderDisplayName(folder *resourceManagerV3.Folder, displayName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if folder.DisplayName != displayName {
 			return fmt.Errorf("Incorrect display name . Expected '%s', got '%s'", displayName, folder.DisplayName)
@@ -137,7 +137,7 @@ func testAccCheckGoogleFolderDisplayName(folder *resourceManagerV2.Folder, displ
 	}
 }
 
-func testAccCheckGoogleFolderParent(folder *resourceManagerV2.Folder, parent string) resource.TestCheckFunc {
+func testAccCheckGoogleFolderParent(folder *resourceManagerV3.Folder, parent string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if folder.Parent != parent {
 			return fmt.Errorf("Incorrect parent. Expected '%s', got '%s'", parent, folder.Parent)

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -36,7 +36,7 @@ import (
 	"google.golang.org/api/cloudiot/v1"
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
-	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
+	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
 <% if version == "ga" -%>
 	"google.golang.org/api/composer/v1"
 <% else -%>
@@ -193,7 +193,7 @@ type Config struct {
 	ContainerBasePath string
 	DataflowBasePath string
 	IamCredentialsBasePath string
-	ResourceManagerV2BasePath string
+	ResourceManagerV3BasePath string
 	IAMBasePath string
 	CloudIoTBasePath string
 	ServiceNetworkingBasePath string
@@ -234,7 +234,7 @@ const ContainerBasePathKey = "Container"
 const DataflowBasePathKey = "Dataflow"
 const IAMBasePathKey = "IAM"
 const IamCredentialsBasePathKey = "IamCredentials"
-const ResourceManagerV2BasePathKey = "ResourceManagerV2"
+const ResourceManagerV3BasePathKey = "ResourceManagerV3"
 const ServiceNetworkingBasePathKey = "ServiceNetworking"
 const StorageTransferBasePathKey = "StorageTransfer"
 const BigtableAdminBasePathKey = "BigtableAdmin"
@@ -261,7 +261,7 @@ var DefaultBasePaths = map[string]string{
 	DataflowBasePathKey : "https://dataflow.googleapis.com/v1b3/",
 	IAMBasePathKey : "https://iam.googleapis.com/v1/",
 	IamCredentialsBasePathKey : "https://iamcredentials.googleapis.com/v1/",
-	ResourceManagerV2BasePathKey : "https://cloudresourcemanager.googleapis.com/v2/",
+	ResourceManagerV3BasePathKey : "https://cloudresourcemanager.googleapis.com/v3/",
 	ServiceNetworkingBasePathKey : "https://servicenetworking.googleapis.com/v1/",
 	StorageTransferBasePathKey : "https://storagetransfer.googleapis.com/v1/",
 	BigtableAdminBasePathKey : "https://bigtableadmin.googleapis.com/v2/",
@@ -629,18 +629,18 @@ func (c *Config) NewResourceManagerClient(userAgent string) *cloudresourcemanage
 	return clientResourceManager
 }
 
-func (c *Config) NewResourceManagerV2Client(userAgent string) *resourceManagerV2.Service {
-	resourceManagerV2BasePath := removeBasePathVersion(c.ResourceManagerV2BasePath)
-	log.Printf("[INFO] Instantiating Google Cloud ResourceManager V client for path %s", resourceManagerV2BasePath)
-	clientResourceManagerV2, err := resourceManagerV2.NewService(c.context, option.WithHTTPClient(c.client))
+func (c *Config) NewResourceManagerV3Client(userAgent string) *resourceManagerV3.Service {
+	resourceManagerV3BasePath := removeBasePathVersion(c.ResourceManagerV3BasePath)
+	log.Printf("[INFO] Instantiating Google Cloud ResourceManager V3 client for path %s", resourceManagerV3BasePath)
+	clientResourceManagerV3, err := resourceManagerV3.NewService(c.context, option.WithHTTPClient(c.client))
 	if err != nil {
-		log.Printf("[WARN] Error creating client resource manager v2: %s", err)
+		log.Printf("[WARN] Error creating client resource manager v3: %s", err)
 		return nil
 	}
-	clientResourceManagerV2.UserAgent = userAgent
-	clientResourceManagerV2.BasePath = resourceManagerV2BasePath
+	clientResourceManagerV3.UserAgent = userAgent
+	clientResourceManagerV3.BasePath = resourceManagerV3BasePath
 
-	return clientResourceManagerV2
+	return clientResourceManagerV3
 }
 
 <% unless version == 'ga' -%>
@@ -1060,7 +1060,7 @@ func ConfigureBasePaths(c *Config) {
 	c.DataprocBasePath = DefaultBasePaths[DataprocBasePathKey]
 	c.DataflowBasePath = DefaultBasePaths[DataflowBasePathKey]
 	c.IamCredentialsBasePath = DefaultBasePaths[IamCredentialsBasePathKey]
-	c.ResourceManagerV2BasePath = DefaultBasePaths[ResourceManagerV2BasePathKey]
+	c.ResourceManagerV3BasePath = DefaultBasePaths[ResourceManagerV3BasePathKey]
 	c.IAMBasePath = DefaultBasePaths[IAMBasePathKey]
 	c.ServiceNetworkingBasePath = DefaultBasePaths[ServiceNetworkingBasePathKey]
 	c.BigQueryBasePath = DefaultBasePaths[BigQueryBasePathKey]

--- a/mmv1/third_party/terraform/utils/iam_folder.go
+++ b/mmv1/third_party/terraform/utils/iam_folder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/cloudresourcemanager/v1"
-	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
+	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
 )
 
 var IamFolderSchema = map[string]*schema.Schema{
@@ -62,7 +62,7 @@ func (u *FolderIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Pol
 		return err
 	}
 
-	_, err = u.Config.NewResourceManagerV2Client(userAgent).Folders.SetIamPolicy(u.folderId, &resourceManagerV2.SetIamPolicyRequest{
+	_, err = u.Config.NewResourceManagerV3Client(userAgent).Folders.SetIamPolicy(u.folderId, &resourceManagerV3.SetIamPolicyRequest{
 		Policy:     v2Policy,
 		UpdateMask: "bindings,etag,auditConfigs",
 	}).Do()
@@ -95,8 +95,8 @@ func canonicalFolderId(folder string) string {
 }
 
 // v1 and v2 policy are identical
-func v1PolicyToV2(in *cloudresourcemanager.Policy) (*resourceManagerV2.Policy, error) {
-	out := &resourceManagerV2.Policy{}
+func v1PolicyToV2(in *cloudresourcemanager.Policy) (*resourceManagerV3.Policy, error) {
+	out := &resourceManagerV3.Policy{}
 	err := Convert(in, out)
 	if err != nil {
 		return nil, errwrap.Wrapf("Cannot convert a v1 policy to a v2 policy: {{err}}", err)
@@ -104,7 +104,7 @@ func v1PolicyToV2(in *cloudresourcemanager.Policy) (*resourceManagerV2.Policy, e
 	return out, nil
 }
 
-func v2PolicyToV1(in *resourceManagerV2.Policy) (*cloudresourcemanager.Policy, error) {
+func v2PolicyToV1(in *resourceManagerV3.Policy) (*cloudresourcemanager.Policy, error) {
 	out := &cloudresourcemanager.Policy{}
 	err := Convert(in, out)
 	if err != nil {
@@ -115,9 +115,9 @@ func v2PolicyToV1(in *resourceManagerV2.Policy) (*cloudresourcemanager.Policy, e
 
 // Retrieve the existing IAM Policy for a folder
 func getFolderIamPolicyByFolderName(folderName, userAgent string, config *Config) (*cloudresourcemanager.Policy, error) {
-	p, err := config.NewResourceManagerV2Client(userAgent).Folders.GetIamPolicy(folderName,
-		&resourceManagerV2.GetIamPolicyRequest{
-			Options: &resourceManagerV2.GetPolicyOptions{
+	p, err := config.NewResourceManagerV3Client(userAgent).Folders.GetIamPolicy(folderName,
+		&resourceManagerV3.GetIamPolicyRequest{
+			Options: &resourceManagerV3.GetPolicyOptions{
 				RequestedPolicyVersion: iamPolicyVersion,
 			},
 		}).Do()

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -167,7 +167,7 @@ func Provider() *schema.Provider {
 			ContainerCustomEndpointEntryKey:              ContainerCustomEndpointEntry,
 			DataflowCustomEndpointEntryKey:               DataflowCustomEndpointEntry,
 			IamCredentialsCustomEndpointEntryKey:         IamCredentialsCustomEndpointEntry,
-			ResourceManagerV2CustomEndpointEntryKey:      ResourceManagerV2CustomEndpointEntry,
+			ResourceManagerV3CustomEndpointEntryKey:      ResourceManagerV3CustomEndpointEntry,
 			<% unless version == "ga" -%>
 			RuntimeConfigCustomEndpointEntryKey:          RuntimeConfigCustomEndpointEntry,
 			<% end -%>
@@ -679,7 +679,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	config.ContainerBasePath = d.Get(ContainerCustomEndpointEntryKey).(string)
 	config.DataflowBasePath = d.Get(DataflowCustomEndpointEntryKey).(string)
 	config.IamCredentialsBasePath = d.Get(IamCredentialsCustomEndpointEntryKey).(string)
-	config.ResourceManagerV2BasePath = d.Get(ResourceManagerV2CustomEndpointEntryKey).(string)
+	config.ResourceManagerV3BasePath = d.Get(ResourceManagerV3CustomEndpointEntryKey).(string)
 	<% unless version == "ga" -%>
 	config.RuntimeConfigBasePath = d.Get(RuntimeConfigCustomEndpointEntryKey).(string)
 	<% end -%>

--- a/mmv1/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
@@ -69,14 +69,14 @@ var IamCredentialsCustomEndpointEntry = &schema.Schema{
 	}, DefaultBasePaths[IamCredentialsBasePathKey]),
 }
 
-var ResourceManagerV2CustomEndpointEntryKey = "resource_manager_v2_custom_endpoint"
-var ResourceManagerV2CustomEndpointEntry = &schema.Schema{
+var ResourceManagerV3CustomEndpointEntryKey = "resource_manager_v3_custom_endpoint"
+var ResourceManagerV3CustomEndpointEntry = &schema.Schema{
 	Type:         schema.TypeString,
 	Optional:     true,
 	ValidateFunc: validateCustomEndpoint,
 	DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-		"GOOGLE_RESOURCE_MANAGER_V2_CUSTOM_ENDPOINT",
-	}, DefaultBasePaths[ResourceManagerV2BasePathKey]),
+		"GOOGLE_RESOURCE_MANAGER_V3_CUSTOM_ENDPOINT",
+	}, DefaultBasePaths[ResourceManagerV3BasePathKey]),
 }
 
 <% unless version == 'ga' -%>

--- a/mmv1/third_party/validator/constants.go
+++ b/mmv1/third_party/validator/constants.go
@@ -18,7 +18,7 @@ var ErrEmptyIdentityField = errors.New("empty identity field")
 // ErrResourceInaccessible can be returned when fetching an IAM resource
 // on a project that has not yet been created or if the service account
 // lacks sufficient permissions
-var ErrResourceInaccessible = errors.New("resource does not exist or service account is lacking suffient permissions")
+var ErrResourceInaccessible = errors.New("resource does not exist or service account is lacking sufficient permissions")
 
 // Global MutexKV
 var mutexKV = NewMutexKV()


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Migrate cloud resource manager v2 to v3 API. 
This is to support terraform validator to use v3 API to fetch project and folder parents to construct the list of ancestors.  


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
