### PR TITLE
Ensure paths exist before generating their contents

### DIFF
--- a/mmv1/provider/file_template.rb
+++ b/mmv1/provider/file_template.rb
@@ -61,8 +61,8 @@ module Provider
       ctx.local_variable_set('pwd', pwd)
 
       # check if the parent folder exists, and make it if not
-      parentPath = File.dirname(path)
-      FileUtils.mkdir_p(parentPath) unless File.directory?(parentPath)
+      parent_path = File.dirname(path)
+      FileUtils.mkdir_p(parent_path) unless File.directory?(parent_path)
 
       Google::LOGGER.debug "Generating #{path}"
       File.open(path, 'w') { |f| f.puts compile_file(ctx, pwd + '/' + template) }

--- a/mmv1/provider/file_template.rb
+++ b/mmv1/provider/file_template.rb
@@ -60,6 +60,10 @@ module Provider
                              relative_path(@output_folder + '/' + path, @output_folder).to_s)
       ctx.local_variable_set('pwd', pwd)
 
+      # check if the parent folder exists, and make it if not
+      parentPath = File.dirname(path)
+      FileUtils.mkdir_p(parentPath) unless File.directory?(parentPath)
+
       Google::LOGGER.debug "Generating #{path}"
       File.open(path, 'w') { |f| f.puts compile_file(ctx, pwd + '/' + template) }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This should get rid of the timing issue when adding new folders!


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
