### PR TITLE
Handle `email`-less services in `google_project_service_identity`

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_project_service_identity.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_project_service_identity.go.erb
@@ -36,6 +36,7 @@ func resourceProjectServiceIdentity() *schema.Resource {
 			},
 			"email": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 		},
@@ -88,16 +89,16 @@ func resourceProjectServiceIdentityCreate(d *schema.ResourceData, meta interface
 	}
 	d.SetId(id)
 
-	emailVal, ok := opRes["email"]
-	if !ok {
-		return fmt.Errorf("response %v missing 'email'", opRes)
-	}
-	email, ok := emailVal.(string)
-	if !ok {
-		return fmt.Errorf("unexpected type for email: got %T, want string", email)
-	}
-	if err := d.Set("email", email); err != nil {
-		return fmt.Errorf("Error setting email: %s", err)
+	// This API may not return the service identity's details, even if the relevant
+	// Google API is configured for service identities.
+	if emailVal, ok := opRes["email"]; ok {
+		email, ok := emailVal.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type for email: got %T, want string", email)
+		}
+		if err := d.Set("email", email); err != nil {
+			return fmt.Errorf("Error setting email: %s", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
# Description
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/10367

This PR changes the `google_project_service_identity` resource to handle scenarios when it successfully creates a service identity for a given Google API via [generateServiceIdentity](https://cloud.google.com/service-usage/docs/reference/rest/v1beta1/services/generateServiceIdentity) but the response doesn't contain the service identity's email. Now `email` will only be set if the response contains an email.

**The downside is that if the email isn't returned by the API, user won't know until they try to reference the email attribute elsewhere**


Examples of the endpoint succeeding & returning an email, succeeding but not returning an email, and erroring:
```bash
$ gcloud beta services identity create --service=containerscanning.googleapis.com                    
Service identity created: service-XXXXXXXXXX@gcp-sa-containerscanning.iam.gserviceaccount.com

$ gcloud beta services identity create --service=logging.googleapis.com          
Service identity created

$ gcloud beta services identity create --service=stackdriverprovisioning.googleapis.com
ERROR: (gcloud.beta.services.identity.create) INVALID_ARGUMENT: Service stackdriverprovisioning.googleapis.com has not been configured for service identities.
```


# Checklist
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: fixed an issue where `google_project_service_identity` didn't handle service identities without emails correctly (beta)
```
