### PR TITLE
Set url_mask optional for network endpoint group

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8544,7 +8544,7 @@ objects:
               API Gateway: Unused, App Engine: The service version, Cloud Functions: Unused, Cloud Run: The service tag
           - !ruby/object:Api::Type::String
             name: 'urlMask'
-            required: true
+            required: false
             description: |
               A template to parse platform-specific fields from a request URL. URL mask allows for routing to multiple resources
               on the same serverless platform without having to create multiple Network Endpoint Groups and backend resources.


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#11242
Replaces hashicorp/terraform-provider-google-beta#4161

This argument isn't required - the gcloud command correctly creates a
serverless NEG with an API gateway resource without url_mask specified.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests (see [comment](https://github.com/GoogleCloudPlatform/magic-modules/pull/5883#issuecomment-1087153685)).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed url_mask required mis-annotation in `google_compute_region_network_endpoint_group`, making it optional
```
