### PR TITLE
Fix `instances` descriptions in instance group

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group.go.erb
@@ -66,7 +66,7 @@ func resourceComputeInstanceGroup() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         selfLinkRelativePathHash,
-				Description: `List of instances in the group. They should be given as self_link URLs. When adding instances they must all be in the same network and zone as the instance group.`,
+				Description: `The list of instances in the group, in `self_link` format. When adding instances they must all be in the same network and zone as the instance group.`,
 			},
 
 			"named_port": {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -135,9 +135,8 @@ The following arguments are supported:
 * `description` - (Optional) An optional textual description of the instance
     group.
 
-* `instances` - (Optional) List of instances in the group. They should be given
-    as either self_link or id. When adding instances they must all be in the same
-    network and zone as the instance group.
+* `instances` - (Optional) The list of instances in the group, in `self_link` format.
+    When adding instances they must all be in the same network and zone as the instance group.
 
 * `named_port` - (Optional) The named port configuration. See the section below
     for details on configuration. Structure is [documented below](#nested_named_port).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10797

Seems like there was drift between the resource code and the docs- `id` and `self_link` used to be the same format, but that was changed in `3.0.0`. https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_3_upgrade#id-format-changes. Saying that ids are similar to `self_link` is... not very true. We use GCE's partial URI format, the resource name from google.aip.dev/122 for the most part.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
