### PR TITLE
Update validator with changes to support the user agent parameter

### DIFF
--- a/mmv1/third_party/validator/getconfig.go
+++ b/mmv1/third_party/validator/getconfig.go
@@ -2,12 +2,8 @@ package google
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
-
-	"github.com/GoogleCloudPlatform/terraform-validator/version"
 )
 
 // Return the value of the private userAgent field
@@ -15,10 +11,10 @@ func (c *Config) UserAgent() string {
 	return c.userAgent
 }
 
-func GetConfig(ctx context.Context, project string, offline bool) (*Config, error) {
+func GetConfig(ctx context.Context, project string, offline bool, userAgent string) (*Config, error) {
 	cfg := &Config{
 		Project:   project,
-		userAgent: fmt.Sprintf("config-validator-tf/%s", version.BuildVersion()),
+		userAgent: userAgent,
 	}
 
 	// Search for default credentials
@@ -47,12 +43,6 @@ func GetConfig(ctx context.Context, project string, offline bool) (*Config, erro
 		"GCLOUD_REGION",
 		"CLOUDSDK_COMPUTE_REGION",
 	})
-
-	// opt in extension for adding to the User-Agent header
-	if ext := os.Getenv("GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION"); ext != "" {
-		ua := cfg.userAgent
-		cfg.userAgent = fmt.Sprintf("%s %s", ua, ext)
-	}
 
 	if !offline {
 		ConfigureBasePaths(cfg)

--- a/mmv1/third_party/validator/getconfig_test.go
+++ b/mmv1/third_party/validator/getconfig_test.go
@@ -116,13 +116,6 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 			expected:       "whatever",
 			getConfigValue: getRegionValue,
 		},
-		{
-			name:           "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
-			envKey:         "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
-			envValue:       "whatever",
-			expected:       "config-validator-tf/dev whatever",
-			getConfigValue: getUserAgent,
-		},
 	}
 
 	for _, c := range cases {
@@ -133,7 +126,7 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 				t.Fatalf("error setting env var %s=%s: %s", c.envKey, c.envValue, err)
 			}
 
-			cfg, err := GetConfig(ctx, "project", offline)
+			cfg, err := GetConfig(ctx, "project", offline, "")
 			if err != nil {
 				t.Fatalf("error building converter: %s", err)
 			}
@@ -151,6 +144,35 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 					t.Fatalf("error unsetting env var %s: %s", c.envKey, err)
 				}
 			}
+		})
+	}
+}
+
+func TestGetConfigUserAgent(t *testing.T) {
+	ctx := context.Background()
+	offline := true
+	cases := []struct {
+		userAgent string
+		expected  string
+	}{
+		{
+			userAgent: "",
+			expected:  "",
+		},
+		{
+			userAgent: "whatever",
+			expected:  "whatever",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.userAgent, func(t *testing.T) {
+			cfg, err := GetConfig(ctx, "project", offline, c.userAgent)
+			if err != nil {
+				t.Fatalf("error building converter: %s", err)
+			}
+
+			assert.Equal(t, c.expected, getUserAgent(cfg))
 		})
 	}
 }

--- a/mmv1/third_party/validator/tests/source/read_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/read_test.go.erb
@@ -65,7 +65,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 			ancestryCache := map[string]string{
 				data.Provider["project"]: data.Ancestry,
 			}
-			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], ancestryCache, true, false, zaptest.NewLogger(t))
+			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], ancestryCache, true, false, zaptest.NewLogger(t), "")
 			if err != nil {
 				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], ancestryCache, true, err)
 			}


### PR DESCRIPTION
This change was made in terraform-validator in order to support application-specific user-agents. See https://github.com/GoogleCloudPlatform/terraform-validator/pull/727

b/232132100

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
