### PR TITLE
Added Cloud SQL flags and user examples

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -368,6 +368,46 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           private_ip_address: "private-ip-address"
           private_ip_sql_instance: "private-ip-sql-instance"
         skip_test: true
+    ### Flags and User ###
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_mysql_instance_flags"
+        primary_resource_id: "instance"
+        primary_resource_type: "google_sql_database_instance"
+        vars:
+          mysql_instance: "mysql-instance"
+          username: "username"
+          deletion_protection: "true"
+        skip_test: true
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_postgres_instance_flags"
+        primary_resource_id: "instance"
+        primary_resource_type: "google_sql_database_instance"
+        vars:
+          postgres_instance: "postgres-instance"
+          username: "username"
+          deletion_protection: "true"
+        skip_test: true
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_sqlserver_instance_flags"
+        primary_resource_id: "instance"
+        primary_resource_type: "google_sql_database_instance"
+        vars:
+          sqlserver_instance: "sqlserver-instance"
+          username: "username"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+          - "root_password"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"
@@ -377,7 +417,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           new_bucket: "new-bucket"
           new_object: "new-object"
     properties:
-    
+
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_flags.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_flags.tf.erb
@@ -1,0 +1,34 @@
+
+# [START cloud_sql_mysql_instance_flags]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  database_version = "MYSQL_8_0"
+  name             = "<%= ctx[:vars]['mysql_instance'] %>"
+  region           = "us-central1"
+  settings {
+    database_flags {
+      name  = "general_log"
+      value = "on"
+    }
+    database_flags {
+      name  = "skip_show_database"
+      value = "on"
+    }
+    database_flags {
+      name  = "wait_timeout"
+      value = "200000"
+    }
+    disk_type             = "PD_SSD"
+    tier         = "db-n1-standard-2"
+  }
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_mysql_instance_flags]
+
+# [START cloud_sql_mysql_instance_user]
+resource "google_sql_user" "user" {
+  name     = "<%= ctx[:vars]['username'] %>"
+  host     = "%"
+  instance = google_sql_database_instance.instance.name
+  password = "changeme"
+}
+# [END cloud_sql_mysql_instance_user]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_flags.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_flags.tf.erb
@@ -1,0 +1,28 @@
+# [START cloud_sql_postgres_instance_flags]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['postgres_instance'] %>"
+  region           = "us-central1"
+  database_version = "POSTGRES_14"
+  settings {
+    database_flags {
+      name  = "log_connections"
+      value = "on"
+    }
+    database_flags {
+      name  = "log_min_error_statement"
+      value = "error"
+    }
+    tier = "db-custom-2-7680"
+  }
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_postgres_instance_flags]
+
+# [START cloud_sql_postgres_instance_user]
+resource "google_sql_user" "user" {
+  name     = "<%= ctx[:vars]['username'] %>"
+  host     = "%"
+  instance = google_sql_database_instance.mysql_instance.name
+  password = "changeme"
+}
+# [END cloud_sql_postgres_instance_user]

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_flags.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_flags.tf.erb
@@ -1,0 +1,33 @@
+# [START cloud_sql_sqlserver_instance_flags]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['sqlserver_instance'] %>"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2019_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    database_flags {
+      name  = "general_log"
+      value = "on"
+    }
+    database_flags {
+      name  = "skip_show_database"
+      value = "on"
+    }
+    database_flags {
+      name  = "wait_timeout"
+      value = "200000"
+    }
+    tier = "db-custom-2-7680"
+  }
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_sqlserver_instance_flags]
+
+# [START cloud_sql_sqlserver_instance_user]
+resource "google_sql_user" "user" {
+  name     = "<%= ctx[:vars]['username'] %>"
+  host     = "%"
+  instance = google_sql_database_instance.mysql_instance.name
+  password = "changeme"
+}
+# [END cloud_sql_sqlserver_instance_user]


### PR DESCRIPTION
Intending to add these here:

https://cloud.google.com/sql/docs/mysql/flags
https://cloud.google.com/sql/docs/postgres/flags
https://cloud.google.com/sql/docs/sqlserver/flags

https://cloud.google.com/sql/docs/mysql/create-manage-users
https://cloud.google.com/sql/docs/postgres/create-manage-users
https://cloud.google.com/sql/docs/sqlserver/create-manage-users

```release-note:none
```