### PR TITLE
Add DynamicPortAllocation for Cloud NAT

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13391,6 +13391,15 @@ objects:
         name: minPortsPerVm
         description: |
           Minimum number of ports allocated to a VM from this NAT.
+      - !ruby/object:Api::Type::Boolean
+        name: enableDynamicPortAllocation
+        description: |
+          Enable Dynamic Port Allocation.
+          If minPorts is set, minPortsPerVm must be set to a power of two greater than or equal to 32. 
+          If minPortsPerVm is not set, a minimum of 32 ports will be allocated to a VM from this NAT config.
+
+          Mutually exclusive with enableEndpointIndependentMapping.
+        default_value: false
       - !ruby/object:Api::Type::Integer
         name: udpIdleTimeoutSec
         description: |

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -171,7 +171,7 @@ func TestAccComputeRouterNat_withManualIpAndSubnetConfiguration(t *testing.T) {
 	})
 }
 
-func TestAccComputeRouterNat_withDisabledIndependentEndpointMapping(t *testing.T) {
+func TestAccComputeRouterNat_withPortAllocationMethods(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
@@ -183,7 +183,7 @@ func TestAccComputeRouterNat_withDisabledIndependentEndpointMapping(t *testing.T
 		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterNatWithDisabledIndependentEndpointMapping(routerName, true),
+				Config: testAccComputeRouterNatWithAllocationMethod(routerName, true, false),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -191,7 +191,7 @@ func TestAccComputeRouterNat_withDisabledIndependentEndpointMapping(t *testing.T
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterNatWithDisabledIndependentEndpointMapping(routerName, false),
+				Config: testAccComputeRouterNatWithAllocationMethod(routerName, false, false),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -199,7 +199,15 @@ func TestAccComputeRouterNat_withDisabledIndependentEndpointMapping(t *testing.T
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterNatWithDisabledIndependentEndpointMapping(routerName, true),
+				Config: testAccComputeRouterNatWithAllocationMethod(routerName, true, false),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatWithAllocationMethod(routerName, false, true),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -607,7 +615,7 @@ resource "google_compute_router_nat" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName)
 }
 
-func testAccComputeRouterNatWithDisabledIndependentEndpointMapping(routerName string, enabled bool) string {
+func testAccComputeRouterNatWithAllocationMethod(routerName string, enableEndpointIndependentMapping, enableDynamicPortAllocation bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
   name                    = "%s-net"
@@ -647,8 +655,9 @@ resource "google_compute_router_nat" "foobar" {
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
   enable_endpoint_independent_mapping = %t
+  enable_dynamic_port_allocation = %t
 }
-`, routerName, routerName, routerName, routerName, routerName, enabled)
+`, routerName, routerName, routerName, routerName, routerName, enableEndpointIndependentMapping, enableDynamicPortAllocation)
 }
 
 <% unless version == 'ga' -%>


### PR DESCRIPTION
Adds the `enable_dynamic_port_allocation` (see equivalent on `enableDynamicPortAllocation` field in the [respective API](https://cloud.google.com/compute/docs/reference/rest/v1/routers)) field for the `google_compute_router_nat` resource.

Solves this issue: https://github.com/hashicorp/terraform-provider-google/issues/11052

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
> For the google_compute_router_nat resource this does not seem to apply

- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `enable_dynamic_port_allocation` to `google_compute_router_nat`
```
