### PR TITLE
Add ancestors into test comparison

### DIFF
--- a/mmv1/third_party/validator/tests/source/read_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/read_test.go.erb
@@ -51,20 +51,9 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 
 			// Unmarshal payload from testfile into `want` variable.
 			f := filepath.Join(dir, c.name+".json")
-			payload, err := ioutil.ReadFile(f)
+			want, err := readExpectedTestFile(f)
 			if err != nil {
-				t.Fatalf("cannot open %s, got: %s", f, err)
-			}
-			var want []google.Asset
-			if err := json.Unmarshal(payload, &want); err != nil {
-				t.Fatalf("cannot unmarshal JSON into assets: %s", err)
-			}
-			for ix := range want {
-				ancestors, err := ancestryPathToAncestors(want[ix].Ancestry)
-				if err != nil {
-					t.Fatalf("failed to convert to ancestors: %s", err)
-				}
-				want[ix].Ancestors = ancestors
+				t.Fatal(err)
 			}
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")

--- a/mmv1/third_party/validator/tests/source/read_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/read_test.go.erb
@@ -22,7 +22,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		name string
 	}{
 		// read-only, the following tests are not in cli_test or
-		// have unique paramters that separate them
+		// have unique parameters that separate them
 		{name: "example_project_create"},
 		{name: "example_project_update"},
 		{name: "example_project_iam_binding"},
@@ -58,6 +58,13 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 			var want []google.Asset
 			if err := json.Unmarshal(payload, &want); err != nil {
 				t.Fatalf("cannot unmarshal JSON into assets: %s", err)
+			}
+			for ix := range want {
+				ancestors, err := ancestryPathToAncestors(want[ix].Ancestry)
+				if err != nil {
+					t.Fatalf("failed to convert to ancestors: %s", err)
+				}
+				want[ix].Ancestors = ancestors
 			}
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")

--- a/mmv1/third_party/validator/tests/source/utils_test.go
+++ b/mmv1/third_party/validator/tests/source/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -30,22 +29,9 @@ func testConvertCommand(t *testing.T, dir, name string, offline bool, compare co
 	}
 
 	// Load expected assets
-	var expectedRaw []byte
-	testfile := filepath.Join(dir, name+".json")
-	expectedRaw, err := ioutil.ReadFile(testfile)
+	expected, err := readExpectedTestFile(filepath.Join(dir, name+".json"))
 	if err != nil {
-		t.Fatalf("Error reading %v: %v", testfile, err)
-	}
-	var expected []google.Asset
-	if err := json.Unmarshal(expectedRaw, &expected); err != nil {
-		t.Fatalf("unmarshaling: %v", err)
-	}
-	for ix := range expected {
-		ancestors, err := ancestryPathToAncestors(expected[ix].Ancestry)
-		if err != nil {
-			t.Fatalf("failed to convert to ancestors: %s", err)
-		}
-		expected[ix].Ancestors = ancestors
+		t.Fatal(err)
 	}
 
 	// Get converted assets

--- a/mmv1/third_party/validator/tests/source/utils_test.go
+++ b/mmv1/third_party/validator/tests/source/utils_test.go
@@ -40,6 +40,13 @@ func testConvertCommand(t *testing.T, dir, name string, offline bool, compare co
 	if err := json.Unmarshal(expectedRaw, &expected); err != nil {
 		t.Fatalf("unmarshaling: %v", err)
 	}
+	for ix := range expected {
+		ancestors, err := ancestryPathToAncestors(expected[ix].Ancestry)
+		if err != nil {
+			t.Fatalf("failed to convert to ancestors: %s", err)
+		}
+		expected[ix].Ancestors = ancestors
+	}
 
 	// Get converted assets
 	var actualRaw []byte


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/GoogleCloudPlatform/terraform-validator/issues/105
Adding ancestors into Asset, and update test comparison logic to derive ancestors from ancestry path for the expected object. 



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
