### PR TITLE
Replace tabs with spaces in Cloud Run examples

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
@@ -30,7 +30,7 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
         image = "gcr.io/cloudrun/hello"
         env {
           name = "SECRET_ENV_VAR"
-	  value_from {
+          value_from {
             secret_key_ref {
               name = google_secret_manager_secret.secret.secret_id
               key = "1"

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
 
   lifecycle {
     ignore_changes = [
-        metadata.0.annotations,
+      metadata.0.annotations,
     ]
   }
 

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
@@ -28,22 +28,22 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
     spec {
       containers {
         image = "gcr.io/cloudrun/hello"
-	volume_mounts {
-	  name = "a-volume"
-	  mount_path = "/secrets"
-	}
+        volume_mounts {
+          name = "a-volume"
+          mount_path = "/secrets"
+        }
       }
       volumes {
         name = "a-volume"
-	secret {
-	  secret_name = google_secret_manager_secret.secret.secret_id
-	  default_mode = 292 # 0444
-	  items {
+        secret {
+          secret_name = google_secret_manager_secret.secret.secret_id
+          default_mode = 292 # 0444
+          items {
             key = "1"
-	    path = "my-secret"
-	    mode = 256 # 0400
-	  }
-	}
+            path = "my-secret"
+            mode = 256 # 0400
+          }
+        }
       }
     }
   }

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
@@ -62,7 +62,7 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
 
   lifecycle {
     ignore_changes = [
-        metadata.0.annotations,
+      metadata.0.annotations,
     ]
   }
 

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -97,8 +97,8 @@ resource "google_cloud_run_service" "default" {
           container_port = 8080
         }
       }
-      container_concurrency = %s
-      timeout_seconds = %s
+	  container_concurrency = %s
+	  timeout_seconds = %s
     }
   }
 

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -200,20 +200,20 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "gcr.io/cloudrun/hello"
-        volume_mounts {
-          name = "a-volume"
-          mount_path = "/secrets"
-        }
+	volume_mounts {
+	  name = "a-volume"
+	  mount_path = "/secrets"
+	}
       }
       volumes {
         name = "a-volume"
-        secret {
-          secret_name = %s
-          items {
+	secret {
+	  secret_name = %s
+	  items {
             key = "1"
-            path = "my-secret"
-          }
-        }
+	    path = "my-secret"
+	  }
+	}
       }
     }
   }
@@ -326,7 +326,7 @@ resource "google_cloud_run_service" "default" {
         image = "gcr.io/cloudrun/hello"
         env {
           name = "SECRET_ENV_VAR"
-          value_from {
+	  value_from {
             secret_key_ref {
               name = %s
               key = "1"

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -2,82 +2,82 @@
 package google
 
 import (
-	"fmt"
-	"testing"
+  "fmt"
+  "testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-	project := getTestProjectFromEnv()
-	name := "tftest-cloudrun-" + randString(t, 6)
+  project := getTestProjectFromEnv()
+  name := "tftest-cloudrun-" + randString(t, 6)
 
-	vcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "50", "300"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-		},
-	})
+  vcrTest(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "50", "300"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+    },
+  })
 }
 
 // this test checks that Terraform does not fail with a 409 recreating the same service
 func TestAccCloudRunService_foregroundDeletion(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-	project := getTestProjectFromEnv()
-	name := "tftest-cloudrun-" + randString(t, 6)
+  project := getTestProjectFromEnv()
+  name := "tftest-cloudrun-" + randString(t, 6)
 
-	vcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-			{
-				Config: " ", // very explicitly add a space, as the test runner fails if this is just ""
-			},
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-		},
-	})
+  vcrTest(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+      {
+        Config: " ", // very explicitly add a space, as the test runner fails if this is just ""
+      },
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+    },
+  })
 }
 
 func testAccCloudRunService_cloudRunServiceUpdate(name, project, concurrency, timeoutSeconds string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
   name     = "%s"
   location = "us-central1"
@@ -97,8 +97,8 @@ resource "google_cloud_run_service" "default" {
           container_port = 8080
         }
       }
-	  container_concurrency = %s
-	  timeout_seconds = %s
+      container_concurrency = %s
+      timeout_seconds = %s
     }
   }
 
@@ -118,39 +118,39 @@ resource "google_cloud_run_service" "default" {
 }
 
 func TestAccCloudRunService_secretVolume(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-	project := getTestProjectFromEnv()
-	name := "tftest-cloudrun-" + randString(t, 6)
+  project := getTestProjectFromEnv()
+  name := "tftest-cloudrun-" + randString(t, 6)
 
-	vcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-		},
-	})
+  vcrTest(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+    },
+  })
 }
 
 func testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, secretName1, secretName2, secretRef string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 data "google_project" "project" {
 }
 
@@ -200,20 +200,20 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "gcr.io/cloudrun/hello"
-	volume_mounts {
-	  name = "a-volume"
-	  mount_path = "/secrets"
-	}
+  volume_mounts {
+    name = "a-volume"
+    mount_path = "/secrets"
+  }
       }
       volumes {
         name = "a-volume"
-	secret {
-	  secret_name = %s
-	  items {
+  secret {
+    secret_name = %s
+    items {
             key = "1"
-	    path = "my-secret"
-	  }
-	}
+      path = "my-secret"
+    }
+  }
       }
     }
   }
@@ -242,39 +242,39 @@ resource "google_cloud_run_service" "default" {
 }
 
 func TestAccCloudRunService_secretEnvironmentVariable(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-	project := getTestProjectFromEnv()
-	name := "tftest-cloudrun-" + randString(t, 6)
+  project := getTestProjectFromEnv()
+  name := "tftest-cloudrun-" + randString(t, 6)
 
-	vcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-			{
-				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-			},
-		},
-	})
+  vcrTest(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+      {
+        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+      },
+    },
+  })
 }
 
 func testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, secretName1, secretName2, secretRef string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 data "google_project" "project" {
 }
 
@@ -326,7 +326,7 @@ resource "google_cloud_run_service" "default" {
         image = "gcr.io/cloudrun/hello"
         env {
           name = "SECRET_ENV_VAR"
-	  value_from {
+          value_from {
             secret_key_ref {
               name = %s
               key = "1"

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -2,82 +2,82 @@
 package google
 
 import (
-  "fmt"
-  "testing"
+	"fmt"
+	"testing"
 
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  project := getTestProjectFromEnv()
-  name := "tftest-cloudrun-" + randString(t, 6)
+	project := getTestProjectFromEnv()
+	name := "tftest-cloudrun-" + randString(t, 6)
 
-  vcrTest(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    Steps: []resource.TestStep{
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "50", "300"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-    },
-  })
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "50", "300"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+		},
+	})
 }
 
 // this test checks that Terraform does not fail with a 409 recreating the same service
 func TestAccCloudRunService_foregroundDeletion(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  project := getTestProjectFromEnv()
-  name := "tftest-cloudrun-" + randString(t, 6)
+	project := getTestProjectFromEnv()
+	name := "tftest-cloudrun-" + randString(t, 6)
 
-  vcrTest(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    Steps: []resource.TestStep{
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-      {
-        Config: " ", // very explicitly add a space, as the test runner fails if this is just ""
-      },
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-    },
-  })
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+			{
+				Config: " ", // very explicitly add a space, as the test runner fails if this is just ""
+			},
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+		},
+	})
 }
 
 func testAccCloudRunService_cloudRunServiceUpdate(name, project, concurrency, timeoutSeconds string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
   name     = "%s"
   location = "us-central1"
@@ -118,39 +118,39 @@ resource "google_cloud_run_service" "default" {
 }
 
 func TestAccCloudRunService_secretVolume(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  project := getTestProjectFromEnv()
-  name := "tftest-cloudrun-" + randString(t, 6)
+	project := getTestProjectFromEnv()
+	name := "tftest-cloudrun-" + randString(t, 6)
 
-  vcrTest(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    Steps: []resource.TestStep{
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-    },
-  })
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+		},
+	})
 }
 
 func testAccCloudRunService_cloudRunServiceUpdateWithSecretVolume(name, project, secretName1, secretName2, secretRef string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 data "google_project" "project" {
 }
 
@@ -200,20 +200,20 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "gcr.io/cloudrun/hello"
-  volume_mounts {
-    name = "a-volume"
-    mount_path = "/secrets"
-  }
+        volume_mounts {
+          name = "a-volume"
+          mount_path = "/secrets"
+        }
       }
       volumes {
         name = "a-volume"
-  secret {
-    secret_name = %s
-    items {
+        secret {
+          secret_name = %s
+          items {
             key = "1"
-      path = "my-secret"
-    }
-  }
+            path = "my-secret"
+          }
+        }
       }
     }
   }
@@ -242,39 +242,39 @@ resource "google_cloud_run_service" "default" {
 }
 
 func TestAccCloudRunService_secretEnvironmentVariable(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  project := getTestProjectFromEnv()
-  name := "tftest-cloudrun-" + randString(t, 6)
+	project := getTestProjectFromEnv()
+	name := "tftest-cloudrun-" + randString(t, 6)
 
-  vcrTest(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    Steps: []resource.TestStep{
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-      {
-        Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
-      },
-      {
-        ResourceName:            "google_cloud_run_service.default",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
-      },
-    },
-  })
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 5), "secret-"+randString(t, 6), "google_secret_manager_secret.secret1.secret_id"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, "secret-"+randString(t, 10), "secret-"+randString(t, 11), "google_secret_manager_secret.secret2.secret_id"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+		},
+	})
 }
 
 func testAccCloudRunService_cloudRunServiceUpdateWithSecretEnvVar(name, project, secretName1, secretName2, secretRef string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 data "google_project" "project" {
 }
 

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -97,8 +97,8 @@ resource "google_cloud_run_service" "default" {
           container_port = 8080
         }
       }
-	  container_concurrency = %s
-	  timeout_seconds = %s
+      container_concurrency = %s
+      timeout_seconds = %s
     }
   }
 

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -200,20 +200,20 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "gcr.io/cloudrun/hello"
-	volume_mounts {
-	  name = "a-volume"
-	  mount_path = "/secrets"
-	}
+        volume_mounts {
+          name = "a-volume"
+          mount_path = "/secrets"
+        }
       }
       volumes {
         name = "a-volume"
-	secret {
-	  secret_name = %s
-	  items {
+        secret {
+          secret_name = %s
+          items {
             key = "1"
-	    path = "my-secret"
-	  }
-	}
+            path = "my-secret"
+          }
+        }
       }
     }
   }
@@ -232,7 +232,7 @@ resource "google_cloud_run_service" "default" {
 
   lifecycle {
     ignore_changes = [
-        metadata.0.annotations,
+      metadata.0.annotations,
     ]
   }
 
@@ -326,7 +326,7 @@ resource "google_cloud_run_service" "default" {
         image = "gcr.io/cloudrun/hello"
         env {
           name = "SECRET_ENV_VAR"
-	  value_from {
+          value_from {
             secret_key_ref {
               name = %s
               key = "1"
@@ -351,7 +351,7 @@ resource "google_cloud_run_service" "default" {
 
   lifecycle {
     ignore_changes = [
-        metadata.0.annotations,
+      metadata.0.annotations,
     ]
   }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Some examples have tabs mixed in with spaces, this causes indentation issues when rendered in [Terraform registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service#example-usage---cloud-run-service-secret-volumes):

![CleanShot 2022-05-24 at 10 19 48@2x](https://user-images.githubusercontent.com/4773707/170058361-20bef069-eed8-475b-a84a-aa8766e5d9b6.png)

This PR replaces tabs with spaces in Cloud Run examples

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrun: fixed indentation in Terraform examples
```
