### PR TITLE
Changed hyphens to underscores

### DIFF
--- a/mmv1/templates/terraform/examples/sql_instance_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_instance_cmek.tf.erb
@@ -1,5 +1,5 @@
 # [START cloud_sql_instance_service_identity]
-resource "google_project_service_identity" "gcp-sa-cloud-sql" {
+resource "google_project_service_identity" "gcp_sa_cloud_sql" {
   provider = google-beta
   service  = "sqladmin.googleapis.com"
 }
@@ -26,7 +26,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   members = [
-    "serviceAccount:${google_project_service_identity.gcp-sa-cloud-sql.email}",
+    "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
   ]
 }
 # [END cloud_sql_instance_crypto_key]


### PR DESCRIPTION
The service identity resource "gcp-sa-cloud-sql" should use underscores instead of hyphens (and the one reference to it, too).

```release-note:none
```