### PR TITLE
update dataproc cluster image version

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -575,7 +575,7 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 				Config: testAccDataprocCluster_withImageVersion(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_image_version", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", "1.3.7-deb9"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", "1.5.62-debian10"),
 				),
 			},
 		},
@@ -1518,7 +1518,7 @@ resource "google_dataproc_cluster" "with_image_version" {
 
   cluster_config {
     software_config {
-      image_version = "1.3.7-deb9"
+      image_version = "1.5.62-debian10"
     }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_dataproc_workflow_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_workflow_template_test.go.erb
@@ -72,7 +72,7 @@ resource "google_dataproc_workflow_template" "template" {
           num_instances = 2
         }
         software_config {
-          image_version = "1.3.7-deb9"
+          image_version = "1.5.62-debian10"
         }
       }
     }

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -73,7 +73,7 @@ resource "google_dataproc_cluster" "mycluster" {
 
     # Override or set some custom properties
     software_config {
-      image_version = "1.3.7-deb9"
+      image_version = "1.5.62-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -470,7 +470,7 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
 cluster_config {
   # Override or set some custom properties
   software_config {
-    image_version = "1.3.7-deb9"
+    image_version = "1.5.62-debian10"
 
     override_properties = {
       "dataproc:dataproc.allow.zero.workers" = "true"

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
@@ -46,7 +46,7 @@ resource "google_dataproc_workflow_template" "template" {
           num_instances = 2
         }
         software_config {
-          image_version = "1.3.7-deb9"
+          image_version = "1.5.62-debian10"
         }
       }
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11319

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
