### PR TITLE
google_sql_database_instance - support for secondary_zone

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -375,6 +375,11 @@ is set to true.`,
 										AtLeastOneOf: []string{"settings.0.location_preference.0.follow_gae_application", "settings.0.location_preference.0.zone"},
 										Description:  `The preferred compute engine zone.`,
 									},
+									"secondary_zone": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Description:  `The preferred Compute Engine zone for the secondary/failover`,
+									},
 								},
 							},
 						},
@@ -1070,6 +1075,7 @@ func expandLocationPreference(configured []interface{}) *sqladmin.LocationPrefer
 	return &sqladmin.LocationPreference{
 		FollowGaeApplication: _locationPreference["follow_gae_application"].(string),
 		Zone:                 _locationPreference["zone"].(string),
+	    SecondaryZone:        _locationPreference["secondary_zone"].(string),
 	}
 }
 
@@ -1560,6 +1566,7 @@ func flattenLocationPreference(locationPreference *sqladmin.LocationPreference) 
 	data := map[string]interface{}{
 		"follow_gae_application": locationPreference.FollowGaeApplication,
 		"zone":                   locationPreference.Zone,
+		"secondary_zone":         locationPreference.SecondaryZone,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -1075,7 +1075,7 @@ func expandLocationPreference(configured []interface{}) *sqladmin.LocationPrefer
 	return &sqladmin.LocationPreference{
 		FollowGaeApplication: _locationPreference["follow_gae_application"].(string),
 		Zone:                 _locationPreference["zone"].(string),
-	    SecondaryZone:        _locationPreference["secondary_zone"].(string),
+		SecondaryZone:        _locationPreference["secondary_zone"].(string),
 	}
 }
 

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -300,6 +300,30 @@ func TestAccSqlDatabaseInstance_settings_basic(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_settings_secondary(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_settings_secondary, databaseName),
+			},
+			resource.TestStep{
+				ResourceName:      "google_sql_database_instance.instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_settings_deletionProtection(t *testing.T) {
 	t.Parallel()
 
@@ -1576,6 +1600,39 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `
+
+var testGoogleSqlDatabaseInstance_settings_secondary = `
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+  settings {
+    tier                   = "db-f1-micro"
+    location_preference {
+      zone           = "us-central1-f"
+	  secondary_zone = "us-central1-a"	  
+    }
+
+    ip_configuration {
+      ipv4_enabled = "true"
+      authorized_networks {
+        value           = "108.12.12.12"
+        name            = "misc"
+        expiration_time = "2037-11-15T16:19:00.094Z"
+      }
+    }
+
+    backup_configuration {
+      enabled    = "true"
+      start_time = "19:19"
+    }
+
+    activation_policy = "ALWAYS"
+  }
+}
+`
+
 var testGoogleSqlDatabaseInstance_settings_deletionProtection = `
 resource "google_sql_database_instance" "instance" {
   name                = "%s"

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -326,6 +326,8 @@ The optional `settings.location_preference` subblock supports:
 * `zone` - (Optional) The preferred compute engine
     [zone](https://cloud.google.com/compute/docs/zones?hl=en).
 
+* `secondary_zone` - (Optional) The preferred Compute Engine zone for the secondary/failover.
+
 The optional `settings.maintenance_window` subblock for instances declares a one-hour
 [maintenance window](https://cloud.google.com/sql/docs/instance-settings?hl=en#maintenance-window-2ndgen)
 when an Instance can automatically restart to apply updates. The maintenance window is specified in UTC time. It supports:

--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.tf
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.tf
@@ -90,6 +90,7 @@ resource "google_sql_database_instance" "main" {
     location_preference {
       follow_gae_application = "test-follow_gae_application"
       zone                   = "us-central1-a"
+      secondary_zone         = "us-central1-b"
     }
     maintenance_window {
       day          = 42

--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.tfplan.json
@@ -123,7 +123,8 @@
                 "location_preference": [
                   {
                     "follow_gae_application": "test-follow_gae_application",
-                    "zone": "us-central1-a"
+                    "zone": "us-central1-a",
+                    "secondary_zone": "us-central1-b"
                   }
                 ],
                 "maintenance_window": [


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes [#10663](https://github.com/hashicorp/terraform-provider-google/issues/10663)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added `settings.location_preference.secondary_zone` field in `google_sql_database_instance`
```
