### PR TITLE
Add mutex to `google_tags_tag_binding`

### DIFF
--- a/mmv1/products/tags/terraform.yaml
+++ b/mmv1/products/tags/terraform.yaml
@@ -71,7 +71,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     autogen_async: true
     id_format: "tagBindings/{{name}}"
     import_format: ["tagBindings/{{name}}", "{{name}}"]
-    mutex: tagValues/{{parent}}
+    mutex: tagBindings/{{parent}}
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/tags_tag_binding_name.erb'

--- a/mmv1/products/tags/terraform.yaml
+++ b/mmv1/products/tags/terraform.yaml
@@ -71,6 +71,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     autogen_async: true
     id_format: "tagBindings/{{name}}"
     import_format: ["tagBindings/{{name}}", "{{name}}"]
+    mutex: tagValues/{{parent}}
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/tags_tag_binding_name.erb'


### PR DESCRIPTION
closes: https://github.com/hashicorp/terraform-provider-google/issues/11381


**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
tags: fixed issue where tags could not be applied sequentially to the same parent in `google_tags_tag_binding`
```
