### PR TITLE
Prepared storage_pubsub_notifications snippet for inclusion on C.G.C

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -558,7 +558,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "main"
         primary_resource_id: "topic"
-        primary_resource_type: "google_pubsub_topic"
         vars:
           example_bucket_name: "example-bucket-name"
           your_topic_name: "your_topic_name"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -555,6 +555,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         #   - "port_range"
         #   - "target"
         #   - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "main"
+        primary_resource_id: "topic"
+        primary_resource_type: "google_pubsub_topic"
+        vars:
+          example_bucket_name: "example-bucket-name"
+          your_topic_name: "your_topic_name"
+        min_version: beta
+        # ignore_read_extra:
+        #   - "port_range"
+        #   - "target"
+        #   - "ip_address"
     properties:
 
 

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -551,10 +551,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           example_bucket_name: "example-bucket-name"
         min_version: beta
-        # ignore_read_extra:
-        #   - "port_range"
-        #   - "target"
-        #   - "ip_address"
       - !ruby/object:Provider::Terraform::Examples
         name: "main"
         primary_resource_id: "topic"
@@ -562,10 +558,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           example_bucket_name: "example-bucket-name"
           your_topic_name: "your_topic_name"
         min_version: beta
-        # ignore_read_extra:
-        #   - "port_range"
-        #   - "target"
-        #   - "ip_address"
     properties:
 
 

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -553,6 +553,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: beta
       - !ruby/object:Provider::Terraform::Examples
         name: "storage_pubsub_notifications"
+        primary_resource_type: "google_pubsub_topic"
         primary_resource_id: "topic"
         vars:
           example_bucket_name: "example-bucket-name"

--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -552,7 +552,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           example_bucket_name: "example-bucket-name"
         min_version: beta
       - !ruby/object:Provider::Terraform::Examples
-        name: "main"
+        name: "storage_pubsub_notifications"
         primary_resource_id: "topic"
         vars:
           example_bucket_name: "example-bucket-name"

--- a/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
@@ -11,13 +11,13 @@ data "google_storage_project_service_account" "gcs_account" {
 }
 
 resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
-  # name    = "default_iam_binding"
+  name    = "default_iam_binding"
   topic   = google_pubsub_topic.topic.id
   role    = "roles/pubsub.publisher"
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
 
-// Create a new storage bucket
+// Create a new storage bucket.
 resource "google_storage_bucket" "bucket" {
   name     = "<%= ctx[:vars]['example_bucket_name'] %>"
   location = "US"

--- a/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
@@ -1,0 +1,30 @@
+# [START storage_create_pubsub_notifications_tf]
+resource "google_storage_notification" "notification" {
+  bucket         = google_storage_bucket.bucket.name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.topic.id
+  depends_on = [google_pubsub_topic_iam_binding.binding]
+}
+
+// Enable notifications by giving the correct IAM permission to the unique service account.
+data "google_storage_project_service_account" "gcs_account" {
+}
+
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+  # name    = "default_iam_binding"
+  topic   = google_pubsub_topic.topic.id
+  role    = "roles/pubsub.publisher"
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+
+// End enabling notifications
+resource "google_storage_bucket" "bucket" {
+  name     = "<%= ctx[:vars]['example_bucket_name'] %>"
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_pubsub_topic" "topic" {
+  name = "<%= ctx[:vars]['your_topic_name'] %>"
+}
+# [END storage_create_pubsub_notifications_tf]

--- a/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
@@ -1,4 +1,5 @@
 # [START storage_create_pubsub_notifications_tf]
+// Create a Pub/Sub notification.
 resource "google_storage_notification" "notification" {
   bucket         = google_storage_bucket.bucket.name
   payload_format = "JSON_API_V1"
@@ -10,6 +11,7 @@ resource "google_storage_notification" "notification" {
 data "google_storage_project_service_account" "gcs_account" {
 }
 
+// Create a Pub/Sub topic.
 resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
   name    = "default_iam_binding"
   topic   = google_pubsub_topic.topic.id

--- a/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
@@ -17,7 +17,7 @@ resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
 
-// End enabling notifications
+// Create a new storage bucket
 resource "google_storage_bucket" "bucket" {
   name     = "<%= ctx[:vars]['example_bucket_name'] %>"
   location = "US"

--- a/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
@@ -13,7 +13,6 @@ data "google_storage_project_service_account" "gcs_account" {
 
 // Create a Pub/Sub topic.
 resource "google_pubsub_topic_iam_binding" "binding" {
-  name    = "default_iam_binding"
   topic   = google_pubsub_topic.topic.id
   role    = "roles/pubsub.publisher"
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]

--- a/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_pubsub_notifications.tf.erb
@@ -12,7 +12,7 @@ data "google_storage_project_service_account" "gcs_account" {
 }
 
 // Create a Pub/Sub topic.
-resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+resource "google_pubsub_topic_iam_binding" "binding" {
   name    = "default_iam_binding"
   topic   = google_pubsub_topic.topic.id
   role    = "roles/pubsub.publisher"
@@ -26,7 +26,7 @@ resource "google_storage_bucket" "bucket" {
   uniform_bucket_level_access = true
 }
 
-resource "google_pubsub_topic" "topic" {
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['your_topic_name'] %>"
 }
 # [END storage_create_pubsub_notifications_tf]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
