### PR TITLE
Add some basic logging, VERBOSE flag for tpgtools

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,6 +38,10 @@ else
   serialize_compile = --path "api" --overrides "overrides"
 endif
 
+ifneq ($(VERBOSE),)
+  tpgtools_compile += --logtostderr=1 --stderrthreshold=2
+endif
+
 UNAME := $(shell uname)
 
 # The inplace editing semantics are different between linux and osx.

--- a/README.md
+++ b/README.md
@@ -301,3 +301,5 @@ Target single resource
 
 For more advanced usage of mmv1 compiler flags, please execute the compiler directly
 from within the mmv1 directory.
+
+For additional logging in the tpgtools compiler set `VERBOSE=true` when executing the `make` command

--- a/tpgtools/main.go
+++ b/tpgtools/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -80,12 +79,7 @@ func main() {
 		if skipResource(resource) {
 			continue
 		}
-		resJSON, err := json.MarshalIndent(resource, "", "  ")
-		if err != nil {
-			glog.Errorf("Failed to marshal resource struct")
-		} else {
-			glog.Infof("Generating from resource %s", string(resJSON))
-		}
+		glog.Infof("Generating from resource %s", resource.TitleCaseFullName())
 
 		generateResourceFile(resource)
 		generateSweeperFile(resource)
@@ -193,6 +187,9 @@ func loadAndModelResources() (map[Version][]*Resource, map[Version][]*ProductMet
 				}
 
 				overrides := loadOverrides(packagePath, resourceFile.Name())
+				if(len(overrides) > 0){
+					glog.Infof("Loaded overrides for %s", resourceFile.Name())
+				}
 
 				newResources = append(newResources, createResourcesFromDocumentAndOverrides(document, overrides, packagePath, version)...)
 			}
@@ -203,6 +200,8 @@ func loadAndModelResources() (map[Version][]*Resource, map[Version][]*ProductMet
 			}
 
 			products[version] = append(products[version], GetProductMetadataFromDocument(document, packagePath))
+			glog.Infof("Loaded product %s", packagePath)
+
 			resources[version] = append(resources[version], newResources...)
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9916



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
