### PR TITLE
dns: Support Routing Policy in DNS Record Set

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/resources/resource_dns_record_set.go
@@ -92,12 +92,69 @@ func resourceDnsRecordSet() *schema.Resource {
 
 			"rrdatas": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 				DiffSuppressFunc: rrdatasDnsDiffSuppress,
 				Description:      `The string data for the records in this record set whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding \" if you don't want your string to get split on spaces. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add \"\" inside the Terraform configuration string (e.g. "first255characters\"\"morecharacters").`,
+				ExactlyOneOf:     []string{"rrdatas", "routing_policy"},
+			},
+
+			"routing_policy": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The configuration for steering traffic based on query. You can specify either Weighted Round Robin(WRR) type or Geolocation(GEO) type.",
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"wrr": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `The configuration for Weighted Round Robin based routing policy.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"weight": {
+										Type:        schema.TypeFloat,
+										Required:    true,
+										Description: `The ratio of traffic routed to the target.`,
+									},
+									"rrdatas": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+							ExactlyOneOf: []string{"routing_policy.0.wrr", "routing_policy.0.geo"},
+						},
+						"geo": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `The configuration for Geolocation based routing policy.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"region": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The region name defined in Google Cloud.`,
+									},
+									"rrdatas": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+							ExactlyOneOf: []string{"routing_policy.0.wrr", "routing_policy.0.geo"},
+						},
+					},
+				},
+				ExactlyOneOf: []string{"rrdatas", "routing_policy"},
 			},
 
 			"ttl": {
@@ -141,15 +198,19 @@ func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error 
 	rType := d.Get("type").(string)
 
 	// Build the change
+	rset := &dns.ResourceRecordSet{
+		Name: name,
+		Type: rType,
+		Ttl:  int64(d.Get("ttl").(int)),
+	}
+	if rrdatas := rrdata(d); len(rrdatas) > 0 {
+		rset.Rrdatas = rrdatas
+	}
+	if rp := routingPolicy(d); rp != nil {
+		rset.RoutingPolicy = rp
+	}
 	chg := &dns.Change{
-		Additions: []*dns.ResourceRecordSet{
-			{
-				Name:    name,
-				Type:    rType,
-				Ttl:     int64(d.Get("ttl").(int)),
-				Rrdatas: rrdata(d),
-			},
-		},
+		Additions: []*dns.ResourceRecordSet{rset},
 	}
 
 	// The terraform provider is authoritative, so what we do here is check if
@@ -232,15 +293,22 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	if len(resp.Rrsets) > 1 {
 		return fmt.Errorf("Only expected 1 record set, got %d", len(resp.Rrsets))
 	}
-
-	if err := d.Set("type", resp.Rrsets[0].Type); err != nil {
+	rrset := resp.Rrsets[0]
+	if err := d.Set("type", rrset.Type); err != nil {
 		return fmt.Errorf("Error setting type: %s", err)
 	}
-	if err := d.Set("ttl", resp.Rrsets[0].Ttl); err != nil {
+	if err := d.Set("ttl", rrset.Ttl); err != nil {
 		return fmt.Errorf("Error setting ttl: %s", err)
 	}
-	if err := d.Set("rrdatas", resp.Rrsets[0].Rrdatas); err != nil {
-		return fmt.Errorf("Error setting rrdatas: %s", err)
+	if len(rrset.Rrdatas) > 0 {
+		if err := d.Set("rrdatas", rrset.Rrdatas); err != nil {
+			return fmt.Errorf("Error setting rrdatas: %s", err)
+		}
+	}
+	if rrset.RoutingPolicy != nil {
+		if err := d.Set("routing_policy", flattenDnsRecordSetRoutingPolicy(rrset.RoutingPolicy)); err != nil {
+			return fmt.Errorf("Error setting routing_policy: %s", err)
+		}
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
@@ -287,10 +355,11 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 	chg := &dns.Change{
 		Deletions: []*dns.ResourceRecordSet{
 			{
-				Name:    d.Get("name").(string),
-				Type:    d.Get("type").(string),
-				Ttl:     int64(d.Get("ttl").(int)),
-				Rrdatas: rrdata(d),
+				Name:          d.Get("name").(string),
+				Type:          d.Get("type").(string),
+				Ttl:           int64(d.Get("ttl").(int)),
+				Rrdatas:       rrdata(d),
+				RoutingPolicy: routingPolicy(d),
 			},
 		},
 	}
@@ -337,21 +406,26 @@ func resourceDnsRecordSetUpdate(d *schema.ResourceData, meta interface{}) error 
 	oldCountRaw, _ := d.GetChange("rrdatas.#")
 	oldCount := oldCountRaw.(int)
 
+	oldRoutingPolicyRaw, _ := d.GetChange("routing_policy")
+	oldRoutingPolicyList := oldRoutingPolicyRaw.([]interface{})
+
 	chg := &dns.Change{
 		Deletions: []*dns.ResourceRecordSet{
 			{
-				Name:    recordName,
-				Type:    oldType.(string),
-				Ttl:     int64(oldTtl.(int)),
-				Rrdatas: make([]string, oldCount),
+				Name:          recordName,
+				Type:          oldType.(string),
+				Ttl:           int64(oldTtl.(int)),
+				Rrdatas:       make([]string, oldCount),
+				RoutingPolicy: convertRoutingPolicy(oldRoutingPolicyList),
 			},
 		},
 		Additions: []*dns.ResourceRecordSet{
 			{
-				Name:    recordName,
-				Type:    newType.(string),
-				Ttl:     int64(newTtl.(int)),
-				Rrdatas: rrdata(d),
+				Name:          recordName,
+				Type:          newType.(string),
+				Ttl:           int64(newTtl.(int)),
+				Rrdatas:       rrdata(d),
+				RoutingPolicy: routingPolicy(d),
 			},
 		},
 	}
@@ -402,13 +476,143 @@ func resourceDnsRecordSetImportState(d *schema.ResourceData, meta interface{}) (
 	return []*schema.ResourceData{d}, nil
 }
 
-func rrdata(
-	d *schema.ResourceData,
-) []string {
+func rrdata(d *schema.ResourceData) []string {
+	if _, ok := d.GetOk("rrdatas"); !ok {
+		return []string{}
+	}
 	rrdatasCount := d.Get("rrdatas.#").(int)
 	data := make([]string, rrdatasCount)
 	for i := 0; i < rrdatasCount; i++ {
 		data[i] = d.Get(fmt.Sprintf("rrdatas.%d", i)).(string)
 	}
 	return data
+}
+
+func routingPolicy(d *schema.ResourceData) *dns.RRSetRoutingPolicy {
+	rp, ok := d.GetOk("routing_policy")
+	if !ok {
+		return nil
+	}
+	rps := rp.([]interface{})
+	if len(rps) == 0 {
+		return nil
+	}
+	return convertRoutingPolicy(rps)
+}
+
+// converconvertRoutingPolicy converts []interface{} type value to *dns.RRSetRoutingPolicy one if ps is valid data.
+func convertRoutingPolicy(ps []interface{}) *dns.RRSetRoutingPolicy {
+	if len(ps) != 1 {
+		return nil
+	}
+	p, ok := ps[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	wrrRawItems, _ := p["wrr"].([]interface{})
+	geoRawItems, _ := p["geo"].([]interface{})
+
+	if len(wrrRawItems) > 0 {
+		wrrItems := make([]*dns.RRSetRoutingPolicyWrrPolicyWrrPolicyItem, len(wrrRawItems))
+		for i, item := range wrrRawItems {
+			wi, _ := item.(map[string]interface{})
+			irrdatas := wi["rrdatas"].([]interface{})
+			if len(irrdatas) == 0 {
+				return nil
+			}
+			rrdatas := make([]string, len(irrdatas))
+			for j, rrdata := range irrdatas {
+				rrdatas[j], ok = rrdata.(string)
+				if !ok {
+					return nil
+				}
+			}
+			weight, ok := wi["weight"].(float64)
+			if !ok {
+				return nil
+			}
+			wrrItems[i] = &dns.RRSetRoutingPolicyWrrPolicyWrrPolicyItem{
+				Weight:  weight,
+				Rrdatas: rrdatas,
+			}
+		}
+
+		return &dns.RRSetRoutingPolicy{
+			Wrr: &dns.RRSetRoutingPolicyWrrPolicy{
+				Items: wrrItems,
+			},
+		}
+	}
+
+	if len(geoRawItems) > 0 {
+		geoItems := make([]*dns.RRSetRoutingPolicyGeoPolicyGeoPolicyItem, len(geoRawItems))
+		for i, item := range geoRawItems {
+			gi, _ := item.(map[string]interface{})
+			irrdatas := gi["rrdatas"].([]interface{})
+			if len(irrdatas) == 0 {
+				return nil
+			}
+			rrdatas := make([]string, len(irrdatas))
+			for j, rrdata := range irrdatas {
+				rrdatas[j], ok = rrdata.(string)
+				if !ok {
+					return nil
+				}
+			}
+			location, ok := gi["region"].(string)
+			if !ok {
+				return nil
+			}
+			geoItems[i] = &dns.RRSetRoutingPolicyGeoPolicyGeoPolicyItem{
+				Location: location,
+				Rrdatas:  rrdatas,
+			}
+		}
+
+		return &dns.RRSetRoutingPolicy{
+			Geo: &dns.RRSetRoutingPolicyGeoPolicy{
+				Items: geoItems,
+			},
+		}
+	}
+
+	return nil // unreachable here if ps is valid data
+}
+
+func flattenDnsRecordSetRoutingPolicy(policy *dns.RRSetRoutingPolicy) []interface{} {
+	if policy == nil {
+		return []interface{}{}
+	}
+	ps := make([]interface{}, 0, 1)
+	p := make(map[string]interface{})
+	if policy.Wrr != nil {
+		p["wrr"] = flattenDnsRecordSetRoutingPolicyWRR(policy.Wrr)
+	}
+	if policy.Geo != nil {
+		p["geo"] = flattenDnsRecordSetRoutingPolicyGEO(policy.Geo)
+	}
+	return append(ps, p)
+}
+
+func flattenDnsRecordSetRoutingPolicyWRR(wrr *dns.RRSetRoutingPolicyWrrPolicy) []interface{} {
+	ris := make([]interface{}, 0, len(wrr.Items))
+	for _, item := range wrr.Items {
+		ri := make(map[string]interface{})
+		ri["weight"] = item.Weight
+		ri["rrdatas"] = item.Rrdatas
+		ris = append(ris, ri)
+	}
+	return ris
+}
+
+func flattenDnsRecordSetRoutingPolicyGEO(geo *dns.RRSetRoutingPolicyGeoPolicy) []interface{} {
+	ris := make([]interface{}, 0, len(geo.Items))
+	for _, item := range geo.Items {
+		ri := make(map[string]interface{})
+		ri["region"] = item.Location
+		ri["rrdatas"] = item.Rrdatas
+		ris = append(ris, ri)
+	}
+	return ris
 }

--- a/mmv1/third_party/terraform/resources/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/resources/resource_dns_record_set.go
@@ -133,13 +133,13 @@ func resourceDnsRecordSet() *schema.Resource {
 						"geo": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Description: `The configuration for Geolocation based routing policy.`,
+							Description: `The configuration for Geo location based routing policy.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"region": {
+									"location": {
 										Type:        schema.TypeString,
 										Required:    true,
-										Description: `The region name defined in Google Cloud.`,
+										Description: `The location name defined in Google Cloud.`,
 									},
 									"rrdatas": {
 										Type:     schema.TypeList,
@@ -560,7 +560,7 @@ func convertRoutingPolicy(ps []interface{}) *dns.RRSetRoutingPolicy {
 					return nil
 				}
 			}
-			location, ok := gi["region"].(string)
+			location, ok := gi["location"].(string)
 			if !ok {
 				return nil
 			}
@@ -610,7 +610,7 @@ func flattenDnsRecordSetRoutingPolicyGEO(geo *dns.RRSetRoutingPolicyGeoPolicy) [
 	ris := make([]interface{}, 0, len(geo.Items))
 	for _, item := range geo.Items {
 		ri := make(map[string]interface{})
-		ri["region"] = item.Location
+		ri["location"] = item.Location
 		ri["rrdatas"] = item.Rrdatas
 		ris = append(ris, ri)
 	}

--- a/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
@@ -245,6 +245,38 @@ func TestAccDNSRecordSet_uppercaseMX(t *testing.T) {
 	})
 }
 
+func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordSetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordSet_routingPolicyWRR(zoneName, "127.0.0.10", 300, 0.1),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", getTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsRecordSet_routingPolicyGEO(zoneName, "127.0.0.10", 300, "us-central1"),
+			},
+			{
+				ResourceName:  "google_dns_record_set.foobar",
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", getTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:   true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+
 func testAccCheckDnsRecordSetDestroyProducer(t *testing.T) func(s *terraform.State) error {
 
 	return func(s *terraform.State) error {
@@ -374,3 +406,60 @@ resource "google_dns_record_set" "foobar" {
 }
 `, name, name, name, ttl)
 }
+
+func testAccDnsRecordSet_routingPolicyWRR(zoneName, addr2 string, ttl int, weight float64) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest.com."
+  description = "Test Description"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = "test-record.%s.hashicorptest.com."
+  type         = "A"
+  ttl          = %d
+
+  routing_policy {
+    wrr {
+      weight       = 0.9
+      rrdatas      = ["127.0.0.1"]
+    }
+    wrr {
+      weight       = %g
+      rrdatas      = ["%s"]
+    }
+  }
+}
+`, zoneName, zoneName, zoneName, ttl, weight, addr2)
+}
+
+func testAccDnsRecordSet_routingPolicyGEO(zoneName, addr2  string, ttl int, region string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest.com."
+  description = "Test Description"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = "test-record.%s.hashicorptest.com."
+  type         = "A"
+  ttl          = %d
+
+  routing_policy {
+    geo {
+      region       = "asia-east1"
+      rrdatas      = ["127.0.0.1"]
+    }
+    geo {
+      region       = "%s"
+      rrdatas      = ["%s"]
+    }
+  }
+}
+`, zoneName, zoneName, zoneName, ttl, region, addr2)
+}
+

--- a/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
@@ -435,7 +435,7 @@ resource "google_dns_record_set" "foobar" {
 `, zoneName, zoneName, zoneName, ttl, weight, addr2)
 }
 
-func testAccDnsRecordSet_routingPolicyGEO(zoneName, addr2  string, ttl int, region string) string {
+func testAccDnsRecordSet_routingPolicyGEO(zoneName, addr2  string, ttl int, location string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "parent-zone" {
   name        = "%s"
@@ -451,15 +451,15 @@ resource "google_dns_record_set" "foobar" {
 
   routing_policy {
     geo {
-      region       = "asia-east1"
-      rrdatas      = ["127.0.0.1"]
+      location = "asia-east1"
+      rrdatas  = ["127.0.0.1"]
     }
     geo {
-      region       = "%s"
-      rrdatas      = ["%s"]
+      location = "%s"
+      rrdatas  = ["%s"]
     }
   }
 }
-`, zoneName, zoneName, zoneName, ttl, region, addr2)
+`, zoneName, zoneName, zoneName, ttl, location, addr2)
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -134,6 +134,52 @@ resource "google_dns_managed_zone" "prod" {
 }
 ```
 
+### Setting Routing Policy instead of using rrdatas
+#### Weighted Round Robin
+
+```hcl
+resource "google_dns_record_set" "wrr" {
+  name         = "backend.${google_dns_managed_zone.prod.dns_name}"
+  managed_zone = google_dns_managed_zone.prod.name
+  type         = "A"
+  ttl          = 300
+
+  routing_policy {
+    wrr {
+      weight  = 0.8
+      rrdatas =  ["10.128.1.1"]
+    }
+
+    wrr {
+      weight  = 0.2
+      rrdatas =  ["10.130.1.1"]
+    }
+  }
+```
+
+#### Geolocation
+
+```hcl
+resource "google_dns_record_set" "geo" {
+  name         = "backend.${google_dns_managed_zone.prod.dns_name}"
+  managed_zone = google_dns_managed_zone.prod.name
+  type         = "A"
+  ttl          = 300
+
+  routing_policy {
+    geo {
+      region  = "asia-east1"
+      rrdatas =  ["10.128.1.1"]
+    }
+
+    geo {
+      region  = "us-central1"
+      rrdatas =  ["10.130.1.1"]
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -143,18 +189,41 @@ The following arguments are supported:
 
 * `name` - (Required) The DNS name this record set will apply to.
 
-* `rrdatas` - (Required) The string data for the records in this record set
-    whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding `\"` if you don't want your string to get split on spaces. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\" \"` inside the Terraform configuration string (e.g. `"first255characters\" \"morecharacters"`).
-
-
 * `type` - (Required) The DNS record set type.
 
 - - -
+
+* `rrdatas` - (Optional) The string data for the records in this record set
+    whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding `\"` if you don't want your string to get split on spaces. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\" \"` inside the Terraform configuration string (e.g. `"first255characters\" \"morecharacters"`).
+
+* `routing_policy` - (Optional) The configuration for steering traffic based on query.
+    Now you can specify either Weighted Round Robin(WRR) type or Geolocation(GEO) type.
+    Structure is [documented below](#nested_routing_policy).
 
 * `ttl` - (Optional) The time-to-live of this record set (seconds).
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
+
+<a name="nested_routing_policy"></a>The `routing_policy` block supports:
+
+* `wrr` - (Optional) The configuration for Weighted Round Robin based routing policy.
+    Structure is [document below](#nested_wrr).
+
+* `geo` - (Optional) The configuration for Geolocation based routing policy.
+    Structure is [document below](#nested_geo).
+
+<a name="nested_wee"></a>The `wrr` block supports:
+
+* `weight`  - (Required) The ratio of traffic routed to the target.
+
+* `rrdatas` - (Required) Same as `rrdatas` above.
+
+<a name="nested_geo"></a>The `geo` block supports:
+
+* `region` - (Required) The region name defined in Google Cloud.
+
+* `rrdatas` - (Required) Same as `rrdatas` above.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -168,13 +168,13 @@ resource "google_dns_record_set" "geo" {
 
   routing_policy {
     geo {
-      region  = "asia-east1"
-      rrdatas =  ["10.128.1.1"]
+      location = "asia-east1"
+      rrdatas  =  ["10.128.1.1"]
     }
 
     geo {
-      region  = "us-central1"
-      rrdatas =  ["10.130.1.1"]
+      location = "us-central1"
+      rrdatas  =  ["10.130.1.1"]
     }
   }
 }
@@ -221,7 +221,7 @@ The following arguments are supported:
 
 <a name="nested_geo"></a>The `geo` block supports:
 
-* `region` - (Required) The region name defined in Google Cloud.
+* `location` - (Required) The location name defined in Google Cloud.
 
 * `rrdatas` - (Required) Same as `rrdatas` above.
 

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -213,7 +213,7 @@ The following arguments are supported:
 * `geo` - (Optional) The configuration for Geolocation based routing policy.
     Structure is [document below](#nested_geo).
 
-<a name="nested_wee"></a>The `wrr` block supports:
+<a name="nested_wrr"></a>The `wrr` block supports:
 
 * `weight`  - (Required) The ratio of traffic routed to the target.
 


### PR DESCRIPTION
## Description

This PR implements Routing Policy in Cloud DNS's Record Set.

fixes https://github.com/hashicorp/terraform-provider-google/issues/11038

### Status
Reviewable. If you have an opinion about the API design, please let me know.

---

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

---

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: added `routing_policy` to `google_dns_record_set` resource
```
