### PR TITLE
Update examples for Cloud Bigtable AppProfile

### DIFF
--- a/mmv1/products/bigtable/terraform.yaml
+++ b/mmv1/products/bigtable/terraform.yaml
@@ -23,7 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        name: "bigtable_app_profile_multicluster"
+        name: "bigtable_app_profile_anycluster"
         primary_resource_id: "ap"
         vars:
           instance_name: "bt-instance"
@@ -37,6 +37,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "ignore_warnings"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigtable_app_profile_singlecluster"
+        primary_resource_id: "ap"
+        vars:
+          instance_name: "bt-instance"
+          app_profile_name: "bt-profile"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        oics_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "ignore_warnings"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigtable_app_profile_multicluster"
         primary_resource_id: "ap"
         vars:
           instance_name: "bt-instance"

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_anycluster.tf.erb
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_anycluster.tf.erb
@@ -17,7 +17,7 @@ resource "google_bigtable_instance" "instance" {
     zone         = "us-central1-c"
     num_nodes    = 3
     storage_type = "HDD"
-  }
+  }  
 
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }
@@ -26,9 +26,8 @@ resource "google_bigtable_app_profile" "ap" {
   instance       = google_bigtable_instance.instance.name
   app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
 
-  // Requests will be routed to the following 2 clusters.
+  // Requests will be routed to any of the 3 clusters.
   multi_cluster_routing_use_any = true
-  multi_cluster_routing_cluster_ids = ["cluster-1", "cluster-2"]
 
   ignore_warnings               = true
 }

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
@@ -1,7 +1,7 @@
 resource "google_bigtable_instance" "instance" {
   name = "<%= ctx[:vars]['instance_name'] %>"
   cluster {
-    cluster_id   = "<%= ctx[:vars]['instance_name'] %>"
+    cluster_id   = "cluster-1"
     zone         = "us-central1-b"
     num_nodes    = 3
     storage_type = "HDD"
@@ -14,8 +14,9 @@ resource "google_bigtable_app_profile" "ap" {
   instance       = google_bigtable_instance.instance.name
   app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
 
+  // Requests will be routed to the following cluster.
   single_cluster_routing {
-    cluster_id                 = "<%= ctx[:vars]['instance_name'] %>"
+    cluster_id                 = "cluster-1"
     allow_transactional_writes = true
   }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

With latest cluster group support, users can create 3 different flavors of AppProfile:

Any cluster: requests can be routed to any of the clusters in an instance.
Single cluster: requests can be routed to the only cluster specified in the AppProfile.
Muti cluster: request can be routed to a group of clusters specified in the AppProfile.
Update the examples to show users can create all 3 different flavors of AppProfile mentioned above.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: Update the examples to show users can create all 3 different flavors of AppProfile
```
