### PR TITLE
Add support for network tags in Autopilot clusters and NAP node pools

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1020,6 +1020,36 @@ func resourceContainerCluster() *schema.Resource {
 				ConflictsWith: []string{"enable_autopilot"},
 			},
 
+<% unless version == "ga" -%>
+			"node_pool_auto_config": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: emptyOrUnsetBlockDiffSuppress,
+				MaxItems:         1,
+				Description:      `Node pool configs that apply to all auto-provisioned node pools in autopilot clusters and node auto-provisioning enabled clusters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"network_tags": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: `Collection of Compute Engine network tags that can be applied to a node's underlying VM instance.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tags": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `List of network tags applied to auto-provisioned node pools.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+<% end -%>
+
 			"node_version": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1634,6 +1664,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		NotificationConfig: expandNotificationConfig(d.Get("notification_config")),
 		ConfidentialNodes: expandConfidentialNodes(d.Get("confidential_nodes")),
 		ResourceLabels: expandStringMap(d, "resource_labels"),
+<% unless version == 'ga' -%>
+		NodePoolAutoConfig: expandNodePoolAutoConfig(d.Get("node_pool_auto_config")),
+<% end -%>
 	}
 
 	v:= d.Get("enable_shielded_nodes")
@@ -1755,6 +1788,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("monitoring_config"); ok {
 		cluster.MonitoringConfig = expandMonitoringConfig(v)
 	}
+
+<% unless version == 'ga' -%>
+	if err := validateNodePoolAutoConfig(cluster); err != nil {
+		return err
+	}
+<% end -%>
 
 	if err := validatePrivateClusterConfig(cluster); err != nil {
 		return err
@@ -2117,6 +2156,12 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("monitoring_config", flattenMonitoringConfig(cluster.MonitoringConfig)); err != nil {
 		return err
 	}
+
+<% unless version == 'ga' -%>
+	if err := d.Set("node_pool_auto_config", flattenNodePoolAutoConfig(cluster.NodePoolAutoConfig)); err != nil {
+		return err
+	}
+<% end -%>
 
 	return nil
 }
@@ -3031,6 +3076,29 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s resource usage export config has been updated", d.Id())
 	}
 
+<% unless version == 'ga' -%>
+	if d.HasChange("node_pool_auto_config.0.network_tags.0.tags") {
+		tags := d.Get("node_pool_auto_config.0.network_tags.0.tags").([]interface{})
+
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredNodePoolAutoConfigNetworkTags: &container.NetworkTags{
+					Tags:            convertStringArr(tags),
+					ForceSendFields: []string{"Tags"},
+				},
+			},
+		}
+
+		updateF := updateFunc(req, "updating GKE cluster node pool auto config network tags")
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s node pool auto config network tags have been updated", d.Id())
+	}
+<% end -%>
+
 	d.Partial(false)
 
 <% unless version == 'ga' -%>
@@ -3925,6 +3993,36 @@ func expandContainerClusterAuthenticatorGroupsConfig(configured interface{}) *co
 	}
 }
 
+<% unless version == 'ga' -%>
+func expandNodePoolAutoConfig(configured interface{}) *container.NodePoolAutoConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	npac := &container.NodePoolAutoConfig{}
+	config := l[0].(map[string]interface{})
+
+	if v, ok := config["network_tags"]; ok && len(v.([]interface{})) > 0 {
+		npac.NetworkTags = expandNodePoolAutoConfigNetworkTags(v)
+	}
+	return npac
+}
+
+func expandNodePoolAutoConfigNetworkTags(configured interface{}) *container.NetworkTags {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	nt := &container.NetworkTags{}
+	config := l[0].(map[string]interface{})
+
+	if v, ok := config["tags"]; ok && len(v.([]interface{})) > 0 {
+		nt.Tags = convertStringArr(v.([]interface{}))
+	}
+	return nt
+}
+<% end -%>
+
 func flattenNotificationConfig(c *container.NotificationConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
@@ -4490,6 +4588,32 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
 }
 <% end -%>
 
+<% unless version == 'ga' -%>
+func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	if c.NetworkTags != nil {
+		result["network_tags"] = flattenNodePoolAutoConfigNetworkTags(c.NetworkTags)
+	}
+	return []map[string]interface{}{result}
+}
+
+func flattenNodePoolAutoConfigNetworkTags(c *container.NetworkTags) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	if c.Tags != nil {
+		result["tags"] = c.Tags
+	}
+	return []map[string]interface{}{result}
+}
+<% end -%>
+
 func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 
@@ -4704,3 +4828,18 @@ func BinaryAuthorizationDiffSuppress(k, old, new string, r *schema.ResourceData)
 
 	return false
 }
+
+<% unless version == 'ga' -%>
+func validateNodePoolAutoConfig(cluster *container.Cluster) error {
+	if cluster == nil || cluster.NodePoolAutoConfig == nil {
+		return nil
+	}
+	if cluster.NodePoolAutoConfig != nil && cluster.NodePoolAutoConfig.NetworkTags != nil && len(cluster.NodePoolAutoConfig.NetworkTags.Tags) > 0 {
+		if (cluster.Autopilot == nil || !cluster.Autopilot.Enabled) && (cluster.Autoscaling == nil || !cluster.Autoscaling.EnableNodeAutoprovisioning) {
+			return fmt.Errorf("node_pool_auto_config network tags can only be set if enable_autopilot or cluster_autoscaling is enabled")
+		}
+	}
+
+	return nil
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -12,6 +12,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+<% unless version == 'ga' -%>
+	container "google.golang.org/api/container/v1beta1"
+<% end -%>
 )
 
 func init() {
@@ -1770,7 +1774,7 @@ func TestAccContainerCluster_nodeAutoprovisioning(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autoprovisioning(clusterName, true),
+				Config: testAccContainerCluster_autoprovisioning(clusterName, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning",
 						"cluster_autoscaling.0.enabled", "true"),
@@ -1783,7 +1787,7 @@ func TestAccContainerCluster_nodeAutoprovisioning(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 			{
-				Config: testAccContainerCluster_autoprovisioning(clusterName, false),
+				Config: testAccContainerCluster_autoprovisioning(clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning",
 						"cluster_autoscaling.0.enabled", "false"),
@@ -1831,6 +1835,35 @@ func TestAccContainerCluster_nodeAutoprovisioningDefaults(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccContainerCluster_nodeAutoprovisioningNetworkTags(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autoprovisioning(clusterName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning",
+						"node_pool_auto_config.0.network_tags.0.tags.0", "test-network-tag"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autoprovisioning",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 	t.Parallel()
 
@@ -1873,7 +1906,7 @@ func TestAccContainerCluster_withAutopilot(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAutopilot(containerNetName, clusterName, "us-central1", true),
+				Config: testAccContainerCluster_withAutopilot(containerNetName, clusterName, "us-central1", true, false),
 			},
 			{
 				ResourceName: "google_container_cluster.with_autopilot",
@@ -1897,12 +1930,38 @@ func TestAccContainerCluster_errorAutopilotLocation(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerCluster_withAutopilot(containerNetName, clusterName, "us-central1-a", true),
+				Config:      testAccContainerCluster_withAutopilot(containerNetName, clusterName, "us-central1-a", true, false),
 				ExpectError: regexp.MustCompile(`Autopilot clusters must be regional clusters.`),
 			},
 		},
 	})
 }
+
+<% unless version == 'ga' -%>
+func TestAccContainerCluster_withAutopilotNetworkTags(t *testing.T) {
+	t.Parallel()
+
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", randString(t, 10))
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAutopilot(containerNetName, clusterName, "us-central1", true, true),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autopilot",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+<% end -%>
 
 func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
 	t.Parallel()
@@ -4133,7 +4192,7 @@ resource "google_container_cluster" "autoscaling_with_profile" {
 }
 <% end -%>
 
-func testAccContainerCluster_autoprovisioning(cluster string, autoprovisioning bool) string {
+func testAccContainerCluster_autoprovisioning(cluster string, autoprovisioning, withNetworkTag bool) string {
 	config := fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -4162,6 +4221,14 @@ resource "google_container_cluster" "with_autoprovisioning" {
 		config += `
   cluster_autoscaling {
     enabled = false
+  }`
+	}
+	if withNetworkTag {
+		config += `
+  node_pool_auto_config {
+    network_tags {
+      tags = ["test-network-tag"]
+    }
   }`
 	}
 	config += `
@@ -5410,8 +5477,8 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
-func testAccContainerCluster_withAutopilot(containerNetName string, clusterName string, location string, enabled bool) string {
-	return fmt.Sprintf(`
+func testAccContainerCluster_withAutopilot(containerNetName string, clusterName string, location string, enabled bool, withNetworkTag bool) string {
+	config := fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
 	name                    = "%s"
 	auto_create_subnetworks = false
@@ -5460,9 +5527,18 @@ resource "google_container_cluster" "with_autopilot" {
 	}
 	vertical_pod_autoscaling {
 		enabled = true
+	}`, containerNetName, clusterName, location, enabled)
+	if withNetworkTag {
+		config += `
+	node_pool_auto_config {
+		network_tags {
+			tags = ["test-network-tag"]
+		}
+	}`
 	}
-}
-`, containerNetName, clusterName, location, enabled)
+	config += `
+}`
+	return config
 }
 
 func testAccContainerCluster_withDNSConfig(clusterName string, clusterDns string, clusterDnsDomain string, clusterDnsScope string) string {
@@ -5686,5 +5762,88 @@ resource "google_container_cluster" "with_tpu_config" {
 	}
 }
 `, network, cluster)
+}
+<% end -%>
+
+<% unless version == 'ga' -%>
+func TestValidateNodePoolAutoConfig(t *testing.T) {
+	withTags := &container.NodePoolAutoConfig{
+		NetworkTags: &container.NetworkTags{
+			Tags: []string{"not-empty"},
+		},
+	}
+	noTags := &container.NodePoolAutoConfig{}
+
+	cases := map[string]struct {
+		Input       *container.Cluster
+		ExpectError bool
+	}{
+		"with tags, nap nil, autopilot nil": {
+			Input:       &container.Cluster{NodePoolAutoConfig: withTags},
+			ExpectError: true,
+		},
+		"with tags, autopilot disabled": {
+			Input: &container.Cluster{
+				Autopilot:          &container.Autopilot{Enabled: false},
+				NodePoolAutoConfig: withTags,
+			},
+			ExpectError: true,
+		},
+		"with tags, nap disabled": {
+			Input: &container.Cluster{
+				Autoscaling:        &container.ClusterAutoscaling{EnableNodeAutoprovisioning: false},
+				NodePoolAutoConfig: withTags,
+			},
+			ExpectError: true,
+		},
+		"with tags, autopilot enabled": {
+			Input: &container.Cluster{
+				Autopilot:          &container.Autopilot{Enabled: true},
+				NodePoolAutoConfig: withTags,
+			},
+			ExpectError: false,
+		},
+		"with tags, nap enabled": {
+			Input: &container.Cluster{
+				Autoscaling:        &container.ClusterAutoscaling{EnableNodeAutoprovisioning: true},
+				NodePoolAutoConfig: withTags,
+			},
+			ExpectError: false,
+		},
+		"no tags, autopilot enabled": {
+			Input: &container.Cluster{
+				Autopilot:          &container.Autopilot{Enabled: true},
+				NodePoolAutoConfig: noTags,
+			},
+			ExpectError: false,
+		},
+		"no tags, nap enabled": {
+			Input: &container.Cluster{
+				Autoscaling:        &container.ClusterAutoscaling{EnableNodeAutoprovisioning: true},
+				NodePoolAutoConfig: noTags,
+			},
+			ExpectError: false,
+		},
+		"no tags, autopilot disabled": {
+			Input: &container.Cluster{
+				Autopilot:          &container.Autopilot{Enabled: false},
+				NodePoolAutoConfig: noTags,
+			},
+			ExpectError: false,
+		},
+		"no tags, nap disabled": {
+			Input: &container.Cluster{
+				Autoscaling:        &container.ClusterAutoscaling{EnableNodeAutoprovisioning: false},
+				NodePoolAutoConfig: noTags,
+			},
+			ExpectError: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if err := validateNodePoolAutoConfig(tc.Input); (err != nil) != tc.ExpectError {
+			t.Fatalf("bad: '%s', expected error: %t, received error: %t", tn, tc.ExpectError, (err != nil))
+		}
+	}
 }
 <% end -%>

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -111,6 +111,15 @@ func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 // its values to empty.
 func emptyOrUnsetBlockDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
+	return emptyOrUnsetBlockDiffSuppressLogic(k, old, new, o, n)
+}
+
+// The core logic for emptyOrUnsetBlockDiffSuppress, in a format that is more conducive
+// to unit testing.
+func emptyOrUnsetBlockDiffSuppressLogic(k, old, new string, o, n interface{}) bool {
+	if !strings.HasSuffix(k, ".#") {
+		return false
+	}
 	var l []interface{}
 	if old == "0" && new == "1" {
 		l = n.([]interface{})
@@ -121,7 +130,10 @@ func emptyOrUnsetBlockDiffSuppress(k, old, new string, d *schema.ResourceData) b
 		return false
 	}
 
-	contents := l[0].(map[string]interface{})
+	contents, ok := l[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
 	for _, v := range contents {
 		if !isEmptyValue(reflect.ValueOf(v)) {
 			return false

--- a/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
@@ -324,3 +324,103 @@ func TestLastSlashDiffSuppress(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyOrUnsetBlockDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Key, Old, New      string
+		OldVal, NewVal     interface{}
+		ExpectDiffSuppress bool
+	}{
+		"empty block vs. block containing empty string": {
+			Key:                "example_block.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             []interface{}{},
+			NewVal:             []interface{}{map[string]interface{}{"empty_string": ""}},
+			ExpectDiffSuppress: true,
+		},
+		"empty block vs. block containing false bool": {
+			Key:                "example_block.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             []interface{}{},
+			NewVal:             []interface{}{map[string]interface{}{"false_bool": false}},
+			ExpectDiffSuppress: true,
+		},
+		"empty block vs. block containing empty list": {
+			Key:                "example_block.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             []interface{}{},
+			NewVal:             []interface{}{map[string]interface{}{"example_list": []interface{}{}}},
+			ExpectDiffSuppress: true,
+		},
+		// If a parent block returns an empty sub-block in lieu of nil or an empty map, the values of the undefined
+		// parent block and an empty, but defined block will be identical while the array count will have changed
+		"nested block, defined empty vs. undefined": {
+			Key:                "example_block.#",
+			Old:                "1",
+			New:                "0",
+			OldVal:             []interface{}{map[string]interface{}{"nested_block": []interface{}{}}},
+			NewVal:             []interface{}{map[string]interface{}{"nested_block": []interface{}{}}},
+			ExpectDiffSuppress: true,
+		},
+		"nested block, defined empty vs. nil": {
+			Key:                "node_pool_auto_config.#",
+			Old:                "1",
+			New:                "0",
+			OldVal:             []interface{}{map[string]interface{}{"network_tags": []interface{}{}}},
+			NewVal:             nil,
+			ExpectDiffSuppress: true,
+		},
+		"nested block, empty vs. non-empty list": {
+			Key:                "node_pool_auto_config.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             []interface{}{},
+			NewVal:             []interface{}{map[string]interface{}{"network_tags": []interface{}{map[string]interface{}{"tags": []interface{}{"test-network-tag"}}}}},
+			ExpectDiffSuppress: false,
+		},
+		"nested block with nil list": {
+			Key:                "node_pool_auto_config.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             nil,
+			NewVal:             []interface{}{map[string]interface{}{"network_tags": []interface{}{map[string]interface{}{"tags": nil}}}},
+			ExpectDiffSuppress: false,
+		},
+		"nested block with empty list": {
+			Key:                "node_pool_auto_config.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             nil,
+			NewVal:             []interface{}{map[string]interface{}{"network_tags": []interface{}{map[string]interface{}{"tags": []interface{}{}}}}},
+			ExpectDiffSuppress: false,
+		},
+		"list inside nested optional block": {
+			Key:                "node_pool_auto_config.0.network_tags.0.tags.#",
+			Old:                "0",
+			New:                "1",
+			OldVal:             []interface{}{},
+			NewVal:             []interface{}{"test-network-tag"},
+			ExpectDiffSuppress: false,
+		},
+		"list item inside optional block": {
+			Key:                "node_pool_auto_config.0.network_tags.0.tags.0",
+			Old:                "",
+			New:                "test-network-tag",
+			OldVal:             "",
+			NewVal:             "test-network-tag",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if emptyOrUnsetBlockDiffSuppressLogic(tc.Key, tc.Old, tc.New, tc.OldVal, tc.NewVal) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+		if emptyOrUnsetBlockDiffSuppressLogic(tc.Key, tc.New, tc.Old, tc.NewVal, tc.OldVal) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s (reverse check), '%s' => '%s' expect %t", tn, tc.New, tc.Old, tc.ExpectDiffSuppress)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -262,6 +262,10 @@ region are guaranteed to support the same version.
     to say "these are the _only_ node pools associated with this cluster", use the
     [google_container_node_pool](container_node_pool.html) resource instead of this property.
 
+* `node_pool_auto_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Node pool configs that apply to auto-provisioned node pools in
+    [autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison) clusters and
+    [node auto-provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)-enabled clusters. Structure is [documented below](#nested_node_pool_auto_config).
+
 * `node_version` - (Optional) The Kubernetes version on the nodes. Must either be unset
     or set to the same value as `min_master_version` on create. Defaults to the default
     version set by GKE which is not necessarily the latest version. This only affects
@@ -835,6 +839,22 @@ linux_node_config {
 ```hcl
 workload_identity_config {
   workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
+}
+```
+
+<a name="nested_node_pool_auto_config"></a>The `node_pool_auto_config` block supports:
+
+* `network_tags` (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) - The network tag config for the cluster's automatically provisioned node pools.
+
+The `network_tags` block supports:
+
+* `tags` (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) - List of network tags applied to auto-provisioned node pools.
+
+```hcl
+node_pool_auto_config {
+  network_tags {
+    tags = ["foo", "bar"]
+  }
 }
 ```
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Hey, I took a stab at adding support for network tags on Autopilot clusters and NAP node pools. The placement and naming of the field were a bit tricky since the same API is used for both Autopilot and NAP, but I'm open to suggestions.

I also added a pair of new acceptance tests to go along with it that I believe should pass, but I haven't been able to run them since they violate my company's org-level GCP constraints. I did however do manual tests provisioning/updating autopilot clusters and they were successful. I expect NAP clusters should work fine given it's the same API call, but I wanted to get the PR submitted for comments and to make sure the acceptance tests run successfully.

fixes hashicorp/terraform-provider-google#11051

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added field `auto_provisioning_network_tags` to `google_container_cluster` (beta)
```
