### PR TITLE
Retry all GCE's 403 per-minute quota exceeded errors

### DIFF
--- a/mmv1/third_party/terraform/utils/common_operation.go
+++ b/mmv1/third_party/terraform/utils/common_operation.go
@@ -111,7 +111,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 		op, err := w.QueryOp()
 		if err != nil {
 			// Retry 404 when getting operation (not resource state)
-			if isRetryableError(err, isNotFoundRetryableError("GET operation"), isOperationReadQuotaError) {
+			if isRetryableError(err, isNotFoundRetryableError("GET operation")) {
 				log.Printf("[DEBUG] Dismissed retryable error on GET operation %q: %s", w.OpName(), err)
 				return nil, "done: false", nil
 			}

--- a/mmv1/third_party/terraform/utils/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates.go
@@ -46,7 +46,7 @@ var defaultErrorRetryPredicates = []RetryErrorPredicateFunc{
 	// reads, causing significant failure for our CI and for large customers.
 	// GCE returns the wrong error code, as this should be a 429, which we retry
 	// already.
-	isGCE403QuotaExceededPerMinuteError,
+	is403QuotaExceededPerMinuteError,
 }
 
 /** END GLOBAL ERROR RETRY PREDICATES HERE **/
@@ -126,16 +126,14 @@ func isSubnetworkUnreadyError(err error) (bool, string) {
 	return false, ""
 }
 
-var QuotaRegex = regexp.MustCompile(`Quota exceeded for quota metric '(?P<Metric>.*)' and limit '(?P<Limit>.* per minute)' of service 'compute.googleapis.com'`)
-
 // GCE (and possibly other APIs) incorrectly return a 403 rather than a 429 on
 // rate limits.
-func isGCE403QuotaExceededPerMinuteError(err error) (bool, string) {
+func is403QuotaExceededPerMinuteError(err error) (bool, string) {
 	gerr, ok := err.(*googleapi.Error)
 	if !ok {
 		return false, ""
 	}
-
+	var QuotaRegex = regexp.MustCompile(`Quota exceeded for quota metric '(?P<Metric>.*)' and limit '(?P<Limit>.* per minute)' of service`)
 	if gerr.Code == 403 && QuotaRegex.MatchString(gerr.Body) {
 		matches := QuotaRegex.FindStringSubmatch(gerr.Body)
 		metric := matches[QuotaRegex.SubexpIndex("Metric")]

--- a/mmv1/third_party/terraform/utils/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"google.golang.org/api/googleapi"
@@ -45,7 +46,7 @@ var defaultErrorRetryPredicates = []RetryErrorPredicateFunc{
 	// reads, causing significant failure for our CI and for large customers.
 	// GCE returns the wrong error code, as this should be a 429, which we retry
 	// already.
-	is403ReadRequestsForMinuteError,
+	isGCE403QuotaExceededPerMinuteError,
 }
 
 /** END GLOBAL ERROR RETRY PREDICATES HERE **/
@@ -127,15 +128,21 @@ func isSubnetworkUnreadyError(err error) (bool, string) {
 
 // GCE (and possibly other APIs) incorrectly return a 403 rather than a 429 on
 // rate limits.
-func is403ReadRequestsForMinuteError(err error) (bool, string) {
+func isGCE403QuotaExceededPerMinuteError(err error) (bool, string) {
 	gerr, ok := err.(*googleapi.Error)
 	if !ok {
 		return false, ""
 	}
 
-	if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota metric") && strings.Contains(gerr.Body, "Read requests per minute") {
-		log.Printf("[DEBUG] Dismissed an error as retryable based on error code 403 and error message 'Quota exceeded for quota metric' on metric `Read requests per minute`: %s", err)
-		return true, "Read requests per minute"
+	if gerr.Code == 403 {
+		re := regexp.MustCompile(`Quota exceeded for quota metric '(?P<Metric>.*)' and limit '(?P<Limit>.* per minute)' of service 'compute.googleapis.com'`)
+		if re.MatchString(gerr.Body) {
+			matches := re.FindStringSubmatch(gerr.Body)
+			metric := matches[re.SubexpIndex("Metric")]
+			limit := matches[re.SubexpIndex("Limit")]
+			log.Printf("[DEBUG] Dismissed an error as retryable based on error code 403 and error message 'Quota exceeded for quota metric `%s`: %s", metric, err)
+			return true, fmt.Sprintf("Waiting for quota limit %s to refresh", limit)
+		}
 	}
 	return false, ""
 }
@@ -255,17 +262,6 @@ func isBigqueryIAMQuotaError(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 403 && strings.Contains(strings.ToLower(gerr.Body), "exceeded rate limits") {
 			return true, "Waiting for Bigquery edit quota to refresh"
-		}
-	}
-	return false, ""
-}
-
-// Retry if operation returns a 403 with the message for
-// exceeding the quota limit for 'OperationReadGroup'
-func isOperationReadQuotaError(err error) (bool, string) {
-	if gerr, ok := err.(*googleapi.Error); ok {
-		if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota group") {
-			return true, "Waiting for quota to refresh"
 		}
 	}
 	return false, ""

--- a/mmv1/third_party/terraform/utils/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates_test.go
@@ -81,23 +81,34 @@ func TestIsCommonRetryableErrorCode_otherError(t *testing.T) {
 	}
 }
 
-func TestIsGCE403QuotaExceededPerMinuteError_perMinuteQuotaExceeded(t *testing.T) {
+func TestIsOperationReadQuotaError_quotaExceeded(t *testing.T) {
 	err := googleapi.Error{
 		Code: 403,
-		Body: "Quota exceeded for quota metric 'Queries' and limit 'Queries per minute' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
+		Body: "Quota exceeded for quota metric 'OperationReadGroup' and limit 'Operation read requests per minute' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
 	}
-	isRetryable, _ := isGCE403QuotaExceededPerMinuteError(&err)
+	isRetryable, _ := is403QuotaExceededPerMinuteError(&err)
 	if !isRetryable {
 		t.Errorf("Error not detected as retryable")
 	}
 }
 
-func TestIsGCE403QuotaExceededPerMinuteError_perDayQuotaExceededNotRetryable(t *testing.T) {
+func TestIs403QuotaExceededPerMinuteError_perMinuteQuotaExceeded(t *testing.T) {
+	err := googleapi.Error{
+		Code: 403,
+		Body: "Quota exceeded for quota metric 'Queries' and limit 'Queries per minute' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
+	}
+	isRetryable, _ := is403QuotaExceededPerMinuteError(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}
+
+func TestIs403QuotaExceededPerMinuteError_perDayQuotaExceededNotRetryable(t *testing.T) {
 	err := googleapi.Error{
 		Code: 403,
 		Body: "Quota exceeded for quota metric 'Queries' and limit 'Queries per day' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
 	}
-	isRetryable, _ := isGCE403QuotaExceededPerMinuteError(&err)
+	isRetryable, _ := is403QuotaExceededPerMinuteError(&err)
 	if isRetryable {
 		t.Errorf("Error incorrectly detected as retryable")
 	}

--- a/mmv1/third_party/terraform/utils/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates_test.go
@@ -81,14 +81,25 @@ func TestIsCommonRetryableErrorCode_otherError(t *testing.T) {
 	}
 }
 
-func TestIsOperationReadQuotaError_quotaExceeded(t *testing.T) {
+func TestIsGCE403QuotaExceededPerMinuteError_perMinuteQuotaExceeded(t *testing.T) {
 	err := googleapi.Error{
 		Code: 403,
-		Body: "Quota exceeded for quota group 'OperationReadGroup' and limit 'Operation read requests per 100 seconds' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
+		Body: "Quota exceeded for quota metric 'Queries' and limit 'Queries per minute' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
 	}
-	isRetryable, _ := isOperationReadQuotaError(&err)
+	isRetryable, _ := isGCE403QuotaExceededPerMinuteError(&err)
 	if !isRetryable {
 		t.Errorf("Error not detected as retryable")
+	}
+}
+
+func TestIsGCE403QuotaExceededPerMinuteError_perDayQuotaExceededNotRetryable(t *testing.T) {
+	err := googleapi.Error{
+		Code: 403,
+		Body: "Quota exceeded for quota metric 'Queries' and limit 'Queries per day' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
+	}
+	isRetryable, _ := isGCE403QuotaExceededPerMinuteError(&err)
+	if isRetryable {
+		t.Errorf("Error incorrectly detected as retryable")
 	}
 }
 


### PR DESCRIPTION
Also removed isOperationReadQuotaError function as
its functionality is now included in the new function
and it was checking for an obsolete error message

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
provider: modified request retry logic to retry all per-minute quota limits returned with a 403 error code. Previously, only read requests were retried. This will generally affect Google Compute Engine resources.
```
