### PR TITLE
Support ANALYTICS_V2 and LOSSLESS schema types.

### DIFF
--- a/mmv1/products/healthcare/api.yaml
+++ b/mmv1/products/healthcare/api.yaml
@@ -361,12 +361,16 @@ objects:
                     - !ruby/object:Api::Type::Enum
                       name: schemaType
                       description: |
-                        Specifies the output schema type. Only ANALYTICS is supported at this time.
+                        Specifies the output schema type.
                          * ANALYTICS: Analytics schema defined by the FHIR community.
                           See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md.
+                         * ANALYTICS_V2: Analytics V2, similar to schema defined by the FHIR community, with added support for extensions with one or more occurrences and contained resources in stringified JSON.
+                         * LOSSLESS: A data-driven schema generated from the fields present in the FHIR data being exported, with no additional simplification.
                       default_value: :ANALYTICS
                       values:
                         - :ANALYTICS
+                        - :ANALYTICS_V2
+                        - :LOSSLESS
                     - !ruby/object:Api::Type::Integer
                       name: recursiveStructureDepth
                       required: true


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/11401

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added support for `ANALYTICS_V2 `and `LOSSLESS` BigQueryDestination schema types to `google_healthcare_fhir_store`
```
