### PR TITLE
Removed SSH key metadata and added OS Login

### DIFF
--- a/mmv1/templates/terraform/examples/flask_google_cloud_quickstart.tf.erb
+++ b/mmv1/templates/terraform/examples/flask_google_cloud_quickstart.tf.erb
@@ -6,10 +6,9 @@ resource "google_compute_instance" "<%= ctx[:primary_resource_id] %>" {
   zone         = "us-west1-a"
   tags         = ["ssh"]
 
-  # Uncomment and enter valid path to file
-  # metadata = {
-  #   ssh-keys = "${file("~/.ssh/id_ed25519.pub")}"
-  # }
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-9"


### PR DESCRIPTION
Comment from morgantep:

With OS Login, I think we can actually remove all the SSH parts from this guide: https://cloud.google.com/compute/docs/oslogin

It's substantially easier to just log in using OS login.

```release-note:NONE
```