### PR TITLE
Composer fix scheduler count update

### DIFF
--- a/mmv1/Gemfile.lock
+++ b/mmv1/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       ast (~> 2.4.0)
     public_suffix (3.0.3)
     rainbow (3.0.0)
-    rake (12.3.3)
+    rake (13.0.6)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -74,5 +74,4 @@ DEPENDENCIES
   rubocop (>= 0.77.0)
 
 BUNDLED WITH
-   1.17.2
-
+   2.3.16

--- a/mmv1/Gemfile.lock
+++ b/mmv1/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       ast (~> 2.4.0)
     public_suffix (3.0.3)
     rainbow (3.0.0)
-    rake (13.0.6)
+    rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -74,4 +74,5 @@ DEPENDENCIES
   rubocop (>= 0.77.0)
 
 BUNDLED WITH
-   2.3.16
+   1.17.2
+

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -883,6 +883,21 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 		}
 <% end -%>
 
+		if d.HasChange("config.0.software_config.0.scheduler_count") {
+			patchObj := &composer.Environment{
+				Config: &composer.EnvironmentConfig{
+					SoftwareConfig: &composer.SoftwareConfig{},
+				},
+			}
+			if config != nil && config.SoftwareConfig != nil {
+				patchObj.Config.SoftwareConfig.SchedulerCount = config.SoftwareConfig.SchedulerCount
+			}
+			err = resourceComposerEnvironmentPatchField("config.softwareConfig.schedulerCount", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
+
 		if d.HasChange("config.0.software_config.0.airflow_config_overrides") {
 			patchObj := &composer.Environment{
 				Config: &composer.EnvironmentConfig{

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -719,8 +719,11 @@ func TestAccComposerEnvironmentAirflow2_withSoftwareConfig(t *testing.T) {
 				Config: testAccComposerEnvironment_airflow2SoftwareCfg(envName, network, subnetwork),
 			},
 			{
-				ResourceName:      "google_composer_environment.test",
-				ImportState:       true,
+				Config: testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(envName, network, subnetwork),
+			},
+			{
+				ResourceName:			"google_composer_environment.test",
+				ImportState:			 true,
 				ImportStateVerify: true,
 			},
 			// This is a terrible clean-up step in order to get destroy to succeed,
@@ -729,8 +732,8 @@ func TestAccComposerEnvironmentAirflow2_withSoftwareConfig(t *testing.T) {
 			{
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
-				Config:             testAccComposerEnvironment_airflow2SoftwareCfg(envName, network, subnetwork),
-				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+				Config:						  testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(envName, network, subnetwork),
+				Check:							testAccCheckClearComposerEnvironmentFirewalls(t, network),
 			},
 		},
 	})
@@ -1712,6 +1715,40 @@ resource "google_compute_subnetwork" "test" {
 	ip_cidr_range = "10.2.0.0/16"
 	region        = "us-central1"
 	network       = google_compute_network.test.self_link
+}
+`, name, network, subnetwork)
+}
+
+func testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-central1"
+  config {
+    node_config {
+      network    = google_compute_network.test.self_link
+      subnetwork = google_compute_subnetwork.test.self_link
+      zone       = "us-central1-a"
+    }
+    software_config {
+      image_version  = "composer-1-airflow-2"
+      scheduler_count = 3
+    }
+  }
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
 }

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -719,6 +719,11 @@ func TestAccComposerEnvironmentAirflow2_withSoftwareConfig(t *testing.T) {
 				Config: testAccComposerEnvironment_airflow2SoftwareCfg(envName, network, subnetwork),
 			},
 			{
+				ResourceName:			"google_composer_environment.test",
+				ImportState:			 true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(envName, network, subnetwork),
 			},
 			{
@@ -732,8 +737,8 @@ func TestAccComposerEnvironmentAirflow2_withSoftwareConfig(t *testing.T) {
 			{
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
-				Config:						  testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(envName, network, subnetwork),
-				Check:							testAccCheckClearComposerEnvironmentFirewalls(t, network),
+				Config:             testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -727,8 +727,8 @@ func TestAccComposerEnvironmentAirflow2_withSoftwareConfig(t *testing.T) {
 				Config: testAccComposerEnvironmentUpdate_airflow2SoftwareCfg(envName, network, subnetwork),
 			},
 			{
-				ResourceName:			"google_composer_environment.test",
-				ImportState:			 true,
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			// This is a terrible clean-up step in order to get destroy to succeed,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes bug with Cloud Composer scheduler_count updates described in https://github.com/hashicorp/terraform-provider-google/issues/11940


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
composer: fix a problem with updating Cloud Composer's scheduler_count field (https://github.com/hashicorp/terraform-provider-google/issues/11940)
```
