### PR TITLE
Fix test using project number

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -193,7 +193,7 @@ data "google_project" "project" {
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"
-  scopes = ["projects/${google_project.project.number}"]
+  scopes = ["projects/${data.google_project.project.number}"]
 }
 `, org, title)
 }

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -168,7 +168,6 @@ resource "google_access_context_manager_access_policy" "test-access" {
 
 func testAccAccessContextManagerAccessPolicy_scopedTest(t *testing.T) {
 	org := getTestOrgFromEnv(t)
-	project := getTestProjectFromEnv()
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -176,7 +175,7 @@ func testAccAccessContextManagerAccessPolicy_scopedTest(t *testing.T) {
 		CheckDestroy: testAccCheckAccessContextManagerAccessPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerAccessPolicy_scoped(org, project, "scoped policy"),
+				Config: testAccAccessContextManagerAccessPolicy_scoped(org, "scoped policy"),
 			},
 			{
 				ResourceName:      "google_access_context_manager_access_policy.test-access",
@@ -187,12 +186,14 @@ func testAccAccessContextManagerAccessPolicy_scopedTest(t *testing.T) {
 	})
 }
 
-func testAccAccessContextManagerAccessPolicy_scoped(org, project, title string) string {
+func testAccAccessContextManagerAccessPolicy_scoped(org, title string) string {
 	return fmt.Sprintf(`
+data "google_project" "project" {
+}
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"
-  scopes = ["projects/%s"]
+  scopes = ["projects/${google_project.project.number}"]
 }
-`, org, title, project)
+`, org, title)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes testAccAccessContextManagerAccessPolicy_scopedTest



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
