### PR TITLE
Update accesscontextmanager to include externalResources in egressTo

### DIFF
--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -1073,6 +1073,13 @@ objects:
                     then this `EgressTo` rule will authorize access to all resources outside 
                     the perimeter.                  
                 - !ruby/object:Api::Type::Array
+                  name: 'externalResources'
+                  item_type: Api::Type::String
+                  description: |
+                    A list of external resources that are allowed to be accessed. A request
+                    matches if it contains an external resource in this list (Example:
+                    s3://bucket/path). Currently '*' is not allowed.
+                - !ruby/object:Api::Type::Array
                   name: 'operations'
                   description: |
                     A list of `ApiOperations` that this egress rule applies to. A request matches 
@@ -1328,7 +1335,14 @@ objects:
                     `projects/<projectnumber>`, that match this to stanza. A request matches 
                     if it contains a resource in this list. If * is specified for resources, 
                     then this `EgressTo` rule will authorize access to all resources outside 
-                    the perimeter.                  
+                    the perimeter. 
+                - !ruby/object:Api::Type::Array
+                  name: 'externalResources'
+                  item_type: Api::Type::String
+                  description: |
+                    A list of external resources that are allowed to be accessed. A request
+                    matches if it contains an external resource in this list (Example:
+                    s3://bucket/path). Currently '*' is not allowed.                      
                 - !ruby/object:Api::Type::Array
                   name: 'operations'
                   description: |
@@ -1685,7 +1699,14 @@ objects:
                           `projects/<projectnumber>`, that match this to stanza. A request matches 
                           if it contains a resource in this list. If * is specified for resources, 
                           then this `EgressTo` rule will authorize access to all resources outside 
-                          the perimeter.                  
+                          the perimeter.   
+                      - !ruby/object:Api::Type::Array
+                        name: 'externalResources'
+                        item_type: Api::Type::String
+                        description: |
+                          A list of external resources that are allowed to be accessed. A request
+                          matches if it contains an external resource in this list (Example:
+                          s3://bucket/path). Currently '*' is not allowed.                
                       - !ruby/object:Api::Type::Array
                         name: 'operations'
                         description: |
@@ -1948,7 +1969,14 @@ objects:
                           `projects/<projectnumber>`, that match this to stanza. A request matches 
                           if it contains a resource in this list. If * is specified for resources, 
                           then this `EgressTo` rule will authorize access to all resources outside 
-                          the perimeter.                  
+                          the perimeter.
+                      - !ruby/object:Api::Type::Array
+                        name: 'externalResources'
+                        item_type: Api::Type::String
+                        description: |
+                          A list of external resources that are allowed to be accessed. A request
+                          matches if it contains an external resource in this list (Example:
+                          s3://bucket/path). Currently '*' is not allowed.                      
                       - !ruby/object:Api::Type::Array
                         name: 'operations'
                         description: |

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_services_perimeters_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_services_perimeters_test.go
@@ -19,7 +19,7 @@ func testAccAccessContextManagerServicePerimeters_basicTest(t *testing.T) {
 		CheckDestroy: testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerServicePerimeters_basic(org, "my policy", "level", "storage_perimeter", "bigtable_perimeter"),
+				Config: testAccAccessContextManagerServicePerimeters_basic(org, "my policy", "level", "storage_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter"),
 			},
 			{
 				ResourceName:      "google_access_context_manager_service_perimeters.test-access",
@@ -27,7 +27,7 @@ func testAccAccessContextManagerServicePerimeters_basicTest(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAccessContextManagerServicePerimeters_update(org, "my policy", "level", "storage_perimeter", "bigquery_perimeter", "bigtable_perimeter"),
+				Config: testAccAccessContextManagerServicePerimeters_update(org, "my policy", "level", "storage_perimeter", "bigquery_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter"),
 			},
 			{
 				ResourceName:      "google_access_context_manager_service_perimeters.test-access",
@@ -70,7 +70,7 @@ func testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t *testing
 	}
 }
 
-func testAccAccessContextManagerServicePerimeters_basic(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2 string) string {
+func testAccAccessContextManagerServicePerimeters_basic(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3 string) string {
 	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
@@ -110,11 +110,31 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
       restricted_services = ["bigtable.googleapis.com"]
     }
   }
+
+  service_perimeters {
+    name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+    title          = "%s"
+    perimeter_type = "PERIMETER_TYPE_REGULAR"
+    status {
+      restricted_services = ["bigquery.googleapis.com"]
+      egress_policies {
+        egress_to {
+          external_resources = ["s3://bucket1"]
+          operations {
+            service_name = "bigquery.googleapis.com"
+            method_selectors {
+              method = "*"
+            }
+          }
+        }
+      }
+    }
+  }
 }
-`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName1, perimeterTitleName1, perimeterTitleName2, perimeterTitleName2)
+`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName1, perimeterTitleName1, perimeterTitleName2, perimeterTitleName2, perimeterTitleName3, perimeterTitleName3)
 }
 
-func testAccAccessContextManagerServicePerimeters_update(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3 string) string {
+func testAccAccessContextManagerServicePerimeters_update(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3, perimeterTitleName4 string) string {
 	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
@@ -165,8 +185,28 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
       restricted_services = ["bigtable.googleapis.com"]
     }
   }
+
+  service_perimeters {
+    name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+    title          = "%s"
+    perimeter_type = "PERIMETER_TYPE_REGULAR"
+    status {
+      restricted_services = ["bigquery.googleapis.com"]
+      egress_policies {
+        egress_to {
+          external_resources = ["s3://bucket2"]
+          operations {
+            service_name = "bigquery.googleapis.com"
+            method_selectors {
+              method = "*"
+            }
+          }
+        }
+      }
+    }
+  }
 }
-`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName1, perimeterTitleName1, perimeterTitleName2, perimeterTitleName2, perimeterTitleName3, perimeterTitleName3)
+`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName1, perimeterTitleName1, perimeterTitleName2, perimeterTitleName2, perimeterTitleName3, perimeterTitleName3, perimeterTitleName4, perimeterTitleName4)
 }
 
 func testAccAccessContextManagerServicePerimeters_empty(org, policyTitle, levelTitleName string) string {


### PR DESCRIPTION
Update accesscontextmanager to include externalResources in egressTo, which is a list of external resources that are allowed to be accessed.

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: Added `external_resources` to `egress_to` in `google_access_context_manager_service_perimeter` and `google_access_context_manager_service_perimeters` resource
```
