### PR TITLE
feat: add Cloud Run Scheduled Invocations example

### DIFF
--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -131,6 +131,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
       - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_run_service_scheduled"
+        primary_resource_type: "google_cloud_run_service"
+        primary_resource_id: "default"
+        vars:
+          service_name: "my-scheduled-service"
+          sa_name: "scheduler-sa"
+          scheduled_cloud_run_job: "scheduled-cloud-run-job"
+        test_env_vars:
+          project: :PROJECT_NAME
+        min_version: beta
+        # ignore_read_extra:
+        #   - "port_range"
+        #   - "target"
+        #   - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_secret_environment_variables"
         primary_resource_id: "default"
         primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random_suffix\"])"

--- a/mmv1/templates/terraform/examples/cloud_run_service_scheduled.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_scheduled.erb
@@ -1,0 +1,94 @@
+resource "google_project_service" "run_api" {
+  project                    = "<%= ctx[:test_env_vars]['project'] %>"
+  service                    = "run.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "iam_api" {
+  project                    = "<%= ctx[:test_env_vars]['project'] %>"
+  service                    = "iam.googleapis.com"
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "resource_manager_api" {
+  project                    = "<%= ctx[:test_env_vars]['project'] %>"
+  service                    = "cloudresourcemanager.googleapis.com"
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "scheduler_api" {
+  project                    = "<%= ctx[:test_env_vars]['project'] %>"
+  service                    = "cloudscheduler.googleapis.com"
+  disable_on_destroy         = false
+}
+
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  project  = "<%= ctx[:test_env_vars]['project'] %>"
+  name     = "<%= ctx[:vars]['service_name'] %>"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  # Use an explicit depends_on clause to wait until API is enabled
+  depends_on = [
+    google_project_service.run_api
+  ]
+}
+
+resource "google_service_account" "default" {
+  project      = "<%= ctx[:test_env_vars]['project'] %>"
+  account_id   = "<%= ctx[:vars]['sa_name'] %>"
+  description  = "Cloud Scheduler service account; used to trigger scheduled Cloud Run jobs."
+  display_name = "scheduler-sa"
+
+  # Use an explicit depends_on clause to wait until API is enabled
+  depends_on = [
+    google_project_service.iam_api
+  ]
+}
+
+resource "google_cloud_scheduler_job" "default" {
+  name             = "<%= ctx[:vars]['scheduled_cloud_run_job'] %>"
+  description      = "Invoke a Cloud Run container on a schedule."
+  schedule         = "*/8 * * * *"
+  time_zone        = "America/New_York"
+  attempt_deadline = "320s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = google_cloud_run_service.default.status[0].url
+
+    oidc_token {
+      service_account_email = google_service_account.default.email
+    }
+  }
+
+  # Use an explicit depends_on clause to wait until API is enabled
+  depends_on = [
+    google_project_service.scheduler_api
+  ]
+}
+
+resource "google_cloud_run_service_iam_member" "default" {
+  project = "<%= ctx[:test_env_vars]['project'] %>"
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/run.invoker"
+  member = google_service_account.default.email
+}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: Added scheduled invocations Terraform example for Cloud Run.
```