### PR TITLE
Fixed statement about HA

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -163,9 +163,12 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							Default:      "ZONAL",
 							ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "ZONAL"}, false),
 							Description:  `The availability type of the Cloud SQL instance, high availability
-(REGIONAL) or single zone (ZONAL). Ensure that
+(REGIONAL) or single zone (ZONAL). For MySQL and SQL Server instances, ensure that
 settings.backup_configuration.enabled and
-settings.backup_configuration.binary_log_enabled are both set to true.`,
+settings.backup_configuration.binary_log_enabled are both set to true.
+For Postgres instances, ensure that settings.backup_configuration.enabled
+and settings.backup_configuration.point_in_time_recovery_enabled
+are both set to true.`,
 						},
 						"backup_configuration": {
 							Type:     schema.TypeList,

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -163,7 +163,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							Default:      "ZONAL",
 							ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "ZONAL"}, false),
 							Description:  `The availability type of the Cloud SQL instance, high availability
-(REGIONAL) or single zone (ZONAL). For MySQL instances, ensure that
+(REGIONAL) or single zone (ZONAL). Ensure that
 settings.backup_configuration.enabled and
 settings.backup_configuration.binary_log_enabled are both set to true.`,
 						},

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -230,9 +230,10 @@ The `settings` block supports:
     active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
 
 * `availability_type` - (Optional, Default: `ZONAL`) The availability type of the Cloud SQL
-instance, high availability (`REGIONAL`) or single zone (`ZONAL`).' For MySQL
-instances, ensure that `settings.backup_configuration.enabled` and
-`settings.backup_configuration.binary_log_enabled` are both set to `true`.
+  instance, high availability (`REGIONAL`) or single zone (`ZONAL`).' For MySQL and SQL Server instances,
+  ensure that `settings.backup_configuration.enabled` and `settings.backup_configuration.binary_log_enabled`
+  are both set to `true`. For Postgres instances, ensure that `settings.backup_configuration.enabled`
+  and `settings.backup_configuration.point_in_time_recovery_enabled` are both set to `true`.
 
 * `collation` - (Optional) The name of server instance collation.
 


### PR DESCRIPTION
All Cloud SQL instance types must have backups and binary logs enabled for HA, not just mysql.

See:

https://cloud.google.com/sql/docs/mysql/high-availability#backups-and-restores
https://cloud.google.com/sql/docs/postgres/high-availability#backups-and-restores https://cloud.google.com/sql/docs/sqlserver/high-availability#backups-and-restores

```release-note:none
```