### PR TITLE
Add defaults for expr and description to prevent spurious diffs

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13666,7 +13666,6 @@ objects:
               name: 'description'
               description: |
                 A description of the rule.
-              default_value: ""
             - !ruby/object:Api::Type::Integer
               name: 'priority'
               description: |
@@ -13719,7 +13718,6 @@ objects:
                         e.g. a file name and a position in the file.
                 - !ruby/object:Api::Type::String
                   name: 'versionedExpr'
-                  default_value: ""
                   description: |
                     Preconfigured versioned expression. If this field is specified, config must also be specified.
                     Available preconfigured expressions along with their requirements are: `SRC_IPS_V1` - must specify

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13666,6 +13666,7 @@ objects:
               name: 'description'
               description: |
                 A description of the rule.
+              default_value: ""
             - !ruby/object:Api::Type::Integer
               name: 'priority'
               description: |
@@ -13718,6 +13719,7 @@ objects:
                         e.g. a file name and a position in the file.
                 - !ruby/object:Api::Type::String
                   name: 'versionedExpr'
+                  default_value: ""
                   description: |
                     Preconfigured versioned expression. If this field is specified, config must also be specified.
                     Available preconfigured expressions along with their requirements are: `SRC_IPS_V1` - must specify

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -111,6 +111,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 									"versioned_expr": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										Default:      "",
 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
 										Description:  `Predefined rule expression. If this field is specified, config must also be specified. Available options:   SRC_IPS_V1: Must specify the corresponding src_ip_ranges field in config.`,
 									},
@@ -150,6 +151,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 
 						"description": {
 							Type:        schema.TypeString,
+							Default:     "",
 							Optional:    true,
 							Description: `An optional description of this rule. Max size is 64.`,
 						},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9084

Probably.

Problem sort of explained here (https://github.com/hashicorp/terraform-provider-google/issues/9084#issuecomment-1067103455) where the state value seems to be changing between `null` & `""` which causes the diff on the rule. Setting default values for both description & versioned_expr seems to fix this as far as I can tell



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed extra diffs generated on `google_security_policy` `rules` when modifying a rule
```
