### PR TITLE
[WIP] Fix Dataproc Metastore resource

### DIFF
--- a/mmv1/products/metastore/api.yaml
+++ b/mmv1/products/metastore/api.yaml
@@ -68,10 +68,8 @@ objects:
         name: 'location'
         url_param_only: true
         input: true
-        default_value: global
         description: |
-          The  location where the autoscaling policy should reside.
-          The default value is `global`.
+          The  location where the metastore service should reside.
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -153,6 +151,7 @@ objects:
             name: 'version'
             input: true
             required: true
+            default_value: "3.1.2"
             description: |
               The Hive metastore schema version.
           - !ruby/object:Api::Type::KeyValuePairs


### PR DESCRIPTION
* Change location to be accurate, DPMS doesn't support global location,
  remove default, this shouldn't be breaking because nobody should be
  successfully creating with a global region.
* Add default_value to version as the version defaults to 3.1.2 via the
  API.

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
metastore: Fix default location being global when it isn't supported. 
```
```release-note:enhancement
metastore: Set default version to 3.1.2  
```