### PR TITLE
Support subordinate CA activation via first and third party issuers.

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -60,6 +60,11 @@ objects:
           'https://cloud.google.com/certificate-authority-service'
       api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest'
     properties:
+      - !ruby/object:Api::Type::String
+        name: pem_ca_certificate
+        description: |
+          The signed CA certificate issued from the subordinated CA's CSR. This is needed when activating the subordiante CA with a third party issuer.
+        url_param_only: true                
       - !ruby/object:Api::Type::Boolean
         name: 'ignore_active_certificates_on_deletion'
         default_value: false
@@ -422,34 +427,64 @@ objects:
         required: true
         input: true
         properties:
-        - !ruby/object:Api::Type::String
-          name: 'cloudKmsKeyVersion'
-          description: |
-            The resource name for an existing Cloud KMS CryptoKeyVersion in the format
-            `projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*`.
-          input: true
-          exactly_one_of:
-          - key_spec.0.cloud_kms_key_version
-          - key_spec.0.algorithm
-        - !ruby/object:Api::Type::Enum
-          name: 'algorithm'
-          description: |
-            The algorithm to use for creating a managed Cloud KMS key for a for a simplified
-            experience. All managed keys will be have their ProtectionLevel as HSM.
-          input: true
-          values:
-            - :SIGN_HASH_ALGORITHM_UNSPECIFIED
-            - :RSA_PSS_2048_SHA256
-            - :RSA_PSS_3072_SHA256
-            - :RSA_PSS_4096_SHA256
-            - :RSA_PKCS1_2048_SHA256
-            - :RSA_PKCS1_3072_SHA256
-            - :RSA_PKCS1_4096_SHA256
-            - :EC_P256_SHA256
-            - :EC_P384_SHA384
-          exactly_one_of:
-          - key_spec.0.cloud_kms_key_version
-          - key_spec.0.algorithm
+          - !ruby/object:Api::Type::String
+            name: 'cloudKmsKeyVersion'
+            description: |
+              The resource name for an existing Cloud KMS CryptoKeyVersion in the format
+              `projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*`.
+            input: true
+            exactly_one_of:
+            - key_spec.0.cloud_kms_key_version
+            - key_spec.0.algorithm
+          - !ruby/object:Api::Type::Enum
+            name: 'algorithm'
+            description: |
+              The algorithm to use for creating a managed Cloud KMS key for a for a simplified
+              experience. All managed keys will be have their ProtectionLevel as HSM.
+            input: true
+            values:
+              - :SIGN_HASH_ALGORITHM_UNSPECIFIED
+              - :RSA_PSS_2048_SHA256
+              - :RSA_PSS_3072_SHA256
+              - :RSA_PSS_4096_SHA256
+              - :RSA_PKCS1_2048_SHA256
+              - :RSA_PKCS1_3072_SHA256
+              - :RSA_PKCS1_4096_SHA256
+              - :EC_P256_SHA256
+              - :EC_P384_SHA384
+            exactly_one_of:
+            - key_spec.0.cloud_kms_key_version
+            - key_spec.0.algorithm
+      - !ruby/object:Api::Type::NestedObject
+        name: 'subordinateConfig'
+        description: |
+          If this is a subordinate CertificateAuthority, this field will be set
+          with the subordinate configuration, which describes its issuers.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'certificateAuthority'
+            description: |
+              This can refer to a CertificateAuthority that was used to create a
+              subordinate CertificateAuthority. This field is used for information
+              and usability purposes only. The resource name is in the format
+              `projects/*/locations/*/caPools/*/certificateAuthorities/*`. 
+            exactly_one_of:
+              - subordinate_config.0.certificate_authority
+              - subordinate_config.0.pem_issuer_chain
+          - !ruby/object:Api::Type::NestedObject
+            name: 'pemIssuerChain'
+            description: |
+              Contains the PEM certificate chain for the issuers of this CertificateAuthority, 
+              but not pem certificate for this CA itself.
+            exactly_one_of:
+              - subordinate_config.0.certificate_authority
+              - subordinate_config.0.pem_issuer_chain
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'pemCertificates'
+                description: |
+                  Expected to be in leaf-to-root order according to RFC 5246.
+                item_type: Api::Type::String
       - !ruby/object:Api::Type::Enum
         name: 'state'
         description: The State for this CertificateAuthority.
@@ -546,7 +581,10 @@ objects:
       - !ruby/object:Api::Type::String
         name: certificate_authority
         description:  |
-          Certificate Authority name.
+          The Certificate Authority ID that should issue the certificate. For example, to issue a Certificate from
+          a Certificate Authority with resource name `projects/my-project/locations/us-central1/caPools/my-pool/certificateAuthorities/my-ca`,
+          argument `pool` should be set to `projects/my-project/locations/us-central1/caPools/my-pool`, argument `certificate_authority`
+          should be set to `my-ca`.
         input: true
         url_param_only: true                
     properties:
@@ -566,7 +604,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'issuerCertificateAuthority'
         description: |
-          The resource name of the issuing CertificateAuthority in the format projects/*/locations/*/caPools/*/certificateAuthorities/*.
+          The resource name of the issuing CertificateAuthority in the format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
         output: true
       - !ruby/object:Api::Type::String
         name: 'lifetime'

--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -92,15 +92,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           {{description}}
 
           ~> **Note:** For `SUBORDINATE` Certificate Authorities, they need to
-          be manually activated (via Cloud Console of `gcloud`) before they can
-          issue certificates.
+          be activated before they can issue certificates.
       config.x509Config: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/privateca_certificate_509_config.go.erb'
         custom_expand: 'templates/terraform/custom_expand/privateca_certificate_509_config.go.erb'
+      subordinateConfig.certificateAuthority: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareResourceNames'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: 'templates/terraform/constants/privateca_certificate_authority.go.erb'
       resource_definition: 'templates/terraform/resource_definition/privateca_certificate_authority.go.erb'
       decoder: templates/terraform/decoders/treat_deleted_state_as_gone.go.erb
+      pre_create: templates/terraform/pre_create/privateca_certificate_authority.go.erb
       post_create: templates/terraform/post_create/privateca_certificate_authority.go.erb
       pre_update: templates/terraform/pre_update/privateca_certificate_authority.go.erb
       pre_delete: templates/terraform/pre_delete/privateca_authority_disable.go.erb

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
@@ -1,11 +1,52 @@
 # [START privateca_create_subordinateca]
+resource "google_privateca_certificate_authority" "root-ca" {
+  pool = "<%= ctx[:vars]["pool_name"] %>"
+  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>-root"
+  location = "us-central1"
+  deletion_protection = false
+  ignore_active_certificates_on_deletion = true
+  config {
+    subject_config {
+      subject {
+        organization = "HashiCorp"
+        common_name = "my-certificate-authority"
+      }
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    x509_config {
+      ca_options {
+        # is_ca *MUST* be true for certificate authorities
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          # cert_sign and crl_sign *MUST* be true for certificate authorities
+          cert_sign = true
+          crl_sign = true
+        }
+        extended_key_usage {
+          server_auth = false
+        }
+      }
+    }
+  }
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+}
+
 resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
   // This example assumes this pool already exists.
   // Pools cannot be deleted in normal test circumstances, so we depend on static pools
   pool = "<%= ctx[:vars]["pool_name"] %>"
-  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>-sub"
   location = "<%= ctx[:vars]["pool_location"] %>"
   deletion_protection = "<%= ctx[:vars]["deletion_protection"] %>"
+  subordinate_config {
+    certificate_authority = google_privateca_certificate_authority.root-ca.name
+  }
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/post_create/privateca_certificate_authority.go.erb
+++ b/mmv1/templates/terraform/post_create/privateca_certificate_authority.go.erb
@@ -1,26 +1,24 @@
 staged := d.Get("type").(string) == "SELF_SIGNED"
 
+if d.Get("type").(string) == "SUBORDINATE" {
+	if _, ok := d.GetOk("subordinate_config"); ok {
+		// First party issuer
+		log.Printf("[DEBUG] Activating CertificateAuthority with first party issuer")
+		if err := activateSubCAWithFirstPartyIssuer(config, d, project, billingProject, userAgent); err != nil {
+			return fmt.Errorf("Error activating subordinate CA with first party issuer: %v", err)
+		}
+		staged = true
+		log.Printf("[DEBUG] CertificateAuthority activated")
+	}
+}
+
+
 // Enable the CA if `desired_state` is unspecified or specified as `ENABLED`.
 if p, ok := d.GetOk("desired_state"); !ok || p.(string) == "ENABLED" {
 	// Skip enablement on SUBORDINATE CA for backward compatible.
 	if staged {
-		url, err = replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:enable")
-		if err != nil {
-			return err
-		}
-
-		log.Printf("[DEBUG] Enabling CertificateAuthority: %#v", obj)
-
-		res, err = sendRequest(config, "POST", billingProject, url, userAgent, nil)
-		if err != nil {
-			return fmt.Errorf("Error enabling CertificateAuthority: %s", err)
-		}
-
-		err = privatecaOperationWaitTimeWithResponse(
-			config, res, &opRes, project, "Enabling CertificateAuthority", userAgent,
-			d.Timeout(schema.TimeoutCreate))
-		if err != nil {
-			return fmt.Errorf("Error waiting to enable CertificateAuthority: %s", err)
+		if err := enableCA(config, d, project, billingProject, userAgent); err != nil {
+			return fmt.Errorf("Error enabling CertificateAuthority: %v", err)
 		}
 	}
 }

--- a/mmv1/templates/terraform/pre_create/privateca_certificate_authority.go.erb
+++ b/mmv1/templates/terraform/pre_create/privateca_certificate_authority.go.erb
@@ -1,0 +1,3 @@
+// Drop `subordinateConfig` as it can not be set during CA creation.
+// It can be used to activate CA during post_create or pre_update.
+delete(obj, "subordinateConfig")

--- a/mmv1/templates/terraform/pre_update/privateca_certificate_authority.go.erb
+++ b/mmv1/templates/terraform/pre_update/privateca_certificate_authority.go.erb
@@ -1,48 +1,41 @@
+if d.HasChange("subordinate_config") {
+	if d.Get("type").(string) != "SUBORDINATE" {
+		return fmt.Errorf("`subordinate_config` can only be configured on subordinate CA")
+	}
+
+	// Activate subordinate CA in `AWAITING_USER_ACTIVATION` state.
+	if d.Get("state") == "AWAITING_USER_ACTIVATION" {
+		if _, ok := d.GetOk("pem_ca_certificate"); ok {
+			// Third party issuer
+			log.Printf("[DEBUG] Activating CertificateAuthority with third party issuer")
+			if err := activateSubCAWithThirdPartyIssuer(config, d, project, billingProject, userAgent); err != nil {
+				return fmt.Errorf("Error activating subordinate CA with third party issuer: %v", err)
+			}
+		} else {
+			// First party issuer
+			log.Printf("[DEBUG] Activating CertificateAuthority with first party issuer")
+			if err := activateSubCAWithFirstPartyIssuer(config, d, project, billingProject, userAgent); err != nil {
+				return fmt.Errorf("Error activating subordinate CA with first party issuer: %v", err)
+			}
+		}
+		log.Printf("[DEBUG] CertificateAuthority activated")
+	}
+}
+
+log.Printf("[DEBUG] checking desired_state")
 if d.HasChange("desired_state") {
 	// Currently, most CA state update operations are not idempotent.
 	// Try to change state only if the current `state` does not match the `desired_state`.
 	if p, ok := d.GetOk("desired_state"); ok && p.(string) != d.Get("state").(string) {
 		switch p.(string) {
 		case "ENABLED":
-			enableUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:enable")
-			if err != nil {
-				return err
-			}
-
-			log.Printf("[DEBUG] Enabling CA: %#v", obj)
-
-			res, err := sendRequest(config, "POST", billingProject, enableUrl, userAgent, nil)
-			if err != nil {
-				return fmt.Errorf("Error enabling CA: %s", err)
-			}
-
-			var opRes map[string]interface{}
-			err = privatecaOperationWaitTimeWithResponse(
-				config, res, &opRes, project, "Enabling CA", userAgent,
-				d.Timeout(schema.TimeoutCreate))
-			if err != nil {
-				return fmt.Errorf("Error waiting to enable CA: %s", err)
+			if err := enableCA(config, d, project, billingProject, userAgent); err != nil {
+				return fmt.Errorf("Error enabling CertificateAuthority: %v", err)
 			}
 		case "DISABLED":
-			disableUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:disable")
-			if err != nil {
-				return err
+			if err := disableCA(config, d, project, billingProject, userAgent); err != nil {
+				return fmt.Errorf("Error disabling CertificateAuthority: %v", err)
 			}
-
-			log.Printf("[DEBUG] Disabling CA: %#v", obj)
-
-			dRes, err := sendRequest(config, "POST", billingProject, disableUrl, userAgent, nil)
-			if err != nil {
-				return fmt.Errorf("Error disabling CA: %s", err)
-			}
-
-			var opRes map[string]interface{}
-			err = privatecaOperationWaitTimeWithResponse(
-				config, dRes, &opRes, project, "Disabling CA", userAgent,
-				d.Timeout(schema.TimeoutDelete))
-			if err != nil {
-				return fmt.Errorf("Error waiting to disable CA: %s", err)
-			}	
 		default:
 			return fmt.Errorf("Unsupported value in field `desired_state`")
 		}

--- a/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_certificate_authority_test.go
@@ -85,6 +85,32 @@ func TestAccPrivatecaCertificateAuthority_subordinateCaCreatedInAwaitingUserActi
 	})
 }
 
+func TestAccPrivatecaCertificateAuthority_subordinateCaActivatedByFirstPartyIssuerOnCreation(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"pool_name":           BootstrapSharedCaPoolInLocation(t, "us-central1"),
+		"pool_location":       "us-central1",
+		"deletion_protection": false,
+		"random_suffix":       randString(t, 10),
+	}
+
+	resourceName := "google_privateca_certificate_authority.default"
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPrivatecaCertificateAuthorityDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -365,6 +391,117 @@ resource "google_privateca_certificate_authority" "default" {
 	certificate_authority_id = "tf-test-my-certificate-authority-%{random_suffix}"
 	location = "%{pool_location}"
 	deletion_protection = false
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
+	}
+	type = "SUBORDINATE"
+}
+`, context)
+}
+
+// testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer provides a config
+// which contains
+// * A root CA
+// * A subordinate CA which should be activated by the above root CA
+func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_privateca_certificate_authority" "root-1" {
+	// This example assumes this pool already exists.
+	// Pools cannot be deleted in normal test circumstances, so we depend on static pools
+	pool = "%{pool_name}"
+	certificate_authority_id = "tf-test-my-certificate-authority-root-%{random_suffix}"
+	location = "%{pool_location}"
+	deletion_protection = false
+	ignore_active_certificates_on_deletion = true
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
+	}
+}
+
+resource "google_privateca_certificate_authority" "default" {
+	// This example assumes this pool already exists.
+	// Pools cannot be deleted in normal test circumstances, so we depend on static pools
+	pool = "%{pool_name}"
+	certificate_authority_id = "tf-test-my-certificate-authority-sub-%{random_suffix}"
+	location = "%{pool_location}"
+	deletion_protection = false
+	subordinate_config {
+		certificate_authority = google_privateca_certificate_authority.root-1.name
+	}
 	config {
 		subject_config {
 		subject {

--- a/mmv1/third_party/terraform/utils/privateca_ca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_ca_utils.go
@@ -1,0 +1,221 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// CA related utilities.
+
+func enableCA(config *Config, d *schema.ResourceData, project string, billingProject string, userAgent string) error {
+	enableUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:enable")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Enabling CertificateAuthority")
+
+	res, err := sendRequest(config, "POST", billingProject, enableUrl, userAgent, nil)
+	if err != nil {
+		return fmt.Errorf("Error enabling CertificateAuthority: %s", err)
+	}
+
+	var opRes map[string]interface{}
+	err = privatecaOperationWaitTimeWithResponse(
+		config, res, &opRes, project, "Enabling CertificateAuthority", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("Error waiting to enable CertificateAuthority: %s", err)
+	}
+	return nil
+}
+
+func disableCA(config *Config, d *schema.ResourceData, project string, billingProject string, userAgent string) error {
+	disableUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:disable")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Disabling CA")
+
+	dRes, err := sendRequest(config, "POST", billingProject, disableUrl, userAgent, nil)
+	if err != nil {
+		return fmt.Errorf("Error disabling CA: %s", err)
+	}
+
+	var opRes map[string]interface{}
+	err = privatecaOperationWaitTimeWithResponse(
+		config, dRes, &opRes, project, "Disabling CA", userAgent,
+		d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return fmt.Errorf("Error waiting to disable CA: %s", err)
+	}
+	return nil
+}
+
+func activateSubCAWithThirdPartyIssuer(config *Config, d *schema.ResourceData, project string, billingProject string, userAgent string) error {
+	// 1. prepare parameters
+	signedCACert := d.Get("pem_ca_certificate").(string)
+
+	sc, ok := d.GetOk("subordinate_config")
+	if !ok {
+		return fmt.Errorf("subordinate_config is required to activate subordinate CA")
+	}
+	c := sc.([]interface{})
+	if len(c) == 0 || c[0] == nil {
+		return fmt.Errorf("subordinate_config is required to activate subordinate CA")
+	}
+	chain, ok := c[0].(map[string]interface{})["pem_issuer_chain"]
+	if !ok {
+		return fmt.Errorf("subordinate_config.pem_issuer_chain is required to activate subordinate CA with third party issuer")
+	}
+	issuerChain := chain.([]interface{})
+	if len(issuerChain) == 0 || issuerChain[0] == nil {
+		return fmt.Errorf("subordinate_config.pem_issuer_chain is required to activate subordinate CA with third party issuer")
+	}
+	pc := issuerChain[0].(map[string]interface{})["pem_certificates"].([]interface{})
+	pemIssuerChain := make([]string, 0, len(pc))
+	for _, pem := range pc {
+		pemIssuerChain = append(pemIssuerChain, pem.(string))
+	}
+
+	// 2. activate CA
+	activateObj := make(map[string]interface{})
+	activateObj["pemCaCertificate"] = signedCACert
+	activateObj["subordinateConfig"] = make(map[string]interface{})
+	activateObj["subordinateConfig"].(map[string]interface{})["pemIssuerChain"] = make(map[string]interface{})
+	activateObj["subordinateConfig"].(map[string]interface{})["pemIssuerChain"].(map[string]interface{})["pemCertificates"] = pemIssuerChain
+
+	activateUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:activate")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Activating CertificateAuthority: %#v", activateObj)
+	res, err := sendRequest(config, "POST", billingProject, activateUrl, userAgent, activateObj)
+	if err != nil {
+		return fmt.Errorf("Error enabling CertificateAuthority: %s", err)
+	}
+
+	var opRes map[string]interface{}
+	err = privatecaOperationWaitTimeWithResponse(
+		config, res, &opRes, project, "Activating CertificateAuthority", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("Error waiting to actiavte CertificateAuthority: %s", err)
+	}
+	return nil
+}
+
+func activateSubCAWithFirstPartyIssuer(config *Config, d *schema.ResourceData, project string, billingProject string, userAgent string) error {
+	// 1. get issuer
+	sc, ok := d.GetOk("subordinate_config")
+	if !ok {
+		return fmt.Errorf("subordinate_config is required to activate subordinate CA")
+	}
+	c := sc.([]interface{})
+	if len(c) == 0 || c[0] == nil {
+		return fmt.Errorf("subordinate_config is required to activate subordinate CA")
+	}
+	ca, ok := c[0].(map[string]interface{})["certificate_authority"]
+	if !ok {
+		return fmt.Errorf("subordinate_config.certificate_authority is required to activate subordinate CA with first party issuer")
+	}
+	issuer := ca.(string)
+
+	// 2. fetch CSR
+	fetchCSRUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:fetch")
+	if err != nil {
+		return err
+	}
+	res, err := sendRequest(config, "GET", billingProject, fetchCSRUrl, userAgent, nil)
+	if err != nil {
+		return fmt.Errorf("failed to fetch CSR: %v", err)
+	}
+	csr := res["pemCsr"]
+
+	// 3. sign the CSR with first party issuer
+	genCertId := func() string {
+		currentTime := time.Now()
+		dateStr := currentTime.Format("20060102")
+
+		rand.Seed(time.Now().UnixNano())
+		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		rand1 := make([]byte, 3)
+		for i := range rand1 {
+			rand1[i] = letters[rand.Intn(len(letters))]
+		}
+		rand2 := make([]byte, 3)
+		for i := range rand2 {
+			rand2[i] = letters[rand.Intn(len(letters))]
+		}
+		return fmt.Sprintf("subordinate-%v-%v-%v", dateStr, string(rand1), string(rand2))
+	}
+
+	// parseCAName parses a CA name and return the CaPool name and CaId.
+	parseCAName := func(n string) (string, string, error) {
+		parts := regexp.MustCompile(`(projects/[a-z0-9-]+/locations/[a-z0-9-]+/caPools/[a-zA-Z0-9-]+)/certificateAuthorities/([a-zA-Z0-9-]+)`).FindStringSubmatch(n)
+		if len(parts) != 3 {
+			return "", "", fmt.Errorf("failed to parse CA name: %v, parts: %v", n, parts)
+		}
+		return parts[1], parts[2], err
+	}
+
+	obj := make(map[string]interface{})
+	obj["pemCsr"] = csr
+	obj["lifetime"] = d.Get("lifetime")
+
+	certId := genCertId()
+	poolName, issuerId, err := parseCAName(issuer)
+	if err != nil {
+		return err
+	}
+
+	PrivatecaBasePath, err := replaceVars(d, config, "{{PrivatecaBasePath}}")
+	if err != nil {
+		return err
+	}
+	signUrl := fmt.Sprintf("%v%v/certificates?certificateId=%v", PrivatecaBasePath, poolName, certId)
+	signUrl, err = addQueryParams(signUrl, map[string]string{"issuingCertificateAuthorityId": issuerId})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Signing CA Certificate: %#v", obj)
+	res, err = sendRequestWithTimeout(config, "POST", billingProject, signUrl, userAgent, obj, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("Error creating Certificate: %s", err)
+	}
+	signedCACert := res["pemCertificate"]
+
+	// 4. activate sub CA with the signed CA cert.
+	activateObj := make(map[string]interface{})
+	activateObj["pemCaCertificate"] = signedCACert
+	activateObj["subordinateConfig"] = make(map[string]interface{})
+	activateObj["subordinateConfig"].(map[string]interface{})["certificateAuthority"] = issuer
+
+	activateUrl, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:activate")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Activating CertificateAuthority: %#v", activateObj)
+	res, err = sendRequest(config, "POST", billingProject, activateUrl, userAgent, activateObj)
+	if err != nil {
+		return fmt.Errorf("Error enabling CertificateAuthority: %s", err)
+	}
+
+	var opRes map[string]interface{}
+	err = privatecaOperationWaitTimeWithResponse(
+		config, res, &opRes, project, "Enabling CertificateAuthority", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("Error waiting to actiavte CertificateAuthority: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/9844


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: added support to subordinate CA activation
```
