### PR TITLE
Add a new field `is_staged` to create a CertificateAuthority in `STAGED` state.

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -418,6 +418,7 @@ objects:
           - :STATE_UNSPECIFIED
           - :ENABLED
           - :DISABLED
+          - :STAGED
           - :PENDING_ACTIVATION
           - :PENDING_DELETION
       - !ruby/object:Api::Type::Array

--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -54,6 +54,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           kms_key_name: 'BootstrapKMSKeyWithPurposeInLocation(t, "ASYMMETRIC_SIGN", "us-central1").CryptoKey.Name'
           pool_name: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
           pool_location: "\"us-central1\""
+    virtual_fields:
+      - !ruby/object:Api::Type::Boolean
+        name: 'is_staged'
+        default_value: false
+        description: |
+          By default, a CA will be enabled after its creation. Set this field
+          to `true` to create a CA in `STAGED` state.
     properties:
       type: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
@@ -67,6 +74,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_expand: 'templates/terraform/custom_expand/privateca_certificate_509_config.go.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       decoder: templates/terraform/decoders/treat_deleted_state_as_gone.go.erb
+      pre_update: templates/terraform/pre_update/privateca_authority_update.go.erb
       post_create: templates/terraform/post_create/privateca_authority_enable.go.erb
       pre_delete: templates/terraform/pre_delete/privateca_authority_disable.go.erb
       post_import: templates/terraform/post_import/privateca_import.go.erb

--- a/mmv1/templates/terraform/post_create/privateca_authority_enable.go.erb
+++ b/mmv1/templates/terraform/post_create/privateca_authority_enable.go.erb
@@ -1,4 +1,4 @@
-if d.Get("type").(string) != "SUBORDINATE" {
+if !d.Get("is_staged").(bool) && d.Get("type").(string) != "SUBORDINATE" {
 	url, err = replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:enable")
 	if err != nil {
 		return err

--- a/mmv1/templates/terraform/pre_update/privateca_authority_update.go.erb
+++ b/mmv1/templates/terraform/pre_update/privateca_authority_update.go.erb
@@ -1,0 +1,28 @@
+
+if d.HasChange("is_staged") {
+	if d.Get("is_staged").(bool) {
+		return fmt.Errorf("Field `is_staged` can only be set to true when creating a new CertificateAuthority")
+	}
+	if d.Get("state").(string) == "STAGED" {
+		// Enable a CA which currently in STAGED state.
+		enableUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:enable")
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Enabling CertificateAuthority: %#v", obj)
+
+		res, err := sendRequest(config, "POST", billingProject, enableUrl, userAgent, nil)
+		if err != nil {
+			return fmt.Errorf("Error enabling CertificateAuthority: %s", err)
+		}
+
+		var opRes map[string]interface{}
+		err = privatecaOperationWaitTimeWithResponse(
+			config, res, &opRes, project, "Enabling CertificateAuthority", userAgent,
+			d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return fmt.Errorf("Error waiting to enable CertificateAuthority: %s", err)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_test.go
@@ -6,6 +6,38 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityIsStaged(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"pool_name":           BootstrapSharedCaPoolInLocation(t, "us-central1"),
+		"pool_location":       "us-central1",
+		"deletion_protection": false,
+		"random_suffix":       randString(t, 10),
+	}
+
+	resourceName := "google_privateca_certificate_authority.default"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPrivatecaCertificateAuthorityDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityIsStaged(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "STAGED"),
+				),
+			},
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -22,7 +54,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 		CheckDestroy: testAccCheckPrivatecaCertificateAuthorityDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityStart(context),
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context),
 			},
 			{
 				ResourceName:            "google_privateca_certificate_authority.default",
@@ -40,7 +72,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool"},
 			},
 			{
-				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityStart(context),
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context),
 			},
 			{
 				ResourceName:            "google_privateca_certificate_authority.default",
@@ -52,7 +84,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 	})
 }
 
-func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityStart(context map[string]interface{}) string {
+func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_privateca_certificate_authority" "default" {
 	// This example assumes this pool already exists.
@@ -154,6 +186,59 @@ resource "google_privateca_certificate_authority" "default" {
 	}
 	labels = {
 		foo = "bar"
+	}
+}
+`, context)
+}
+
+func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityIsStaged(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_privateca_certificate_authority" "default" {
+	// This example assumes this pool already exists.
+	// Pools cannot be deleted in normal test circumstances, so we depend on static pools
+	pool = "%{pool_name}"
+	certificate_authority_id = "tf-test-my-certificate-authority-%{random_suffix}"
+	location = "%{pool_location}"
+	is_staged = true
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
 	}
 }
 `, context)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [x] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: add a new field `is_staged` to create a CertificateAuthority in `STAGED` state.
```
