### PR TITLE
Fix sidebar placement of resources generated by tpgtools

### DIFF
--- a/tpgtools/names.go
+++ b/tpgtools/names.go
@@ -22,6 +22,10 @@ type lowercaseName interface {
 	lowercase() string
 }
 
+type kebabCaseName interface {
+	kebabcase() string
+}
+
 // e.g. `google_compute_instance` or `google_orgpolicy_policy`.
 type SnakeCaseTerraformResourceName string
 
@@ -72,6 +76,18 @@ func snakeToLowercase(s snakeCaseName) ConjoinedString {
 // snakeToTitleCase converts a snake_case string to TitleCase / Go struct case.
 func snakeToTitleCase(s snakeCaseName) miscellaneousNameTitleCase {
 	return miscellaneousNameTitleCase(strings.Join(snakeToParts(s, true), ""))
+}
+
+// e.g. `google-compute-instance` or `google-orgpolicy-policy`.
+type KebabCaseTerraformResourceName string
+
+// snakeToKebabCase converts a snake_case string to kebab case.
+func snakeToKebabCase(s snakeCaseName) miscellaneousNameKebabCase {
+	return miscellaneousNameKebabCase(strings.Join(snakeToParts(s, false), "-"))
+}
+
+func (s SnakeCaseFullName) ToKebab() RenderedString {
+	return RenderedString(snakeToKebabCase(s).kebabcase())
 }
 
 // A type for a string that is not meant for further conversion.  Some functions return a
@@ -141,5 +157,11 @@ func (m miscellaneousNameTitleCase) titlecase() string {
 type miscellaneousNameLowercase string
 
 func (m miscellaneousNameLowercase) lowercase() string {
+	return string(m)
+}
+
+type miscellaneousNameKebabCase string
+
+func (m miscellaneousNameKebabCase) kebabcase() string {
 	return string(m)
 }

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -229,6 +229,12 @@ func (r Resource) TerraformName() SnakeCaseFullName {
 	return SnakeCaseFullName(concatenateSnakeCase(googlePrefix, r.ProductName(), r.Name()))
 }
 
+// TerraformName is the Terraform resource type used for the sidebar_current field in documentation.
+// For example, "google-compute-instance"
+func (r Resource) SidebarCurrentName() KebabCaseTerraformResourceName {
+	return KebabCaseTerraformResourceName(r.TerraformName().ToKebab())
+}
+
 // PathType is the title-cased name of a resource preceded by its package,
 // often used to namespace functions. For example, "RedisInstance".
 func (r Resource) PathType() TitleCaseFullName {
@@ -492,17 +498,17 @@ func createResource(schema *openapi.Schema, info *openapi.Info, typeFetcher *Typ
 	res.Properties = props
 
 	onlyLongFormFormat := shouldAllowForwardSlashInFormat(res.ID, res.Properties)
-        // Resource Override: Import formats
-        ifd := ImportFormatDetails{}
-        ifdOk, err := overrides.ResourceOverrideWithDetails(ImportFormat, &ifd, location)
-        if err != nil {
-                return nil, fmt.Errorf("failed to decode import format details: %v", err)
-        }
-        if ifdOk {
-                res.ImportFormats = ifd.Formats
-        } else {
-                res.ImportFormats = defaultImportFormats(res.ID, onlyLongFormFormat)
-        }
+	// Resource Override: Import formats
+	ifd := ImportFormatDetails{}
+	ifdOk, err := overrides.ResourceOverrideWithDetails(ImportFormat, &ifd, location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode import format details: %v", err)
+	}
+	if ifdOk {
+		res.ImportFormats = ifd.Formats
+	} else {
+		res.ImportFormats = defaultImportFormats(res.ID, onlyLongFormFormat)
+	}
 
 	_, res.HasProject = schema.Properties["project"]
 

--- a/tpgtools/templates/resource.html.markdown.tmpl
+++ b/tpgtools/templates/resource.html.markdown.tmpl
@@ -29,6 +29,7 @@
 subcategory: "{{$.DocsSection}}"
 layout: "google"
 page_title: "Google: {{$.TerraformName}}"
+sidebar_current: "docs-{{$.SidebarCurrentName}}"
 description: |-
   {{$.Description}}
 ---


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10937

`sidebar_current` was missing in the tpgtools templates. Followed the new naming logic introduced earlier

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
