### PR TITLE
Promote gce_persistent_disk_csi_driver_config to GA

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -66,9 +66,9 @@ var (
 		"addons_config.0.cloudrun_config",
 		"addons_config.0.gcp_filestore_csi_driver_config",
 		"addons_config.0.dns_cache_config",
+		"addons_config.0.gce_persistent_disk_csi_driver_config",
 	<% unless version == 'ga' -%>
 		"addons_config.0.istio_config",
-		"addons_config.0.gce_persistent_disk_csi_driver_config",
 		"addons_config.0.kalm_config",
 		"addons_config.0.config_connector_config",
 		"addons_config.0.gke_backup_agent_config",
@@ -316,6 +316,22 @@ func resourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						"gce_persistent_disk_csi_driver_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Description:  `Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to enabled; set disabled = true to disable.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
 						<% unless version == 'ga' -%>
 						"istio_config": {
 							Type:         schema.TypeList,
@@ -338,22 +354,6 @@ func resourceContainerCluster() *schema.Resource {
 										DiffSuppressFunc: emptyOrDefaultStringSuppress("AUTH_NONE"),
 										ValidateFunc:     validation.StringInSlice([]string{"AUTH_NONE", "AUTH_MUTUAL_TLS"}, false),
 										Description:      `The authentication type between services in Istio. Available options include AUTH_MUTUAL_TLS.`,
-									},
-								},
-							},
-						},
-						"gce_persistent_disk_csi_driver_config": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: addonsConfigKeys,
-							MaxItems:     1,
-							Description:  `Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set enabled = true to enable.`,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enabled": {
-										Type:     schema.TypeBool,
-										Required: true,
 									},
 								},
 							},
@@ -3167,6 +3167,14 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
+	if v, ok := config["gce_persistent_disk_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.GcePersistentDiskCsiDriverConfig = &container.GcePersistentDiskCsiDriverConfig{
+			Enabled:         !addon["disabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+
 <% unless version == 'ga' -%>
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
@@ -3174,14 +3182,6 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 			Disabled:        addon["disabled"].(bool),
 			Auth:            addon["auth"].(string),
 			ForceSendFields: []string{"Disabled"},
-		}
-	}
-
-	if v, ok := config["gce_persistent_disk_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
-		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.GcePersistentDiskCsiDriverConfig = &container.GcePersistentDiskCsiDriverConfig{
-			Enabled:         addon["enabled"].(bool),
-			ForceSendFields: []string{"Enabled"},
 		}
 	}
 
@@ -3862,20 +3862,20 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		}
 	}
 
+	if c.GcePersistentDiskCsiDriverConfig != nil {
+		result["gce_persistent_disk_csi_driver_config"] = []map[string]interface{}{
+			{
+				"disabled": !c.GcePersistentDiskCsiDriverConfig.Enabled,
+			},
+		}
+	}
+
 <% unless version == 'ga' -%>
 	if c.IstioConfig != nil {
 		result["istio_config"] = []map[string]interface{}{
 			{
 				"disabled": c.IstioConfig.Disabled,
 				"auth":     c.IstioConfig.Auth,
-			},
-		}
-	}
-
-	if c.GcePersistentDiskCsiDriverConfig != nil {
-		result["gce_persistent_disk_csi_driver_config"] = []map[string]interface{}{
-			{
-				"enabled": c.GcePersistentDiskCsiDriverConfig.Enabled,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -325,7 +325,7 @@ func resourceContainerCluster() *schema.Resource {
 							Description:  `Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to enabled; set disabled = true to disable.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"disabled": {
+									"enabled": {
 										Type:     schema.TypeBool,
 										Required: true,
 									},
@@ -3170,7 +3170,7 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 	if v, ok := config["gce_persistent_disk_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.GcePersistentDiskCsiDriverConfig = &container.GcePersistentDiskCsiDriverConfig{
-			Enabled:         !addon["disabled"].(bool),
+			Enabled:         addon["enabled"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
 	}
@@ -3865,7 +3865,7 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 	if c.GcePersistentDiskCsiDriverConfig != nil {
 		result["gce_persistent_disk_csi_driver_config"] = []map[string]interface{}{
 			{
-				"disabled": !c.GcePersistentDiskCsiDriverConfig.Enabled,
+				"enabled": c.GcePersistentDiskCsiDriverConfig.Enabled,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2843,13 +2843,13 @@ resource "google_container_cluster" "primary" {
 	dns_cache_config {
       enabled = false
     }
+	gce_persistent_disk_csi_driver_config {
+	  disabled = true
+	}
 <% unless version == 'ga' -%>
     istio_config {
       disabled = true
       auth     = "AUTH_MUTUAL_TLS"
-    }
-    gce_persistent_disk_csi_driver_config {
-      enabled = false
     }
     kalm_config {
 	  enabled = false
@@ -2902,15 +2902,14 @@ resource "google_container_cluster" "primary" {
 	dns_cache_config {
       enabled = true
 	}
+	gce_persistent_disk_csi_driver_config {
+	  disabled = false
+	}
 <% unless version == 'ga' -%>
     istio_config {
       disabled = false
       auth     = "AUTH_NONE"
     }
-
-    gce_persistent_disk_csi_driver_config {
-      enabled = true
-	}
 	kalm_config {
 	  enabled = true
 	}

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2840,12 +2840,12 @@ resource "google_container_cluster" "primary" {
     cloudrun_config {
       disabled = true
     }
-	dns_cache_config {
+    dns_cache_config {
       enabled = false
     }
-	gce_persistent_disk_csi_driver_config {
-	  disabled = true
-	}
+    gce_persistent_disk_csi_driver_config {
+      disabled = true
+    }
 <% unless version == 'ga' -%>
     istio_config {
       disabled = true
@@ -2899,12 +2899,12 @@ resource "google_container_cluster" "primary" {
     cloudrun_config {
       disabled = false
     }
-	dns_cache_config {
+    dns_cache_config {
       enabled = true
-	}
-	gce_persistent_disk_csi_driver_config {
-	  disabled = false
-	}
+    }
+    gce_persistent_disk_csi_driver_config {
+      disabled = false
+    }
 <% unless version == 'ga' -%>
     istio_config {
       disabled = false

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2844,7 +2844,7 @@ resource "google_container_cluster" "primary" {
       enabled = false
     }
     gce_persistent_disk_csi_driver_config {
-      disabled = true
+      enabled = false
     }
 <% unless version == 'ga' -%>
     istio_config {
@@ -2903,7 +2903,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
     gce_persistent_disk_csi_driver_config {
-      disabled = false
+      enabled = true
     }
 <% unless version == 'ga' -%>
     istio_config {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -385,8 +385,8 @@ subnetwork in which the cluster's instances are launched.
     **Enabling/Disabling NodeLocal DNSCache in an existing cluster is a disruptive operation.
     All cluster nodes running GKE 1.15 and higher are recreated.**
 
-* `gce_persistent_disk_csi_driver_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
-    Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set `enabled = true` to enable.
+* `gce_persistent_disk_csi_driver_config` - (Optional).
+    Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to enabled; set `disabled = true` to disable.
 
 * `kalm_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     Configuration for the KALM addon, which manages the lifecycle of k8s. It is disabled by default; Set `enabled = true` to enable.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -386,7 +386,7 @@ subnetwork in which the cluster's instances are launched.
     All cluster nodes running GKE 1.15 and higher are recreated.**
 
 * `gce_persistent_disk_csi_driver_config` - (Optional).
-    Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to enabled; set `disabled = true` to disable.
+    Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set `enabled = true` to enabled.
 
 * `kalm_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     Configuration for the KALM addon, which manages the lifecycle of k8s. It is disabled by default; Set `enabled = true` to enable.


### PR DESCRIPTION
# Description

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/10759

This PR promotes the [Compute Engine persistent disk CSI Driver GKE add-on](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver) to GA.

I've made the add-on enabled by default and controlled by a `disabled` attribute, which requires negating [the `Enabled` field](https://pkg.go.dev/google.golang.org/api/container/v1#GcePersistentDiskCsiDriverConfig), to follow the proposed solution in the issue https://github.com/hashicorp/terraform-provider-google/issues/10759. I want to double-check if that's wanted or not, as it'd require people to change their configurations.

For acceptance tests, the updated `TestAccContainerCluster_withAddons` test passes locally if I comment out code related to `cloudrun_config` (to avoid a 'DeployPatch failed' error when updating the cluster) 


# Checklist
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Promoted `gce_persistent_disk_csi_driver_config` addon in `google_container_cluster` resource to GA
```
