### PR TITLE
add datafusion instance versions in attempt to keep our tests up to date

### DIFF
--- a/mmv1/products/datafusion/terraform.yaml
+++ b/mmv1/products/datafusion/terraform.yaml
@@ -30,6 +30,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "extended_instance"
         vars:
           instance_name: "my-instance"
+          ip_alloc: "datafusion-ip-alloc"
+          network_name: "datafusion-full-network"
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
@@ -1,3 +1,7 @@
+data "google_data_fusion_instance_versions" "versions" {
+  location = "us-central1"
+}
+
 resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["instance_name"] %>"
   description = "My Data Fusion instance"
@@ -13,7 +17,7 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
     network = "default"
     ip_allocation = "10.89.48.0/22"
   }
-  version = "6.3.0"
+  version = data.google_data_fusion_instance_versions.versions.instance_versions[0].version_number
   dataproc_service_account = data.google_app_engine_default_service_account.default.email
 }
 

--- a/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
@@ -2,6 +2,18 @@ data "google_data_fusion_instance_versions" "versions" {
   location = "us-central1"
 }
 
+resource "google_compute_network" "network" {
+  name = "<%= ctx[:vars]["network_name"] %>"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          = "<%= ctx[:vars]["ip_alloc"] %>"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 22
+  network       = google_compute_network.network.id
+}
+
 resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["instance_name"] %>"
   description = "My Data Fusion instance"
@@ -15,7 +27,7 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
   private_instance = true
   network_config {
     network = "default"
-    ip_allocation = "10.89.48.0/22"
+    ip_allocation = "${google_compute_global_address.private_ip_alloc.address}/${google_compute_global_address.private_ip_alloc.prefix_length}"
   }
   version = data.google_data_fusion_instance_versions.versions.instance_versions[0].version_number
   dataproc_service_account = data.google_app_engine_default_service_account.default.email

--- a/mmv1/third_party/terraform/data_sources/data_source_data_fusion_instance_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_data_fusion_instance_versions.go
@@ -1,0 +1,88 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDataFusionInstanceVersions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDataFusionInstanceVersionsRead,
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"version_number": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDataFusionInstanceVersionsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	location := d.Get("location")
+	url, err := replaceVars(d, config, "{{DataFusionBasePath}}projects/{{project}}/locations/{{location}}/versions")
+	if err != nil {
+		return err
+	}
+
+	versions, err := paginatedListRequest(project, url, userAgent, config, flattenGoogleDataFusionInstanceVersions)
+	if err != nil {
+		return fmt.Errorf("Error listing Data Fusion instance versions: %s", err)
+	}
+
+	log.Printf("[DEBUG] Received Data Fusion Instance Versions: %q", versions)
+
+	if err := d.Set("instance_versions", versions); err != nil {
+		return fmt.Errorf("Error setting instance_versions: %s", err)
+	}
+	if err := d.Set("location", location); err != nil {
+		return fmt.Errorf("Error setting region: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+	d.SetId(fmt.Sprintf("projects/%s/locations/%s", project, location))
+
+	return nil
+}
+
+func flattenGoogleDataFusionInstanceVersions(resp map[string]interface{}) []interface{} {
+	verObjList := resp["availableVersions"].([]interface{})
+	versions := make([]interface{}, len(verObjList))
+	for i, v := range verObjList {
+		verObj := v.(map[string]interface{})
+		versions[i] = map[string]interface{}{
+			"version_number": verObj["versionNumber"],
+		}
+	}
+	return versions
+}

--- a/mmv1/third_party/terraform/tests/data_source_data_fusion_instance_versions_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_data_fusion_instance_versions_test.go
@@ -1,0 +1,70 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceDataFusionInstanceVersions_basic(t *testing.T) {
+	t.Parallel()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataFusionInstanceVersions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleDataFusionInstanceVersionsMeta("data.google_data_fusion_instance_versions.versions"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleDataFusionInstanceVersionsMeta(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find versions data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("versions data source ID not set.")
+		}
+
+		versionCountStr, ok := rs.Primary.Attributes["instance_versions.#"]
+		if !ok {
+			return errors.New("can't find 'image_versions' attribute")
+		}
+
+		versionCount, err := strconv.Atoi(versionCountStr)
+		if err != nil {
+			return errors.New("failed to read number of valid instance versions")
+		}
+		if versionCount < 1 {
+			return fmt.Errorf("expected at least 1 valid instance versions, received %d, this is most likely a bug",
+				versionCount)
+		}
+
+		for i := 0; i < versionCount; i++ {
+			idx := "instance_versions." + strconv.Itoa(i)
+			if v, ok := rs.Primary.Attributes[idx+".version_number"]; !ok || v == "" {
+				return fmt.Errorf("instance_version %v is missing version_number", i)
+			}
+		}
+
+		return nil
+	}
+}
+
+var testAccDataSourceDataFusionInstanceVersions_basic = `
+data "google_data_fusion_instance_versions" "versions" {
+  location = "us-central1"
+}
+`

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -243,6 +243,7 @@ func Provider() *schema.Provider {
 			"google_container_engine_versions":                 dataSourceGoogleContainerEngineVersions(),
 			"google_container_registry_image":                  dataSourceGoogleContainerImage(),
 			"google_container_registry_repository":             dataSourceGoogleContainerRepo(),
+			"google_data_fusion_instance_versions":             dataSourceDataFusionInstanceVersions(),
 			<% unless version == 'ga' -%>
 			"google_dataproc_metastore_service":                dataSourceDataprocMetastoreService(),
 			<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_data_fusion_instance_versions`
```
