### PR TITLE
Added ability to update service accounts

### DIFF
--- a/mmv1/products/cloudfunctions2/api.yaml
+++ b/mmv1/products/cloudfunctions2/api.yaml
@@ -263,7 +263,6 @@ objects:
             output: true
           - !ruby/object:Api::Type::String
             name: 'serviceAccountEmail'
-            output: true
             description: 'The email of the service account for this function.'
           - !ruby/object:Api::Type::Boolean 
             name: 'allTrafficOnLatestRevision'
@@ -296,7 +295,6 @@ objects:
               as the transport topic for the event delivery.
           - !ruby/object:Api::Type::String
             name: 'serviceAccountEmail'
-            output: true
             description: 'The email of the service account for this function.'
           - !ruby/object:Api::Type::Enum 
             name: 'retryPolicy'

--- a/mmv1/products/cloudfunctions2/terraform.yaml
+++ b/mmv1/products/cloudfunctions2/terraform.yaml
@@ -62,3 +62,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       serviceConfig.service: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      serviceConfig.serviceAccountEmail: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      eventTrigger.serviceAccountEmail: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true

--- a/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
@@ -1,3 +1,9 @@
+resource "google_service_account" "account" {
+  provider = google-beta
+  account_id = "test-service-account"
+  display_name = "Test Service Account"
+}
+
 resource "google_pubsub_topic" "sub" {
   provider = google-beta
   name = "pubsub"
@@ -47,6 +53,7 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     }
     ingress_settings = "ALLOW_INTERNAL_ONLY"
     all_traffic_on_latest_revision = true
+    service_account_email = google_service_account.account.email
   }
 
   event_trigger {
@@ -54,5 +61,6 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     event_type = "google.cloud.pubsub.topic.v1.messagePublished"
     pubsub_topic = google_pubsub_topic.sub.id
     retry_policy = "RETRY_POLICY_RETRY"
+    service_account_email = google_service_account.account.email
   }
 }


### PR DESCRIPTION
Removed output flag on service accounts for event trigger and service config to allow users to update service accounts.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to --> Added ability to configure service accounts and removed output only flag. 
https://github.com/hashicorp/terraform-provider-google/issues/11388

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
Added ability to configure service accounts for event triggers and service config. (beta)
```
