### PR TITLE
add certificate manager back in

### DIFF
--- a/mmv1/products/certificatemanager/api.yaml
+++ b/mmv1/products/certificatemanager/api.yaml
@@ -1,0 +1,215 @@
+# Copyright 2021 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: CertificateManager
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://certificatemanager.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://certificatemanager.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-identity
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Network Services API
+    url: https://console.cloud.google.com/apis/library/certificatemanager.googleapis.com
+objects:
+  - !ruby/object:Api::Resource
+    name: 'DnsAuthorization'
+    base_url: 'projects/{{project}}/locations/global/dnsAuthorizations'
+    create_url: 'projects/{{project}}/locations/global/dnsAuthorizations?dnsAuthorizationId={{name}}'
+    self_link: 'projects/{{project}}/locations/global/dnsAuthorizations/{{name}}'
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      DnsAuthorization represents a HTTP-reachable backend for an DnsAuthorization.
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: true
+        allowed:
+          - true
+          - false
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        required: true
+        input: true
+        url_param_only: true
+        description: |
+          Name of the resource; provided by the client when the resource is created.
+          The name must be 1-64 characters long, and match the regular expression [a-zA-Z][a-zA-Z0-9_-]* which means the first character must be a letter,
+          and all following characters must be a dash, underscore, letter or digit.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          A human-readable description of the resource.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: 'Set of label tags associated with the EdgeCache resource.'
+      - !ruby/object:Api::Type::String
+        name: 'domain'
+        input: true
+        required: true
+        description: |
+          A domain which is being authorized. A DnsAuthorization resource covers a
+          single domain and its wildcard, e.g. authorization for "example.com" can
+          be used to issue certificates for "example.com" and "*.example.com".
+      - !ruby/object:Api::Type::NestedObject
+        name: 'dnsResourceRecord'
+        output: true
+        description: |
+          The structure describing the DNS Resource Record that needs to be added
+          to DNS configuration for the authorization to be usable by
+          certificate.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'name'
+            output: true
+            description: |
+              Fully qualified name of the DNS Resource Record.
+          - !ruby/object:Api::Type::String
+            name: 'type'
+            output: true
+            description: |
+              Type of the DNS Resource Record.
+          - !ruby/object:Api::Type::String
+            name: 'data'
+            output: true
+            description: |
+              Data of the DNS Resource Record.
+  - !ruby/object:Api::Resource
+    name: 'Certificate'
+    base_url: 'projects/{{project}}/locations/global/certificates'
+    create_url: 'projects/{{project}}/locations/global/certificates?certificateId={{name}}'
+    self_link: 'projects/{{project}}/locations/global/certificates/{{name}}'
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      Certificate represents a HTTP-reachable backend for an Certificate.
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: true
+        allowed:
+          - true
+          - false
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        required: true
+        input: true
+        url_param_only: true
+        description: |
+          A user-defined name of the certificate. Certificate names must be unique
+          The name must be 1-64 characters long, and match the regular expression [a-zA-Z][a-zA-Z0-9_-]* which means the first character must be a letter,
+          and all following characters must be a dash, underscore, letter or digit.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          A human-readable description of the resource.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: 'Set of label tags associated with the EdgeCache resource.'
+      - !ruby/object:Api::Type::Enum
+        name: scope
+        input: true
+        description: |
+          The scope of the certificate.
+
+          Certificates with default scope are served from core Google data centers.
+          If unsure, choose this option.
+
+          Certificates with scope EDGE_CACHE are special-purposed certificates,
+          served from non-core Google data centers.
+          Currently allowed only for managed certificates.
+        values:
+          - :DEFAULT
+          - :EDGE_CACHE
+        default_value: :DEFAULT
+      - !ruby/object:Api::Type::NestedObject
+        name: selfManaged
+        input: true
+        exactly_one_of:
+          - self_managed
+          - managed
+        description: |
+          Certificate data for a SelfManaged Certificate.
+          SelfManaged Certificates are uploaded by the user. Updating such
+          certificates before they expire remains the user's responsibility.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: certificatePem
+            required: true
+            description: |
+              The certificate chain in PEM-encoded form.
+
+              Leaf certificate comes first, followed by intermediate ones if any.
+          - !ruby/object:Api::Type::String
+            name: privateKeyPem
+            required: true
+            description: |
+              The private key of the leaf certificate in PEM-encoded form.
+      - !ruby/object:Api::Type::NestedObject
+        name: managed
+        input: true
+        exactly_one_of:
+          - self_managed
+          - managed
+        description: |
+          Configuration and state of a Managed Certificate.
+          Certificate Manager provisions and renews Managed Certificates
+          automatically, for as long as it's authorized to do so.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: state
+            output: true
+            description: |
+              State of the managed certificate resource.
+          - !ruby/object:Api::Type::Array
+            name: domains
+            input: true
+            description: |
+              The domains for which a managed SSL certificate will be generated.
+              Wildcard domains are only supported with DNS challenge resolution
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: dnsAuthorizations
+            input: true
+            description: |
+              Authorizations that will be used for performing domain authorization
+            item_type: Api::Type::String
+

--- a/mmv1/products/certificatemanager/terraform.yaml
+++ b/mmv1/products/certificatemanager/terraform.yaml
@@ -1,0 +1,55 @@
+# Copyright 2021 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  DnsAuthorization: !ruby/object:Overrides::Terraform::ResourceOverride
+    docs: !ruby/object:Provider::Terraform::Docs
+      warning: |
+        These resources require allow-listing to use, and are not openly available to all Cloud customers. Engage with your Cloud account team to discuss how to onboard.
+    autogen_async: true
+    import_format: ["projects/{{project}}/locations/global/dnsAuthorizations/{{name}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "certificate_manager_dns_authorization_basic"
+        primary_resource_id: "default"
+        vars:
+          dns_auth_name: "dns-auth"
+          zone_name: "my-zone"
+  Certificate: !ruby/object:Overrides::Terraform::ResourceOverride
+    docs: !ruby/object:Provider::Terraform::Docs
+      warning: |
+        These resources require allow-listing to use, and are not openly available to all Cloud customers. Engage with your Cloud account team to discuss how to onboard.
+    autogen_async: true
+    import_format: ["projects/{{project}}/locations/global/certificates/{{name}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "certificate_manager_certificate_basic"
+        primary_resource_id: "default"
+        vars:
+          dns_auth_name: "dns-auth"
+          dns_auth_subdomain: "subdomain"
+          dns_auth_name2: "dns-auth2"
+          dns_auth_subdomain2: "subdomain2"
+          cert_name: "dns-cert"
+        ignore_read_extra:
+          - "managed.0.dns_authorizations"
+    properties:
+      managed.dnsAuthorizations: !ruby/object:Overrides::Terraform::PropertyOverride
+        # We don't support ignore_read on nested fields
+        ignore_read: true
+        custom_flatten: "templates/terraform/custom_flatten/certificate_manager_certificate_managed_dns_auth.go.erb"
+      selfManaged.certificatePem: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true
+      selfManaged.privateKeyPem: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true

--- a/mmv1/templates/terraform/custom_flatten/certificate_manager_certificate_managed_dns_auth.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/certificate_manager_certificate_managed_dns_auth.go.erb
@@ -1,0 +1,17 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2021 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return d.Get("managed.0.dns_authorizations")
+}

--- a/mmv1/templates/terraform/examples/certificate_manager_certificate_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_certificate_basic.tf.erb
@@ -1,0 +1,29 @@
+resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['cert_name'] %>"
+  description = "The default cert"
+  scope       = "EDGE_CACHE"
+  managed {
+    domains = [
+      google_certificate_manager_dns_authorization.instance.domain,
+      google_certificate_manager_dns_authorization.instance2.domain,
+      ]
+    dns_authorizations = [
+      google_certificate_manager_dns_authorization.instance.id,
+      google_certificate_manager_dns_authorization.instance2.id,
+      ]
+  }
+}
+
+
+resource "google_certificate_manager_dns_authorization" "instance" {
+  name        = "<%= ctx[:vars]['dns_auth_name'] %>"
+  description = "The default dnss"
+  domain      = "<%= ctx[:vars]['dns_auth_subdomain'] %>.hashicorptest.com"
+}
+
+resource "google_certificate_manager_dns_authorization" "instance2" {
+  name        = "<%= ctx[:vars]['dns_auth_name2'] %>"
+  description = "The default dnss"
+  domain      = "<%= ctx[:vars]['dns_auth_subdomain2'] %>.hashicorptest.com"
+}
+

--- a/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_basic.tf.erb
@@ -1,0 +1,17 @@
+resource "google_certificate_manager_dns_authorization" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['dns_auth_name'] %>"
+  description = "The default dnss"
+  domain      = "%{random_suffix}.hashicorptest.com"
+}
+
+output "record_name_to_insert" {
+ value = google_certificate_manager_dns_authorization.<%= ctx[:primary_resource_id] %>.dns_resource_record.0.name
+}
+
+output "record_type_to_insert" {
+ value = google_certificate_manager_dns_authorization.<%= ctx[:primary_resource_id] %>.dns_resource_record.0.type
+}
+
+output "record_data_to_insert" {
+ value = google_certificate_manager_dns_authorization.<%= ctx[:primary_resource_id] %>.dns_resource_record.0.data
+}

--- a/mmv1/templates/terraform/examples/resource_certificate_manager_dns_authorization_test.go
+++ b/mmv1/templates/terraform/examples/resource_certificate_manager_dns_authorization_test.go
@@ -1,0 +1,67 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCertificateManagerDnsAuthorizationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerDnsAuthorization_update0(context),
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name"},
+			},
+			{
+				Config: testAccCertificateManagerDnsAuthorization_update1(context),
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerDnsAuthorization_update0(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = "tf-test-dns-auth%{random_suffix}"
+  description = "The default dnss"
+	labels = {
+		a = "a"
+	}
+  domain      = "%{random_suffix}.hashicorptest.com"
+}
+`, context)
+}
+
+func testAccCertificateManagerDnsAuthorization_update1(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = "tf-test-dns-auth%{random_suffix}"
+  description = "The default dnss2"
+	labels = {
+		a = "b"
+	}
+  domain      = "%{random_suffix}.hashicorptest.com"
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Essentially reverts https://github.com/GoogleCloudPlatform/magic-modules/pull/4968
Adds certificate manager back in

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_certificate_manager_certificate`
```

```release-note:new-resource
`google_certificate_manager_dns_authorization`
```
