### PR TITLE
Added Cloud SQL SSL/TLS example

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -497,6 +497,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     ### SSL cert ###
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_instance_ssl_cert"
+        primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "sqlserver_instance"
         vars:
           mysql_instance: "mysql-instance"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -490,6 +490,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "false"
         ignore_read_extra:
           - "deletion_protection"
+    ### SSL cert ###
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_instance_ssl_cert"
+        primary_resource_id: "sqlserver_instance"
+        vars:
+          mysql_instance: "mysql-instance"
+          postgres_instance: "postgres-instance"
+          sqlserver_instance: "sqlserver-instance"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - "deletion_protection"
+          - "root_password"
     # Storage
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_new_bucket"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -427,6 +427,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           postgres_instance_ha: "postgres-instance-ha"
           sqlserver_instance_ha: "sqlserver-instance-ha"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -458,6 +459,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           mysql_instance_iam_condition: "mysql-instance-iam-condition"
           deletion_protection: "true"
         min_version: beta
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -472,6 +474,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           postgres_instance_labels: "postgres-instance-labels"
           sqlserver_instance_labels: "sqlserver-instance-labels"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -486,6 +489,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           mysql_instance_pitr: "mysql-instance-pitr"
           postgres_instance_pitr: "postgres-instance-pitr"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -499,6 +503,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           postgres_instance: "postgres-instance"
           sqlserver_instance: "sqlserver-instance"
           deletion_protection: "true"
+        skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:

--- a/mmv1/templates/terraform/examples/sql_instance_ssl_cert.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_instance_ssl_cert.tf.erb
@@ -1,0 +1,59 @@
+# [START cloud_sql_mysql-instance_require_ssl]
+resource "google_sql_database_instance" "mysql_instance" {
+  name             = "<%= ctx[:vars]['mysql_instance'] %>"
+  region           = "asia-northeast1"
+  database_version = "MYSQL_8_0"
+  settings {
+    tier              = "db-f1-micro"
+    ip_configuration {
+      require_ssl = "true"
+    }
+  }
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_mysql_instance_require_ssl]
+
+# [START cloud_sql_mysql_instance_ssl_cert]
+resource "google_sql_ssl_cert" "mysql_client_cert" {
+  common_name = "mysql_common_name"
+  instance    = google_sql_database_instance.mysql_instance.name
+}
+# [END cloud_sql_mysql_instance_ssl_cert]
+
+# [START cloud_sql_postgres_instance_require_ssl]
+resource "google_sql_database_instance" "postgres_instance" {
+  name             = "<%= ctx[:vars]['postgres_instance'] %>"
+  region           = "asia-northeast1"
+  database_version = "postgres_14"
+  settings {
+    tier              = "db-custom-2-7680"
+    ip_configuration {
+      require_ssl = "true"
+    }
+  }
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_postgres_instance_require_ssl]
+
+# [START cloud_sql_postgres_instance_ssl_cert]
+resource "google_sql_ssl_cert" "postgres_client_cert" {
+  common_name = "postgres_common_name"
+  instance    = google_sql_database_instance.postgres_instance.name
+}
+# [END cloud_sql_postgres_instance_ssl_cert]
+
+# [START cloud_sql_sqlserver_instance_require_ssl]
+resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['sqlserver_instance'] %>"
+  region           = "asia-northeast1"
+  database_version = "SQLSERVER_2019_STANDARD"
+  root_password = "INSERT-PASSWORD-HERE"
+  settings {
+    tier              = "db-custom-2-7680"
+    ip_configuration {
+      require_ssl = "true"
+    }
+  }
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+# [END cloud_sql_sqlserver_instance_require_ssl]


### PR DESCRIPTION
Intending to add these here:

https://cloud.google.com/sql/docs/sqlserver/configure-ssl-instance
https://cloud.google.com/sql/docs/postgres/configure-ssl-instance
https://cloud.google.com/sql/docs/mysql/configure-ssl-instance

```release-note:none
```