### PR TITLE
Added nested region tags to Cloud SQL private IP examples

### DIFF
--- a/mmv1/templates/terraform/examples/sql_mysql_instance_private_ip.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_private_ip.tf.erb
@@ -1,10 +1,13 @@
 # [START cloud_sql_mysql_instance_private_ip]
 
+# [START vpc_mysql_instance_private_ip_network]
 resource "google_compute_network" "private_network" {
   name                    = "<%= ctx[:vars]['private_network'] %>"
   auto_create_subnetworks = "false"
 }
+# [END vpc_mysql_instance_private_ip_network]
 
+# [START vpc_mysql_instance_private_ip_address]
 resource "google_compute_global_address" "private_ip_address" {
   name          = "<%= ctx[:vars]['private_ip_address'] %>"
   purpose       = "VPC_PEERING"
@@ -12,17 +15,21 @@ resource "google_compute_global_address" "private_ip_address" {
   prefix_length = 16
   network       = google_compute_network.private_network.id
 }
+# [END vpc_mysql_instance_private_ip_address]
 
+# [START vpc_mysql_instance_private_ip_service_connection]
 resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = google_compute_network.private_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }
+# [END vpc_mysql_instance_private_ip_service_connection]
 
+# [START cloud_sql_mysql_instance_private_ip_instance]
 resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   name             = "<%= ctx[:vars]['private_ip_sql_instance'] %>"
   region           = "us-central1"
-  database_version = "MYSQL_5_7"
+  database_version = "MYSQL_8_0"
 
   depends_on = [google_service_networking_connection.private_vpc_connection]
 
@@ -35,4 +42,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   }
   deletion_protection = "false"
 }
+# [END cloud_sql_mysql_instance_private_ip_instance]
+
 # [END cloud_sql_mysql_instance_private_ip]

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_private_ip.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_private_ip.tf.erb
@@ -1,9 +1,13 @@
 # [START cloud_sql_postgres_instance_private_ip]
+
+# [START vpc_postgres_instance_private_ip_network]
 resource "google_compute_network" "private_network" {
   name                    = "<%= ctx[:vars]['private_network'] %>"
   auto_create_subnetworks = "false"
 }
+# [END vpc_postgres_instance_private_ip_network]
 
+# [START vpc_postgres_instance_private_ip_address]
 resource "google_compute_global_address" "private_ip_address" {
   name          = "<%= ctx[:vars]['private_ip_address'] %>"
   purpose       = "VPC_PEERING"
@@ -11,17 +15,21 @@ resource "google_compute_global_address" "private_ip_address" {
   prefix_length = 16
   network       = google_compute_network.private_network.id
 }
+# [END vpc_postgres_instance_private_ip_address]
 
+# [START vpc_postgres_instance_private_ip_service_connection]
 resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = google_compute_network.private_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }
+# [END vpc_postgres_instance_private_ip_service_connection]
 
+# [START cloud_sql_postgres_instance_private_ip_instance]
 resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   name             = "<%= ctx[:vars]['private_ip_sql_instance'] %>"
   region           = "us-central1"
-  database_version = "POSTGRES_12"
+  database_version = "POSTGRES_14"
 
   depends_on = [google_service_networking_connection.private_vpc_connection]
 
@@ -34,4 +42,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   }
   deletion_protection = "false"
 }
+# [END cloud_sql_postgres_instance_private_ip_instance]
+
 # [END cloud_sql_postgres_instance_private_ip]

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_private_ip.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_private_ip.tf.erb
@@ -1,10 +1,13 @@
 # [START cloud_sql_sqlserver_instance_private_ip]
 
+# [START vpc_sqlserver_instance_private_ip_network]
 resource "google_compute_network" "private_network" {
   name                    = "<%= ctx[:vars]['private_network'] %>"
   auto_create_subnetworks = "false"
 }
+# [END vpc_sqlserver_instance_private_ip_network]
 
+# [START vpc_sqlserver_instance_private_ip_address]
 resource "google_compute_global_address" "private_ip_address" {
   name          = "<%= ctx[:vars]['private_ip_address'] %>"
   purpose       = "VPC_PEERING"
@@ -12,17 +15,21 @@ resource "google_compute_global_address" "private_ip_address" {
   prefix_length = 16
   network       = google_compute_network.private_network.id
 }
+# [END vpc_sqlserver_instance_private_ip_address]
 
+# [START vpc_sqlserver_instance_private_ip_service_connection]
 resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = google_compute_network.private_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }
+# [END vpc_sqlserver_instance_private_ip_service_connection]
 
+# [START cloud_sql_sqlserver_instance_private_ip_instance]
 resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   name             = "<%= ctx[:vars]['private_ip_sql_instance'] %>"
   region           = "us-central1"
-  database_version = "SQLSERVER_2017_STANDARD"
+  database_version = "SQLSERVER_2019_STANDARD"
   root_password        = "INSERT-PASSWORD-HERE"
 
   depends_on = [google_service_networking_connection.private_vpc_connection]
@@ -36,4 +43,6 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   }
   deletion_protection = "false"
 }
+# [END cloud_sql_sqlserver_instance_private_ip_instance]
+
 # [END cloud_sql_sqlserver_instance_private_ip]


### PR DESCRIPTION
Intending to use on these pages:

https://cloud.google.com/sql/docs/mysql/configure-private-services-access
https://cloud.google.com/sql/docs/postgres/configure-private-services-access
https://cloud.google.com/sql/docs/sqlserver/configure-private-services-access

```release-note:none
```