### PR TITLE
Fix eventarc test template

### DIFF
--- a/tpgtools/overrides/eventarc/samples/trigger/basic.tf.tmpl
+++ b/tpgtools/overrides/eventarc/samples/trigger/basic.tf.tmpl
@@ -32,9 +32,12 @@ resource "google_cloud_run_service" "default" {
 		spec {
 			containers {
 				image = "gcr.io/cloudrun/hello"
-				args  = ["arrgs"]
+				ports {
+					container_port = 8080
+				}
 			}
-		container_concurrency = 50
+			container_concurrency = 50
+			timeout_seconds = 100
 		}
 	}
 

--- a/tpgtools/overrides/eventarc/samples/trigger/basic_update_transport.tf.tmpl
+++ b/tpgtools/overrides/eventarc/samples/trigger/basic_update_transport.tf.tmpl
@@ -34,9 +34,12 @@ resource "google_cloud_run_service" "default" {
 		spec {
 			containers {
 				image = "gcr.io/cloudrun/hello"
-				args  = ["arrgs"]
+				ports {
+					container_port = 8080
+				}
 			}
-		container_concurrency = 50
+			container_concurrency = 50
+			timeout_seconds = 100
 		}
 	}
 
@@ -58,9 +61,12 @@ resource "google_cloud_run_service" "default2" {
 		spec {
 			containers {
 				image = "gcr.io/cloudrun/hello"
-				args  = ["arrgs"]
+				ports {
+					container_port = 8080
+				}
 			}
-		container_concurrency = 50
+			container_concurrency = 50
+			timeout_seconds = 100
 		}
 	}
 

--- a/tpgtools/overrides/eventarc/samples/trigger/basic_update_transport_2.tf.tmpl
+++ b/tpgtools/overrides/eventarc/samples/trigger/basic_update_transport_2.tf.tmpl
@@ -70,9 +70,12 @@ resource "google_cloud_run_service" "default2" {
 		spec {
 			containers {
 				image = "gcr.io/cloudrun/hello"
-				args  = ["arrgs"]
+				ports {
+					container_port = 8080
+				}
 			}
-		container_concurrency = 50
+			container_concurrency = 50
+			timeout_seconds = 100
 		}
 	}
 

--- a/tpgtools/overrides/eventarc/samples/trigger/basic_update_transport_2.tf.tmpl
+++ b/tpgtools/overrides/eventarc/samples/trigger/basic_update_transport_2.tf.tmpl
@@ -43,9 +43,12 @@ resource "google_cloud_run_service" "default" {
 		spec {
 			containers {
 				image = "gcr.io/cloudrun/hello"
-				args  = ["arrgs"]
+				ports {
+					container_port = 8080
+				}
 			}
-		container_concurrency = 50
+			container_concurrency = 50
+			timeout_seconds = 100
 		}
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The cloud run service fails to set up, this fixes it locally



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
