### PR TITLE
Initial implementation of tpu_config in container cluster

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -543,9 +543,46 @@ func resourceContainerCluster() *schema.Resource {
 				ForceNew:    true,
 				Description: `Whether to enable Cloud TPU resources in this cluster.`,
 <% unless version == 'ga' -%>
-				Default: false,
+				ExactlyOneOf: []string{
+					"enable_tpu",
+					"tpu_config",
+				},
+				Computed: true,
+				// TODO: deprecate when tpu_config is correctly returned by the API
+				// Deprecated: "Deprecated in favor of tpu_config",
 <% end -%>
 			},
+
+<% unless version == 'ga' -%>
+			"tpu_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: `TPU configuration for the cluster.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							ForceNew:    true,
+							Description: `Whether Cloud TPU integration is enabled or not`,
+						},
+						"ipv4_cidr_block": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `IPv4 CIDR block reserved for Cloud TPU in the VPC.`,
+						},
+						"use_service_networking": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Whether to use service networking for Cloud TPU or not`,
+						},
+					},
+				},
+			},
+<% end -%>
 
 			"enable_legacy_abac": {
 				Type:        schema.TypeBool,
@@ -1660,6 +1697,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 <% unless version == 'ga' -%>
 	if v, ok := d.GetOk("identity_service_config"); ok {
 		cluster.IdentityServiceConfig = expandIdentityServiceConfig(v)
+	}
+
+	if v, ok := d.GetOk("tpu_config"); ok {
+		cluster.TpuConfig = expandContainerClusterTpuConfig(v)
 	}
 
 <% end -%>
@@ -3723,6 +3764,19 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 }
 
 <% unless version == 'ga' -%>
+func expandContainerClusterTpuConfig(configured interface{}) *container.TpuConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	config := l[0].(map[string]interface{})
+	return &container.TpuConfig{
+		Enabled:              config["enabled"].(bool),
+		UseServiceNetworking: config["use_service_networking"].(bool),
+	}
+}
+
 func flattenNotificationConfig(c *container.NotificationConfig) []map[string]interface{} {
 	if c == nil {
 		return nil

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -543,10 +543,7 @@ func resourceContainerCluster() *schema.Resource {
 				ForceNew:    true,
 				Description: `Whether to enable Cloud TPU resources in this cluster.`,
 <% unless version == 'ga' -%>
-				ExactlyOneOf: []string{
-					"enable_tpu",
-					"tpu_config",
-				},
+				ConflictsWith: []string{"tpu_config"},
 				Computed: true,
 				// TODO: deprecate when tpu_config is correctly returned by the API
 				// Deprecated: "Deprecated in favor of tpu_config",

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2547,6 +2547,32 @@ func TestAccContainerCluster_withDNSConfig(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccContainerCluster_withTPUConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withTPUConfig(containerNetName, clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_tpu_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// TODO: remove when tpu_config can be read from the API
+				ImportStateVerifyIgnore: []string{"tpu_config"},
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccContainerCluster_masterAuthorizedNetworksDisabled(t *testing.T, resource_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resource_name]
@@ -5320,4 +5346,58 @@ resource "google_container_cluster" "primary" {
   }
 }
 `, name, name, name)
+}
+
+func testAccContainerCluster_withTPUConfig(network, cluster string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+	  
+resource "google_compute_subnetwork" "container_subnetwork" {
+	name                     = google_compute_network.container_network.name
+	network                  = google_compute_network.container_network.name
+	ip_cidr_range            = "10.0.36.0/24"
+	region                   = "us-central1"
+	private_ip_google_access = true
+
+	secondary_ip_range {
+		range_name    = "pod"
+		ip_cidr_range = "10.0.0.0/19"
+	}
+
+	secondary_ip_range {
+		range_name    = "svc"
+		ip_cidr_range = "10.0.32.0/22"
+	}
+}
+	
+resource "google_container_cluster" "with_tpu" {
+	name               = "%s"
+	location           = "us-central1-a"
+	initial_node_count = 1
+	
+	
+	tpu_config {
+		enabled                = true
+		use_service_networking = true
+	}
+	
+	network         = google_compute_network.container_network.name
+	subnetwork      = google_compute_subnetwork.container_subnetwork.name
+	networking_mode = "VPC_NATIVE"
+	
+	private_cluster_config {
+		enable_private_endpoint = true
+		enable_private_nodes    = true
+		master_ipv4_cidr_block  = "10.42.0.0/28"
+	}
+	
+	ip_allocation_policy {
+		cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
+		services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
+	}
+}
+`, network, cluster)
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -5348,6 +5348,8 @@ resource "google_container_cluster" "primary" {
 `, name, name, name)
 }
 
+
+<% unless version == 'ga' -%>
 func testAccContainerCluster_withTPUConfig(network, cluster string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
@@ -5401,3 +5403,4 @@ resource "google_container_cluster" "with_tpu" {
 }
 `, network, cluster)
 }
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -5375,7 +5375,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	}
 }
 	
-resource "google_container_cluster" "with_tpu" {
+resource "google_container_cluster" "with_tpu_config" {
 	name               = "%s"
 	location           = "us-central1-a"
 	initial_node_count = 1

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -5395,6 +5395,8 @@ resource "google_container_cluster" "with_tpu" {
 		enable_private_nodes    = true
 		master_ipv4_cidr_block  = "10.42.0.0/28"
 	}
+	master_authorized_networks_config {
+	}
 	
 	ip_allocation_policy {
 		cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11748

The API does not return `tpu_config` a this time, but moving forward without reading. Added https://github.com/hashicorp/terraform-provider-google/issues/11880 in the interim



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `tpu_config` to `google_container_cluster` (beta only)
```
