### PR TITLE
Add support for Dataproc Metastore CMEK config

### DIFF
--- a/mmv1/products/metastore/api.yaml
+++ b/mmv1/products/metastore/api.yaml
@@ -145,6 +145,21 @@ objects:
               - :SATURDAY
               - :SUNDAY
       - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionConfig'
+        min_version: beta
+        description: |
+          Information used to configure the Dataproc Metastore service to encrypt
+          customer data at rest.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'kmsKey'
+            min_version: beta
+            description: |
+              The fully qualified customer provided Cloud KMS key name to use for customer data encryption.
+              Use the following format: `projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)`
+            required: true
+            input: true
+      - !ruby/object:Api::Type::NestedObject
         name: 'hiveMetastoreConfig'
         description: |
          Configuration information specific to running Hive metastore software as the metastore service.

--- a/mmv1/products/metastore/terraform.yaml
+++ b/mmv1/products/metastore/terraform.yaml
@@ -23,6 +23,24 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
         vars:
           metastore_service_name: "metastore-srv"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dataproc_metastore_service_cmek_test"
+        min_version: beta
+        skip_docs: true
+        primary_resource_id: "default"
+        vars:
+          metastore_service_name: "example-service"
+          key_name: "example-key"
+          keyring_name: "example-keyring"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dataproc_metastore_service_cmek_example"
+        min_version: beta
+        skip_test: true
+        primary_resource_id: "default"
+        vars:
+          metastore_service_name: "example-service"
+          key_name: "example-key"
+          keyring_name: "example-keyring"
     properties:
       network: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_example.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_example.tf.erb
@@ -1,0 +1,27 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+
+  encryption_config {
+    kms_key = google_kms_crypto_key.crypto_key.id
+  }
+
+  hive_metastore_config {
+    version = "3.1.2"
+  }
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['key_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+
+  purpose  = "ENCRYPT_DECRYPT"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['keyring_name'] %>"
+  location = "us-central1"
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_test.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_test.tf.erb
@@ -1,0 +1,49 @@
+data "google_project" "project" {
+  provider = google-beta
+}
+
+data "google_storage_project_service_account" "gcs_account" {
+  provider = google-beta
+}
+
+
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+
+  encryption_config {
+    kms_key = google_kms_crypto_key.crypto_key.id
+  }
+
+  hive_metastore_config {
+    version = "3.1.2"
+  }
+
+  depends_on = [google_kms_crypto_key_iam_binding.crypto_key_binding]
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['key_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+
+  purpose  = "ENCRYPT_DECRYPT"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['keyring_name'] %>"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+  provider      = google-beta
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-metastore.iam.gserviceaccount.com",
+    "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+  ]
+}


### PR DESCRIPTION
Adds support for configuring CMEK during creation for Dataproc Metastore configurations.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
metastore: Added support for encryption_config during service creation.
```