### PR TITLE
Update dataproc image version past log4j

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -565,6 +565,8 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 	t.Parallel()
 
 	rnd := randString(t, 10)
+	version := "2.0-debian10"
+
 	var cluster dataproc.Cluster
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -572,10 +574,10 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withImageVersion(rnd),
+				Config: testAccDataprocCluster_withImageVersion(rnd, version),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_image_version", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", "1.3.7-deb9"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", version),
 				),
 			},
 		},
@@ -1510,7 +1512,7 @@ resource "google_dataproc_cluster" "with_endpoint_config" {
 }
 <% end -%>
 
-func testAccDataprocCluster_withImageVersion(rnd string) string {
+func testAccDataprocCluster_withImageVersion(rnd, version string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_image_version" {
   name   = "tf-test-dproc-%s"
@@ -1518,11 +1520,11 @@ resource "google_dataproc_cluster" "with_image_version" {
 
   cluster_config {
     software_config {
-      image_version = "1.3.7-deb9"
+      image_version = "%s"
     }
   }
 }
-`, rnd)
+`, rnd, version)
 }
 
 func testAccDataprocCluster_withOptionalComponents(rnd string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

```
------- Stdout: -------
=== RUN   TestAccDataprocCluster_withImageVersion
=== PAUSE TestAccDataprocCluster_withImageVersion
=== CONT  TestAccDataprocCluster_withImageVersion
provider_test.go:301: Step 1/1 error: Error running apply: exit status 1
Error: Error creating Dataproc cluster: googleapi: Error 400: Selected software image version 1.3.7-deb9 is vulnerable to remote code execution due to a log4j vulnerability (CVE-2021-44228) and cannot be used to create new clusters. Please upgrade to image versions >=1.3.95, >=1.4.77, >=1.5.53, or >=2.0.27. For more information, see https://cloud.google.com/dataproc/docs/guides/recreate-cluster, badRequest
on terraform_plugin_test.tf line 2, in resource "google_dataproc_cluster" "with_image_version":
2: resource "google_dataproc_cluster" "with_image_version" {
--- FAIL: TestAccDataprocCluster_withImageVersion (4.78s)
FAIL
```


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
