### PR TITLE
add deletion protection for CA

### DIFF
--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -16,6 +16,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   CertificateAuthority: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: true
     import_format: ["projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}"]
+    docs: !ruby/object:Provider::Terraform::Docs
+      warning: |
+        On newer versions of the provider, you must explicitly set `deletion_protection=false`
+        (and run `terraform apply` to write the field to state) in order to destroy a CertificateAuthority.
+        It is recommended to not set this field (or set it to true) until you're ready to destroy.
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_authority_basic"
@@ -24,9 +29,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           certificate_authority_id: "my-certificate-authority"
           pool_name: "ca-pool"
           pool_location: "us-central1"
+          deletion_protection: "true"
         test_vars_overrides:
           pool_name: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
           pool_location: "\"us-central1\""
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_authority_subordinate"
         primary_resource_id: "default"
@@ -34,9 +43,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           certificate_authority_id: "my-certificate-authority"
           pool_name: "ca-pool"
           pool_location: "us-central1"
+          deletion_protection: "true"
         test_vars_overrides:
           pool_name: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
           pool_location: "\"us-central1\""
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
       - !ruby/object:Provider::Terraform::Examples
         # Skip test because it depends on a beta resource, but PrivateCA does
         # not have a beta endpoint
@@ -50,10 +63,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           certificate_authority_id: "my-certificate-authority"
           pool_name: "ca-pool"
           pool_location: "us-central1"
+          deletion_protection: "true"
         test_vars_overrides:
           kms_key_name: 'BootstrapKMSKeyWithPurposeInLocation(t, "ASYMMETRIC_SIGN", "us-central1").CryptoKey.Name'
           pool_name: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
           pool_location: "\"us-central1\""
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+    virtual_fields:
+      - !ruby/object:Api::Type::Boolean
+        name: 'deletion_protection'
+        default_value: true
+        description: |
+          Whether or not to allow Terraform to destroy the CertificateAuthority. Unless this field is set to false
+          in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
     properties:
       type: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
@@ -5,6 +5,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   pool = "<%= ctx[:vars]["pool_name"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "<%= ctx[:vars]["pool_location"] %>"
+  deletion_protection = "<%= ctx[:vars]["deletion_protection"] %>"
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
@@ -26,6 +26,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   pool = "<%= ctx[:vars]["pool_name"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "<%= ctx[:vars]["pool_location"] %>"
+  deletion_protection = "<%= ctx[:vars]["deletion_protection"] %>"
   key_spec {
     cloud_kms_key_version = "<%= ctx[:vars]['kms_key_name'] %>/cryptoKeyVersions/1"
   }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
@@ -5,6 +5,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   pool = "<%= ctx[:vars]["pool_name"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "<%= ctx[:vars]["pool_location"] %>"
+  deletion_protection = "<%= ctx[:vars]["deletion_protection"] %>"
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
@@ -4,6 +4,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
   location = "us-central1"
   pool = "<%= ctx[:vars]["pool"] %>"
   ignore_active_certificates_on_deletion = true
+  deletion_protection = false
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
@@ -3,6 +3,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
   pool = "<%= ctx[:vars]["pool"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "us-central1"
+  deletion_protection = false
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
@@ -5,6 +5,7 @@ resource "google_privateca_certificate_authority" "authority" {
   pool = "<%= ctx[:vars]["pool"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "us-central1"
+  deletion_protection = false
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
@@ -78,6 +78,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
   pool = "<%= ctx[:vars]["pool"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "us-central1"
+  deletion_protection = false
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/pre_delete/privateca_authority_disable.go.erb
+++ b/mmv1/templates/terraform/pre_delete/privateca_authority_disable.go.erb
@@ -1,3 +1,7 @@
+if d.Get("deletion_protection").(bool) {
+	return fmt.Errorf("cannot destroy CertificateAuthority without setting deletion_protection=false and running `terraform apply`")
+}
+
 if d.Get("state").(string) == "ENABLED" {
 	disableUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:disable")
 	if err != nil {

--- a/mmv1/third_party/terraform/tests/data_source_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_certificate_authority_test.go
@@ -39,6 +39,7 @@ resource "google_privateca_certificate_authority" "default" {
   certificate_authority_id = "tf-test-my-certificate-authority%{random_suffix}"
   location = "%{pool_location}"
   type = "SUBORDINATE"
+  deletion_protection = false
   config {
     subject_config {
       subject {

--- a/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_test.go
@@ -28,7 +28,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ResourceName:            "google_privateca_certificate_authority.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool"},
+				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection"},
 			},
 			{
 				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityEnd(context),
@@ -37,7 +37,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ResourceName:            "google_privateca_certificate_authority.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool"},
+				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection"},
 			},
 			{
 				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityStart(context),
@@ -46,7 +46,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ResourceName:            "google_privateca_certificate_authority.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool"},
+				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection"},
 			},
 		},
 	})
@@ -60,6 +60,7 @@ resource "google_privateca_certificate_authority" "default" {
 	pool = "%{pool_name}"
 	certificate_authority_id = "tf-test-my-certificate-authority-%{random_suffix}"
 	location = "%{pool_location}"
+	deletion_protection = false
 	config {
 		subject_config {
 		subject {
@@ -112,6 +113,7 @@ resource "google_privateca_certificate_authority" "default" {
 	pool = "%{pool_name}"
 	certificate_authority_id = "tf-test-my-certificate-authority-%{random_suffix}"
 	location = "%{pool_location}"
+	deletion_protection = false
 	config {
 		subject_config {
 		subject {

--- a/mmv1/third_party/terraform/tests/resource_privateca_certificate_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_certificate_test.go
@@ -60,6 +60,7 @@ resource "google_privateca_certificate_authority" "default" {
 	pool = "%{pool_name}"
 	certificate_authority_id = "tf-test-my-certificate-authority-%{random_suffix}"
 	location = "%{pool_location}"
+	deletion_protection = false
 	config {
 		subject_config {
 			subject {
@@ -137,6 +138,7 @@ resource "google_privateca_certificate_authority" "default" {
 	pool = "%{pool_name}"
 	certificate_authority_id = "tf-test-my-certificate-authority-%{random_suffix}"
 	location = "%{pool_location}"
+	deletion_protection = false
 	config {
 		subject_config {
 			subject {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

CA is a type of fundamental resources like database. Currently, we are facing the risk where a CA could be accidentally deleted or force recreated (delete->recreate). Also, force-recreate will not work as recreating a CA with a used name would fail for 2 reasons. 
* The deleted CA would stay in `PENDING_DELETION` for 30days
* Reuse CA name is not allowed for security concerns.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: add `deletion_protection` for CertificateAuthority.
```
```release-note:note
`google_privateca_certificate_authority` resources now cannot be destroyed unless `deletion_protection = false` is set in state for the resource.
```
