### PR TITLE
Add exclusion scope  in the maintenance exclusion

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3212,8 +3212,8 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 		for _, me := range maintenanceExclusions.(*schema.Set).List() {
 			exclusion := me.(map[string]interface{})
 			exclusions[exclusion["exclusion_name"].(string)] = container.TimeWindow{
-				StartTime:                   exclusion["start_time"].(string),
-				EndTime:                     exclusion["end_time"].(string),
+				StartTime: exclusion["start_time"].(string),
+				EndTime:   exclusion["end_time"].(string),
 			}
 			if exclusionOptions, ok := exclusion["exclusion_options"]; ok && len(exclusionOptions.([]interface{})) > 0 {
 				meo := exclusionOptions.([]interface{})[0].(map[string]interface{})

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3965,9 +3965,16 @@ func flattenMaintenancePolicy(mp *container.MaintenancePolicy) []map[string]inte
 				"exclusion_name": wName,
 			}
 			if window.MaintenanceExclusionOptions != nil {
+				// When the scope is set to NO_UPGRADES which is the default value,
+				// the maintenance exclusion returned by GCP will be empty.
+				// This seems like a bug. To workaround this, assign NO_UPGRADES to the scope explicitly
+				scope := "NO_UPGRADES"
+				if window.MaintenanceExclusionOptions.Scope != "" {
+					scope = window.MaintenanceExclusionOptions.Scope
+				}
 				exclusion["exclusion_options"] = []map[string]interface{}{
 					{
-						"scope": window.MaintenanceExclusionOptions.Scope,
+						"scope": scope,
 					},
 				}
 			}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -693,6 +693,22 @@ func resourceContainerCluster() *schema.Resource {
 										Required:     true,
 										ValidateFunc: validateRFC3339Date,
 									},
+									"exclusion_options": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										MaxItems:    1,
+										Description: `Maintenance exclusion related options.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"scope": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice([]string{"NO_UPGRADES", "NO_MINOR_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"}, false),
+													Description: `The scope of automatic upgrades to restrict in the exclusion window.`,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -3196,8 +3212,17 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 		for _, me := range maintenanceExclusions.(*schema.Set).List() {
 			exclusion := me.(map[string]interface{})
 			exclusions[exclusion["exclusion_name"].(string)] = container.TimeWindow{
-				StartTime: exclusion["start_time"].(string),
-				EndTime:   exclusion["end_time"].(string),
+				StartTime:                   exclusion["start_time"].(string),
+				EndTime:                     exclusion["end_time"].(string),
+			}
+			if exclusionOptions, ok := exclusion["exclusion_options"]; ok && len(exclusionOptions.([]interface{})) > 0 {
+				meo := exclusionOptions.([]interface{})[0].(map[string]interface{})
+				mex := exclusions[exclusion["exclusion_name"].(string)]
+				mex.MaintenanceExclusionOptions = &container.MaintenanceExclusionOptions{
+					Scope:           meo["scope"].(string),
+					ForceSendFields: []string{"Scope"},
+				}
+				exclusions[exclusion["exclusion_name"].(string)] = mex
 			}
 		}
 	}
@@ -3934,11 +3959,19 @@ func flattenMaintenancePolicy(mp *container.MaintenancePolicy) []map[string]inte
 	exclusions := []map[string]interface{}{}
 	if mp.Window.MaintenanceExclusions != nil {
 		for wName, window := range mp.Window.MaintenanceExclusions {
-			exclusions = append(exclusions, map[string]interface{}{
+			exclusion := map[string]interface{}{
 				"start_time":  window.StartTime,
 				"end_time":    window.EndTime,
 				"exclusion_name": wName,
-			})
+			}
+			if window.MaintenanceExclusionOptions != nil {
+				exclusion["exclusion_options"] = []map[string]interface{}{
+					{
+						"scope": window.MaintenanceExclusionOptions.Scope,
+					},
+				}
+			}
+			exclusions = append(exclusions, exclusion)
 		}
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1503,10 +1503,10 @@ func TestAccContainerCluster_deleteMaintenanceExclusionOptions(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerCluster_withExclusionOptions_RecurringMaintenanceWindow(
-					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z", "NO_MINOR_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"),
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z", "NO_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"),
 				Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName,
-							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope", "NO_MINOR_UPGRADES"),
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope", "NO_UPGRADES"),
 						resource.TestCheckResourceAttr(resourceName,
 							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope", "NO_MINOR_OR_NODE_UPGRADES"),
 				),
@@ -1542,9 +1542,9 @@ func TestAccContainerCluster_updateMaintenanceExclusionOptions(t *testing.T) {
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 	resourceName := "google_container_cluster.with_maintenance_exclusion_options"
 
-	// step1: create a new cluster and initialize a maintenancePolicy without exclusion options,
-	// step2: add exclusion options to the maintenancePolicy,
-	// step3: update the exclusion options(scope) with new values
+	// step1: create a new cluster and initialize the maintenceExclusion without exclusion scopes,
+	// step2: add exclusion scopes to the maintenancePolicy,
+	// step3: update the maintenceExclusion with new scopes
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1461,6 +1461,147 @@ func TestAccContainerCluster_withMaintenanceExclusionWindow(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withMaintenanceExclusionOptions(t *testing.T) {
+	t.Parallel()
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	resourceName := "google_container_cluster.with_maintenance_exclusion_options"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withExclusionOptions_RecurringMaintenanceWindow(
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z", "NO_MINOR_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"),
+				Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope", "NO_MINOR_UPGRADES"),
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope", "NO_MINOR_OR_NODE_UPGRADES"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_deleteMaintenanceExclusionOptions(t *testing.T) {
+	t.Parallel()
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	resourceName := "google_container_cluster.with_maintenance_exclusion_options"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withExclusionOptions_RecurringMaintenanceWindow(
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z", "NO_MINOR_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"),
+				Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope", "NO_MINOR_UPGRADES"),
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope", "NO_MINOR_OR_NODE_UPGRADES"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_NoExclusionOptions_RecurringMaintenanceWindow(
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z"),
+				Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckNoResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope"),
+						resource.TestCheckNoResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_updateMaintenanceExclusionOptions(t *testing.T) {
+	t.Parallel()
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	resourceName := "google_container_cluster.with_maintenance_exclusion_options"
+
+	// step1: create a new cluster and initialize a maintenancePolicy without exclusion options,
+	// step2: add exclusion options to the maintenancePolicy,
+	// step3: update the exclusion options(scope) with new values
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_NoExclusionOptions_RecurringMaintenanceWindow(
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z"),
+				Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckNoResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope"),
+						resource.TestCheckNoResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_withExclusionOptions_RecurringMaintenanceWindow(
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z", "NO_MINOR_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"),
+				Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope", "NO_MINOR_UPGRADES"),
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope", "NO_MINOR_OR_NODE_UPGRADES"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateExclusionOptions_RecurringMaintenanceWindow(
+					cluster, "2019-01-01T00:00:00Z", "2019-01-02T00:00:00Z", "2019-05-01T00:00:00Z", "2019-05-02T00:00:00Z", "NO_UPGRADES", "NO_MINOR_UPGRADES"),
+				Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.0.exclusion_options.0.scope", "NO_UPGRADES"),
+						resource.TestCheckResourceAttr(resourceName,
+							"maintenance_policy.0.maintenance_exclusion.1.exclusion_options.0.scope", "NO_MINOR_UPGRADES"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 
 func TestAccContainerCluster_deleteExclusionWindow(t *testing.T) {
 	t.Parallel()
@@ -4035,6 +4176,105 @@ resource "google_container_cluster" "with_maintenance_exclusion_window" {
  }
 }
 `, clusterName, w1startTime, w1endTime, w1startTime, w1endTime, w2startTime, w2endTime)
+}
+
+func testAccContainerCluster_withExclusionOptions_RecurringMaintenanceWindow(cclusterName string, w1startTime, w1endTime, w2startTime, w2endTime string, scope1, scope2 string) string {
+
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_maintenance_exclusion_options" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  maintenance_policy {
+	recurring_window {
+		start_time = "%s"
+		end_time = "%s"
+		recurrence = "FREQ=DAILY"
+	}
+	maintenance_exclusion {
+		exclusion_name = "batch job"
+		start_time = "%s"
+		end_time = "%s"
+		exclusion_options {
+			scope = "%s"
+    	}
+	}
+	maintenance_exclusion {
+		exclusion_name = "holiday data load"
+		start_time = "%s"
+		end_time = "%s"
+		exclusion_options {
+			scope = "%s"
+    	}
+	}
+ }
+}
+`, cclusterName, w1startTime, w1endTime, w1startTime, w1endTime, scope1, w2startTime, w2endTime, scope2)
+}
+
+func testAccContainerCluster_NoExclusionOptions_RecurringMaintenanceWindow(cclusterName string, w1startTime, w1endTime, w2startTime, w2endTime string) string {
+
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_maintenance_exclusion_options" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  maintenance_policy {
+	recurring_window {
+		start_time = "%s"
+		end_time = "%s"
+		recurrence = "FREQ=DAILY"
+	}
+	maintenance_exclusion {
+		exclusion_name = "batch job"
+		start_time = "%s"
+		end_time = "%s"
+	}
+	maintenance_exclusion {
+		exclusion_name = "holiday data load"
+		start_time = "%s"
+		end_time = "%s"
+	}
+ }
+}
+`, cclusterName, w1startTime, w1endTime, w1startTime, w1endTime, w2startTime, w2endTime)
+}
+
+func testAccContainerCluster_updateExclusionOptions_RecurringMaintenanceWindow(cclusterName string, w1startTime, w1endTime, w2startTime, w2endTime string, scope1, scope2 string) string {
+
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_maintenance_exclusion_options" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  maintenance_policy {
+	recurring_window {
+		start_time = "%s"
+		end_time = "%s"
+		recurrence = "FREQ=DAILY"
+	}
+	maintenance_exclusion {
+		exclusion_name = "batch job"
+		start_time = "%s"
+		end_time = "%s"
+		exclusion_options {
+			scope = "%s"
+    	}
+	}
+	maintenance_exclusion {
+		exclusion_name = "holiday data load"
+		start_time = "%s"
+		end_time = "%s"
+		exclusion_options {
+			scope = "%s"
+    	}
+	}
+ }
+}
+`, cclusterName, w1startTime, w1endTime, w1startTime, w1endTime, scope1, w2startTime, w2endTime, scope2)
 }
 
 func testAccContainerCluster_withExclusion_NoMaintenanceWindow(clusterName string, w1startTime, w1endTime string) string {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -564,7 +564,7 @@ maintenance_policy {
     start_time = "2019-01-01T00:00:00Z"
     end_time = "2019-01-02T00:00:00Z"
     exclusion_options {
-		  scope = "NO_UPGRADES"
+      scope = "NO_UPGRADES"
     }
   }
   maintenance_exclusion{
@@ -572,7 +572,7 @@ maintenance_policy {
     start_time = "2019-05-01T00:00:00Z"
     end_time = "2019-05-02T00:00:00Z"
     exclusion_options {
-		  scope = "NO_MINOR_UPGRADES"
+      scope = "NO_MINOR_UPGRADES"
     }
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -538,6 +538,13 @@ maintenance_policy {
 
 * `maintenance_exclusion` - Exceptions to maintenance window. Non-emergency maintenance should not occur in these windows. A cluster can have up to three maintenance exclusions at a time [Maintenance Window and Exclusions](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions)
 
+<a name="nested_maintenance_exclusion"></a>The `maintenance_exclusion` block supports:
+* `exclusion_options` - (Optional) MaintenanceExclusionOptions provides maintenance exclusion related options.
+
+
+<a name="nested_exclusion_options"></a>The `exclusion_options` block supports:
+* `scope` - (Required) The scope of automatic upgrades to restrict in the exclusion window. One of: **NO_UPGRADES | NO_MINOR_UPGRADES | NO_MINOR_OR_NODE_UPGRADES**
+
 Specify `start_time` and `end_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) "Zulu" date format.  The start time's date is
 the initial date that the window starts, and the end time is used for calculating duration.Specify `recurrence` in
 [RFC5545](https://tools.ietf.org/html/rfc5545#section-3.8.5.3) RRULE format, to specify when this recurs.
@@ -556,11 +563,17 @@ maintenance_policy {
     exclusion_name = "batch job"
     start_time = "2019-01-01T00:00:00Z"
     end_time = "2019-01-02T00:00:00Z"
+    exclusion_options {
+			scope = "NO_UPGRADES"
+    	}
   }
   maintenance_exclusion{
     exclusion_name = "holiday data load"
     start_time = "2019-05-01T00:00:00Z"
     end_time = "2019-05-02T00:00:00Z"
+    exclusion_options {
+			scope = "NO_MINOR_UPGRADES"
+    	}
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -564,16 +564,16 @@ maintenance_policy {
     start_time = "2019-01-01T00:00:00Z"
     end_time = "2019-01-02T00:00:00Z"
     exclusion_options {
-			scope = "NO_UPGRADES"
-    	}
+		  scope = "NO_UPGRADES"
+    }
   }
   maintenance_exclusion{
     exclusion_name = "holiday data load"
     start_time = "2019-05-01T00:00:00Z"
     end_time = "2019-05-02T00:00:00Z"
     exclusion_options {
-			scope = "NO_MINOR_UPGRADES"
-    	}
+		  scope = "NO_MINOR_UPGRADES"
+    }
   }
 }
 ```


### PR DESCRIPTION
**Add support for exclusion scope in the maintenance exclusion**
https://github.com/hashicorp/terraform-provider-google/issues/11274


If this PR is for Terraform, I acknowledge that I have:

- [ x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
```release-note:enhancement
container: added field `exclusion_options` to `google_container_cluster`
```