### PR TITLE
Adding new samples for PubSub with Cloud Run tutorials

### DIFF
--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -70,6 +70,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       actions: ['create', 'update']
     examples:
       - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_run_service_pubsub"
+        primary_resource_type: "google_cloud_run_service"
+        primary_resource_id: "default"
+        skip_test: true
+        vars:
+          cloud_run_service_name: "cloud_run_service_name"
+          cloud_run_service_url: "cloud_run_service_url"
+          pubsub_sa: "pubsub_sa"
+          pubsub_topic: "pubsub_topic"
+          pubsub_subscription: "pubsub_subscription"
+      - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_basic"
         primary_resource_id: "default"
         primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random_suffix\"])"

--- a/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_pubsub.tf.erb
@@ -1,0 +1,62 @@
+# [START cloud_run_service_pubsub_service]
+resource "<%= ctx[:vars]['primary_resource_type'] %>" "<%= ctx[:primary_resource_id] %>" {
+    name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+    location = "us-central1"
+    template {
+      spec {
+            containers {
+                image = "gcr.io/cloudrun/hello"
+            }
+      }
+    }
+    traffic {
+      percent         = 100
+      latest_revision = true
+    }
+}
+# [END cloud_run_service_pubsub_service]
+
+# [START cloud_run_service_pubsub_sa]
+resource "google_service_account" "sa" {
+  account_id   = "cloud-run-pubsub-invoker"
+  display_name = "Cloud Run Pub/Sub Invoker"
+}
+# [END cloud_run_service_pubsub_sa]
+
+# [START cloud_run_service_pubsub_run_invoke_permissions]
+resource "google_cloud_run_service_iam_binding" "binding" {
+  location = google_cloud_run_service["<%= ctx[:primary_resource_id] %>"].location
+  service = google_cloud_run_service["<%= ctx[:primary_resource_id] %>"].name
+  role = "roles/run.invoker"
+  members = ["serviceAccount:<%= ctx[:vars]['pubsub_sa'] %>"]
+}
+# [END cloud_run_service_pubsub_run_invoke_permissions]
+
+# [START cloud_run_service_pubsub_token_permissions]
+resource "google_project_iam_binding" "project" {
+  role    = "roles/iam.serviceAccountTokenCreator"
+  members = ["serviceAccount:<%= ctx[:vars]['pubsub_sa'] %>"]
+}
+# [END cloud_run_service_pubsub_token_permissions]
+
+# [START cloud_run_service_pubsub_topic]
+resource "google_pubsub_topic" "topic" {
+  name = "<%= ctx[:vars]['pubsub_topic'] %>"
+}
+# [END cloud_run_service_pubsub_topic]
+
+# [START cloud_run_service_pubsub_sub]
+resource "google_pubsub_subscription" "subscription" {
+  name  = "<%= ctx[:vars]['pubsub_subscription'] %>"
+  topic = google_pubsub_topic["<%= ctx[:vars]['pubsub_topic'] %>"].name
+  push_config {
+    push_endpoint = "<%= ctx[:vars]['cloud_run_service_url'] %>"
+    oidc_token {
+      service_account_email = "<%= ctx[:vars]['pubsub_sa'] %>"
+    }
+    attributes = {
+      x-goog-version = "v1"
+    }
+  }
+}
+# [END cloud_run_service_pubsub_sub]


### PR DESCRIPTION
Related issue: https://github.com/hashicorp/terraform-provider-google/issues/11856

To contribute to the following:
https://cloud.google.com/run/docs/events/pubsub
https://cloud.google.com/run/docs/tutorials/pubsub
https://cloud.google.com/run/docs/triggering/pubsub-push

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
google_cloud_run_service: added samples for pubsub tutorials
```
