### PR TITLE
Prometheus

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3706,7 +3706,7 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	config := l[0].(map[string]interface{})
 <%# In version == 'ga' enable_components will always be specified. %>
 	if v, ok := config["enable_components"]; ok && len(v.([]interface{})) > 0 {
-		enable_components := v.([]interface{})[0].([]interface{})
+		enable_components := v.([]interface{})
 		mc.ComponentConfig = &container.MonitoringComponentConfig{
 			EnableComponents: convertStringArr(enable_components),
 		}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3703,31 +3703,24 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-<% if version == 'ga' -%>
-	config := l[0].(map[string]interface{})
-	return &container.MonitoringConfig{
-		ComponentConfig: &container.MonitoringComponentConfig{
-			EnableComponents: convertStringArr(config["enable_components"].([]interface{})),
-		},
-	}
-<% end -%>
-<% if version == 'beta' -%>
 	mc := &container.MonitoringConfig{}
 	config := l[0].(map[string]interface{})
+	// In version == 'ga' enable_components will always be specified
 	if v, ok := config["enable_components"]; ok && len(v.([]interface{})) > 0 {
 		enable_components := v.([]interface{})[0].([]interface{})
 		mc.ComponentConfig = &container.MonitoringComponentConfig{
 			EnableComponents: convertStringArr(enable_components),
 		}
 	}
+<% if version == 'beta' -%>
 	if v, ok := config["managed_prometheus"]; ok && len(v.([]interface{})) > 0 {
 		managed_prometheus := v.([]interface{})[0].(map[string]interface{})
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
 	}
-	return mc
 <% end -%>
+	return mc
 }
 
 <% unless version == 'ga' -%>

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -743,11 +743,14 @@ func resourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enable_components": {
 							Type:        schema.TypeList,
-							Required:    true,
 <% if version == "ga" -%>
+							Required:    true,
 							Description: `GKE components exposing metrics. Valid values include SYSTEM_COMPONENTS.`,
 <% end -%>
 <% if version == "beta" -%>
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
 							Description: `GKE components exposing metrics. Valid values include SYSTEM_COMPONENTS and WORKLOADS.`,
 <% end -%>
 							Elem: &schema.Schema{
@@ -760,6 +763,24 @@ func resourceContainerCluster() *schema.Resource {
 <% end -%>
 							},
 						},
+<% if version == "beta" -%>
+						"managed_prometheus": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `Configuration for Google Cloud Managed Services for Prometheus.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether or not the managed collection is enabled.`,
+									},
+								},
+							},
+						},
+<% end -%>
 					},
 				},
 			},
@@ -3682,13 +3703,31 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-
+<% if version == 'ga' -%>
 	config := l[0].(map[string]interface{})
 	return &container.MonitoringConfig{
 		ComponentConfig: &container.MonitoringComponentConfig{
 			EnableComponents: convertStringArr(config["enable_components"].([]interface{})),
 		},
 	}
+<% end -%>
+<% if version == 'beta' -%>
+	mc := &container.MonitoringConfig{}
+	config := l[0].(map[string]interface{})
+	if v, ok := config["enable_components"]; ok && len(v.([]interface{})) > 0 {
+		enable_components := v.([]interface{})[0].([]interface{})
+		mc.ComponentConfig = &container.MonitoringComponentConfig{
+			EnableComponents: convertStringArr(enable_components),
+		}
+	}
+	if v, ok := config["managed_prometheus"]; ok && len(v.([]interface{})) > 0 {
+		managed_prometheus := v.([]interface{})[0].(map[string]interface{})
+		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
+			Enabled: managed_prometheus["enabled"].(bool),
+		}
+	}
+	return mc
+<% end -%>
 }
 
 <% unless version == 'ga' -%>
@@ -4216,6 +4255,11 @@ func flattenMonitoringConfig(c *container.MonitoringConfig) []map[string]interfa
 	return []map[string]interface{}{
 		{
 			"enable_components":        c.ComponentConfig.EnableComponents,
+<% if version == 'beta' -%>
+			"managed_prometheus": 		[]map[string]interface{}{
+				{"enabled": c.ManagedPrometheusConfig.Enabled},
+			},
+<% end -%>
 		},
 	}
 }

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -4245,16 +4245,16 @@ func flattenMonitoringConfig(c *container.MonitoringConfig) []map[string]interfa
 		return nil
 	}
 
-	result := []map[string]interface{}{}
+	result := make(map[string]interface{})
 	if c.ComponentConfig != nil {
 		result["enable_components"] = c.ComponentConfig.EnableComponents
 	}
 <% if version == 'beta' -%>
-	if c.ManagedPrometheus != nil {
+	if c.ManagedPrometheusConfig != nil {
 		result["managed_prometheus"] = flattenManagedPrometheusConfig(c.ManagedPrometheusConfig)
 	}
 <% end -%>
-	return result
+	return []map[string]interface{}{result}
 }
 
 <% if version == 'beta' -%>

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -750,7 +750,6 @@ func resourceContainerCluster() *schema.Resource {
 <% if version == "beta" -%>
 							Optional:    true,
 							Computed:    true,
-							MaxItems:    1,
 							Description: `GKE components exposing metrics. Valid values include SYSTEM_COMPONENTS and WORKLOADS.`,
 <% end -%>
 							Elem: &schema.Schema{

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3705,7 +3705,7 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	}
 	mc := &container.MonitoringConfig{}
 	config := l[0].(map[string]interface{})
-	// In version == 'ga' enable_components will always be specified
+<%# In version == 'ga' enable_components will always be specified. %>
 	if v, ok := config["enable_components"]; ok && len(v.([]interface{})) > 0 {
 		enable_components := v.([]interface{})[0].([]interface{})
 		mc.ComponentConfig = &container.MonitoringComponentConfig{
@@ -4245,17 +4245,27 @@ func flattenMonitoringConfig(c *container.MonitoringConfig) []map[string]interfa
 		return nil
 	}
 
+	result := []map[string]interface{}{}
+	if c.ComponentConfig != nil {
+		result["enable_components"] = c.ComponentConfig.EnableComponents
+	}
+<% if version == 'beta' -%>
+	if c.ManagedPrometheus != nil {
+		result["managed_prometheus"] = flattenManagedPrometheusConfig(c.ManagedPrometheusConfig)
+	}
+<% end -%>
+	return result
+}
+
+<% if version == 'beta' -%>
+func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
-			"enable_components":        c.ComponentConfig.EnableComponents,
-<% if version == 'beta' -%>
-			"managed_prometheus": 		[]map[string]interface{}{
-				{"enabled": c.ManagedPrometheusConfig.Enabled},
-			},
-<% end -%>
+			"enabled": c != nil && c.Enabled,
 		},
 	}
 }
+<% end -%>
 
 func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2054,6 +2054,23 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Back to basic settings to test setting Prometheus on its own
+			{
+				Config: testAccContainerCluster_basic(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigPrometheusOnly(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 <% end -%>
 			{
 				Config: testAccContainerCluster_basic(clusterName),
@@ -5250,6 +5267,21 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   monitoring_config {
          enable_components = [ "SYSTEM_COMPONENTS", "WORKLOADS" ]
+         managed_prometheus {
+                 enabled = true
+         }
+  }
+}
+`, name)
+}
+
+func testAccContainerCluster_withMonitoringConfigPrometheusOnly(name string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
          managed_prometheus {
                  enabled = true
          }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2012,6 +2012,61 @@ func TestAccContainerCluster_withLoggingConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_basic(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigEnabled(clusterName),
+			},
+<% if version == 'beta' -%>
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigUpdated(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigPrometheusUpdated(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+<% end -%>
+			{
+				Config: testAccContainerCluster_basic(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withSoleTenantGroup(t *testing.T) {
 	t.Parallel()
 
@@ -5159,6 +5214,50 @@ resource "google_container_cluster" "primary" {
 }
 `, name)
 }
+
+func testAccContainerCluster_withMonitoringConfigEnabled(name string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
+      enable_components = [ "SYSTEM_COMPONENTS" ]
+  }
+}
+`, name)
+}
+
+<% if version == 'beta' -%>
+func testAccContainerCluster_withMonitoringConfigUpdated(name string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
+         enable_components = [ "SYSTEM_COMPONENTS", "WORKLOADS" ]
+  }
+}
+`, name)
+}
+
+func testAccContainerCluster_withMonitoringConfigPrometheusUpdated(name string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
+         enable_components = [ "SYSTEM_COMPONENTS", "WORKLOADS" ]
+         managed_prometheus {
+                 enabled = true
+         }
+  }
+}
+`, name)
+}
+<% end -%>
 
 func testAccContainerCluster_withSoleTenantGroup(name string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -489,7 +489,13 @@ as "Intel Haswell" or "Intel Sandy Bridge".
 
 <a name="nested_monitoring_config"></a>The `monitoring_config` block supports:
 
-*  `enable_components` - (Required) The GKE components exposing logs. `SYSTEM_COMPONENTS` and in beta provider, both `SYSTEM_COMPONENTS` and `WORKLOADS` are supported.
+*  `enable_components` - (Optional) The GKE components exposing metrics. `SYSTEM_COMPONENTS` and in beta provider, both `SYSTEM_COMPONENTS` and `WORKLOADS` are supported. (`WORKLOADS` is deprecated and removed in GKE 1.24.)
+
+*  `managed_prometheus` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for Managed Service for Prometheus. Structure is [documented below](#nested_managed_prometheus).
+
+<a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
+
+* `enabled` - (Required) Whether or not the managed collection is enabled.
 
 <a name="nested_maintenance_policy"></a>The `maintenance_policy` block supports:
 * `daily_maintenance_window` - (Optional) structure documented below.


### PR DESCRIPTION
This PR is a fork of PR #5812

Adds support for Managed Service for Prometheus to google_container_cluster. Closes https://github.com/hashicorp/terraform-provider-google/issues/11224 and corresponding to https://github.com/hashicorp/terraform-provider-google-beta/pull/4105

I omitted 1 commit, which was the commit removing the beta flags because:
1. It was causing an error because WORKLOADS is in "beta" (actually deprecated).
2. GMP is still in beta in GKE (specifically Autopilot) as per [pintohutch](https://github.com/pintohutch).

See the original PR for more information.

I was not able to run the unit tests or linters because due to errors unrelated to this PR.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: add `managed_prometheus` to `monitoring_config` in `google_container_cluster` (beta)
```
