### PR TITLE
Relax the validation of master ipv4 cidr for GKE Autopilot

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -132,7 +132,6 @@ func resourceContainerCluster() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			resourceNodeConfigEmptyGuestAccelerator,
-			containerClusterPrivateClusterConfigCustomDiff,
 			<% unless version == 'ga' -%>
 			customdiff.ForceNewIfChange("enable_l4_ilb_subsetting", isBeenEnabled),
 			<% end -%>
@@ -1084,6 +1083,7 @@ func resourceContainerCluster() *schema.Resource {
 						},
 						"master_ipv4_cidr_block": {
 							Type:         schema.TypeString,
+							Computed:     true,
 							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: orEmpty(validation.IsCIDRNetwork(28, 28)),
@@ -1636,6 +1636,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("monitoring_config"); ok {
 		cluster.MonitoringConfig = expandMonitoringConfig(v)
+	}
+
+	if err := validatePrivateClusterConfig(cluster); err != nil {
+		return err
 	}
 
 	req := &container.CreateClusterRequest{
@@ -4297,31 +4301,16 @@ func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.
 	return false
 }
 
-func containerClusterPrivateClusterConfigCustomDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	pcc, ok := d.GetOk("private_cluster_config")
-	if !ok {
+func validatePrivateClusterConfig(cluster *container.Cluster) error {
+	if cluster == nil || cluster.PrivateClusterConfig == nil {
 		return nil
 	}
-	pccList := pcc.([]interface{})
-	if len(pccList) == 0 {
-		return nil
+	if !cluster.PrivateClusterConfig.EnablePrivateNodes && len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) > 0 {
+		return fmt.Errorf("master_ipv4_cidr_block can only be set if enable_private_nodes is true")
 	}
-	config := pccList[0].(map[string]interface{})
-	if config["enable_private_nodes"].(bool) {
-		block := config["master_ipv4_cidr_block"]
-
-		// We can only apply this validation if we know the final value of the field, and we may
-		// not know the final value if users feed the value into their config in unintuitive ways.
-		// https://github.com/hashicorp/terraform-provider-google/issues/4186
-		blockValueKnown := d.NewValueKnown("private_cluster_config.0.master_ipv4_cidr_block")
-
-		if blockValueKnown && (block == nil || block == "") {
+	if cluster.PrivateClusterConfig.EnablePrivateNodes && len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) == 0 {
+		if cluster.Autopilot == nil || !cluster.Autopilot.Enabled {
 			return fmt.Errorf("master_ipv4_cidr_block must be set if enable_private_nodes is true")
-		}
-	} else {
-		block := config["master_ipv4_cidr_block"]
-		if block != nil && block != "" {
-			return fmt.Errorf("master_ipv4_cidr_block can only be set if enable_private_nodes is true")
 		}
 	}
 	return nil

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -782,8 +782,31 @@ func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(t *testing
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName),
+				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, "us-central1-a", false),
 				ExpectError: regexp.MustCompile("master_ipv4_cidr_block must be set if enable_private_nodes is true"),
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock_withAutopilot(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, "us-central1", true),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_private_cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -4231,7 +4254,7 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
 `, datasetId, clusterName)
 }
 
-func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName string, clusterName string) string {
+func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, location string, autopilotEnabled bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
   name                    = "%s"
@@ -4258,7 +4281,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 
 resource "google_container_cluster" "with_private_cluster" {
   name               = "%s"
-  location           = "us-central1-a"
+  location           = "%s"
   initial_node_count = 1
 
   networking_mode = "VPC_NATIVE"
@@ -4270,6 +4293,8 @@ resource "google_container_cluster" "with_private_cluster" {
     enable_private_nodes    = true
   }
 
+  enable_autopilot = %t
+
   master_authorized_networks_config {}
 
   ip_allocation_policy {
@@ -4277,7 +4302,7 @@ resource "google_container_cluster" "with_private_cluster" {
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
   }
 }
-`, containerNetName, clusterName)
+`, containerNetName, clusterName, location, autopilotEnabled)
 }
 
 func testAccContainerCluster_withPrivateClusterConfig(containerNetName string, clusterName string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Master ipv4 cidr is optional for Autopilot: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#auto_subnet. Relaxing the too-strict validation.

fixes https://github.com/hashicorp/terraform-provider-google/issues/11582

Ref: b/230115120, cl/443715628


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed Autopilot cluster couldn't omit master ipv4 cidr in `google_container_cluster`
```
