### PR TITLE
fix(spanner): fix escaping of database name in spanner ddl with POSTGRES dialect

### DIFF
--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -1,6 +1,6 @@
 obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
 if dialect, ok := obj["databaseDialect"]; ok && dialect == "POSTGRESQL" {
-    obj["createStatement"] = fmt.Sprintf("CREATE DATABASE %s", obj["name"])
+    obj["createStatement"] = fmt.Sprintf("CREATE DATABASE \"%s\"", obj["name"])
 }
 delete(obj, "name")
 delete(obj, "instance")

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -170,7 +170,7 @@ resource "google_spanner_instance" "basic" {
 
 resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
-  name     = "%s_spangres"
+  name     = "%s-spangres"
   database_dialect = "POSTGRESQL"
   deletion_protection = false
 }
@@ -188,7 +188,7 @@ resource "google_spanner_instance" "basic" {
 
 resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
-  name     = "%s_spangres"
+  name     = "%s-spangres"
   database_dialect = "POSTGRESQL"
   ddl = [
      "CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Currently name attribute having `-` in value cannot be populated because of issue in escaping database name
e.g


variables "database_name" {
  type    = string
  default = "dbatest5-postgres"
}

resource "google_spanner_database" "database" {
  instance            = [google_spanner_instance.main.name](http://google_spanner_instance.main.name/)
  name                = "\"${var.database_name}\""
  database_dialect    = "POSTGRESQL"
  deletion_protection = false
}

This PR will fix the escaping with POSTGRES dialect
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
spanner: fix escaping of database names with Postgres dialect in `google_spanner_database`
```
