### PR TITLE
fix ancestry cache type

### DIFF
--- a/mmv1/third_party/validator/tests/source/cli_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/cli_test.go.erb
@@ -56,7 +56,7 @@ func TestCLI(t *testing.T) {
 		compareConvertOutput compareConvertOutputFunc
 	}{
 		// cli-only, the following tests are not in read_test or
-		// have unique paramters that seperate them
+		// have unique paramters that separate them
 		{name: "bucket"},
 		{name: "disk"},
 		{name: "firewall"},

--- a/mmv1/third_party/validator/tests/source/read_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/read_test.go.erb
@@ -22,7 +22,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		name string
 	}{
 		// read-only, the following tests are not in cli_test or
-		// have unique paramters that seperate them
+		// have unique paramters that separate them
 		{name: "example_project_create"},
 		{name: "example_project_update"},
 		{name: "example_project_iam_binding"},
@@ -62,9 +62,12 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")
 			ctx := context.Background()
-			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], data.Ancestry, true, false, zaptest.NewLogger(t))
+			ancestryCache := map[string]string{
+				data.Provider["project"]: data.Ancestry,
+			}
+			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], ancestryCache, true, false, zaptest.NewLogger(t))
 			if err != nil {
-				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], data.Ancestry, true, err)
+				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], ancestryCache, true, err)
 			}
 
 			expectedAssets := normalizeAssets(t, want, true)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Ancestry cache is changed from string to map[string]string in a previous PR, and reverted because of test failure. 
https://github.com/GoogleCloudPlatform/terraform-validator/pull/607
https://github.com/GoogleCloudPlatform/terraform-validator/pull/622

New PR from terraform-validator: https://github.com/GoogleCloudPlatform/terraform-validator/pull/634


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
