### PR TITLE
Add support for checker_type in uptime_check_config

### DIFF
--- a/mmv1/products/monitoring/api.yaml
+++ b/mmv1/products/monitoring/api.yaml
@@ -1765,6 +1765,16 @@ objects:
         message is returned. Not specifying this field will result in uptime checks
         running from all regions.
       item_type: Api::Type::String
+    - !ruby/object:Api::Type::Enum
+      name: checkerType
+      description: The checker type to use for the check. If the monitored resource type 
+        is servicedirectory_service, checkerType must be set to VPC_CHECKERS. If set to
+        CHECKER_TYPE_UNSPECIFIED then checkerType defaults to STATIC_IP_CHECKERS.
+      default_value: :STATIC_IP_CHECKERS
+      values:
+        - :CHECKER_TYPE_UNSPECIFIED
+        - :STATIC_IP_CHECKERS
+        - :VPC_CHECKERS
     - !ruby/object:Api::Type::NestedObject
       name: httpCheck
       description: Contains information needed to make an HTTP or HTTPS check.

--- a/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
@@ -21,5 +21,7 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
   content_matchers {
     content = "example"
   }
+
+  checker_type = "STATIC_IP_CHECKERS"
 }
 


### PR DESCRIPTION
This PR adds in support for the [checker_type field](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.uptimeCheckConfigs#checkertype) on the google_monitoring_uptime_check_config resource.

fixes https://github.com/hashicorp/terraform-provider-google/issues/11537

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: Added `checker_type` field to `google_monitoring_uptime_check_config` resource
```
