### PR TITLE
Handle case where policy_data is empty in terraform validator

### DIFF
--- a/mmv1/third_party/validator/iam_helpers.go
+++ b/mmv1/third_party/validator/iam_helpers.go
@@ -12,13 +12,17 @@ import (
 // expandIamPolicyBindings is used in google_<type>_iam_policy resources.
 func expandIamPolicyBindings(d TerraformResourceData) ([]IAMBinding, error) {
 	ps := d.Get("policy_data").(string)
+	var bindings []IAMBinding
+	// policy_data is (known after apply) in terraform plan, hence an empty string
+	if ps == "" {
+		return bindings, nil
+	}
 	// The policy string is just a marshaled cloudresourcemanager.Policy.
 	policy := &cloudresourcemanager.Policy{}
 	if err := json.Unmarshal([]byte(ps), policy); err != nil {
-		return nil, fmt.Errorf("Could not unmarshal %s:\n: %v", ps, err)
+		return nil, fmt.Errorf("Could not unmarshal %s: %v", ps, err)
 	}
 
-	var bindings []IAMBinding
 	for _, b := range policy.Bindings {
 		bindings = append(bindings, IAMBinding{
 			Role:    b.Role,
@@ -134,7 +138,7 @@ func mergeDeleteAdditiveBindings(existing, incoming []IAMBinding) []IAMBinding {
 		}
 		if newMembers != nil {
 			newExisting = append(newExisting, IAMBinding{
-				Role: binding.Role,
+				Role:    binding.Role,
 				Members: newMembers,
 			})
 		}

--- a/mmv1/third_party/validator/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.json
+++ b/mmv1/third_party/validator/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "//bigquery.googleapis.com/projects/{{.Provider.project}}/datasets/example_dataset",
+    "asset_type": "bigquery.googleapis.com/Dataset",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v2",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
+      "discovery_name": "Dataset",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "datasetReference": {
+          "datasetId": "example_dataset"
+        },
+        "location": "US"
+      }
+    },
+    "iam_policy": {
+      "bindings": null
+    }
+  }
+]

--- a/mmv1/third_party/validator/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.tf
+++ b/mmv1/third_party/validator/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.tf
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+
+data "google_iam_policy" "owner" {
+  binding {
+    role = "roles/bigquery.dataOwner"
+
+    members = [
+      "${random_string.suffix.result}:jane@example.com",
+    ]
+  }
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "example_dataset"
+}
+
+resource "google_bigquery_dataset_iam_policy" "dataset" {
+  dataset_id  = google_bigquery_dataset.dataset.dataset_id
+  policy_data = data.google_iam_policy.owner.policy_data
+}

--- a/mmv1/third_party/validator/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.tfplan.json
@@ -1,0 +1,326 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.10",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.google_iam_policy.owner",
+          "mode": "data",
+          "type": "google_iam_policy",
+          "name": "owner",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "audit_config": [],
+            "binding": [
+              {
+                "condition": [],
+                "members": [],
+                "role": "roles/bigquery.dataOwner"
+              }
+            ]
+          },
+          "sensitive_values": {
+            "audit_config": [],
+            "binding": [
+              {
+                "condition": [],
+                "members": [
+                  false
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "address": "google_bigquery_dataset.dataset",
+          "mode": "managed",
+          "type": "google_bigquery_dataset",
+          "name": "dataset",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "dataset_id": "example_dataset",
+            "default_encryption_configuration": [],
+            "default_partition_expiration_ms": null,
+            "default_table_expiration_ms": null,
+            "delete_contents_on_destroy": false,
+            "description": null,
+            "friendly_name": null,
+            "labels": null,
+            "location": "US",
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "access": [],
+            "default_encryption_configuration": []
+          }
+        },
+        {
+          "address": "google_bigquery_dataset_iam_policy.dataset",
+          "mode": "managed",
+          "type": "google_bigquery_dataset_iam_policy",
+          "name": "dataset",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "dataset_id": "example_dataset"
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "random_string.suffix",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "suffix",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 1,
+          "values": {
+            "keepers": null,
+            "length": 4,
+            "lower": true,
+            "min_lower": 0,
+            "min_numeric": 0,
+            "min_special": 0,
+            "min_upper": 0,
+            "number": true,
+            "override_special": null,
+            "special": false,
+            "upper": false
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "data.google_iam_policy.owner",
+      "mode": "data",
+      "type": "google_iam_policy",
+      "name": "owner",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "read"
+        ],
+        "before": null,
+        "after": {
+          "audit_config": [],
+          "binding": [
+            {
+              "condition": [],
+              "members": [],
+              "role": "roles/bigquery.dataOwner"
+            }
+          ]
+        },
+        "after_unknown": {
+          "audit_config": [],
+          "binding": [
+            {
+              "condition": [],
+              "members": [
+                true
+              ]
+            }
+          ],
+          "id": true,
+          "policy_data": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "audit_config": [],
+          "binding": [
+            {
+              "condition": [],
+              "members": [
+                false
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "address": "google_bigquery_dataset.dataset",
+      "mode": "managed",
+      "type": "google_bigquery_dataset",
+      "name": "dataset",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "dataset_id": "example_dataset",
+          "default_encryption_configuration": [],
+          "default_partition_expiration_ms": null,
+          "default_table_expiration_ms": null,
+          "delete_contents_on_destroy": false,
+          "description": null,
+          "friendly_name": null,
+          "labels": null,
+          "location": "US",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "access": true,
+          "creation_time": true,
+          "default_encryption_configuration": [],
+          "etag": true,
+          "id": true,
+          "last_modified_time": true,
+          "project": true,
+          "self_link": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "access": [],
+          "default_encryption_configuration": []
+        }
+      }
+    },
+    {
+      "address": "google_bigquery_dataset_iam_policy.dataset",
+      "mode": "managed",
+      "type": "google_bigquery_dataset_iam_policy",
+      "name": "dataset",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "dataset_id": "example_dataset"
+        },
+        "after_unknown": {
+          "etag": true,
+          "id": true,
+          "policy_data": true,
+          "project": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "random_string.suffix",
+      "mode": "managed",
+      "type": "random_string",
+      "name": "suffix",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": null,
+          "length": 4,
+          "lower": true,
+          "min_lower": 0,
+          "min_numeric": 0,
+          "min_special": 0,
+          "min_upper": 0,
+          "number": true,
+          "override_special": null,
+          "special": false,
+          "upper": false
+        },
+        "after_unknown": {
+          "id": true,
+          "result": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_bigquery_dataset.dataset",
+          "mode": "managed",
+          "type": "google_bigquery_dataset",
+          "name": "dataset",
+          "provider_config_key": "google",
+          "expressions": {
+            "dataset_id": {
+              "constant_value": "example_dataset"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "google_bigquery_dataset_iam_policy.dataset",
+          "mode": "managed",
+          "type": "google_bigquery_dataset_iam_policy",
+          "name": "dataset",
+          "provider_config_key": "google",
+          "expressions": {
+            "dataset_id": {
+              "references": [
+                "google_bigquery_dataset.dataset.dataset_id",
+                "google_bigquery_dataset.dataset"
+              ]
+            },
+            "policy_data": {
+              "references": [
+                "data.google_iam_policy.owner.policy_data",
+                "data.google_iam_policy.owner"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "random_string.suffix",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "suffix",
+          "provider_config_key": "random",
+          "expressions": {
+            "length": {
+              "constant_value": 4
+            },
+            "special": {
+              "constant_value": false
+            },
+            "upper": {
+              "constant_value": false
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "data.google_iam_policy.owner",
+          "mode": "data",
+          "type": "google_iam_policy",
+          "name": "owner",
+          "provider_config_key": "google",
+          "expressions": {
+            "binding": [
+              {
+                "members": {
+                  "references": [
+                    "random_string.suffix.result",
+                    "random_string.suffix"
+                  ]
+                },
+                "role": {
+                  "constant_value": "roles/bigquery.dataOwner"
+                }
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

b/225382823
Handle the case when policy_data is empty, it should not throw unmarshal error. 
- added a case to make policy_data contain a var, then in terraform plan it will show as (known as apply), in terraform json data, it will be empty string. 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
