### PR TITLE
Switch to using folder LIST over SEARCH

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
@@ -41,7 +41,7 @@ func dataSourceGoogleActiveFolderRead(d *schema.ResourceData, meta interface{}) 
 	token := ""
 
 	for paginate := true; paginate; {
-		resp, err := config.NewResourceManagerV2Client(userAgent).Folders.List().Parent(parent).PageToken(token).Do()
+		resp, err := config.NewResourceManagerV2Client(userAgent).Folders.List().Parent(parent).PageSize(300).PageToken(token).Do()
 		if err != nil {
 			return fmt.Errorf("error reading folder list: %s", err)
 		}

--- a/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
@@ -35,26 +35,37 @@ func dataSourceGoogleActiveFolderRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	var folderMatch *resourceManagerV2.Folder
 	parent := d.Get("parent").(string)
 	displayName := d.Get("display_name").(string)
+	token := ""
 
-	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=\"%s\"", parent, displayName)
-	searchRequest := &resourceManagerV2.SearchFoldersRequest{
-		Query: queryString,
-	}
-	searchResponse, err := config.NewResourceManagerV2Client(userAgent).Folders.Search(searchRequest).Do()
-	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("Folder Not Found : %s", displayName))
-	}
-
-	for _, folder := range searchResponse.Folders {
-		if folder.DisplayName == displayName {
-			d.SetId(folder.Name)
-			if err := d.Set("name", folder.Name); err != nil {
-				return fmt.Errorf("Error setting folder name: %s", err)
-			}
-			return nil
+	for paginate := true; paginate; {
+		resp, err := config.NewResourceManagerV2Client(userAgent).Folders.List().Parent(parent).PageToken(token).Do()
+		if err != nil {
+			return fmt.Errorf("error reading folder list: %s", err)
 		}
+
+		for _, folder := range resp.Folders {
+			if folder.DisplayName == displayName && folder.LifecycleState == "ACTIVE" {
+				if folderMatch != nil {
+					return fmt.Errorf("more than one matching folder found")
+				}
+				folderMatch = folder
+			}
+		}
+		token = resp.NextPageToken
+		paginate = token != ""
 	}
-	return fmt.Errorf("Folder not found")
+
+	if folderMatch == nil {
+		return fmt.Errorf("folder not found: %s", displayName)
+	}
+
+	d.SetId(folderMatch.Name)
+	if err := d.Set("name", folderMatch.Name); err != nil {
+		return fmt.Errorf("Error setting folder name: %s", err)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -255,25 +255,33 @@ func testAccCheckGoogleFolderIamBindingExists(t *testing.T, expected *cloudresou
 }
 
 func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config *Config) (*cloudresourcemanager.Policy, error) {
-	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=%s", parent, displayName)
-	searchRequest := &resourceManagerV2.SearchFoldersRequest{
-		Query: queryString,
-	}
-	searchResponse, err := config.NewResourceManagerV2Client(config.userAgent).Folders.Search(searchRequest).Do()
-	if err != nil {
-		if isGoogleApiErrorWithCode(err, 404) {
-			return nil, fmt.Errorf("Folder not found: %s,%s", parent, displayName)
+	var folderMatch *resourceManagerV2.Folder
+	token := ""
+
+	for paginate := true; paginate; {
+		resp, err := config.NewResourceManagerV2Client(config.userAgent).Folders.List().Parent(parent).PageToken(token).Do()
+		if err != nil {
+			return nil, fmt.Errorf("Error reading folder list: %s", err)
 		}
 
-		return nil, errwrap.Wrapf("Error reading folders: {{err}}", err)
+		for _, folder := range resp.Folders {
+			if folder.DisplayName == displayName {
+				if folderMatch != nil {
+					return nil, fmt.Errorf("More than one matching folder found")
+				}
+				folderMatch = folder
+			}
+		}
+
+		token = resp.NextPageToken
+		paginate = token != ""
 	}
 
-	folders := searchResponse.Folders
-	if len(folders) != 1 {
-		return nil, fmt.Errorf("expected exactly 1 folder, found %d", len(folders))
+	if folderMatch == nil {
+		return nil, fmt.Errorf("Folder not found: %s", displayName)
 	}
 
-	return getFolderIamPolicyByFolderName(folders[0].Name, config.userAgent, config)
+	return getFolderIamPolicyByFolderName(folderMatch.Name, config.userAgent, config)
 }
 
 func testAccFolderIamBasic(org, fname string) string {

--- a/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -259,7 +259,7 @@ func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config
 	token := ""
 
 	for paginate := true; paginate; {
-		resp, err := config.NewResourceManagerV2Client(config.userAgent).Folders.List().Parent(parent).PageToken(token).Do()
+		resp, err := config.NewResourceManagerV2Client(config.userAgent).Folders.List().Parent(parent).PageSize(300).PageToken(token).Do()
 		if err != nil {
 			return nil, fmt.Errorf("Error reading folder list: %s", err)
 		}

--- a/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/10286

acc to b/228499462 
```
Search provides an eventually consistent view of the folders
http://cloud/resource-manager/reference/rest/v2/folders/search.

List is strongly consistent
http://cloud/resource-manager/reference/rest/v2/folders/list
```
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
