### PR TITLE
Add samples for PubSub with Cloud Run tutorials

### DIFF
--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -72,13 +72,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_pubsub"
         primary_resource_type: "google_cloud_run_service"
-        primary_resource_id: "cloud_run"
+        primary_resource_id: "default"
+        skip_vcr: true
+        skip_test: true
         vars:
           cloud_run_service_name: "cloud_run_service_name"
           pubsub_topic: "pubsub_topic"
           pubsub_subscription: "pubsub_subscription"
-        test_env_vars:
-          project: :PROJECT_NAME
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_basic"
         primary_resource_id: "default"

--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -79,7 +79,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           pubsub_subscription: "pubsub_subscription"
         test_env_vars:
           project: :PROJECT_NAME
-        min_version: beta
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_basic"
         primary_resource_id: "default"

--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -70,6 +70,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       actions: ['create', 'update']
     examples:
       - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_run_service_pubsub"
+        primary_resource_type: "google_cloud_run_service"
+        primary_resource_id: "cloud_run"
+        vars:
+          cloud_run_service_name: "cloud_run_service_name"
+          pubsub_topic: "pubsub_topic"
+          pubsub_subscription: "pubsub_subscription"
+        test_env_vars:
+          project: :PROJECT_NAME
+        min_version: beta
+      - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_basic"
         primary_resource_id: "default"
         primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random_suffix\"])"

--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -73,10 +73,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "cloud_run_service_pubsub"
         primary_resource_type: "google_cloud_run_service"
         primary_resource_id: "default"
-        skip_vcr: true
         skip_test: true
         vars:
           cloud_run_service_name: "cloud_run_service_name"
+          cloud_run_service_url: "cloud_run_service_url"
+          pubsub_sa: "pubsub_sa"
           pubsub_topic: "pubsub_topic"
           pubsub_subscription: "pubsub_subscription"
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
@@ -2,7 +2,6 @@
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
     name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
     location = "us-central1"
-
     template {
       spec {
             containers {
@@ -25,15 +24,14 @@ resource "google_service_account" "sa" {
 # [START cloud_run_service_pubsub_sa]
 
 locals {
-  cloud_run_url = google_cloud_run_service.cloud-run.status[0].url
+  cloud_run_url = google_cloud_run_service.default.status[0].url
   pubsub_sa= google_service_account.sa.email
 }
 
 # [START cloud_run_service_pubsub_run_invoke_permissions]
 resource "google_cloud_run_service_iam_binding" "binding" {
-  location = google_cloud_run_service.cloud-run.location
-  project = google_cloud_run_service.cloud-run.project
-  service = google_cloud_run_service.cloud-run.name
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
   role = "roles/run.invoker"
   members = ["serviceAccount:${local.pubsub_sa}"]
 }
@@ -41,7 +39,6 @@ resource "google_cloud_run_service_iam_binding" "binding" {
 
 # [START cloud_run_service_pubsub_token_permissions]
 resource "google_project_iam_binding" "project" {
-  project = "<%= ctx[:test_env_vars]["project"] %>"
   role    = "roles/iam.serviceAccountTokenCreator"
   members = ["serviceAccount:${local.pubsub_sa}"]
 }

--- a/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
@@ -1,0 +1,62 @@
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+    name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+    location = "us-central1"
+
+    template {
+      spec {
+            containers {
+                image = "gcr.io/cloudrun/hello"
+            }
+      }
+    }
+    traffic {
+      percent         = 100
+      latest_revision = true
+    }
+}
+
+resource "google_service_account" "sa" {
+  account_id   = "cloud-run-pubsub-invoker"
+  display_name = "Cloud Run Pub/Sub Invoker"
+}
+
+locals {
+  cloud_run_url = google_cloud_run_service.cloud-run.status[0].url
+  pubsub_sa= google_service_account.sa.email
+}
+
+resource "google_cloud_run_service_iam_binding" "binding" {
+  location = google_cloud_run_service.cloud-run.location
+  project = google_cloud_run_service.cloud-run.project
+  service = google_cloud_run_service.cloud-run.name
+  role = "roles/run.invoker"
+  members = ["serviceAccount:${local.pubsub_sa}"]
+}
+
+resource "google_project_iam_binding" "project" {
+  project = "<%= ctx[:test_env_vars]["project"] %>"
+  role    = "roles/iam.serviceAccountTokenCreator"
+  members = ["serviceAccount:${local.pubsub_sa}"]
+}
+
+
+# [START cloud_run_service_pubsub]
+resource "google_pubsub_topic" "topic" {
+  name = "<%= ctx[:vars]['pubsub_topic'] %>"
+}
+
+resource "google_pubsub_subscription" "subscription" {
+  name  = "<%= ctx[:vars]['pubsub_subscription'] %>"
+  topic = google_pubsub_topic.topic.name
+
+  push_config {
+    push_endpoint = "${local.cloud_run_url}"
+    oidc_token {
+      service_account_email = "${local.pubsub_sa}"
+    }
+    attributes = {
+      x-goog-version = "v1"
+    }
+  }
+}
+# [END cloud_run_service_pubsub]

--- a/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
@@ -1,3 +1,4 @@
+# [START cloud_run_service_pubsub_service]
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
     name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
     location = "us-central1"
@@ -14,17 +15,21 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
       latest_revision = true
     }
 }
+# [END cloud_run_service_pubsub_service]
 
+# [START cloud_run_service_pubsub_sa]
 resource "google_service_account" "sa" {
   account_id   = "cloud-run-pubsub-invoker"
   display_name = "Cloud Run Pub/Sub Invoker"
 }
+# [START cloud_run_service_pubsub_sa]
 
 locals {
   cloud_run_url = google_cloud_run_service.cloud-run.status[0].url
   pubsub_sa= google_service_account.sa.email
 }
 
+# [START cloud_run_service_pubsub_run_invoke_permissions]
 resource "google_cloud_run_service_iam_binding" "binding" {
   location = google_cloud_run_service.cloud-run.location
   project = google_cloud_run_service.cloud-run.project
@@ -32,19 +37,23 @@ resource "google_cloud_run_service_iam_binding" "binding" {
   role = "roles/run.invoker"
   members = ["serviceAccount:${local.pubsub_sa}"]
 }
+# [END cloud_run_service_pubsub_run_invoke_permissions]
 
+# [START cloud_run_service_pubsub_token_permissions]
 resource "google_project_iam_binding" "project" {
   project = "<%= ctx[:test_env_vars]["project"] %>"
   role    = "roles/iam.serviceAccountTokenCreator"
   members = ["serviceAccount:${local.pubsub_sa}"]
 }
+# [END cloud_run_service_pubsub_token_permissions]
 
-
-# [START cloud_run_service_pubsub]
+# [START cloud_run_service_pubsub_topic]
 resource "google_pubsub_topic" "topic" {
   name = "<%= ctx[:vars]['pubsub_topic'] %>"
 }
+# [END cloud_run_service_pubsub_topic]
 
+# [START cloud_run_service_pubsub_sub]
 resource "google_pubsub_subscription" "subscription" {
   name  = "<%= ctx[:vars]['pubsub_subscription'] %>"
   topic = google_pubsub_topic.topic.name
@@ -59,4 +68,4 @@ resource "google_pubsub_subscription" "subscription" {
     }
   }
 }
-# [END cloud_run_service_pubsub]
+# [END cloud_run_service_pubsub_sub]

--- a/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
@@ -21,26 +21,21 @@ resource "google_service_account" "sa" {
   account_id   = "cloud-run-pubsub-invoker"
   display_name = "Cloud Run Pub/Sub Invoker"
 }
-# [START cloud_run_service_pubsub_sa]
-
-locals {
-  cloud_run_url = google_cloud_run_service.default.status[0].url
-  pubsub_sa= google_service_account.sa.email
-}
+# [END cloud_run_service_pubsub_sa]
 
 # [START cloud_run_service_pubsub_run_invoke_permissions]
 resource "google_cloud_run_service_iam_binding" "binding" {
   location = google_cloud_run_service.default.location
   service = google_cloud_run_service.default.name
   role = "roles/run.invoker"
-  members = ["serviceAccount:${local.pubsub_sa}"]
+  members = ["serviceAccount:<%= ctx[:pubsub_sa] %>"]
 }
 # [END cloud_run_service_pubsub_run_invoke_permissions]
 
 # [START cloud_run_service_pubsub_token_permissions]
 resource "google_project_iam_binding" "project" {
   role    = "roles/iam.serviceAccountTokenCreator"
-  members = ["serviceAccount:${local.pubsub_sa}"]
+  members = ["serviceAccount:<%= ctx[:pubsub_sa] %>"]
 }
 # [END cloud_run_service_pubsub_token_permissions]
 
@@ -54,11 +49,10 @@ resource "google_pubsub_topic" "topic" {
 resource "google_pubsub_subscription" "subscription" {
   name  = "<%= ctx[:vars]['pubsub_subscription'] %>"
   topic = google_pubsub_topic.topic.name
-
   push_config {
-    push_endpoint = "${local.cloud_run_url}"
+    push_endpoint = "<%= ctx[:cloud_run_service_url] %>"
     oidc_token {
-      service_account_email = "${local.pubsub_sa}"
+      service_account_email = "<%= ctx[:pubsub_sa] %>"
     }
     attributes = {
       x-goog-version = "v1"


### PR DESCRIPTION
Related issue: https://github.com/hashicorp/terraform-provider-google/issues/11856

To contribute to the following:
https://cloud.google.com/run/docs/events/pubsub
https://cloud.google.com/run/docs/tutorials/pubsub
https://cloud.google.com/run/docs/triggering/pubsub-push

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
google_cloud_run_service: added samples for pubsub tutorials
```
