### PR TITLE
Adding JSONPath content matching fields.

### DIFF
--- a/mmv1/products/monitoring/api.yaml
+++ b/mmv1/products/monitoring/api.yaml
@@ -1757,6 +1757,25 @@ objects:
             - :NOT_CONTAINS_STRING
             - :MATCHES_REGEX
             - :NOT_MATCHES_REGEX
+            - :MATCHES_JSON_PATH
+            - :NOT_MATCHES_JSON_PATH
+        - !ruby/object:Api::Type::NestedObject
+          name: jsonPathMatcher
+          description: Information needed to perform a JSONPath content match.
+            Used for `ContentMatcherOption::MATCHES_JSON_PATH` and
+            `ContentMatcherOption::NOT_MATCHES_JSON_PATH`.
+          properties:
+          - !ruby/object:Api::Type::String
+            name: jsonPath
+            description: JSONPath within the response output pointing to the expected
+              `ContentMatcher::content` to match against.
+          - !ruby/object:Api::Type::Enum
+            name: jsonMatcher
+            description: Options to perform JSONPath content matching.
+            default_value: :EXACT_MATCH
+            values:
+              - :EXACT_MATCH
+              - :REGEX_MATCH
     - !ruby/object:Api::Type::Array
       name: selectedRegions
       description: The list of regions from which the check will be run. Some regions
@@ -1941,7 +1960,8 @@ objects:
       input: true
       description: 'The monitored resource (https://cloud.google.com/monitoring/api/resources)
         associated with the configuration. The following monitored resource types are
-        supported for uptime checks:  uptime_url  gce_instance  gae_app  aws_ec2_instance  aws_elb_load_balancer'
+        supported for uptime checks:  uptime_url  gce_instance  gae_app  aws_ec2_instance 
+        aws_elb_load_balancer  k8s_service  servicedirectory_service'
       exactly_one_of:
         - monitored_resource
         - resource_group

--- a/mmv1/products/monitoring/api.yaml
+++ b/mmv1/products/monitoring/api.yaml
@@ -1769,6 +1769,7 @@ objects:
             name: jsonPath
             description: JSONPath within the response output pointing to the expected
               `ContentMatcher::content` to match against.
+            required: true
           - !ruby/object:Api::Type::Enum
             name: jsonMatcher
             description: Options to perform JSONPath content matching.

--- a/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
@@ -19,7 +19,12 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
   }
 
   content_matchers {
-    content = "example"
+    content = "\"example\""
+    matcher = "MATCHES_JSON_PATH"
+    json_path_matcher {
+      json_path = "$.path"
+      json_matcher = "EXACT_MATCH"
+    }
   }
 
   checker_type = "STATIC_IP_CHECKERS"

--- a/mmv1/templates/terraform/examples/uptime_check_config_https.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_config_https.tf.erb
@@ -19,5 +19,10 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
 
   content_matchers {
     content = "example"
+    matcher = "MATCHES_JSON_PATH"
+    json_path_matcher {
+      json_path = "$.path"
+      json_matcher = "REGEX_MATCH"
+    }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds support for the JSONPath content matchers for an Uptime Check. This lets users validate expected content is within the response of an Uptime Check probe, or that content is explicitly not present.

fixes https://github.com/hashicorp/terraform-provider-google/issues/11777

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added support for JSONPath content matchers for Uptime Checks
```
