### PR TITLE
Add a review time call-to-action to the Magician

### DIFF
--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -43,11 +43,18 @@ ASSIGNEE=$(shuf -n 1 <(printf "rileykarson\nslevenick\nc2thorn\nscottsuarez\nmel
 comment=$(cat << EOF
 Hello!  I am a robot who works on Magic Modules PRs.
 
-I have detected that you are a community contributor, so your PR will be assigned to someone with a commit-bit on this repo for initial review.
+I've detected that you're a community contributor. @$ASSIGNEE, a repository maintainer, has been assigned to assist you and help review your changes. 
 
-Thanks for your contribution!  A human will be with you soon.
+<details>
+  <summary>:question: First time contributing? Click here for more details</summary>
+  
+Your assigned reviewer will help review your code by ensuring it's backwards compatible, covers common eror cases, etc., and summarizing the change into a user-facing changelog note. They'll also run tests against your changes whether automatically through "VCR", a set of presubmit tests, or with manual test runs.
 
-@$ASSIGNEE, please review this PR or find an appropriate assignee.
+You can help make sure that review is quick by running local tests and ensuring they're passing in between each push you make to your PR's branch. Also, try to leave a comment with each push you make, as pushes generally don't generate notifications for maintainers.
+
+If your reviewer doesn't get back to you within a week of your most recent change or comment, please feel free to leave a comment on the issue asking them to take a look! In the absence of a dedicated review dashboard most maintainers manage their pending reviews through email, and those will sometimes get lost in their inbox.
+</details>
+
 EOF
 )
 

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -51,7 +51,7 @@ I've detected that you're a community contributor. @$ASSIGNEE, a repository main
 ---
 
 Your assigned reviewer will help review your code by: 
-* Ensuring it's backwards compatible, covers common eror cases, etc.
+* Ensuring it's backwards compatible, covers common error cases, etc.
 * Summarizing the change into a user-facing changelog note.
 * Passes tests, either our "VCR" suite, a set of presubmit tests, or with manual test runs.
 

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -47,12 +47,20 @@ I've detected that you're a community contributor. @$ASSIGNEE, a repository main
 
 <details>
   <summary>:question: First time contributing? Click here for more details</summary>
-  
-Your assigned reviewer will help review your code by ensuring it's backwards compatible, covers common eror cases, etc., and summarizing the change into a user-facing changelog note. They'll also run tests against your changes whether automatically through "VCR", a set of presubmit tests, or with manual test runs.
 
-You can help make sure that review is quick by running local tests and ensuring they're passing in between each push you make to your PR's branch. Also, try to leave a comment with each push you make, as pushes generally don't generate notifications for maintainers.
+---
 
-If your reviewer doesn't get back to you within a week of your most recent change or comment, please feel free to leave a comment on the issue asking them to take a look! In the absence of a dedicated review dashboard most maintainers manage their pending reviews through email, and those will sometimes get lost in their inbox.
+Your assigned reviewer will help review your code by: 
+* Ensuring it's backwards compatible, covers common eror cases, etc.
+* Summarizing the change into a user-facing changelog note.
+* Passes tests, either our "VCR" suite, a set of presubmit tests, or with manual test runs.
+
+You can help make sure that review is quick by running local tests and ensuring they're passing in between each push you make to your PR's branch. Also, try to leave a comment with each push you make, as pushes generally don't generate emails.
+
+If your reviewer doesn't get back to you within a week after your most recent change, please feel free to leave a comment on the issue asking them to take a look! In the absence of a dedicated review dashboard most maintainers manage their pending reviews through email, and those will sometimes get lost in their inbox.
+
+---
+
 </details>
 
 EOF


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/11428

Test comment @ https://github.com/hashicorp/terraform-provider-google/issues/11428#issuecomment-1104445826


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
