### PR TITLE
fix(cloudfunctions2): fix update method

### DIFF
--- a/mmv1/products/cloudfunctions2/api.yaml
+++ b/mmv1/products/cloudfunctions2/api.yaml
@@ -32,6 +32,7 @@ objects:
     create_url: projects/{{project}}/locations/{{location}}/functions?functionId={{name}}
     self_link: projects/{{project}}/locations/{{location}}/functions/{{name}}
     create_verb: :POST
+    update_verb: :PATCH
     references: !ruby/object:Api::Resource::ReferenceLinks
       api: 'https://cloud.google.com/functions/docs/reference/rest/v2beta/projects.locations.functions'
     description: |


### PR DESCRIPTION
google api requires a PATCH method to update a cloudfunctionv2: https://cloud.google.com/functions/docs/reference/rest/v2beta/projects.locations.functions/patch

This should solve this issue:  https://github.com/hashicorp/terraform-provider-google/issues/11434

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:bug
fix cloudfunctions2 update method
```
