### PR TITLE
Turn Spot VMs to GA on GCE.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -50,9 +50,7 @@ var (
 		"scheduling.0.preemptible",
 		"scheduling.0.node_affinities",
 		"scheduling.0.min_node_cpus",
-<% unless version == 'ga' -%>
 		"scheduling.0.provisioning_model",
-<% end -%>
 	}
 
 	shieldedInstanceConfigKeys = []string{
@@ -628,7 +626,6 @@ func resourceComputeInstance() *schema.Resource {
 							Optional:     true,
 							AtLeastOneOf: schedulingKeys,
 						},
- <% unless version == 'ga' -%>
 						"provisioning_model": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -637,7 +634,6 @@ func resourceComputeInstance() *schema.Resource {
 							AtLeastOneOf: schedulingKeys,
 							Description:  `Whether the instance is spot. If this is set as SPOT.`,
 						},
-<% end -%>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -29,9 +29,7 @@ var (
 		"scheduling.0.preemptible",
 		"scheduling.0.node_affinities",
 		"scheduling.0.min_node_cpus",
-<% unless version == 'ga' -%>
 		"scheduling.0.provisioning_model",
- <% end -%>
 	}
 
 	shieldedInstanceTemplateConfigKeys = []string{
@@ -539,7 +537,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							AtLeastOneOf: schedulingInstTemplateKeys,
 							Description:  `Minimum number of cpus for the instance.`,
 						},
-<% unless version == 'ga' -%>
 						"provisioning_model": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -548,7 +545,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							AtLeastOneOf: schedulingInstTemplateKeys,
 							Description:  `Whether the instance is spot. If this is set as SPOT.`,
 						},
-<% end -%>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1080,7 +1080,6 @@ func TestAccComputeInstanceTemplate_queueCount(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeInstanceTemplate_spot(t *testing.T) {
 	t.Parallel()
 
@@ -1109,7 +1108,6 @@ func TestAccComputeInstanceTemplate_spot(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func testAccCheckComputeInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -1258,7 +1256,6 @@ func testAccCheckComputeInstanceTemplatePreemptible(instanceTemplate *compute.In
 	}
 }
 
-<% unless version == 'ga' -%>
 func testAccCheckComputeInstanceTemplateProvisioningModel(instanceTemplate *compute.InstanceTemplate, provisioning_model string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.Scheduling.ProvisioningModel != provisioning_model {
@@ -1267,7 +1264,6 @@ func testAccCheckComputeInstanceTemplateProvisioningModel(instanceTemplate *comp
 		return nil
 	}
 }
-<% end -%>
 
 
 func testAccCheckComputeInstanceTemplateAutomaticRestart(instanceTemplate *compute.InstanceTemplate, automaticRestart bool) resource.TestCheckFunc {
@@ -2731,7 +2727,6 @@ resource "google_compute_instance_template" "foobar" {
 `, instanceTemplateName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeInstanceTemplate_spot(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -2771,6 +2766,4 @@ resource "google_compute_instance_template" "foobar" {
 }
 `, suffix)
 }
-<% end -%>
-
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -2217,7 +2217,6 @@ func TestAccComputeInstance_queueCount(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeInstance_spotVM(t *testing.T) {
 	t.Parallel()
 
@@ -2271,7 +2270,6 @@ func TestAccComputeInstance_spotVM_update(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestComputeInstance_networkIPCustomizedDiff(t *testing.T) {
 	t.Parallel()
@@ -6238,7 +6236,6 @@ resource "google_compute_instance" "foobar" {
 `, instance)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeInstance_spotVM(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -6270,6 +6267,4 @@ resource "google_compute_instance" "foobar" {
 }
 `, instance)
 }
-<% end -%>
-
 

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -123,12 +123,10 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 	if v, ok := original["min_node_cpus"]; ok {
 		scheduling.MinNodeCpus = int64(v.(int))
 	}
-<% unless version == 'ga' -%>
 	if v, ok := original["provisioning_model"]; ok {
 		scheduling.ProvisioningModel = v.(string)
 		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "ProvisioningModel")
 	}
-<% end -%>
 	return scheduling, nil
 }
 
@@ -137,9 +135,7 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 		"on_host_maintenance": resp.OnHostMaintenance,
 		"preemptible":         resp.Preemptible,
 		"min_node_cpus":       resp.MinNodeCpus,
-<% unless version == 'ga' -%>
 		"provisioning_model":  resp.ProvisioningModel,
-<% end -%>
 	}
 
 	if resp.AutomaticRestart != nil {
@@ -484,11 +480,9 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 		return true
 	}
 
-<% unless version == 'ga' -%>
         if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
 	        return true
 	}
-<% end -%>
 
 	return false
 }

--- a/mmv1/third_party/validator/compute_instance.go.erb
+++ b/mmv1/third_party/validator/compute_instance.go.erb
@@ -125,9 +125,7 @@ func expandComputeInstance(project string, d TerraformResourceData, config *Conf
 			AutomaticRestart:  googleapi.Bool(d.Get(prefix + ".automatic_restart").(bool)),
 			Preemptible:       d.Get(prefix + ".preemptible").(bool),
 			OnHostMaintenance: d.Get(prefix + ".on_host_maintenance").(string),
-<% unless version == 'ga' -%>
 			ProvisioningModel: d.Get(prefix + ".provisioning_model").(string),
-<% end -%>
 			ForceSendFields:   []string{"AutomaticRestart", "Preemptible"},
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The SPOT API is released on Apr 20, 2022. To align with this progress, we need to change the SPOT feature from beta to GA.
This is the follow up pull request of https://github.com/GoogleCloudPlatform/magic-modules/pull/5662
https://github.com/hashicorp/terraform-provider-google/issues/11550
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
   
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `provisioning_model` field to `google_compute_instance` resource to support Spot VM
```

```release-note:enhancement
compute: added `provisioning_model` field to `google_compute_instance_template ` resource to support Spot VM
```

