### PR TITLE
Promote monitoring-monitoredproject to GA

### DIFF
--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -1515,3 +1515,5 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.10.3 h1:Ds
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.10.3/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0 h1:ZGyOhpvdhu9P7KFR3GtqresK5WyCX5bRP3AwCsRTjqw=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0 h1:ZGyOhpvdhu9P7KFR3GtqresK5WyCX5bRP3AwCsRTjqw=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -1515,5 +1515,3 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.10.3 h1:Ds
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.10.3/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0 h1:ZGyOhpvdhu9P7KFR3GtqresK5WyCX5bRP3AwCsRTjqw=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0 h1:ZGyOhpvdhu9P7KFR3GtqresK5WyCX5bRP3AwCsRTjqw=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.11.0/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -505,9 +505,7 @@ end     # products.each do
 				"google_gke_hub_feature_membership":            resourceGkeHubFeatureMembership(),
 				<% end -%>
 				"google_logging_log_view":                      resourceLoggingLogView(),
-				<% unless version == 'ga' -%>
 				"google_monitoring_monitored_project":          resourceMonitoringMonitoredProject(),
-				<% end -%>
 				"google_network_connectivity_hub":              resourceNetworkConnectivityHub(),
 				"google_network_connectivity_spoke":            resourceNetworkConnectivitySpoke(),
 				"google_org_policy_policy":                     resourceOrgPolicyPolicy(),

--- a/tpgtools/overrides/monitoring/monitored_project.yaml
+++ b/tpgtools/overrides/monitoring/monitored_project.yaml
@@ -1,32 +1,17 @@
 # Copyright 2021 Google LLC. All Rights Reserved.
-#
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-dependencies:
-- samples/basic.cloudresourcemanager.project.json
-description: A basic example of a monitoring monitored project
-name: basic_monitored_project
-resource: samples/basic.monitored_project.json
-type: monitored_project
-variables:
-- name: id
-  type: resource_name
-  docs_value: my-monitored-project
-- name: org_id
-  type: org_id
-- name: project
-  type: project
-  docs_value: existing-metrics-scope-project
-versions:
-- beta
-- ga
 
+- type: APPEND_TO_BASE_PATH
+  details:
+    string: v1

--- a/tpgtools/overrides/monitoring/tpgtools_product.yaml
+++ b/tpgtools/overrides/monitoring/tpgtools_product.yaml
@@ -1,0 +1,5 @@
+## product level overrides
+
+- type: PRODUCT_DOCS_SECTION
+  details:
+    docssection: Cloud (Stackdriver) Monitoring


### PR DESCRIPTION
Promote monitoring-monitoredproject to GA

fixes:
https://github.com/hashicorp/terraform-provider-google/issues/10527
https://b.corp.google.com/issues/205704646


If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:new-resource
monitoring: Promoted 'monitoredproject' to GA
```
