### PR TITLE
pulls external providers for TestAccCGCSnippet_sqlDatabaseInstanceSql…

### DIFF
--- a/mmv1/products/cgc/terraform.yaml
+++ b/mmv1/products/cgc/terraform.yaml
@@ -102,6 +102,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "sql_database_instance_sqlserver"
         primary_resource_type: "google_sql_database_instance"
         primary_resource_id: "instance"
+        pull_external: true
         # Random provider
         skip_vcr: true
         vars:

--- a/mmv1/third_party/terraform/resources/resource_sql_user.go
+++ b/mmv1/third_party/terraform/resources/resource_sql_user.go
@@ -86,7 +86,6 @@ func resourceSqlUser() *schema.Resource {
 			"sql_server_user_details": {
 				Type:     schema.TypeList,
 				Computed: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"disabled": {

--- a/mmv1/third_party/terraform/tests/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_user_test.go
@@ -358,9 +358,8 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_user" "user1" {
-  name     = "admin"
+  name     = "admin1"
   instance = google_sql_database_instance.instance.name
-  host     = "google.com"
   password = "%s"
   sql_server_user_details {
     disabled = "%t"
@@ -369,9 +368,8 @@ resource "google_sql_user" "user1" {
 }
 
 resource "google_sql_user" "user2" {
-  name     = "admin"
+  name     = "admin2"
   instance = google_sql_database_instance.instance.name
-  host     = "gmail.com"
   password = "hunter2"
   depends_on = [google_sql_user.user1]
 }

--- a/mmv1/third_party/terraform/tests/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_user_test.go
@@ -257,7 +257,7 @@ func TestAccSqlUser_mysqlPasswordPolicy(t *testing.T) {
 		CheckDestroy: testAccSqlUserDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlUser_mysqlPasswordPolicy(instance, "password", false),
+				Config: testGoogleSqlUser_mysqlPasswordPolicy(instance, "password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
@@ -265,7 +265,7 @@ func TestAccSqlUser_mysqlPasswordPolicy(t *testing.T) {
 			},
 			{
 				// Update password
-				Config: testGoogleSqlUser_mysqlPasswordPolicy(instance, "new_password", false),
+				Config: testGoogleSqlUser_mysqlPasswordPolicy(instance, "new_password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
@@ -310,7 +310,7 @@ resource "google_sql_user" "user2" {
 `, instance, password)
 }
 
-func testGoogleSqlUser_mysqlPasswordPolicy(instance, password string, disabled bool) string {
+func testGoogleSqlUser_mysqlPasswordPolicy(instance, password string) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
   name                = "%s"
@@ -327,10 +327,7 @@ resource "google_sql_user" "user1" {
   instance = google_sql_database_instance.instance.name
   host     = "google.com"
   password = "%s"
-  sql_server_user_details {
-    disabled = "%t"
-    server_roles = [ "admin" ]  	
-  }
+
   password_policy {
     allowed_failed_attempts  = 6
     password_expiration_duration  =  "2592000s"
@@ -349,7 +346,7 @@ resource "google_sql_user" "user2" {
     enable_failed_attempts_check = true
   }
 }
-`, instance, password, disabled)
+`, instance, password)
 }
 
 func testGoogleSqlUser_postgres(instance, password string) string {

--- a/mmv1/third_party/terraform/tests/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_user_test.go
@@ -45,40 +45,6 @@ func TestAccSqlUser_mysql(t *testing.T) {
 	})
 }
 
-func TestAccSqlUser_mysqlDisabled(t *testing.T) {
-	t.Parallel()
-
-	instance := fmt.Sprintf("i-%d", randInt(t))
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccSqlUserDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testGoogleSqlUser_sqlServer(instance, "password", true),
-			},
-			{
-				ResourceName:            "google_sql_user.user1",
-				ImportStateId:           fmt.Sprintf("%s/%s/gmail.com/admin", getTestProjectFromEnv(), instance),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
-			},
-			{
-				// Update password
-				Config: testGoogleSqlUser_sqlServer(instance, "password", false),
-			},
-			{
-				ResourceName:            "google_sql_user.user1",
-				ImportStateId:           fmt.Sprintf("%s/%s/gmail.com/admin", getTestProjectFromEnv(), instance),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
-			},
-		},
-	})
-}
-
 func TestAccSqlUser_iamUser(t *testing.T) {
 	// Multiple fine-grained resources
 	skipIfVcr(t)
@@ -342,38 +308,6 @@ resource "google_sql_user" "user2" {
   password = "hunter2"
 }
 `, instance, password)
-}
-
-func testGoogleSqlUser_sqlServer(instance, password string, disabled bool) string {
-	return fmt.Sprintf(`
-resource "google_sql_database_instance" "instance" {
-  name                = "%s"
-  region              = "us-central1"
-  database_version    = "SQLSERVER_2019_STANDARD"
-  root_password       = "INSERT-PASSWORD-HERE "
-  deletion_protection = false
-  settings {
-    tier = "db-custom-2-7680"
-  }
-}
-
-resource "google_sql_user" "user1" {
-  name     = "admin1"
-  instance = google_sql_database_instance.instance.name
-  password = "%s"
-  sql_server_user_details {
-    disabled = "%t"
-    server_roles = [ "admin" ]  	
-  }
-}
-
-resource "google_sql_user" "user2" {
-  name     = "admin2"
-  instance = google_sql_database_instance.instance.name
-  password = "hunter2"
-  depends_on = [google_sql_user.user1]
-}
-`, instance, password, disabled)
 }
 
 func testGoogleSqlUser_mysqlPasswordPolicy(instance, password string, disabled bool) string {

--- a/mmv1/third_party/terraform/tests/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_user_test.go
@@ -20,7 +20,7 @@ func TestAccSqlUser_mysql(t *testing.T) {
 		CheckDestroy: testAccSqlUserDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlUser_mysql(instance, "password", false),
+				Config: testGoogleSqlUser_mysql(instance, "password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
@@ -28,7 +28,7 @@ func TestAccSqlUser_mysql(t *testing.T) {
 			},
 			{
 				// Update password
-				Config: testGoogleSqlUser_mysql(instance, "new_password", false),
+				Config: testGoogleSqlUser_mysql(instance, "new_password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
@@ -55,7 +55,7 @@ func TestAccSqlUser_mysqlDisabled(t *testing.T) {
 		CheckDestroy: testAccSqlUserDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlUser_mysql(instance, "password", true),
+				Config: testGoogleSqlUser_sqlServer(instance, "password", true),
 			},
 			{
 				ResourceName:            "google_sql_user.user1",
@@ -66,7 +66,7 @@ func TestAccSqlUser_mysqlDisabled(t *testing.T) {
 			},
 			{
 				// Update password
-				Config: testGoogleSqlUser_mysql(instance, "password", false),
+				Config: testGoogleSqlUser_sqlServer(instance, "password", false),
 			},
 			{
 				ResourceName:            "google_sql_user.user1",
@@ -316,7 +316,7 @@ func TestAccSqlUser_mysqlPasswordPolicy(t *testing.T) {
 	})
 }
 
-func testGoogleSqlUser_mysql(instance, password string, disabled bool) string {
+func testGoogleSqlUser_mysql(instance, password string) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
   name                = "%s"
@@ -325,6 +325,35 @@ resource "google_sql_database_instance" "instance" {
   deletion_protection = false
   settings {
     tier = "db-f1-micro"
+  }
+}
+
+resource "google_sql_user" "user1" {
+  name     = "admin"
+  instance = google_sql_database_instance.instance.name
+  host     = "google.com"
+  password = "%s"
+}
+
+resource "google_sql_user" "user2" {
+  name     = "admin"
+  instance = google_sql_database_instance.instance.name
+  host     = "gmail.com"
+  password = "hunter2"
+}
+`, instance, password)
+}
+
+func testGoogleSqlUser_sqlServer(instance, password string, disabled bool) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "SQLSERVER_2019_STANDARD"
+  root_password       = "INSERT-PASSWORD-HERE "
+  deletion_protection = false
+  settings {
+    tier = "db-custom-2-7680"
   }
 }
 


### PR DESCRIPTION
…serverExample

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11825

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
sql: updated `google_sql_user.sql_server_user_details` to be read only. Any configuration attempting to set this field is invalid and will cause the provider to crash during plan time.
```
