### PR TITLE
Adds support for Graceful Updater in Compute Managed Instance Groups.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -205,8 +205,9 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"minimal_action": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
+							Default:      "REPLACE",
 							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
 						},
 
@@ -925,9 +926,19 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
 
-		updatePolicy.MinimalAction = data["minimal_action"].(string)
-		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
-		updatePolicy.ForceSendFields = []string{"MinimalAction", "MostDisruptiveAllowedAction"}
+		updatePolicy.NullFields = []string{}
+		minimalAction := data["minimal_action"].(string)
+		if minimalAction != "" {
+			updatePolicy.MinimalAction = minimalAction
+		} else {
+			updatePolicy.NullFields = append(updatePolicy.NullFields, "MinimalAction")
+		}
+		mostDisruptiveAllowedAction := data["most_disruptive_allowed_action"].(string)
+		if mostDisruptiveAllowedAction != "" {
+			updatePolicy.MostDisruptiveAllowedAction = mostDisruptiveAllowedAction
+		} else {
+			updatePolicy.NullFields = append(updatePolicy.NullFields, "MostDisruptiveAllowedAction")
+		}
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -943,7 +943,7 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>
 		updatePolicy.MinReadySec = int64(data["min_ready_sec"].(int))
-		updatePolicy.ForceSendFields = append(updatePolicy.ForceSendFields, "MinReadySec")
+		updatePolicy.ForceSendFields = []string{"MinReadySec"}
 <% end -%>
 
 		// percent and fixed values are conflicting

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -927,11 +927,12 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 
 		updatePolicy.MinimalAction = data["minimal_action"].(string)
 		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
+		updatePolicy.ForceSendFields = []string{"MinimalAction", "MostDisruptiveAllowedAction"}
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>
 		updatePolicy.MinReadySec = int64(data["min_ready_sec"].(int))
-		updatePolicy.ForceSendFields = []string{"MinReadySec"}
+		updatePolicy.ForceSendFields = append(updatePolicy.ForceSendFields, "MinReadySec")
 <% end -%>
 
 		// percent and fixed values are conflicting

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -205,9 +205,8 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"minimal_action": {
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
-							Default:      "REPLACE",
 							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
 						},
 
@@ -926,13 +925,7 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
 
-		updatePolicy.NullFields = []string{}
-		minimalAction := data["minimal_action"].(string)
-		if minimalAction != "" {
-			updatePolicy.MinimalAction = minimalAction
-		} else {
-			updatePolicy.NullFields = append(updatePolicy.NullFields, "MinimalAction")
-		}
+		updatePolicy.MinimalAction = data["minimal_action"].(string)
 		mostDisruptiveAllowedAction := data["most_disruptive_allowed_action"].(string)
 		if mostDisruptiveAllowedAction != "" {
 			updatePolicy.MostDisruptiveAllowedAction = mostDisruptiveAllowedAction

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -206,8 +206,15 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 						"minimal_action": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"RESTART", "REPLACE"}, false),
-							Description:  `Minimal action to be taken on an instance. You can specify either RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a RESTART, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
+							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
+							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
+						},
+
+						"most_disruptive_allowed_action": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"NONE", "REFRESH", "RESTART", "REPLACE"}, false),
+							Description:  `Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.`,
 						},
 
 						"type": {
@@ -919,6 +926,7 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 		data := raw.(map[string]interface{})
 
 		updatePolicy.MinimalAction = data["minimal_action"].(string)
+		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>
@@ -1010,6 +1018,7 @@ func flattenUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdatePolicy)
 		up["min_ready_sec"] = updatePolicy.MinReadySec
 <% end -%>
 		up["minimal_action"] = updatePolicy.MinimalAction
+		up["most_disruptive_allowed_action"] = updatePolicy.MostDisruptiveAllowedAction
 		up["type"] = updatePolicy.Type
 		up["replacement_method"] = updatePolicy.ReplacementMethod
 		results = append(results, up)

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -795,13 +795,12 @@ func expandRegionUpdatePolicy(configured []interface{}) *compute.InstanceGroupMa
 		} else {
 			updatePolicy.NullFields = append(updatePolicy.NullFields, "MostDisruptiveAllowedAction")
 		}
-		updatePolicy.ForceSendFields = []string{"MinimalAction", "MostDisruptiveAllowedAction"}
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.InstanceRedistributionType = data["instance_redistribution_type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>
 		updatePolicy.MinReadySec = int64(data["min_ready_sec"].(int))
-		updatePolicy.ForceSendFields = append(updatePolicy.ForceSendFields, "MinReadySec")
+		updatePolicy.ForceSendFields = []string{"MinReadySec"}
 <% end -%>
 
 		// percent and fixed values are conflicting

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -243,7 +243,8 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"minimal_action": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
+							Default:      "REPLACE",
 							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
 							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
 						},
@@ -781,14 +782,26 @@ func expandRegionUpdatePolicy(configured []interface{}) *compute.InstanceGroupMa
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
 
-		updatePolicy.MinimalAction = data["minimal_action"].(string)
-		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
+		updatePolicy.NullFields = []string{}
+		minimalAction := data["minimal_action"].(string)
+		if minimalAction != "" {
+			updatePolicy.MinimalAction = minimalAction
+		} else {
+			updatePolicy.NullFields = append(updatePolicy.NullFields, "MinimalAction")
+		}
+		mostDisruptiveAllowedAction := data["most_disruptive_allowed_action"].(string)
+		if mostDisruptiveAllowedAction != "" {
+			updatePolicy.MostDisruptiveAllowedAction = mostDisruptiveAllowedAction
+		} else {
+			updatePolicy.NullFields = append(updatePolicy.NullFields, "MostDisruptiveAllowedAction")
+		}
+		updatePolicy.ForceSendFields = []string{"MinimalAction", "MostDisruptiveAllowedAction"}
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.InstanceRedistributionType = data["instance_redistribution_type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
 <% unless version == "ga" -%>
 		updatePolicy.MinReadySec = int64(data["min_ready_sec"].(int))
-		updatePolicy.ForceSendFields = []string{"MinReadySec"}
+		updatePolicy.ForceSendFields = append(updatePolicy.ForceSendFields, "MinReadySec")
 <% end -%>
 
 		// percent and fixed values are conflicting

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -244,8 +244,15 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 						"minimal_action": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"RESTART", "REPLACE"}, false),
-							Description:  `Minimal action to be taken on an instance. You can specify either RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a RESTART, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
+							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
+							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
+						},
+
+						"most_disruptive_allowed_action": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"NONE", "REFRESH", "RESTART", "REPLACE"}, false),
+							Description:  `Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.`,
 						},
 
 						"type": {
@@ -775,6 +782,7 @@ func expandRegionUpdatePolicy(configured []interface{}) *compute.InstanceGroupMa
 		data := raw.(map[string]interface{})
 
 		updatePolicy.MinimalAction = data["minimal_action"].(string)
+		updatePolicy.MostDisruptiveAllowedAction = data["most_disruptive_allowed_action"].(string)
 		updatePolicy.Type = data["type"].(string)
 		updatePolicy.InstanceRedistributionType = data["instance_redistribution_type"].(string)
 		updatePolicy.ReplacementMethod = data["replacement_method"].(string)
@@ -838,6 +846,7 @@ func flattenRegionUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdateP
 		up["min_ready_sec"] = updatePolicy.MinReadySec
 <% end -%>
 		up["minimal_action"] = updatePolicy.MinimalAction
+		up["most_disruptive_allowed_action"] = updatePolicy.MostDisruptiveAllowedAction
 		up["type"] = updatePolicy.Type
 		up["instance_redistribution_type"] = updatePolicy.InstanceRedistributionType
 		up["replacement_method"] = updatePolicy.ReplacementMethod

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -243,8 +243,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"minimal_action": {
 							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "REPLACE",
+							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"REFRESH", "RESTART", "REPLACE"}, false),
 							Description:  `Minimal action to be taken on an instance. You can specify either REFRESH to update without stopping instances, RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a REFRESH, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.`,
 						},
@@ -782,13 +781,7 @@ func expandRegionUpdatePolicy(configured []interface{}) *compute.InstanceGroupMa
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
 
-		updatePolicy.NullFields = []string{}
-		minimalAction := data["minimal_action"].(string)
-		if minimalAction != "" {
-			updatePolicy.MinimalAction = minimalAction
-		} else {
-			updatePolicy.NullFields = append(updatePolicy.NullFields, "MinimalAction")
-		}
+		updatePolicy.MinimalAction = data["minimal_action"].(string)
 		mostDisruptiveAllowedAction := data["most_disruptive_allowed_action"].(string)
 		if mostDisruptiveAllowedAction != "" {
 			updatePolicy.MostDisruptiveAllowedAction = mostDisruptiveAllowedAction

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -1034,7 +1034,6 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
   target_size        = 3
   update_policy {
     type                  = "PROACTIVE"
-    minimal_action        = "REPLACE"
     max_surge_fixed       = 2
     max_unavailable_fixed = 0
   }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -933,10 +933,11 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
   zone               = "us-central1-c"
   target_size        = 3
   update_policy {
-    type                  = "PROACTIVE"
-    minimal_action        = "REPLACE"
-    max_surge_fixed       = 2
-    max_unavailable_fixed = 2
+    type                           = "PROACTIVE"
+    minimal_action                 = "REPLACE"
+    most_disruptive_allowed_action = "REPLACE"
+    max_surge_fixed                = 2
+    max_unavailable_fixed          = 2
   }
   named_port {
     name = "customhttp"

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -1034,6 +1034,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
   target_size        = 3
   update_policy {
     type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
     max_surge_fixed       = 2
     max_unavailable_fixed = 0
   }

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -1297,6 +1297,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
   update_policy {
     type                           = "PROACTIVE"
     instance_redistribution_type   = "NONE"
+    minimal_action                 = "REPLACE"
     most_disruptive_allowed_action = "REPLACE"
     max_surge_fixed                = 0
     max_unavailable_fixed          = 2

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -1297,7 +1297,6 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
   update_policy {
     type                           = "PROACTIVE"
     instance_redistribution_type   = "NONE"
-    minimal_action                 = "REPLACE"
     most_disruptive_allowed_action = "REPLACE"
     max_surge_fixed                = 0
     max_unavailable_fixed          = 2

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -1295,15 +1295,16 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
   distribution_policy_zones = ["us-central1-a", "us-central1-f"]
   target_size               = 3
   update_policy {
-    type                         = "PROACTIVE"
-    instance_redistribution_type = "NONE"
-    minimal_action               = "REPLACE"
-    max_surge_fixed              = 0
-    max_unavailable_fixed        = 2
+    type                           = "PROACTIVE"
+    instance_redistribution_type   = "NONE"
+    minimal_action                 = "REPLACE"
+    most_disruptive_allowed_action = "REPLACE"
+    max_surge_fixed                = 0
+    max_unavailable_fixed          = 2
 <% unless version == "ga" -%>
-    min_ready_sec                = 10
+    min_ready_sec                  = 10
 <% end -%>
-    replacement_method           = "RECREATE"
+    replacement_method             = "RECREATE"
   }
   named_port {
     name = "customhttp"

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -159,7 +159,7 @@ update_policy {
 }
 ```
 
-* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+* `minimal_action` - (Optional) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
 
 * `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -149,16 +149,19 @@ group. You can specify only one value. Structure is [documented below](#nested_a
 
 ```hcl
 update_policy {
-  type                  = "PROACTIVE"
-  minimal_action        = "REPLACE"
-  max_surge_percent     = 20
-  max_unavailable_fixed = 2
-  min_ready_sec         = 50
-  replacement_method    = "RECREATE"
+  type                           = "PROACTIVE"
+  minimal_action                 = "REPLACE"
+  most_disruptive_allowed_action = "REPLACE"
+  max_surge_percent              = 20
+  max_unavailable_fixed          = 2
+  min_ready_sec                  = 50
+  replacement_method             = "RECREATE"
 }
 ```
 
-* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `RESTART`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+
+* `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
 
 * `type` - (Required) - The type of update process. You can specify either `PROACTIVE` so that the instance group manager proactively executes actions in order to bring instances to their target versions or `OPPORTUNISTIC` so that no action is proactively executed but the update will be performed as part of other actions (for example, resizes or recreateInstances calls).
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -159,7 +159,7 @@ update_policy {
 }
 ```
 
-* `minimal_action` - (Optional) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
 
 * `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -169,7 +169,7 @@ update_policy {
 }
 ```
 
-* `minimal_action` - (Optional) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
 
 * `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -169,7 +169,7 @@ update_policy {
 }
 ```
 
-* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+* `minimal_action` - (Optional) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
 
 * `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -158,17 +158,20 @@ group. You can specify one or more values. For more information, see the [offici
 
 ```hcl
 update_policy {
-  type                         = "PROACTIVE"
-  instance_redistribution_type = "PROACTIVE"
-  minimal_action               = "REPLACE"
-  max_surge_percent            = 20
-  max_unavailable_fixed        = 2
-  min_ready_sec                = 50
-  replacement_method           = "RECREATE"
+  type                           = "PROACTIVE"
+  instance_redistribution_type   = "PROACTIVE"
+  minimal_action                 = "REPLACE"
+  most_disruptive_allowed_action = "REPLACE"
+  max_surge_percent              = 20
+  max_unavailable_fixed          = 2
+  min_ready_sec                  = 50
+  replacement_method             = "RECREATE"
 }
 ```
 
-* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `RESTART`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. You can specify either `REFRESH` to update without stopping instances, `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `REFRESH`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
+
+* `most_disruptive_allowed_action` - (Optional) - Most disruptive action that is allowed to be taken on an instance. You can specify either NONE to forbid any actions, REFRESH to allow actions that do not need instance restart, RESTART to allow actions that can be applied without instance replacing or REPLACE to allow all possible actions. If the Updater determines that the minimal update action needed is more disruptive than most disruptive allowed action you specify it will not perform the update at all.
 
 * `type` - (Required) - The type of update process. You can specify either `PROACTIVE` so that the instance group manager proactively executes actions in order to bring instances to their target versions or `OPPORTUNISTIC` so that no action is proactively executed but the update will be performed as part of other actions (for example, resizes or recreateInstances calls).
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9153

Adds support for Graceful Updater in Compute Managed Instance Groups.

Logic in previous [pull request](https://github.com/GoogleCloudPlatform/magic-modules/pull/4956) was not forcing sending empty fields and it was [reverted](https://github.com/GoogleCloudPlatform/magic-modules/pull/5964).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
I was not able to run acceptance tests today since my local test environment is currently unavailable. I'm hoping that the pull request will trigger acceptance tests.
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `update_policy.most_disruptive_allowed_action` to `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```

```release-note:enhancement
compute: added value `REFRESH` to field update_policy.minimal_action` in `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```
