### PR TITLE
Add IAM condition support for privateca CaPool

### DIFF
--- a/mmv1/api/resource/iam_policy.rb
+++ b/mmv1/api/resource/iam_policy.rb
@@ -121,7 +121,8 @@ module Api
         check :admin_iam_role, type: String
         check :parent_resource_attribute, type: String, default: 'id'
         check :test_project_name, type: String
-        check :iam_conditions_request_type, type: Symbol, allowed: %i[REQUEST_BODY QUERY_PARAM]
+        check :iam_conditions_request_type, type: Symbol, allowed: %i[REQUEST_BODY QUERY_PARAM
+                                                                      QUERY_PARAM_NESTED]
         check :base_url, type: String
         check :self_link, type: String
         check :import_format, type: Array, item_type: String

--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -143,6 +143,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       method_name_separator: ':'
       parent_resource_attribute: ca_pool
       example_config_body: 'templates/terraform/iam/example_config_body/privateca_ca_pool.tf.erb'
+      iam_conditions_request_type: :QUERY_PARAM_NESTED
     autogen_async: true
     import_format: ["projects/{{project}}/locations/{{location}}/caPools/{{name}}"]
     examples:

--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -194,6 +194,11 @@ func (u *<%= resource_name -%>IamUpdater) GetResourceIamPolicy() (*cloudresource
 	if err != nil {
 		return nil, err
 	}
+<% elsif object.iam_policy.iam_conditions_request_type == :QUERY_PARAM_NESTED -%>
+	url, err = addQueryParams(url, map[string]string{"options.requestedPolicyVersion": fmt.Sprintf("%d", <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>)})
+	if err != nil {
+		return nil, err
+	}
 <% elsif object.iam_policy.iam_conditions_request_type == :REQUEST_BODY -%>
 	obj = map[string]interface{}{
 		"options": map[string]interface{}{


### PR DESCRIPTION
Add support for IAM conditions to CaPool.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: Added support for IAM conditions to CaPool
```

