### PR TITLE
Add support for aliases like airflow-2 in Composer image version field

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -22,7 +22,7 @@ import (
 const (
 	composerEnvironmentEnvVariablesRegexp          = "[a-zA-Z_][a-zA-Z0-9_]*."
 	composerEnvironmentReservedAirflowEnvVarRegexp = "AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+"
-	composerEnvironmentVersionRegexp               = `composer-(([0-9]+)(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-(([0-9]+\.[0-9]+)(\.[0-9]+)?)`
+	composerEnvironmentVersionRegexp               = `composer-(([0-9]+)(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-(([0-9]+)((\.[0-9]+)(\.[0-9]+)?)?)`
 )
 
 var composerEnvironmentReservedEnvVar = map[string]struct{}{
@@ -370,7 +370,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										AtLeastOneOf:     composerSoftwareConfigKeys,
 										ValidateFunc:     validateRegexp(composerEnvironmentVersionRegexp),
 										DiffSuppressFunc: composerImageVersionDiffSuppress,
-										Description:      `The version of the software running in the environment. This encapsulates both the version of Cloud Composer functionality and the version of Apache Airflow. It must match the regular expression composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+)?). The Cloud Composer portion of the image version is a full semantic version, or an alias in the form of major version number or 'latest'. The Apache Airflow portion of the image version is a full semantic version that points to one of the supported Apache Airflow versions, or an alias in the form of only major and minor versions specified. See documentation for more details and version list.`,
+										Description:      `The version of the software running in the environment. This encapsulates both the version of Cloud Composer functionality and the version of Apache Airflow. It must match the regular expression composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?). The Cloud Composer portion of the image version is a full semantic version, or an alias in the form of major version number or 'latest'. The Apache Airflow portion of the image version is a full semantic version that points to one of the supported Apache Airflow versions, or an alias in the form of only major or major.minor versions specified. See documentation for more details and version list.`,
 									},
 									"python_version": {
 										Type:         schema.TypeString,
@@ -2085,7 +2085,7 @@ func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 	versionRe := regexp.MustCompile(composerEnvironmentVersionRegexp)
 	oldVersions := versionRe.FindStringSubmatch(old)
 	newVersions := versionRe.FindStringSubmatch(new)
-	if oldVersions == nil || len(oldVersions) < 8 {
+	if oldVersions == nil || len(oldVersions) < 10 {
 		// Somehow one of the versions didn't match the regexp or didn't
 		// have values in the capturing groups. In that case, fall back to
 		// an equality check.
@@ -2094,7 +2094,7 @@ func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 		}
 		return old == new
 	}
-	if newVersions == nil || len(newVersions) < 8 {
+	if newVersions == nil || len(newVersions) < 10 {
 		// Somehow one of the versions didn't match the regexp or didn't
 		// have values in the capturing groups. In that case, fall back to
 		// an equality check.
@@ -2105,11 +2105,23 @@ func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 	}
 
 	oldAirflow := oldVersions[5]
-	oldAirflowMajorMinor := oldVersions[6]
+	oldAirflowMajor := oldVersions[6]
+	oldAirflowMajorMinor := oldVersions[6] + oldVersions[8]
 	newAirflow := newVersions[5]
-	newAirflowMajorMinor := newVersions[6]
+	newAirflowMajor := newVersions[6]
+	newAirflowMajorMinor := newVersions[6] + newVersions[8]
 	// Check Airflow versions.
-	if oldAirflow == oldAirflowMajorMinor || newAirflow == newAirflowMajorMinor {
+	if oldAirflow == oldAirflowMajor || newAirflow == newAirflowMajor {
+		// If one of the Airflow versions specifies only major version
+		// (like 1), we can only compare major versions.
+		eq, err := versionsEqual(oldAirflowMajor, newAirflowMajor)
+		if err != nil {
+			log.Printf("[WARN] Could not parse airflow version, %s", err)
+		}
+		if !eq {
+			return false
+		}
+	} else if oldAirflow == oldAirflowMajorMinor || newAirflow == newAirflowMajorMinor {
 		// If one of the Airflow versions specifies only major and minor version
 		// (like 1.10), we can only compare major and minor versions.
 		eq, err := versionsEqual(oldAirflowMajorMinor, newAirflowMajorMinor)

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -39,11 +39,13 @@ func TestComposerImageVersionDiffSuppress(t *testing.T) {
 		{"preview matches", "composer-1.17.0-preview.0-airflow-2.0.1", "composer-1.17.0-preview.0-airflow-2.0.1", true},
 		{"old latest", "composer-latest-airflow-1.10.0", "composer-1.4.1-airflow-1.10.0", true},
 		{"new latest", "composer-1.4.1-airflow-1.10.0", "composer-latest-airflow-1.10.0", true},
-		{"composer alias equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1-airflow-1.10", true},
-		{"composer alias different", "composer-1.4.0-airflow-2.1.4", "composer-2-airflow-2.2", false},
+		{"composer major alias equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1-airflow-1.10", true},
+		{"composer major alias different", "composer-1.4.0-airflow-2.1.4", "composer-2-airflow-2.2", false},
 		{"composer different", "composer-1.4.0-airflow-1.10.0", "composer-1.4.1-airflow-1.10.0", false},
-		{"airflow alias equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1.10", true},
-		{"airflow alias different", "composer-1.4.0-airflow-2.1.4", "composer-1.4.0-airflow-2.2", false},
+		{"airflow major alias equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1", true},
+		{"airflow major alias different", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-2", false},
+		{"airflow major.minor alias equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1.10", true},
+		{"airflow major.minor alias different", "composer-1.4.0-airflow-2.1.4", "composer-1.4.0-airflow-2.2", false},
 		{"airflow different", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1.9.0", false},
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1242,15 +1242,6 @@ resource "google_compute_subnetwork" "test" {
 
 func testAccComposerEnvironment_composerV2(envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "2"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-east1"
@@ -1265,7 +1256,7 @@ resource "google_composer_environment" "test" {
     	}
 
   		software_config {
-  		  image_version = local.matching_images[0]
+  		  image_version = "composer-2-airflow-2"
   		}
 
   		workloads_config {
@@ -1317,15 +1308,6 @@ resource "google_compute_subnetwork" "test" {
 
 func testAccComposerEnvironment_composerV2PrivateServiceConnect(envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "2"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1337,7 +1319,7 @@ resource "google_composer_environment" "test" {
     	}
 
   		software_config {
-  		  image_version = local.matching_images[0]
+  		  image_version = "composer-2-airflow-2"
   		}
   		private_environment_config {
 				cloud_composer_connection_subnetwork		= google_compute_subnetwork.test.self_link
@@ -1365,15 +1347,6 @@ resource "google_compute_subnetwork" "test" {
 <% unless version == "ga" -%>
 func testAccComposerEnvironment_MasterAuthNetworks(compVersion, airflowVersion, envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "%s"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "%s"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1385,7 +1358,7 @@ resource "google_composer_environment" "test" {
 		}
 
 		software_config {
-			image_version = local.matching_images[0]
+			image_version = "composer-%s-airflow-%s"
 		}
 
 		master_authorized_networks_config {
@@ -1413,21 +1386,12 @@ resource "google_compute_subnetwork" "test" {
 	network       = google_compute_network.test.self_link
 }
 
-`, compVersion, airflowVersion, envName, network, subnetwork)
+`, envName, compVersion, airflowVersion, network, subnetwork)
 }
 
 
 func testAccComposerEnvironment_MasterAuthNetworksUpdate(compVersion, airflowVersion, envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "%s"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "%s"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1439,7 +1403,7 @@ resource "google_composer_environment" "test" {
 		}
 
 		software_config {
-			image_version = local.matching_images[0]
+			image_version = "composer-%s-airflow-%s"
 		}
 
 		master_authorized_networks_config {
@@ -1464,23 +1428,13 @@ resource "google_compute_subnetwork" "test" {
 	network       = google_compute_network.test.self_link
 }
 
-`, compVersion, airflowVersion, envName, network, subnetwork)
+`, envName, compVersion, airflowVersion, network, subnetwork)
 }
 
 <% end -%>
 
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "1"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
-
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1499,7 +1453,7 @@ resource "google_composer_environment" "test" {
 		}
 
 		software_config {
-			image_version = local.matching_images[0]
+			image_version = "composer-1-airflow-1"
 
 			airflow_config_overrides = {
 				core-load_example = "True"
@@ -1549,15 +1503,6 @@ resource "google_compute_subnetwork" "test" {
 
 func testAccComposerEnvironment_updateComposerV2(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "2"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-east1"
@@ -1572,7 +1517,7 @@ resource "google_composer_environment" "test" {
     	}
 
   		software_config {
-  		  image_version = local.matching_images[0]
+  		  image_version = "composer-2-airflow-2"
   		}
 
   		workloads_config {
@@ -1675,16 +1620,6 @@ resource "google_project_iam_member" "composer-worker" {
 
 func testAccComposerEnvironment_softwareCfg(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "1"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
-
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1695,7 +1630,7 @@ resource "google_composer_environment" "test" {
 			zone       = "us-central1-a"
 		}
 		software_config {
-			image_version  = local.matching_images[0]
+			image_version  = "composer-1-airflow-1"
 			python_version = "3"
 		}
 	}
@@ -1754,17 +1689,6 @@ resource "google_compute_subnetwork" "test" {
 
 func testAccComposerEnvironment_airflow2SoftwareCfg(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-locals {
-	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,
-	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
-	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
-	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
-}
-
-
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1775,7 +1699,7 @@ resource "google_composer_environment" "test" {
 			zone       = "us-central1-a"
 		}
 		software_config {
-			image_version  = local.matching_images[0]
+			image_version  = "composer-1-airflow-2"
 			scheduler_count = 2
 		}
 	}

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -60,7 +60,7 @@ resource "google_composer_environment" "test" {
  
  config {
     software_config {
-      image_version = "composer-2-airflow-2.2.3"
+      image_version = "composer-2-airflow-2"
     }
   }
 }
@@ -157,7 +157,7 @@ resource "google_composer_environment" "test" {
   config {
  
     software_config {
-      image_version = "composer-2-airflow-2.2.3"
+      image_version = "composer-2-airflow-2"
     }
  
     workloads_config {
@@ -451,11 +451,11 @@ The following arguments are supported:
 
   The version of the software running in the environment. This encapsulates both the version of Cloud Composer
   functionality and the version of Apache Airflow. It must match the regular expression
-  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+)?)`.
+  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?)`.
   The Cloud Composer portion of the image version is a full semantic version, or an alias in the form of major
   version number or 'latest'.
   The Apache Airflow portion of the image version is a full semantic version that points to one of the
-  supported Apache Airflow versions, or an alias in the form of only major and minor versions specified.
+  supported Apache Airflow versions, or an alias in the form of only major or major.minor versions specified.
   For more information about Cloud Composer images, see
   [Cloud Composer version list](https://cloud.google.com/composer/docs/concepts/versioning/composer-versions).
 
@@ -765,11 +765,11 @@ The `software_config` block supports:
 
   The version of the software running in the environment. This encapsulates both the version of Cloud Composer
   functionality and the version of Apache Airflow. It must match the regular expression
-  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+)?)`.
+  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?)`.
   The Cloud Composer portion of the image version is a full semantic version, or an alias in the form of major
   version number or 'latest'.
   The Apache Airflow portion of the image version is a full semantic version that points to one of the
-  supported Apache Airflow versions, or an alias in the form of only major and minor versions specified.
+  supported Apache Airflow versions, or an alias in the form of only major or major.minor versions specified.
   **Important**: You can only upgrade in-place between minor or patch versions of Cloud Composer or Apache
   Airflow. For example, you can upgrade your environment from `composer-1.16.x` to `composer-1.17.x`, or from
   `airflow-2.1.x` to `airflow-2.2.x`. You cannot upgrade between major Cloud Composer or Apache Airflow


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This covers the new aliases for Airflow major version (`airflow-1`, `airflow-2`) in image version field, and updates to the related documentation.

I also switched Composer tests to use the new Composer and Airflow image version aliases. Instead of finding the latest available image version for the given Composer and Airflow major versions, the new image version aliases are
used to let Composer resolve them on the server side: `composer-1-airflow-1`, `composer-1-airflow-2`, `composer-2-airflow-2`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11390

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: Added support for `airflow-1` and `airflow-2` aliases in image version argument
```
