### PR TITLE
Added Cloud SQL user example

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -56,6 +56,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           database_instance_name: "sqlserver-instance"
           deletion_protection: "true"
+          user: "user"
         test_vars_overrides:
           deletion_protection: "false"
         ignore_read_extra:
@@ -68,6 +69,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           database_instance_name: "postgres-instance"
           deletion_protection: "true"
+          user: "user"
         skip_test: true
         test_vars_overrides:
           deletion_protection: "false"
@@ -80,6 +82,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           database_instance_name: "mysql-instance"
           deletion_protection: "true"
+          user: "user"
         skip_test: true
         test_vars_overrides:
           deletion_protection: "false"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -53,6 +53,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "sql_database_instance_sqlserver"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
+        # Random provider
+        skip_vcr: true
         vars:
           database_instance_name: "sqlserver-instance"
           deletion_protection: "true"
@@ -66,6 +68,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "sql_database_instance_postgres"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
+        # Random provider
+        skip_vcr: true
         vars:
           database_instance_name: "postgres-instance"
           deletion_protection: "true"
@@ -79,6 +83,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "sql_database_instance_my_sql"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
+        # Random provider
+        skip_vcr: true
         vars:
           database_instance_name: "mysql-instance"
           deletion_protection: "true"

--- a/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.erb
@@ -9,3 +9,16 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_mysql_instance_80_db_n1_s2]
+
+# [START cloud_sql_mysql_instance_user]
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    name = "user"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+# [END cloud_sql_mysql_instance_user]

--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.erb
@@ -9,3 +9,16 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_postgres_instance_80_db_n1_s2]
+
+# [START cloud_sql_postgres_instance_user]
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    name = "user"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+# [END cloud_sql_postgres_instance_user]

--- a/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.erb
@@ -10,3 +10,16 @@ resource "google_sql_database_instance" "<%= ctx[:primary_resource_id] %>" {
   deletion_protection =  "<%= ctx[:vars]['deletion_protection'] %>"
 }
 # [END cloud_sql_sqlserver_instance_80_db_n1_s2]
+
+# [START cloud_sql_sqlserver_instance_user]
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    name = "user"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+# [END cloud_sql_sqlserver_instance_user]


### PR DESCRIPTION
Intending to add here:

https://cloud.google.com/sql/docs/sqlserver/create-manage-users
https://cloud.google.com/sql/docs/postgres/create-manage-users
https://cloud.google.com/sql/docs/mysql/create-manage-users

```release-note:none
```
