### PR TITLE
Add `include_build_logs` to `google_cloudbuild_trigger`

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -78,6 +78,15 @@ objects:
           ([PROJECT_NUM]@system.gserviceaccount.com) will be used instead.
           
           Format: projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT_ID_OR_EMAIL}
+      - !ruby/object:Api::Type::Enum
+        name: 'includeBuildLogs'
+        values:
+          - :INCLUDE_BUILD_LOGS_UNSPECIFIED
+          - :INCLUDE_BUILD_LOGS_WITH_STATUS
+        description: |
+          Build logs will be sent back to GitHub as part of the checkrun
+          result.  Values can be INCLUDE_BUILD_LOGS_UNSPECIFIED or
+          INCLUDE_BUILD_LOGS_WITH_STATUS
       - !ruby/object:Api::Type::String
         name: 'filename'
         exactly_one_of:

--- a/mmv1/products/cloudbuild/terraform.yaml
+++ b/mmv1/products/cloudbuild/terraform.yaml
@@ -33,6 +33,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "cloudbuild_trigger_service_account"
         primary_resource_id: "service-account-trigger"
       - !ruby/object:Provider::Terraform::Examples
+        name: "cloudbuild_trigger_include_build_logs"
+        primary_resource_id: "include-build-logs-trigger"
+        skip_test: true
+      - !ruby/object:Provider::Terraform::Examples
         name: "cloudbuild_trigger_pubsub_config"
         primary_resource_id: "pubsub-config-trigger"
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_include_build_logs.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_include_build_logs.tf.erb
@@ -1,0 +1,14 @@
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:primary_resource_id] %>"
+  filename = "cloudbuild.yaml"
+
+  github {
+    owner = "hashicorp"
+    name  = "terraform-provider-google-beta"
+    push {
+      branch = "^main$"
+    }
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}


### PR DESCRIPTION
Add support for `include_build_logs` to the `google_cloudbuild_trigger` resource
    
Fixes hashicorp/terraform-provider-google#11762

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: Added `include_build_logs` to `google_cloudbuild_trigger`
```
