### PR TITLE
Fixed binary log doc

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -181,7 +181,7 @@ are both set to true.`,
 										Type:         schema.TypeBool,
 										Optional:     true,
 										AtLeastOneOf: backupConfigurationKeys,
-										Description:  `True if binary logging is enabled. If settings.backup_configuration.enabled is false, this must be as well. Cannot be used with Postgres.`,
+										Description:  `True if binary logging is enabled. If settings.backup_configuration.enabled is false, this must be as well. Can only be used with MySQL.`,
 									},
 									"enabled": {
 										Type:         schema.TypeBool,

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -163,12 +163,11 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							Default:      "ZONAL",
 							ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "ZONAL"}, false),
 							Description:  `The availability type of the Cloud SQL instance, high availability
-(REGIONAL) or single zone (ZONAL). For MySQL and SQL Server instances, ensure that
-settings.backup_configuration.enabled and
-settings.backup_configuration.binary_log_enabled are both set to true.
-For Postgres instances, ensure that settings.backup_configuration.enabled
-and settings.backup_configuration.point_in_time_recovery_enabled
-are both set to true.`,
+(REGIONAL) or single zone (ZONAL). For all instances, ensure that
+settings.backup_configuration.enabled is set to true.
+For MySQL instances, ensure that settings.backup_configuration.binary_log_enabled is set to true.
+For Postgres instances, ensure that settings.backup_configuration.point_in_time_recovery_enabled
+is set to true.`,
 						},
 						"backup_configuration": {
 							Type:     schema.TypeList,

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -230,10 +230,11 @@ The `settings` block supports:
     active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
 
 * `availability_type` - (Optional, Default: `ZONAL`) The availability type of the Cloud SQL
-  instance, high availability (`REGIONAL`) or single zone (`ZONAL`).' For MySQL and SQL Server instances,
-  ensure that `settings.backup_configuration.enabled` and `settings.backup_configuration.binary_log_enabled`
-  are both set to `true`. For Postgres instances, ensure that `settings.backup_configuration.enabled`
-  and `settings.backup_configuration.point_in_time_recovery_enabled` are both set to `true`.
+  instance, high availability (`REGIONAL`) or single zone (`ZONAL`).' For all instances, ensure that
+  `settings.backup_configuration.enabled` is set to `true`.
+  For MySQL instances, ensure that `settings.backup_configuration.binary_log_enabled` is set to `true`.
+  For Postgres instances, ensure that `settings.backup_configuration.point_in_time_recovery_enabled`
+  is set to `true`.
 
 * `collation` - (Optional) The name of server instance collation.
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -256,7 +256,7 @@ The optional `settings.database_flags` sublist supports:
 The optional `settings.backup_configuration` subblock supports:
 
 * `binary_log_enabled` - (Optional) True if binary logging is enabled.
-    Cannot be used with Postgres.
+    Can only be used with MySQL.
 
 * `enabled` - (Optional) True if backup configuration is enabled.
 


### PR DESCRIPTION
Here is the error when trying to use binary-log for a SQL Server instance:

```
google_sql_database_instance.default: Creating...
╷
│ Error: Error, failed to create instance sqlserver-instance-ha: googleapi: Error 400: Invalid request: Binary log can only be enabled for MySQL instances., invalid
```


```release-note:none
```