### PR TITLE
Revert "Support new features of IGM.updatePolicy"

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -206,15 +206,8 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 						"minimal_action": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
-							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
-						},
-
-						"most_disruptive_allowed_action": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"NONE", "REFRESH", "RESTART", "REPLACE"}, false),
-							Description:  `Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.`,
+							ValidateFunc: validation.StringInSlice([]string{"RESTART", "REPLACE"}, false),
+							Description:  `Minimal action to be taken on an instance. You can specify either RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a RESTART, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
 						},
 
 						"type": {
@@ -926,7 +919,6 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 		data := raw.(map[string]interface{})
 
 		updatePolicy.MinimalAction = data["minimal_action"].(string)
-		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>
@@ -1018,7 +1010,6 @@ func flattenUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdatePolicy)
 		up["min_ready_sec"] = updatePolicy.MinReadySec
 <% end -%>
 		up["minimal_action"] = updatePolicy.MinimalAction
-		up["most_disruptive_allowed_action"] = updatePolicy.MostDisruptiveAllowedAction
 		up["type"] = updatePolicy.Type
 		up["replacement_method"] = updatePolicy.ReplacementMethod
 		results = append(results, up)

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -244,15 +244,8 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 						"minimal_action": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
-							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
-						},
-
-						"most_disruptive_allowed_action": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"NONE", "REFRESH", "RESTART", "REPLACE"}, false),
-							Description:  `Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.`,
+							ValidateFunc: validation.StringInSlice([]string{"RESTART", "REPLACE"}, false),
+							Description:  `Minimal action to be taken on an instance. You can specify either RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a RESTART, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
 						},
 
 						"type": {
@@ -782,7 +775,6 @@ func expandRegionUpdatePolicy(configured []interface{}) *compute.InstanceGroupMa
 		data := raw.(map[string]interface{})
 
 		updatePolicy.MinimalAction = data["minimal_action"].(string)
-		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.InstanceRedistributionType = data["instance_redistribution_type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
@@ -846,7 +838,6 @@ func flattenRegionUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdateP
 		up["min_ready_sec"] = updatePolicy.MinReadySec
 <% end -%>
 		up["minimal_action"] = updatePolicy.MinimalAction
-		up["most_disruptive_allowed_action"] = updatePolicy.MostDisruptiveAllowedAction
 		up["type"] = updatePolicy.Type
 		up["instance_redistribution_type"] = updatePolicy.InstanceRedistributionType
 		up["replacement_method"] = updatePolicy.ReplacementMethod

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -933,11 +933,10 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
-    type                           = "PROACTIVE"
-    minimal_action                 = "REPLACE"
-    most_disruptive_allowed_action = "REPLACE"
-    max_surge_fixed                = 2
-    max_unavailable_fixed          = 2
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_surge_fixed       = 2
+    max_unavailable_fixed = 2
   }
   named_port {
     name = "customhttp"

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -1295,16 +1295,15 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
   distribution_policy_zones = ["us-central1-a", "us-central1-f"]
   target_size               = 3
   update_policy {
-    type                           = "PROACTIVE"
-    instance_redistribution_type   = "NONE"
-    minimal_action                 = "REPLACE"
-    most_disruptive_allowed_action = "REPLACE"
-    max_surge_fixed                = 0
-    max_unavailable_fixed          = 2
+    type                         = "PROACTIVE"
+    instance_redistribution_type = "NONE"
+    minimal_action               = "REPLACE"
+    max_surge_fixed              = 0
+    max_unavailable_fixed        = 2
 <% unless version == "ga" -%>
-    min_ready_sec                  = 10
+    min_ready_sec                = 10
 <% end -%>
-    replacement_method             = "RECREATE"
+    replacement_method           = "RECREATE"
   }
   named_port {
     name = "customhttp"

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -149,19 +149,16 @@ group. You can specify only one value. Structure is [documented below](#nested_a
 
 ```hcl
 update_policy {
-  type                           = "PROACTIVE"
-  minimal_action                 = "REPLACE"
-  most_disruptive_allowed_action = "REPLACE"
-  max_surge_percent              = 20
-  max_unavailable_fixed          = 2
-  min_ready_sec                  = 50
-  replacement_method             = "RECREATE"
+  type                  = "PROACTIVE"
+  minimal_action        = "REPLACE"
+  max_surge_percent     = 20
+  max_unavailable_fixed = 2
+  min_ready_sec         = 50
+  replacement_method    = "RECREATE"
 }
 ```
 
-* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
-
-* `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `RESTART`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
 
 * `type` - (Required) - The type of update process. You can specify either `PROACTIVE` so that the instance group manager proactively executes actions in order to bring instances to their target versions or `OPPORTUNISTIC` so that no action is proactively executed but the update will be performed as part of other actions (for example, resizes or recreateInstances calls).
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -158,20 +158,17 @@ group. You can specify one or more values. For more information, see the [offici
 
 ```hcl
 update_policy {
-  type                           = "PROACTIVE"
-  instance_redistribution_type   = "PROACTIVE"
-  minimal_action                 = "REPLACE"
-  most_disruptive_allowed_action = "REPLACE"
-  max_surge_percent              = 20
-  max_unavailable_fixed          = 2
-  min_ready_sec                  = 50
-  replacement_method             = "RECREATE"
+  type                         = "PROACTIVE"
+  instance_redistribution_type = "PROACTIVE"
+  minimal_action               = "REPLACE"
+  max_surge_percent            = 20
+  max_unavailable_fixed        = 2
+  min_ready_sec                = 50
+  replacement_method           = "RECREATE"
 }
 ```
 
-* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
-
-* `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `RESTART`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
 
 * `type` - (Required) - The type of update process. You can specify either `PROACTIVE` so that the instance group manager proactively executes actions in order to bring instances to their target versions or `OPPORTUNISTIC` so that no action is proactively executed but the update will be performed as part of other actions (for example, resizes or recreateInstances calls).
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#4956

Looks like this test is now failing due to this:
```
=== CONT  TestAccInstanceGroupManager_updatePolicy
provider_test.go:309: Step 5/10 error: After applying this test step, the plan was not empty.
stdout:
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# google_compute_instance_group_manager.igm-rolling-update-policy will be updated in-place
~ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
id                        = "the-id"
name                      = "tf-test-igm-b7129onri3"
# (12 unchanged attributes hidden)
~ update_policy {
- most_disruptive_allowed_action = "REPLACE" -> null
# (8 unchanged attributes hidden)
}
# (2 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
```

Probably need a default_from_api: true on this field. Not sure why the tests passed in the PR though...

```release-note:none
```