### PR TITLE
Update examples for Cloud Bigtable AppProfile

### DIFF
--- a/mmv1/products/bigtable/terraform.yaml
+++ b/mmv1/products/bigtable/terraform.yaml
@@ -23,7 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        name: "bigtable_app_profile_multicluster"
+        name: "bigtable_app_profile_anycluster"
         primary_resource_id: "ap"
         vars:
           instance_name: "bt-instance"
@@ -37,6 +37,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "ignore_warnings"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigtable_app_profile_singlecluster"
+        primary_resource_id: "ap"
+        vars:
+          instance_name: "bt-instance"
+          app_profile_name: "bt-profile"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        oics_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "ignore_warnings"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigtable_app_profile_multicluster"
         primary_resource_id: "ap"
         vars:
           instance_name: "bt-instance"

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_anycluster.tf.erb
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_anycluster.tf.erb
@@ -17,7 +17,7 @@ resource "google_bigtable_instance" "instance" {
     zone         = "us-central1-c"
     num_nodes    = 3
     storage_type = "HDD"
-  }
+  }  
 
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }
@@ -26,9 +26,8 @@ resource "google_bigtable_app_profile" "ap" {
   instance       = google_bigtable_instance.instance.name
   app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
 
-  // Requests will be routed to the following 2 clusters.
+  // Requests will be routed to any of the 3 clusters.
   multi_cluster_routing_use_any = true
-  multi_cluster_routing_cluster_ids = ["cluster-1", "cluster-2"]
 
   ignore_warnings               = true
 }

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
@@ -1,7 +1,7 @@
 resource "google_bigtable_instance" "instance" {
   name = "<%= ctx[:vars]['instance_name'] %>"
   cluster {
-    cluster_id   = "<%= ctx[:vars]['instance_name'] %>"
+    cluster_id   = "cluster-1"
     zone         = "us-central1-b"
     num_nodes    = 3
     storage_type = "HDD"
@@ -14,8 +14,9 @@ resource "google_bigtable_app_profile" "ap" {
   instance       = google_bigtable_instance.instance.name
   app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
 
+  // Requests will be routed to the following cluster.
   single_cluster_routing {
-    cluster_id                 = "<%= ctx[:vars]['instance_name'] %>"
+    cluster_id                 = "cluster-1"
     allow_transactional_writes = true
   }
 

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cloud.google.com/go/bigtable"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -53,6 +54,9 @@ func TestAccBigtableGCPolicy_swapOffDeprecated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
 						t, "google_bigtable_gc_policy.policy"),
+					// Verify can write some data.
+					testAccBigtableCanWriteData(
+						t, "google_bigtable_gc_policy.policy", 10),
 				),
 			},
 			{
@@ -60,6 +64,9 @@ func TestAccBigtableGCPolicy_swapOffDeprecated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
 						t, "google_bigtable_gc_policy.policy"),
+					// Verify no data loss after the GC policy update.
+					testAccBigtableCanReadData(
+						t, "google_bigtable_gc_policy.policy", 10),
 				),
 			},
 		},
@@ -263,6 +270,84 @@ func testAccBigtableGCPolicyExists(t *testing.T, n string) resource.TestCheckFun
 		}
 
 		return fmt.Errorf("Error retrieving gc policy. Could not find policy in family %s", rs.Primary.Attributes["column_family"])
+	}
+}
+
+func testAccBigtableCanWriteData(t *testing.T, n string, numberOfRows int) resource.TestCheckFunc {
+	var ctx = context.Background()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := googleProviderConfig(t)
+		c, err := config.BigTableClientFactory(config.userAgent).NewClient(config.Project, rs.Primary.Attributes["instance_name"])
+		if err != nil {
+			return fmt.Errorf("Error starting client. %s", err)
+		}
+
+		defer c.Close()
+
+		table := c.Open(rs.Primary.Attributes["table"])
+		rowKeys := make([]string, numberOfRows)
+		mutations := make([]*bigtable.Mutation, numberOfRows)
+		columnFamily := rs.Primary.Attributes["column_family"]
+		for i := 0; i < 10; i++ {
+			rowKeys[i] = fmt.Sprintf("row%d", i)
+			mutations[i] = bigtable.NewMutation()
+			mutations[i].Set(columnFamily, "column", bigtable.Now(), []byte(fmt.Sprintf("value%d", i)))
+		}
+
+		rowErrs, err := table.ApplyBulk(ctx, rowKeys, mutations)
+		if err != nil {
+			return fmt.Errorf("could not write elements to bigtable: %v", err)
+		} else if rowErrs != nil {
+			for _, rowErr := range rowErrs {
+				return fmt.Errorf("could not write element to bigtable: %v", rowErr)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccBigtableCanReadData(t *testing.T, n string, numberOfRows int) resource.TestCheckFunc {
+	var ctx = context.Background()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := googleProviderConfig(t)
+		c, err := config.BigTableClientFactory(config.userAgent).NewClient(config.Project, rs.Primary.Attributes["instance_name"])
+		if err != nil {
+			return fmt.Errorf("Error starting client. %s", err)
+		}
+
+		defer c.Close()
+
+		table := c.Open(rs.Primary.Attributes["table"])
+		var rows []bigtable.Row
+		if err := table.ReadRows(ctx, bigtable.InfiniteRange(""), func(row bigtable.Row) bool {
+			rows = append(rows, row)
+			return true
+		}); err != nil {
+			return fmt.Errorf("Could not read elements from bigtable: %v", err)
+		}
+
+		if len(rows) != numberOfRows {
+			return fmt.Errorf("Expecting %d rows but got: %d", numberOfRows, len(rows))
+		}
+
+		return nil
 	}
 }
 

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -305,12 +305,10 @@ func testAccBigtableCanWriteData(t *testing.T, n string, numberOfRows int) resou
 		rowErrs, err := table.ApplyBulk(ctx, rowKeys, mutations)
 		if err != nil {
 			return fmt.Errorf("could not write elements to bigtable: %v", err)
-		} else if rowErrs != nil {
-			for _, rowErr := range rowErrs {
-				return fmt.Errorf("could not write element to bigtable: %v", rowErr)
-			}
 		}
-
+		for _, rowErr := range rowErrs {
+			return fmt.Errorf("could not write element to bigtable: %v", rowErr)
+                }
 		return nil
 	}
 }

--- a/mmv1/third_party/terraform/utils/bigtable_client_factory.go
+++ b/mmv1/third_party/terraform/utils/bigtable_client_factory.go
@@ -48,3 +48,19 @@ func (s BigtableClientFactory) NewAdminClient(project, instance string) (*bigtab
 
 	return bigtable.NewAdminClient(context.Background(), project, instance, opts...)
 }
+
+func (s BigtableClientFactory) NewClient(project, instance string) (*bigtable.Client, error) {
+	var opts []option.ClientOption
+	if requestReason := os.Getenv("CLOUDSDK_CORE_REQUEST_REASON"); requestReason != "" {
+		opts = append(opts, option.WithRequestReason(requestReason))
+	}
+
+	if s.UserProjectOverride && s.BillingProject != "" {
+		opts = append(opts, option.WithQuotaProject(s.BillingProject))
+	}
+
+	opts = append(opts, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
+	opts = append(opts, s.gRPCLoggingOptions...)
+
+	return bigtable.NewClient(context.Background(), project, instance, opts...)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

With latest cluster group support, users can create 3 different flavors of AppProfile:
1. Any cluster: requests can be routed to any of the clusters in an instance.
2. Single cluster: requests can be routed to the only cluster specified in the AppProfile.
3. Muti cluster: request can be routed to a group of clusters specified in the AppProfile.

Update the examples to show users can create all 3 different flavors of AppProfile mentioned above.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
