### PR TITLE
Added new terraform example for spot VM

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -30,6 +30,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "metadata"
           - "metadata_startup_script"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "spot_instance_basic"
+        primary_resource_type: "google_compute_instance"
+        primary_resource_id: "spot_vm_instance"
+        vars:
+          spot_instance_name: "spot-instance-name"
 #    ### SQL Server VM ###
 #      - !ruby/object:Provider::Terraform::Examples
 #        name: "sql_sqlserver_vm_instance"

--- a/mmv1/templates/terraform/examples/spot_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/spot_instance_basic.tf.erb
@@ -1,0 +1,27 @@
+# [START compute_spot_instace_create]
+
+resource "google_compute_instance" "<%= ctx[:primary_resource_id] %>" {
+  name         = "<%= ctx[:vars]['spot_instance_name'] %>"
+  machine_type = "f1-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+  
+  scheduling {
+      preemptible = true
+      automatic_restart = false
+      provisioning_model = "SPOT"
+  }
+
+  network_interface {
+    # A default network is created for all GCP projects
+    network = "default"
+    access_config {
+    }
+  }
+}
+
+# [END compute_spot_instace_create]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Intend to use the example in the main spot vm documentation here https://cloud.google.com/compute/docs/instances/create-use-spot#create 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
