### PR TITLE
spotVM for GKE Node Pools is out of beta

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1559,9 +1559,7 @@ resource "google_container_node_pool" "with_workload_metadata_config" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {
-<% unless  version == 'ga' -%>
     spot         = true
-<% end -%>
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -221,7 +221,6 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `Whether the nodes are created as preemptible VM instances.`,
 				},
 
-<% unless version == 'ga' -%>
 				"spot": {
 					Type:        schema.TypeBool,
 					Optional:    true,
@@ -229,7 +228,6 @@ func schemaNodeConfig() *schema.Schema {
 					Default:     false,
 					Description: `Whether the nodes are created as spot VM instances.`,
 				},
-<% end -%>
 
 				"service_account": {
 					Type:     schema.TypeString,
@@ -536,9 +534,9 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 
 	// Preemptible Is Optional+Default, so it always has a value
 	nc.Preemptible = nodeConfig["preemptible"].(bool)
-<% unless version == 'ga' -%>
+
+	// Spot Is Optional+Default, so it always has a value
 	nc.Spot = nodeConfig["spot"].(bool)
-<% end -%>
 
 	if v, ok := nodeConfig["min_cpu_platform"]; ok {
 		nc.MinCpuPlatform = v.(string)
@@ -684,9 +682,7 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 		"labels":                   c.Labels,
 		"tags":                     c.Tags,
 		"preemptible":              c.Preemptible,
-<% unless version == 'ga' -%>
 		"spot":                     c.Spot,
-<% end -%>
 		"min_cpu_platform":         c.MinCpuPlatform,
 		"shielded_instance_config": flattenShieldedInstanceConfig(c.ShieldedInstanceConfig),
 		"taint":                    flattenTaints(c.Taints),

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -719,8 +719,8 @@ gvnic {
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
-* `spot` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) A boolean
-    that represents whether the underlying node VMs are spot. See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
+* `spot` - (Optional) A boolean that represents whether the underlying node VMs are spot.
+    See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
     for more information. Defaults to false.
 
 * `sandbox_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods) configuration. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version = "1.12.7-gke.17"` or later to use it.


### PR DESCRIPTION
Hi,
following this PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/5443

Spot VM for GKE is out of beta: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/NodeConfig

Thanks

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). **--> I guess it's a small change**
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests. **--> Link doesn't work**
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests). **--> Links don't work**
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `spot` field to `node_config` sub-resource
```
