### PR TITLE
Add support for cacheKeyPolicy in BackendBuckets

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -621,6 +621,31 @@ objects:
         name: 'cdnPolicy'
         description: 'Cloud CDN configuration for this Backend Bucket.'
         properties:
+        - !ruby/object:Api::Type::NestedObject
+          name: 'cacheKeyPolicy'
+          description: 'The CacheKeyPolicy for this CdnPolicy.'
+          properties:
+          - !ruby/object:Api::Type::Array
+            send_empty_value: true
+            name: 'queryStringWhitelist'
+            at_least_one_of:
+              - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+              - cdn_policy.0.cache_key_policy.0.include_http_headers
+            description: |
+              Names of query string parameters to include in cache keys.
+              Default parameters are always included. '&' and '=' will
+              be percent encoded and not treated as delimiters.
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            send_empty_value: true
+            name: 'includeHttpHeaders'
+            at_least_one_of:
+              - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+              - cdn_policy.0.cache_key_policy.0.include_http_headers
+            description: |
+              Allows HTTP request headers (by name) to be used in the
+              cache key.
+            item_type: Api::Type::String
         - !ruby/object:Api::Type::Integer
           name: 'signedUrlCacheMaxAgeSec'
           description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -166,6 +166,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           backend_bucket_name: "image-backend-bucket"
           bucket_name: "image-store-bucket"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "backend_bucket_cache_key_policy"
+        primary_resource_id: "image_backend"
+        vars:
+          backend_bucket_name: "image-backend-bucket"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: 'templates/terraform/post_create/compute_backend_bucket_security_policy.go.erb'
       post_update: 'templates/terraform/post_create/compute_backend_bucket_security_policy.go.erb'

--- a/mmv1/templates/terraform/examples/backend_bucket_cache_key_policy.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_bucket_cache_key_policy.tf.erb
@@ -1,0 +1,16 @@
+resource "google_compute_backend_bucket" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['backend_bucket_name'] %>"
+  description = "Contains beautiful images"
+  bucket_name = google_storage_bucket.image_bucket.name
+  enable_cdn  = true
+  cdn_policy {
+    cache_key_policy {
+        query_string_whitelist = ["image-version"]
+    }
+  }
+}
+
+resource "google_storage_bucket" "image_bucket" {
+  name     = "<%= ctx[:vars]['backend_bucket_name'] %>"
+  location = "EU"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds support for [cacheKeyPolicy](https://cloud.google.com/compute/docs/reference/rest/v1/backendBuckets) in `google_compute_backend_bucket`.

Resolves https://github.com/hashicorp/terraform-provider-google/issues/11114.

This is my first PR to this repo so feel free to correct me if there is anything wrong.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `cache_key_policy` field to `google_compute_backend_bucket` resource
```

Question:
After I ran `make terraform`, `make lint` fails because of the files that seem to be irrelevant to my changes. Is this an expected behavior?

<details>
<summary>output of `make lint` (hashicorp-provider-google)</summary>

```
$ cd /path/to/hashicorp/terraform-provider-google
$ git log -n 1 | head -n 1
commit 05616d2ee0e1e676ff042fc96187d20dcb51d9ab
$ golangci-lint --version
golangci-lint has version 1.46.2 built from a333689 on 2022-05-17T06:05:08Z
$ make lint
==> Checking source code against linters...
google/config_test.go:67:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/config_test.go:95:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/config_test.go:125:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/config_test.go:165:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_disk_test.go:188:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:21:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:125:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:153:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:221:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:288:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:369:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:449:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:518:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:586:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:659:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:731:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
google/resource_compute_instance_migrate_test.go:797:3: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
		^
make: *** [lint] Error 1
```
</details>