### PR TITLE
Add resource_settings_organization_setting

### DIFF
--- a/mmv1/products/resourcesettings/api.yaml
+++ b/mmv1/products/resourcesettings/api.yaml
@@ -1,0 +1,63 @@
+
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: ResourceSettings
+display_name: Resource Settings
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://resourcesettings.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Resource Settings API
+    url: https://console.cloud.google.com/apis/library/resourcesettings.googleapis.com
+objects:
+  - !ruby/object:Api::Resource
+    name: 'OrganizationSetting'
+    read_query_params: '?view=SETTING_VIEW_LOCAL_VALUE'
+    create_verb: :PATCH
+    update_verb: :PATCH
+    base_url: organizations/{{organization_id}}/settings
+    description: |
+      The Resource Settings API allows users to control and modify the behavior of their GCP resources (e.g., VM, firewall, Project, etc.) across the Cloud Resource Hierarchy.
+
+      The OrganizationSetting resource manages settings at the organization level.
+
+      NOTE: Deletion is not supported.
+    update_mask: false
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: The short name of the setting.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'organization_id'
+        description: The organization the setting should apply to.
+        required: true
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'localValue'
+        description: The configured value of the setting at the given parent resource, ignoring the resource hierarchy.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'stringValue'
+            description: Defines this value as being a string value.

--- a/mmv1/products/resourcesettings/api.yaml
+++ b/mmv1/products/resourcesettings/api.yaml
@@ -36,8 +36,6 @@ objects:
       The Resource Settings API allows users to control and modify the behavior of their GCP resources (e.g., VM, firewall, Project, etc.) across the Cloud Resource Hierarchy.
 
       The OrganizationSetting resource manages settings at the organization level.
-
-      NOTE: Deletion is not supported.
     update_mask: false
     parameters:
       - !ruby/object:Api::Type::String

--- a/mmv1/products/resourcesettings/terraform.yaml
+++ b/mmv1/products/resourcesettings/terraform.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  OrganizationSetting: !ruby/object:Overrides::Terraform::ResourceOverride
+    # Settings can only be updated and read.
+    skip_delete: true
+    examples:
+    - !ruby/object:Provider::Terraform::Examples
+      name: "resource_settings_organization_setting_basic"
+      primary_resource_id: "sa-key-expiry"
+      test_env_vars:
+        org_id: :ORG_ID
+    properties: {}
+
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/mmv1/products/resourcesettings/terraform.yaml
+++ b/mmv1/products/resourcesettings/terraform.yaml
@@ -14,7 +14,9 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   OrganizationSetting: !ruby/object:Overrides::Terraform::ResourceOverride
-    # Settings can only be updated and read.
+    docs: !ruby/object:Provider::Terraform::Docs
+      warning: |
+        Resource Settings do not support deletion. Deleting the terraform resource will not delete or change the GCP Resource Setting.
     skip_delete: true
     examples:
     - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/resourcesettings/terraform.yaml
+++ b/mmv1/products/resourcesettings/terraform.yaml
@@ -22,8 +22,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     - !ruby/object:Provider::Terraform::Examples
       name: "resource_settings_organization_setting_basic"
       primary_resource_id: "sa-key-expiry"
-      test_env_vars:
-        org_id: :ORG_ID
+      skip_test: true
     properties: {}
 
 # This is for copying files over

--- a/mmv1/templates/terraform/examples/resource_settings_organization_setting_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/resource_settings_organization_setting_basic.tf.erb
@@ -1,0 +1,7 @@
+resource "google_resource_settings_organization_setting" "<%= ctx[:primary_resource_id] %>" {
+  organization_id = "<%= ctx[:test_env_vars]['org_id'] %>"
+  name    = "iam-serviceAccountKeyExpiry"
+  local_value {
+    string_value = "24hours"
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_resource_settings_organization_setting_test.go
+++ b/mmv1/third_party/terraform/tests/resource_resource_settings_organization_setting_test.go
@@ -10,7 +10,7 @@ func TestAccResourceSettingsOrganizationSetting_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id": getTestOrgFromEnv(t),
+		"org_id": getTestOrgTargetFromEnv(t),
 	}
 
 	vcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/resource_resource_settings_organization_setting_test.go
+++ b/mmv1/third_party/terraform/tests/resource_resource_settings_organization_setting_test.go
@@ -1,0 +1,82 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceSettingsOrganizationSetting_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id": getTestOrgFromEnv(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSettingsOrganizationSetting_start(context),
+			},
+			{
+				ResourceName:      "google_resource_settings_organization_setting.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccResourceSettingsOrganizationSetting_update(context),
+			},
+			{
+				ResourceName:      "google_resource_settings_organization_setting.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccResourceSettingsOrganizationSetting_end(context),
+			},
+			{
+				ResourceName:      "google_resource_settings_organization_setting.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceSettingsOrganizationSetting_start(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_resource_settings_organization_setting" "default" {
+  organization_id = "%{org_id}"
+  name = "iam-serviceAccountKeyExpiry"
+  local_value {
+    string_value = "24hours"
+  }
+}
+`, context)
+}
+
+func testAccResourceSettingsOrganizationSetting_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_resource_settings_organization_setting" "default" {
+  organization_id = "%{org_id}"
+  name = "iam-serviceAccountKeyExpiry"
+  local_value {
+    string_value = "7days"
+  }
+}
+`, context)
+}
+
+func testAccResourceSettingsOrganizationSetting_end(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_resource_settings_organization_setting" "default" {
+  organization_id = "%{org_id}"
+  name = "iam-serviceAccountKeyExpiry"
+  local_value {
+    string_value = "never"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Add terraform support for the resource settings API.

Adding a single `google_resource_settings_organization_setting` resource at this time. This is the only level at which resource settings can be set currently. This is due to a restriction in the `roles/resourcesettings.admin` role: "Lowest-level resources where you can grant this role: - Organization". (https://cloud.google.com/iam/docs/understanding-roles#resource-settings-roles).

Once the `folder` and `project` levels are supported I think it makes sense to add and test the corresponding `google_resource_settings_<level>_setting` resources.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11016

Closing the [manual PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/5823) in favor of adding the resource to mmv1.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_resource_settings_organization_setting`
```
