### PR TITLE
add https_trigger_security_level to cloudfunction_function

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -300,7 +300,7 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"https_trigger_security_level": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "SECURE_OPTIONAL",
+				Computed:    true,
 				Description: `The security level for the function. Defaults to SECURE_OPTIONAL. Valid only if trigger_http is used.`,
 			},
 

--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -297,6 +297,13 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 				Description: `URL which triggers function execution. Returned only if trigger_http is used.`,
 			},
 
+			"https_trigger_security_level": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "SECURE_OPTIONAL",
+				Description: `The security level for the function. Defaults to SECURE_OPTIONAL. Valid only if trigger_http is used.`,
+			},
+
 			"max_instances": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -481,6 +488,7 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 		function.EventTrigger = expandEventTrigger(v.([]interface{}), project)
 	} else if v, ok := d.GetOk("trigger_http"); ok && v.(bool) {
 		function.HttpsTrigger = &cloudfunctions.HttpsTrigger{}
+		function.HttpsTrigger.SecurityLevel = d.Get("https_trigger_security_level").(string)
 	} else {
 		return fmt.Errorf("One of `event_trigger` or `trigger_http` is required: " +
 			"You must specify a trigger when deploying a new function.")
@@ -644,6 +652,9 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 		if err := d.Set("https_trigger_url", function.HttpsTrigger.Url); err != nil {
 			return fmt.Errorf("Error setting https_trigger_url: %s", err)
 		}
+		if err := d.Set("https_trigger_security_level", function.HttpsTrigger.SecurityLevel); err != nil {
+			return fmt.Errorf("Error setting https_trigger_security_level: %s", err)
+		}
 	}
 
 	if err := d.Set("event_trigger", flattenEventTrigger(function.EventTrigger)); err != nil {
@@ -778,6 +789,11 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("event_trigger") {
 		function.EventTrigger = expandEventTrigger(d.Get("event_trigger").([]interface{}), project)
 		updateMaskArr = append(updateMaskArr, "eventTrigger", "eventTrigger.failurePolicy.retry")
+	}
+
+	if d.HasChange("https_trigger_security_level") {
+		function.HttpsTrigger.SecurityLevel = d.Get("https_trigger_security_level").(string)
+		updateMaskArr = append(updateMaskArr, "httpsTrigger", "httpsTrigger.securityLevel")
 	}
 
 	if d.HasChange("docker_repository") {

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -791,16 +791,17 @@ resource "google_storage_bucket_object" "archive" {
 }
 
 resource "google_cloudfunctions_function" "function" {
-  name                  = "%s"
-  description           = "test function updated"
-  available_memory_mb   = 256
-  source_archive_bucket = google_storage_bucket.bucket.name
-  source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
-  runtime               = "nodejs10"
-  timeout               = 91
-  entry_point           = "helloGET"
-  ingress_settings      = "ALLOW_ALL"
+  name                         = "%s"
+  description                  = "test function updated"
+  available_memory_mb          = 256
+  source_archive_bucket        = google_storage_bucket.bucket.name
+  source_archive_object        = google_storage_bucket_object.archive.name
+  trigger_http                 = true
+  https_trigger_security_level = "SECURE_ALWAYS"
+  runtime                      = "nodejs10"
+  timeout                      = 91
+  entry_point                  = "helloGET"
+  ingress_settings             = "ALLOW_ALL"
   labels = {
     my-label    = "my-updated-label-value"
     a-new-label = "a-new-label-value"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11086


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudfunctions: added `https_trigger_security_level` to `google_cloudfunctions_function`
```
