### PR TITLE
validator: Fix folder_iam logic to use the correct updater

### DIFF
--- a/mmv1/third_party/validator/folder_iam.go
+++ b/mmv1/third_party/validator/folder_iam.go
@@ -90,7 +90,7 @@ func newFolderIamAsset(
 
 func FetchFolderIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	return fetchIamPolicy(
-		NewProjectIamUpdater,
+		NewFolderIamUpdater,
 		d,
 		config,
 		"//cloudresourcemanager.googleapis.com/{{folder}}",

--- a/mmv1/third_party/validator/tests/data/example_folder_iam_member.json
+++ b/mmv1/third_party/validator/tests/data/example_folder_iam_member.json
@@ -1,0 +1,17 @@
+[
+    {
+        "name": "//cloudresourcemanager.googleapis.com/folders/{{.FolderID}}",
+        "asset_type": "cloudresourcemanager.googleapis.com/Folder",
+        "ancestry_path": "{{.Ancestry}}",
+        "iam_policy": {
+            "bindings": [
+                {
+                    "role": "roles/editor",
+                    "members": [
+                        "user:jane@example.com"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/mmv1/third_party/validator/tests/data/example_folder_iam_member.tf
+++ b/mmv1/third_party/validator/tests/data/example_folder_iam_member.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_folder_iam_member" "editor" {
+  folder  = "folders/{{.FolderID}}"
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
+}

--- a/mmv1/third_party/validator/tests/data/example_folder_iam_member.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/example_folder_iam_member.tfplan.json
@@ -1,0 +1,92 @@
+{
+    "format_version": "1.0",
+    "terraform_version": "1.1.9",
+    "planned_values": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "google_folder_iam_member.editor",
+                    "mode": "managed",
+                    "type": "google_folder_iam_member",
+                    "name": "editor",
+                    "provider_name": "registry.terraform.io/hashicorp/google",
+                    "schema_version": 0,
+                    "values": {
+                        "condition": [],
+                        "folder": "folders/{{.FolderID}}",
+                        "member": "user:jane@example.com",
+                        "role": "roles/editor"
+                    },
+                    "sensitive_values": {
+                        "condition": []
+                    }
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "google_folder_iam_member.editor",
+            "mode": "managed",
+            "type": "google_folder_iam_member",
+            "name": "editor",
+            "provider_name": "registry.terraform.io/hashicorp/google",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "condition": [],
+                    "folder": "folders/{{.FolderID}}",
+                    "member": "user:jane@example.com",
+                    "role": "roles/editor"
+                },
+                "after_unknown": {
+                    "condition": [],
+                    "etag": true,
+                    "id": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "condition": []
+                }
+            }
+        }
+    ],
+    "configuration": {
+        "provider_config": {
+            "google": {
+                "name": "google",
+                "expressions": {
+                    "project": {
+                        "constant_value": "{{.Provider.project}}"
+                    }
+                }
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "google_folder_iam_member.editor",
+                    "mode": "managed",
+                    "type": "google_folder_iam_member",
+                    "name": "editor",
+                    "provider_config_key": "google",
+                    "expressions": {
+                        "folder": {
+                            "constant_value": "folders/{{.FolderID}}"
+                        },
+                        "member": {
+                            "constant_value": "user:jane@example.com"
+                        },
+                        "role": {
+                            "constant_value": "roles/editor"
+                        }
+                    },
+                    "schema_version": 0
+                }
+            ]
+        }
+    }
+}

--- a/mmv1/third_party/validator/tests/source/cli_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/cli_test.go.erb
@@ -64,6 +64,7 @@ func TestCLI(t *testing.T) {
 		{name: "sql"},
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_instance"},
+		{name: "example_folder_iam_member", compareConvertOutput: compareMergedIamMemberOutput},
 		{name: "example_project_create", constraints: []constraint{alwaysViolate, constraint{name: "project_match_target", wantViolation: false, wantOutputRegex: ""}}},
 		{name: "example_project_update", constraints: []constraint{alwaysViolate, constraint{name: "project_match_target", wantViolation: true, wantOutputRegex: "Constraint GCPAlwaysViolatesConstraintV1.always_violates_project_match_target on resource"}}},
 		{name: "example_project_iam_binding", compareConvertOutput: compareMergedIamBindingOutput},

--- a/mmv1/third_party/validator/tests/source/read_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/read_test.go.erb
@@ -23,6 +23,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 	}{
 		// read-only, the following tests are not in cli_test or
 		// have unique parameters that separate them
+		{name: "example_folder_iam_member"},
 		{name: "example_project_create"},
 		{name: "example_project_update"},
 		{name: "example_project_iam_binding"},


### PR DESCRIPTION
Fixes the `folder_iam` logic to use the `NewFolderIamUpdater` instead of the `NewProjectIamUpdater`. See https://github.com/GoogleCloudPlatform/terraform-validator/pull/764

b/233071873

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
