### PR TITLE
Change filestore network field to a resourceref

### DIFF
--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -198,13 +198,15 @@ objects:
         input: true
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
-            - !ruby/object:Api::Type::String
+            - !ruby/object:Api::Type::ResourceRef
               name: 'network'
               description: |
                 The name of the GCE VPC network to which the
                 instance is connected.
               required: true
               input: true
+              resource: 'Instance' # really 'Network' in GCE, but the value here doesn't matter
+              imports: 'name' # really `selfLink`, but this resource doesn't have one
             - !ruby/object:Api::Type::Array
               name: 'modes'
               description: |

--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -198,15 +198,13 @@ objects:
         input: true
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
-            - !ruby/object:Api::Type::ResourceRef
+            - !ruby/object:Api::Type::String
               name: 'network'
               description: |
                 The name of the GCE VPC network to which the
                 instance is connected.
               required: true
               input: true
-              resource: 'Instance' # really 'Network' in GCE, but the value here doesn't matter
-              imports: 'name' # really `selfLink`, but this resource doesn't have one
             - !ruby/object:Api::Type::Array
               name: 'modes'
               description: |

--- a/mmv1/products/filestore/terraform.yaml
+++ b/mmv1/products/filestore/terraform.yaml
@@ -46,7 +46,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       networks.connectMode: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
-      networks.network:
+      networks.network: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
       networks.reservedIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/products/filestore/terraform.yaml
+++ b/mmv1/products/filestore/terraform.yaml
@@ -44,10 +44,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
         default_from_api: true
-      networks.reservedIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       networks.connectMode: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+      networks.network:
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+      networks.reservedIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/filestore.erb
       pre_create: templates/terraform/pre_create/filestore_instance.go.erb


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11956


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
filestore: fixed a case where `google_filestore_instance.networks.network` would incorrectly see a diff between state and config when the network `id` format was used
```
