### PR TITLE
IAM resources for google_cloudiot_registry

### DIFF
--- a/mmv1/products/cloudiot/api.yaml
+++ b/mmv1/products/cloudiot/api.yaml
@@ -35,6 +35,12 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/iot/docs/'
       api: 'https://cloud.google.com/iot/docs/reference/cloudiot/rest/'
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      exclude: false
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :POST      
+      parent_resource_attribute: 'name'
+      import_format: ["projects/{{project}}/locations/{{location}}/registries/{{name}}", "{{name}}"]           
     parameters:
       - !ruby/object:Api::Type::String
         name: region

--- a/mmv1/products/cloudiot/terraform.yaml
+++ b/mmv1/products/cloudiot/terraform.yaml
@@ -63,6 +63,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "cloudiot_device_registry_basic"
         primary_resource_id: "test-registry"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-cloudiot-registry%s\", context[\"random_suffix\"])"        
         vars:
           cloudiot_registry_name: "cloudiot-registry"
         test_env_vars:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/9962


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_cloudiot_registry_iam_member
```

```release-note:new-resource
google_cloudiot_registry_iam_binding
```

```release-note:new-resource
google_cloudiot_registry_iam_policy
```

