### PR TITLE
Allow setting SqlServerUserDetails from google_sql_user resource

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_user_test.go
@@ -262,6 +262,8 @@ resource "google_sql_user" "user1" {
   instance = google_sql_database_instance.instance.name
   host     = "google.com"
   password = "%s"
+  disabled = "false"
+  server_roles = [ "admin" ]  
 }
 
 resource "google_sql_user" "user2" {


### PR DESCRIPTION
Allow setting SqlServerUserDetails from google_sql_user resource

This is a lift of https://github.com/hashicorp/terraform-provider-google/pull/11342 into the magic modules repo.

Resolves https://github.com/hashicorp/terraform-provider-google/issues/10438

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added `sql_server_user_details` field to `google_sql_user` resource
```
