### PR TITLE
Promote Cloud SQL CMEK feature to ga

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -475,14 +475,12 @@ is set to true.`,
 				Description: `The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.`,
 			},
 
-<% unless version == 'ga' -%>
 			"encryption_key_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
- <% end -%>
 
 
 			"root_password": {
@@ -839,13 +837,12 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		mutexKV.Lock(instanceMutexKey(project, instance.MasterInstanceName))
 		defer mutexKV.Unlock(instanceMutexKey(project, instance.MasterInstanceName))
 	}
-    <% unless version == 'ga' -%>
-    if k, ok := d.GetOk("encryption_key_name"); ok {
-        instance.DiskEncryptionConfiguration = &sqladmin.DiskEncryptionConfiguration{
-            KmsKeyName: k.(string),
+
+        if k, ok := d.GetOk("encryption_key_name"); ok {
+            instance.DiskEncryptionConfiguration = &sqladmin.DiskEncryptionConfiguration{
+                KmsKeyName: k.(string),
+            }
         }
-    }
-    <% end -%>
 
 	var patchData *sqladmin.DatabaseInstance
 
@@ -1229,13 +1226,12 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("settings", flattenSettings(instance.Settings)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Settings")
 	}
-    <% unless version == 'ga' -%>
-    if instance.DiskEncryptionConfiguration != nil {
-        if err := d.Set("encryption_key_name", instance.DiskEncryptionConfiguration.KmsKeyName); err != nil {
-        	return fmt.Errorf("Error setting encryption_key_name: %s", err)
+
+        if instance.DiskEncryptionConfiguration != nil {
+            if err := d.Set("encryption_key_name", instance.DiskEncryptionConfiguration.KmsKeyName); err != nil {
+                 return fmt.Errorf("Error setting encryption_key_name: %s", err)
+            }
         }
-    }
-    <% end -%>
 
 	if err := d.Set("replica_configuration", flattenReplicaConfiguration(instance.ReplicaConfiguration, d)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Replica Configuration")

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1028,18 +1028,18 @@ func TestAccSqlDatabaseInstance_insights(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccSqlDatabaseInstance_encryptionKey(t *testing.T) {
 	t.Parallel()
 
-	context := map[string]interface{}{
+        context := map[string]interface{}{
+                "project_id": getTestProjectFromEnv(),
 		"key_name": "tf-test-key-" + randString(t, 10),
 		"instance_name": "tf-test-sql-" + randString(t, 10),
 	}
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -1065,14 +1065,15 @@ func TestAccSqlDatabaseInstance_encryptionKey(t *testing.T) {
 func TestAccSqlDatabaseInstance_encryptionKey_replicaInDifferentRegion(t *testing.T) {
 	t.Parallel()
 
-	context := map[string]interface{}{
+        context := map[string]interface{}{
+               "project_id": getTestProjectFromEnv(),
 		"key_name":      "tf-test-key-" + randString(t, 10),
 		"instance_name": "tf-test-sql-" + randString(t, 10),
 	}
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -1094,7 +1095,6 @@ func TestAccSqlDatabaseInstance_encryptionKey_replicaInDifferentRegion(t *testin
 		},
 	})
 }
-<% end -%>
 
 func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 	t.Parallel()
@@ -1889,39 +1889,30 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `
-<% unless version == 'ga' -%>
 var testGoogleSqlDatabaseInstance_encryptionKey = `
-resource "google_project_service_identity" "gcp_sa_cloud_sql" {
-  provider = google-beta
-  service  = "sqladmin.googleapis.com"
+data "google_project" "project" {
+  project_id = "%{project_id}"
 }
-
 resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
-
   name     = "%{key_name}"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "key" {
-  provider = google-beta
-
   name     = "%{key_name}"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key" {
-  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   members = [
-    "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
+  "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com",
   ]
 }
 
 resource "google_sql_database_instance" "master" {
-  provider            = google-beta
   name                = "%{instance_name}-master"
   database_version    = "MYSQL_5_7"
   region              = "us-central1"
@@ -1940,7 +1931,6 @@ resource "google_sql_database_instance" "master" {
 }
 
 resource "google_sql_database_instance" "replica" {
-  provider             = google-beta
   name                 = "%{instance_name}-replica"
   database_version     = "MYSQL_5_7"
   region               = "us-central1"
@@ -1957,37 +1947,32 @@ resource "google_sql_database_instance" "replica" {
 
 
 var testGoogleSqlDatabaseInstance_encryptionKey_replicaInDifferentRegion = `
-resource "google_project_service_identity" "gcp_sa_cloud_sql" {
-  provider = google-beta
-  service  = "sqladmin.googleapis.com"
+
+data "google_project" "project" {
+  project_id = "%{project_id}"
 }
 
 resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
-
   name     = "%{key_name}"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "key" {
-  provider = google-beta
 
   name     = "%{key_name}"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key" {
-  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   members = [
-    "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com",
   ]
 }
 
 resource "google_sql_database_instance" "master" {
-  provider            = google-beta
   name                = "%{instance_name}-master"
   database_version    = "MYSQL_5_7"
   region              = "us-central1"
@@ -2006,31 +1991,27 @@ resource "google_sql_database_instance" "master" {
 }
 
 resource "google_kms_key_ring" "keyring-rep" {
-  provider = google-beta
 
   name     = "%{key_name}-rep"
   location = "us-east1"
 }
 
 resource "google_kms_crypto_key" "key-rep" {
-  provider = google-beta
 
   name     = "%{key_name}-rep"
   key_ring = google_kms_key_ring.keyring-rep.id
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key_rep" {
-  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key-rep.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   members = [
-    "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com",
   ]
 }
 
 resource "google_sql_database_instance" "replica" {
-  provider             = google-beta
   name                 = "%{instance_name}-replica"
   database_version     = "MYSQL_5_7"
   region               = "us-east1"
@@ -2045,8 +2026,6 @@ resource "google_sql_database_instance" "replica" {
   depends_on = [google_sql_database_instance.master]
 }
 `
-<% end -%>
-
 func testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID int, pointInTimeRecoveryEnabled bool) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -198,7 +198,7 @@ includes an up-to-date reference of supported versions.
 
 * `root_password` - (Optional) Initial root password. Required for MS SQL Server, ignored by MySQL and PostgreSQL.
 
-* `encryption_key_name` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+* `encryption_key_name` - (Optional)
     The full path to the encryption key used for the CMEK disk encryption.  Setting
     up disk encryption currently requires manual steps outside of Terraform.
     The provided key must be in the same region as the SQL instance.  In order


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Cloud SQL supports CMEK feature and it has been in GA (https://cloud.google.com/sql/docs/mysql/configure-cmek). So promoting the terraform attribute to ga.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: promoted attribute "encryption_key_name" to GA in `google_sql_database_instance` resource.
```
