### PR TITLE
Move filestore enterprise features out of beta and add support for cu…

### DIFF
--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -250,5 +250,6 @@ objects:
         output: true
       - !ruby/object:Api::Type::String
         name: 'kmsKeyName'
+        input: true
         description: |
           KMS key name used for data encryption.

--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -116,7 +116,7 @@ objects:
         name: 'tier'
         description: |
           The service tier of the instance.
-          Possible values include: STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, HIGH_SCALE_SSD and ENTERPRISE (beta only)
+          Possible values include: STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, HIGH_SCALE_SSD and ENTERPRISE
         required: true
         input: true
       - !ruby/object:Api::Type::KeyValuePairs
@@ -149,7 +149,6 @@ objects:
               description: |
                 Nfs Export Options. There is a limit of 10 export options per file share.
               max_size: 10
-              min_version: beta
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   - !ruby/object:Api::Type::Array
@@ -239,7 +238,6 @@ objects:
                 If not provided, the connect mode defaults to
                 DIRECT_PEERING.
               input: true
-              min_version: beta
               default_value: :DIRECT_PEERING
               values:
                 - :DIRECT_PEERING
@@ -250,3 +248,7 @@ objects:
           Server-specified ETag for the instance resource to prevent
           simultaneous updates from overwriting each other.
         output: true
+      - !ruby/object:Api::Type::String
+        name: 'kmsKeyName'
+        description: |
+          KMS key name used for data encryption.

--- a/mmv1/products/filestore/terraform.yaml
+++ b/mmv1/products/filestore/terraform.yaml
@@ -26,8 +26,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           instance_name: "test-instance"
       - !ruby/object:Provider::Terraform::Examples
         name: "filestore_instance_full"
-        min_version: beta
         primary_resource_id: "instance"
+        vars:
+          instance_name: "test-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "filestore_instance_enterprise"
+        primary_resource_id: "instance"
+        skip_test: true
         vars:
           instance_name: "test-instance"
     properties:

--- a/mmv1/templates/terraform/examples/filestore_instance_enterprise.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_enterprise.tf.erb
@@ -1,0 +1,26 @@
+resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["instance_name"] %>"
+  location = "us-central1"
+  tier = "ENTERPRISE"
+
+  file_shares {
+    capacity_gb = 2560
+    name        = "share1"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+  kms_key_name = google_kms_crypto_key.filestore_key.id
+}
+
+resource "google_kms_key_ring" "filestore_keyring" {
+  name     = "filestore-keyring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "filestore_key" {
+  name            = "filestore-key"
+  key_ring        = google_kms_key_ring.filestore_keyring.id
+}

--- a/mmv1/templates/terraform/examples/filestore_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name = "<%= ctx[:vars]["instance_name"] %>"
   location = "us-central1-b"
   tier = "BASIC_SSD"


### PR DESCRIPTION
Move Filestore enterprise features out of beta and add support for cmek for filestore instances

fixes https://github.com/hashicorp/terraform-provider-google/issues/11173

If this PR is for Terraform, I acknowledge that I have:

- [X ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: promoted enterprise features to GA
filestore: added `kms_key_name` field to `google_filestore_instance` resource to support CMEK
```
