### PR TITLE
Add version retention period to Spanner database resource

### DIFF
--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -178,6 +178,15 @@ objects:
           the instance is created. Values are of the form [a-z][-a-z0-9]*[a-z0-9].
         input: true
         required: true
+      - !ruby/object:Api::Type::String
+        name: 'versionRetentionPeriod'
+        update_url: projects/{{project}}/instances/{{instance}}/databases/{{name}}/ddl
+        update_verb: :PATCH
+        description: |
+          The retention period for the database. The retention period must be between 1 hour
+          and 7 days, and can be specified in days, hours, minutes, or seconds. For example,
+          the values 1d, 24h, 1440m, and 86400s are equivalent. Default value is 1h.
+        required: no
       - !ruby/object:Api::Type::Array
         item_type: Api::Type::String
         name: 'extraStatements'

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -224,9 +224,6 @@ objects:
         description: |
           The dialect of the Cloud Spanner Database.
           If it is not provided, "GOOGLE_STANDARD_SQL" will be used. 
-          Note: Databases that are created with POSTGRESQL dialect do not support 
-          extra DDL statements in the `CreateDatabase` call. You must therefore re-apply 
-          terraform with ddl on the same database after creation.
         values:
           - :GOOGLE_STANDARD_SQL
           - :POSTGRESQL

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -186,6 +186,8 @@ objects:
           The retention period for the database. The retention period must be between 1 hour
           and 7 days, and can be specified in days, hours, minutes, or seconds. For example,
           the values 1d, 24h, 1440m, and 86400s are equivalent. Default value is 1h.
+          If this property is used, you must avoid adding new DDL statements to `ddl` that
+          update the database's version_retention_period. 
         required: no
       - !ruby/object:Api::Type::Array
         item_type: Api::Type::String

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -188,7 +188,6 @@ objects:
           the values 1d, 24h, 1440m, and 86400s are equivalent. Default value is 1h.
           If this property is used, you must avoid adding new DDL statements to `ddl` that
           update the database's version_retention_period. 
-        required: no
       - !ruby/object:Api::Type::Array
         item_type: Api::Type::String
         name: 'extraStatements'

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -61,7 +61,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       versionRetentionPeriod: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: validateDatabaseRetentionPeriod
-        default_value: "1h"
+        default_from_api: true
       extraStatements: !ruby/object:Overrides::Terraform::PropertyOverride
         name: ddl
         ignore_read: true

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -31,11 +31,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         On older versions, it is strongly recommended to set `lifecycle { prevent_destroy = true }`
         on databases in order to prevent accidental data loss. See [Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
         for more information on lifecycle parameters.
-        
-        Note: Databases that are created with POSTGRESQL dialect do not support 
-        extra DDL statements in the `CreateDatabase` call. You must therefore re-apply 
-        terraform with ddl on the same database after creation.
-
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_database_basic"
@@ -75,6 +70,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       decoder: templates/terraform/decoders/spanner_database.go.erb
       update_encoder: templates/terraform/update_encoder/spanner_database.go.erb
       resource_definition: 'templates/terraform/resource_definition/spanner_database.go.erb'
+      post_create: templates/terraform/post_create/spanner_database.go.erb
       pre_delete: templates/terraform/pre_delete/resource_spanner_database.go
   InstanceConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     # This is appropriate for a datasource - doesn't have a create method.

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -58,6 +58,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^[a-z][a-z0-9_\-]*[a-z0-9]$'
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      versionRetentionPeriod: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          regex: '^([1-7]d|\d{2,3}h|\d{4,5}m|\d{5,6}s)$'
+        default_value: "1h"
       extraStatements: !ruby/object:Overrides::Terraform::PropertyOverride
         name: ddl
         ignore_read: true

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -60,7 +60,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       versionRetentionPeriod: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
-          regex: '^([1-7]d|\d{2,3}h|\d{4,5}m|\d{5,6}s)$'
+          function: validateDatabaseRetentionPeriod
         default_value: "1h"
       extraStatements: !ruby/object:Overrides::Terraform::PropertyOverride
         name: ddl

--- a/mmv1/templates/terraform/constants/spanner_database.go.erb
+++ b/mmv1/templates/terraform/constants/spanner_database.go.erb
@@ -46,10 +46,9 @@ func resourceSpannerDBDdlCustomDiff(_ context.Context, diff *schema.ResourceDiff
 
 func validateDatabaseRetentionPeriod(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	
 	valueError := fmt.Errorf("version_retention_period should be in range [1h, 7d], in a format resembling 1d, 24h, 1440m, or 86400s")
 
-	r := regexp.MustCompile("^(\\d{1}d|\\d{2,3}h|\\d{4,5}m|\\d{5,6}s)$")
+	r := regexp.MustCompile("^(\\d{1}d|\\d{1,3}h|\\d{2,5}m|\\d{4,6}s)$")
 	if !r.MatchString(value) {
 		errors = append(errors, valueError)
 		return

--- a/mmv1/templates/terraform/constants/spanner_database.go.erb
+++ b/mmv1/templates/terraform/constants/spanner_database.go.erb
@@ -43,3 +43,42 @@ func resourceSpannerDBDdlCustomDiff(_ context.Context, diff *schema.ResourceDiff
 	// separate func to allow unit testing
 	return resourceSpannerDBDdlCustomDiffFunc(diff)
 }
+
+func validateDatabaseRetentionPeriod(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	
+	valueError := fmt.Errorf("version_retention_period should be in range [1h, 7d], in a format resembling 1d, 24h, 1440m, or 86400s")
+
+	r := regexp.MustCompile("^(\\d{1}d|\\d{2,3}h|\\d{4,5}m|\\d{5,6}s)$")
+	if !r.MatchString(value) {
+		errors = append(errors, valueError)
+		return
+	}
+
+	unit := value[len(value)-1:]
+	multiple := value[:len(value)-1]
+	num, err := strconv.Atoi(multiple)
+	if err != nil {
+		errors = append(errors, valueError)
+		return
+	}
+
+	if unit == "d" && (num < 1 || num > 7) {
+		errors = append(errors, valueError)
+		return
+	}
+	if unit == "h" && (num < 1 || num > 7*24) {
+		errors = append(errors, valueError)
+		return
+	}
+	if unit == "m" && (num < 1*60 || num > 7*24*60) {
+		errors = append(errors, valueError)
+		return
+	}
+	if unit == "s" && (num < 1*60*60 || num > 7*24*60*60) {
+		errors = append(errors, valueError)
+		return
+	}
+
+	return
+}

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -24,7 +24,7 @@ if retentionPeriodOk && dialect != "POSTGRESQL" {
 if retentionPeriodOk && dialect == "POSTGRESQL" {
     // DDL statements other than <CREATE DATABASE> are not allowed in database creation request for PostgreSQL-enabled databases
     // https://cloud.google.com/spanner/docs/create-manage-databases#create_a_database
-    log.Printf("[DEBUG] Skipping setting version_retention_period during creation of PostgreSQL-enabled database. To set this parameter, re-run the plan after the database is created.")
+    log.Printf("[DEBUG] Skipping setting version_retention_period during creation of PostgreSQL-enabled database. To set this parameter, re-apply after the database is created.")
 }
 
 delete(obj, "name")

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -7,8 +7,6 @@ if dialectOk && dialect == "POSTGRESQL" {
 }
 
 if retentionPeriodOk && dialect != "POSTGRESQL" {
-        // Only include GOOGLE_STANDARD_SQL syntax in create encoder because : 
-        // "DDL statements other than <CREATE DATABASE> are not allowed in database creation request for PostgreSQL-enabled databases"
         retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", obj["name"], retentionPeriod)
 
         // Handle scenario where ddl is not set at create stage
@@ -22,6 +20,11 @@ if retentionPeriodOk && dialect != "POSTGRESQL" {
 
         extraStatements = append(extraStatements, retentionDdl)
         obj["extraStatements"] = extraStatements
+}
+if retentionPeriodOk && dialect == "POSTGRESQL" {
+    // DDL statements other than <CREATE DATABASE> are not allowed in database creation request for PostgreSQL-enabled databases
+    // https://cloud.google.com/spanner/docs/create-manage-databases#create_a_database
+    log.Printf("[DEBUG] Skipping setting version_retention_period during creation of PostgreSQL-enabled database. To set this parameter, re-run the plan after the database is created.")
 }
 
 delete(obj, "name")

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -1,33 +1,15 @@
-dialect, dialectOk := obj["databaseDialect"];
-retentionPeriod, retentionPeriodOk := obj["versionRetentionPeriod"];
-
 obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
-if dialectOk && dialect == "POSTGRESQL" {
+if dialect, ok := obj["databaseDialect"]; ok && dialect == "POSTGRESQL" {
     obj["createStatement"] = fmt.Sprintf("CREATE DATABASE \"%s\"", obj["name"])
 }
 
-if retentionPeriodOk && dialect != "POSTGRESQL" {
-        retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", obj["name"], retentionPeriod)
-
-        // Handle scenario where ddl is not set at create stage
-        var extraStatements []interface{}
-        switch v := obj["extraStatements"].(type) {
-        case []interface{}:
-            extraStatements = v
-        default:
-            extraStatements = make([]interface{}, 0)
-        }
-
-        extraStatements = append(extraStatements, retentionDdl)
-        obj["extraStatements"] = extraStatements
-}
-if retentionPeriodOk && dialect == "POSTGRESQL" {
-    // DDL statements other than <CREATE DATABASE> are not allowed in database creation request for PostgreSQL-enabled databases
-    // https://cloud.google.com/spanner/docs/create-manage-databases#create_a_database
-    log.Printf("[DEBUG] Skipping setting version_retention_period during creation of PostgreSQL-enabled database. To set this parameter, re-apply after the database is created.")
-}
+// Extra DDL statements are removed from the create request and instead applied to the database in
+// a post-create action, to accommodate retrictions when creating PostgreSQL-enabled databases.
+// https://cloud.google.com/spanner/docs/create-manage-databases#create_a_database
+log.Printf("[DEBUG] Preparing to create new Database. Any extra DDL statements will be applied to the Database in a separate API call")
 
 delete(obj, "name")
 delete(obj, "versionRetentionPeriod")
 delete(obj, "instance")
+delete(obj, "extraStatements")
 return obj, nil

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -2,6 +2,15 @@ obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
 if dialect, ok := obj["databaseDialect"]; ok && dialect == "POSTGRESQL" {
     obj["createStatement"] = fmt.Sprintf("CREATE DATABASE \"%s\"", obj["name"])
 }
+
+if retentionPeriod, ok := obj["versionRetentionPeriod"]; ok {
+		retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", obj["name"], retentionPeriod)
+		extraStatements := obj["extraStatements"].([]interface{})
+		extraStatements = append(extraStatements, retentionDdl)
+		obj["extraStatements"] = extraStatements
+}
+
 delete(obj, "name")
+delete(obj, "versionRetentionPeriod")
 delete(obj, "instance")
 return obj, nil

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -4,10 +4,19 @@ if dialect, ok := obj["databaseDialect"]; ok && dialect == "POSTGRESQL" {
 }
 
 if retentionPeriod, ok := obj["versionRetentionPeriod"]; ok {
-		retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", obj["name"], retentionPeriod)
-		extraStatements := obj["extraStatements"].([]interface{})
-		extraStatements = append(extraStatements, retentionDdl)
-		obj["extraStatements"] = extraStatements
+        retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", obj["name"], retentionPeriod)
+
+        // Handle scenario where ddl is not set at create stage
+        var extraStatements []interface{}
+        switch v := obj["extraStatements"].(type) {
+        case []interface{}:
+            extraStatements = v
+        default:
+            extraStatements = make([]interface{}, 0)
+        }
+
+        extraStatements = append(extraStatements, retentionDdl)
+        obj["extraStatements"] = extraStatements
 }
 
 delete(obj, "name")

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -1,7 +1,7 @@
-obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
 dialect, dialectOk := obj["databaseDialect"];
 retentionPeriod, retentionPeriodOk := obj["versionRetentionPeriod"];
 
+obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
 if dialectOk && dialect == "POSTGRESQL" {
     obj["createStatement"] = fmt.Sprintf("CREATE DATABASE \"%s\"", obj["name"])
 }

--- a/mmv1/templates/terraform/encoders/spanner_database.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_database.go.erb
@@ -1,9 +1,14 @@
 obj["createStatement"] = fmt.Sprintf("CREATE DATABASE `%s`", obj["name"])
-if dialect, ok := obj["databaseDialect"]; ok && dialect == "POSTGRESQL" {
+dialect, dialectOk := obj["databaseDialect"];
+retentionPeriod, retentionPeriodOk := obj["versionRetentionPeriod"];
+
+if dialectOk && dialect == "POSTGRESQL" {
     obj["createStatement"] = fmt.Sprintf("CREATE DATABASE \"%s\"", obj["name"])
 }
 
-if retentionPeriod, ok := obj["versionRetentionPeriod"]; ok {
+if retentionPeriodOk && dialect != "POSTGRESQL" {
+        // Only include GOOGLE_STANDARD_SQL syntax in create encoder because : 
+        // "DDL statements other than <CREATE DATABASE> are not allowed in database creation request for PostgreSQL-enabled databases"
         retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", obj["name"], retentionPeriod)
 
         // Handle scenario where ddl is not set at create stage

--- a/mmv1/templates/terraform/examples/spanner_database_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/spanner_database_basic.tf.erb
@@ -7,6 +7,7 @@ resource "google_spanner_instance" "main" {
 resource "google_spanner_database" "database" {
   instance = google_spanner_instance.main.name
   name     = "<%= ctx[:vars]['database_name'] %>"
+  version_retention_period = "3d"
   ddl = [
     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
     "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",

--- a/mmv1/templates/terraform/post_create/spanner_database.go.erb
+++ b/mmv1/templates/terraform/post_create/spanner_database.go.erb
@@ -1,0 +1,62 @@
+// Note: Databases that are created with POSTGRESQL dialect do not support extra DDL
+// statements at the time of database creation. To avoid users needing to run 
+// `terraform apply` twice to get their desired outcome, the provider does not set
+// `extraStatements` in the call to the `create` endpoint and all DDL (other than
+//  <CREATE DATABASE>) is run post-create, by calling the `updateDdl` endpoint 
+
+_, ok := opRes["name"]
+if !ok {
+	return fmt.Errorf("Create response didn't contain critical fields. Create may not have succeeded.")
+}
+
+retention, retentionPeriodOk := d.GetOk("version_retention_period")
+retentionPeriod := retention.(string)
+ddl, ddlOk := d.GetOk("ddl")
+ddlStatements := ddl.([]interface{})
+
+if retentionPeriodOk || ddlOk {
+
+	obj := make(map[string]interface{})
+	updateDdls := []string{}
+
+	if ddlOk {
+		for i := 0; i < len(ddlStatements); i++ {
+			updateDdls = append(updateDdls, ddlStatements[i].(string))
+		}
+	}
+
+	if retentionPeriodOk {
+		dbName := d.Get("name")
+		retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", dbName, retentionPeriod)
+		if dialect, ok := d.GetOk("database_dialect"); ok && dialect == "POSTGRESQL" {
+			retentionDdl = fmt.Sprintf("ALTER DATABASE \"%s\" SET spanner.version_retention_period TO \"%s\"", dbName, retentionPeriod)
+		}
+		updateDdls = append(updateDdls, retentionDdl)
+	}
+
+	log.Printf("[DEBUG] Applying extra DDL statements to the new Database: %#v", updateDdls)
+
+	obj["statements"] = updateDdls
+
+	url, err = replaceVars(d, config, "{{SpannerBasePath}}projects/{{project}}/instances/{{instance}}/databases/{{name}}/ddl")
+	if err != nil {
+		return err
+	}
+
+	res, err = sendRequestWithTimeout(config, "PATCH", billingProject, url, userAgent, obj, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return fmt.Errorf("Error executing DDL statements on Database: %s", err)
+	}
+
+	// Use the resource in the operation response to populate
+	// identity fields and d.Id() before read
+	var opRes map[string]interface{}
+	err = spannerOperationWaitTimeWithResponse(
+		config, res, &opRes, project, "Creating Database", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		// The resource didn't actually create
+		d.SetId("")
+		return fmt.Errorf("Error waiting to run DDL against newly-created Database: %s", err)
+	}
+}

--- a/mmv1/templates/terraform/update_encoder/spanner_database.go.erb
+++ b/mmv1/templates/terraform/update_encoder/spanner_database.go.erb
@@ -24,9 +24,9 @@ for i := len(oldDdls); i < len(newDdls); i++ {
 
 //Add statement to update version_retention_period property, if needed
 if d.HasChange("version_retention_period") {
-	dbName := d.Get("name")
-	retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", dbName, obj["versionRetentionPeriod"])
-	updateDdls = append(updateDdls, retentionDdl)
+    dbName := d.Get("name")
+    retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", dbName, obj["versionRetentionPeriod"])
+    updateDdls = append(updateDdls, retentionDdl)
 }
 
 obj["statements"] = updateDdls

--- a/mmv1/templates/terraform/update_encoder/spanner_database.go.erb
+++ b/mmv1/templates/terraform/update_encoder/spanner_database.go.erb
@@ -22,8 +22,16 @@ for i := len(oldDdls); i < len(newDdls); i++ {
     updateDdls = append(updateDdls, newDdls[i].(string))
 }
 
+//Add statement to update version_retention_period property, if needed
+if d.HasChange("version_retention_period") {
+	dbName := d.Get("name")
+	retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", dbName, obj["versionRetentionPeriod"])
+	updateDdls = append(updateDdls, retentionDdl)
+}
+
 obj["statements"] = updateDdls
 delete(obj, "name")
+delete(obj, "versionRetentionPeriod")
 delete(obj, "instance")
 delete(obj, "extraStatements")
 return obj, nil

--- a/mmv1/templates/terraform/update_encoder/spanner_database.go.erb
+++ b/mmv1/templates/terraform/update_encoder/spanner_database.go.erb
@@ -26,6 +26,9 @@ for i := len(oldDdls); i < len(newDdls); i++ {
 if d.HasChange("version_retention_period") {
     dbName := d.Get("name")
     retentionDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (version_retention_period=\"%s\")", dbName, obj["versionRetentionPeriod"])
+    if dialect, ok := d.GetOk("database_dialect"); ok && dialect == "POSTGRESQL" {
+        retentionDdl = fmt.Sprintf("ALTER DATABASE \"%s\" SET spanner.version_retention_period TO \"%s\"", dbName, obj["versionRetentionPeriod"])
+    }
     updateDdls = append(updateDdls, retentionDdl)
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -190,7 +190,7 @@ func TestAccComputeDisk_imageDiffSuppressPublicVendorsFamilyNames(t *testing.T) 
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 
 	config := getInitializedConfig(t)

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_migrate_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_migrate_test.go.erb
@@ -23,7 +23,7 @@ func TestAccComputeInstanceMigrateState(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	cases := map[string]struct {
 		StateVersion int
@@ -127,7 +127,7 @@ func TestAccComputeInstanceMigrateState_empty(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	var is *terraform.InstanceState
 	var meta interface{}
@@ -155,7 +155,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -223,7 +223,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -290,7 +290,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -371,7 +371,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -451,7 +451,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -520,7 +520,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -588,7 +588,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -661,7 +661,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -733,7 +733,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"
@@ -799,7 +799,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	config := getInitializedConfig(t)
 	zone := "us-central1-f"

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -26,6 +26,7 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 				Config: testAccSpannerDatabase_basic(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "1h"), // default set by API
 				),
 			},
 			{
@@ -39,6 +40,7 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 				Config: testAccSpannerDatabase_basicUpdate(instanceName, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "2d"),
 				),
 			},
 			{
@@ -106,6 +108,7 @@ resource "google_spanner_instance" "basic" {
 resource "google_spanner_database" "basic" {
   instance = google_spanner_instance.basic.name
   name     = "%s"
+  version_retention_period = "2d" # increase from default 1h
   ddl = [
 	"CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
 	"CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
@@ -190,6 +193,7 @@ resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
   name     = "%s-spangres"
   database_dialect = "POSTGRESQL"
+  version_retention_period = "2d" # increase from default 1h
   ddl = [
      "CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
      "CREATE TABLE t2 (t2 bigint NOT NULL PRIMARY KEY)",

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -175,6 +175,11 @@ resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
   name     = "%s-spangres"
   database_dialect = "POSTGRESQL"
+  // Confirm that DDL can be run at creation time for POSTGRESQL
+  version_retention_period = "2h"
+  ddl = [
+     "CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
+  ]
   deletion_protection = false
 }
 `, instanceName, instanceName, databaseName)
@@ -193,9 +198,8 @@ resource "google_spanner_database" "basic_spangres" {
   instance = google_spanner_instance.basic.name
   name     = "%s-spangres"
   database_dialect = "POSTGRESQL"
-  version_retention_period = "2d" # increase from default 1h
+  version_retention_period = "4d"
   ddl = [
-     "CREATE TABLE t1 (t1 bigint NOT NULL PRIMARY KEY)",
      "CREATE TABLE t2 (t2 bigint NOT NULL PRIMARY KEY)",
      "CREATE TABLE t3 (t3 bigint NOT NULL PRIMARY KEY)",
      "CREATE TABLE t4 (t4 bigint NOT NULL PRIMARY KEY)",

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -209,6 +209,156 @@ resource "google_spanner_database" "basic_spangres" {
 `, instanceName, instanceName, databaseName)
 }
 
+func TestAccSpannerDatabase_versionRetentionPeriod(t *testing.T) {
+	t.Parallel()
+
+	rnd := randString(t, 10)
+	instanceName := fmt.Sprintf("tf-test-%s", rnd)
+	databaseName := fmt.Sprintf("tfgen_%s", rnd)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpannerDatabaseDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Test creating a database with `version_retention_period` set
+				Config: testAccSpannerDatabase_versionRetentionPeriod(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "2h"),
+				),
+			},
+			{
+				// Test removing `version_retention_period` and setting retention period to a new value with a DDL statement in `ddl`
+				Config: testAccSpannerDatabase_versionRetentionPeriodUpdate1(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "4h"),
+				),
+			},
+			{
+				// Test that adding `version_retention_period` controls retention time, regardless of any previous statements in `ddl`
+				Config: testAccSpannerDatabase_versionRetentionPeriodUpdate2(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "2h"),
+				),
+			},
+			{
+				// Test that changing the retention value via DDL when `version_retention_period` is set:
+				// - changes the value (from 2h to 8h)
+				// - is unstable; non-empty plan afterwards due to conflict
+				Config:             testAccSpannerDatabase_versionRetentionPeriodUpdate3(instanceName, databaseName),
+				ExpectNonEmptyPlan: true, // is unstable
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "8h"),
+				),
+			},
+			{
+				// Test that when the above config is reapplied:
+				// - changes the value (reverts to set value of `version_retention_period`, 2h)
+				// - is stable; no further conflict
+				Config:             testAccSpannerDatabase_versionRetentionPeriodUpdate3(instanceName, databaseName), //same as previous step
+				ExpectNonEmptyPlan: false, // is stable
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "version_retention_period", "2h"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSpannerDatabase_versionRetentionPeriod(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  version_retention_period = "2h"
+  ddl = [
+     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName)
+}
+
+func testAccSpannerDatabase_versionRetentionPeriodUpdate1(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  // Change 1/2 : deleted version_retention_period argument
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "ALTER DATABASE %s SET OPTIONS (version_retention_period=\"4h\")",  // Change 2/2 : set retention with new DDL
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName)
+}
+
+func testAccSpannerDatabase_versionRetentionPeriodUpdate2(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  version_retention_period = "2h" // Change : added version_retention_period argument
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "ALTER DATABASE %s SET OPTIONS (version_retention_period=\"4h\")",
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName)
+}
+
+func testAccSpannerDatabase_versionRetentionPeriodUpdate3(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  version_retention_period = "2h"
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "ALTER DATABASE %s SET OPTIONS (version_retention_period=\"4h\")",
+    "ALTER DATABASE %s SET OPTIONS (version_retention_period=\"8h\")",  // Change : set retention with new DDL
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName, databaseName)
+}
+
 // Unit Tests for type spannerDatabaseId
 func TestDatabaseNameForApi(t *testing.T) {
 	id := spannerDatabaseId{

--- a/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_spanner_database_test.go.erb
@@ -291,6 +291,77 @@ func TestSpannerDatabase_resourceSpannerDBDdlCustomDiffFuncForceNew(t *testing.T
 	}
 }
 
+// Unit Tests for validation of retention period argument
+func TestValidateDatabaseRetentionPeriod(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]struct {
+		input       string
+		expectError bool
+	}{
+		// Not valid input
+		"empty_string": {
+			input:       "",
+			expectError: true,
+		},
+		"number_with_no_unit": {
+			input:       "1",
+			expectError: true,
+		},
+		"less_than_1h": {
+			input:       "59m",
+			expectError: true,
+		},
+		"more_than_7days": {
+			input:       "8d",
+			expectError: true,
+		},
+		// Valid input
+		"1_hour_in_secs": {
+			input:       "3600s",
+			expectError: false,
+		},
+		"1_hour_in_mins": {
+			input:       "60m",
+			expectError: false,
+		},
+		"1_hour_in_hours": {
+			input:       "1h",
+			expectError: false,
+		},
+		"7_days_in_secs": {
+			input:       fmt.Sprintf("%ds", 7*24*60*60),
+			expectError: false,
+		},
+		"7_days_in_mins": {
+			input:       fmt.Sprintf("%dm", 7*24*60),
+			expectError: false,
+		},
+		"7_days_in_hours": {
+			input:       fmt.Sprintf("%dh", 7*24),
+			expectError: false,
+		},
+		"7_days_in_days": {
+			input:       "7d",
+			expectError: false,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			_, errs := validateDatabaseRetentionPeriod(tc.input, "foobar")
+			var wantErrCount string
+			if tc.expectError {
+				wantErrCount = "1+"
+			} else {
+				wantErrCount = "0"
+			}
+			if (len(errs) > 0 && tc.expectError == false) || (len(errs) == 0 && tc.expectError == true) {
+				t.Errorf("failed, expected `%s` test case validation to have %s errors", tn, wantErrCount)
+			}
+		})
+	}
+}
+
 func TestAccSpannerDatabase_deletionProtection(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()

--- a/mmv1/third_party/terraform/utils/config_test.go
+++ b/mmv1/third_party/terraform/utils/config_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -64,7 +63,7 @@ func TestConfigLoadAndValidate_accountFileJSONInvalid(t *testing.T) {
 
 func TestAccConfigLoadValidate_credentials(t *testing.T) {
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	testAccPreCheck(t)
 
@@ -92,7 +91,7 @@ func TestAccConfigLoadValidate_credentials(t *testing.T) {
 
 func TestAccConfigLoadValidate_impersonated(t *testing.T) {
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	testAccPreCheck(t)
 
@@ -122,7 +121,7 @@ func TestAccConfigLoadValidate_impersonated(t *testing.T) {
 
 func TestAccConfigLoadValidate_accessTokenImpersonated(t *testing.T) {
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	testAccPreCheck(t)
 
@@ -162,7 +161,7 @@ func TestAccConfigLoadValidate_accessTokenImpersonated(t *testing.T) {
 
 func TestAccConfigLoadValidate_accessToken(t *testing.T) {
 	if os.Getenv(TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", TestEnvVar))
+		t.Skipf("Network access not allowed; use %s=1 to enable", TestEnvVar)
 	}
 	testAccPreCheck(t)
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
# Description

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8994

This PR lets Terraform users set the retention period of historical versions of a Spanner database's data and schema for [point in time recovery (PITR)](https://cloud.google.com/spanner/docs/pitr).

The retention period of the data used for PITR can be changed by running a DDL statement to update the database's options:

```sql
-- Google Standard SQL
ALTER DATABASE `example-db` SET OPTIONS (version_retention_period="7d";

-- Postgres
ALTER DATABASE `example-db` SET spanner.version_retention_period TO "7d";
```

[See usage notes section here](https://cloud.google.com/spanner/docs/use-pitr) & [docs about equivalent DDL for Postgres](https://cloud.google.com/spanner/docs/reference/postgresql/data-definition-language#alter-database)

These DDL statements can be sent through the REST API and executed at either:
1. **Creation of a new database via the `create` endpoint**
    - as an entry in the `extraStatements` array [in the request body](https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases/create#request-body)
    - ⚠️ **not allowed for Postgres** ⚠️
        - If you provide any `extraStatements` in the create request for a Postgres database, you get this error: `DDL statements other than <CREATE DATABASE> are not allowed in database creation request for PostgreSQL-enabled databases`
2. **Updating a database via the [`updateDdl`](https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases/updateDdl) endpoint**
    - OK for both database dialects

## Approach

I've used the value of the `version_retention_period` field to create an ALTER DDL statement like above and add it to the array of statements in the request bodies of requests sent to the `create` or `updateDdl` endpoints

**Edit 2022-06-27** : I refactored the code for creating databases so that DDL statements (both originating from `ddl` and `version_retention_period` fields) are executed in the database via a separate API call. After the database is made using the `create` endpoint the provider runs DDL against the new database using the `updateDdl` endpoint, all within the creation process in Terraform.

## Postgres issues

~~The DDL restriction when making Postgres databases has been met by the initial version of this PR by skipping setting the retention time during creation, even if the `version_retention_period` is set in the Terraform configuration. When a plan is generated a 2nd time from the Terraform configuration it will plan to update the retention time on the Postgres DB.~~

~~This might be confusing to practitioners, but seems like the need to re-apply plans for Postgres databases [isn't new and is mentioned in the docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database#database_dialect:~:text=You%20must%20therefore%20re%2Dapply%20terraform%20with%20ddl%20on%20the%20same%20database%20after%20creation.%20Possible%20values%20are%20GOOGLE_STANDARD_SQL%20and%20POSTGRESQL.).~~

**Edit 2022-06-27** : By separating all execution of DDL into an API call separate to the initial `create` API call this means Postgres's limitations in Spanner don't require 2nd apply steps

# Open questions

- How does this approach work with acceptance tests, which try to prevent scenarios where 2nd plans from the same config contain changes still. Is that a sign that this should be approached differently?
- Would a more explicit error that disallows `version_retention_period` being set before making the Postgres DB be better? That would avoid the confusion of needing to apply a plan twice to reach the desired goal
- Should there be any protection against users setting the retention time via an `ALTER` statement in the `ddl` parameter of the Terraform provider? The only issue would be if someone added `version_retention_period` to their config but then resumed setting it via `ddl` (`version_retention_period` would always re-assert itself on the next plan&apply)

# PR steps
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
spanner: Added field `version_retention_period` to `google_spanner_database` resource
```
```release-note:enhancement
spanner: Fixed issue where `ddl` and `version_retention_period` could not be set when first creating `google_spanner_database` using POSTGRESQL
```