### PR TITLE
Add IAM support for privateca CertificateTemplate

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -1570,7 +1570,20 @@ objects:
 
           An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass":
           "1.3kg", "count": "3" }.
-
+  # This resource is only used to generate IAM resources. They do not correspond to real
+  # GCP resources, and should not be used to generate anything other than IAM support.
+  - !ruby/object:Api::Resource
+    name: 'CertificateTemplate'
+    base_url: projects/{{project}}/locations/{{location}}/certificateTemplates
+    self_link: projects/{{project}}/locations/{{location}}/certificateTemplates/{{name}}
+    exclude_resource: true
+    description: |
+      Only used to generate IAM resources
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: Dummy property.
+        required: true
 
 
 

--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -165,4 +165,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           my_ca_pool: "my-ca-pool"
           my_certificate: "my-certificate"
-
+  CertificateTemplate: !ruby/object:Overrides::Terraform::ResourceOverride
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      allowed_iam_role: 'roles/privateca.templateUser'
+      method_name_separator: ':'
+      parent_resource_attribute: certificate_template
+      example_config_body: 'templates/terraform/iam/example_config_body/privateca_certificate_template.tf.erb'
+      iam_conditions_request_type: :QUERY_PARAM_NESTED
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "privateca_template_basic"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-template%s\", context[\"random_suffix\"])"
+        primary_resource_id: "default"
+        vars:
+          name: "my-template"

--- a/mmv1/templates/terraform/examples/privateca_template_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_template_basic.tf.erb
@@ -1,0 +1,18 @@
+# [START privateca_create_certificate_template]
+resource "google_privateca_certificate_template" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["name"] %>"
+  location = "us-central1"
+
+  identity_constraints {
+    allow_subject_alt_names_passthrough = true
+    allow_subject_passthrough           = true
+
+    cel_expression {
+      description = "Always true"
+      expression  = "true"
+      location    = "any.file.anywhere"
+      title       = "Sample expression"
+    }
+  }
+}
+# [END privateca_create_certificate_template]

--- a/mmv1/templates/terraform/iam/example_config_body/privateca_certificate_template.tf.erb
+++ b/mmv1/templates/terraform/iam/example_config_body/privateca_certificate_template.tf.erb
@@ -1,0 +1,1 @@
+  certificate_template = google_privateca_certificate_template.default.id


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/10938

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_privateca_certificate_template_iam_binding`
```
```release-note:new-resource
`google_privateca_certificate_template_iam_member`
```
```release-note:new-resource
`google_privateca_certificate_template_iam_policy`
```
