### PR TITLE
Add support for domainNames to Service Attachment

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -14486,6 +14486,15 @@ objects:
           address data in TCP connections that traverse proxies on their way to
           destination servers.
       - !ruby/object:Api::Type::Array
+        name: 'domainNames'
+        input: true
+        item_type: Api::Type::String
+        description: |
+          If specified, the domain name will be used during the integration between
+          the PSC connected endpoints and the Cloud DNS. For example, this is a
+          valid domain name: "p.mycompany.com.". Current max number of domain names
+          supported is 1.
+      - !ruby/object:Api::Type::Array
         name: 'consumerRejectLists'
         item_type: Api::Type::String
         send_empty_value: true

--- a/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
@@ -3,6 +3,7 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
 
+  domain_names             = ["foo.example.com"]
   enable_proxy_protocol    = true
   connection_preference    = "ACCEPT_AUTOMATIC"
   nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]

--- a/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
@@ -3,7 +3,7 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
 
-  domain_names             = ["hashicorptest.com."]
+  domain_names             = ["gcp.tfacc.hashicorptest.com."]
   enable_proxy_protocol    = true
   connection_preference    = "ACCEPT_AUTOMATIC"
   nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]

--- a/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
@@ -3,7 +3,7 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
 
-  domain_names             = ["foo.example.com"]
+  domain_names             = ["hashicorptest.com."]
   enable_proxy_protocol    = true
   connection_preference    = "ACCEPT_AUTOMATIC"
   nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]

--- a/mmv1/templates/terraform/examples/service_attachment_explicit_projects.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_explicit_projects.tf.erb
@@ -3,7 +3,7 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
 
-  domain_names             = ["hashicorptest.com."]
+  domain_names             = ["gcp.tfacc.hashicorptest.com."]
   enable_proxy_protocol    = true
   connection_preference    = "ACCEPT_MANUAL"
   nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]

--- a/mmv1/templates/terraform/examples/service_attachment_explicit_projects.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_explicit_projects.tf.erb
@@ -3,6 +3,7 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
 
+  domain_names             = ["hashicorptest.com."]
   enable_proxy_protocol    = true
   connection_preference    = "ACCEPT_MANUAL"
   nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/11612

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
compute: added support for `domain_names` attribute in `google_compute_service_attachment`
```

For the record, I _did_ run `make lint` which failed with many errors which I believe to be unrelated to mu change.