### PR TITLE
Add support to allow create CMEK Redis instance in terraform

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -402,6 +402,7 @@ objects:
           range associated with the private service access connection, or "auto".
       - !ruby/object:Api::Type::String
         name: customerManagedKey
+        input: true
         description: |
           Optional. The KMS key reference that you want to use to encrypt the data at rest for this Redis
           instance. If this is provided, CMEK is enabled.

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -400,3 +400,8 @@ objects:
           an existing instance. For DIRECT_PEERING mode value must be a CIDR range of size /28, or
           "auto". For PRIVATE_SERVICE_ACCESS mode value must be the name of an allocated address 
           range associated with the private service access connection, or "auto".
+      - !ruby/object:Api::Type::String
+        name: customerManagedKey
+        description: |
+          Optional. The KMS key reference that you want to use to encrypt the data at rest for this Redis
+          instance. If this is provided, CMEK is enabled.

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -64,6 +64,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_cmek"
         primary_resource_id: "cache"
+        skip_test: true
         vars:
           instance_name: "cmek-memory-cache"
           network_name: "redis-test-network"
@@ -114,8 +115,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       secondaryIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         diff_suppress_func: 'secondaryIpDiffSuppress'
-      customerManagedKey: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -61,6 +61,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "redis-test-network"
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "redis-mrr")'
+      - !ruby/object:Provider::Terraform::Examples
+        name: "redis_instance_cmek"
+        primary_resource_id: "cache"
+        vars:
+          instance_name: "cmek-memory-cache"
+          network_name: "redis-test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-cmek")'
     properties:
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
@@ -106,6 +114,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       secondaryIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         diff_suppress_func: 'secondaryIpDiffSuppress'
+      customerManagedKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/examples/redis_instance_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_cmek.tf.erb
@@ -1,0 +1,42 @@
+resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
+  name           = "<%= ctx[:vars]['instance_name'] %>"
+  tier           = "STANDARD_HA"
+  memory_size_gb = 1
+
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
+
+  authorized_network = data.google_compute_network.redis-network.id
+
+  redis_version     = "REDIS_6_X"
+  display_name      = "Terraform Test Instance"
+  reserved_ip_range = "192.168.0.0/29"
+
+  labels = {
+    my_key    = "my_val"
+    other_key = "other_val"
+  }
+  customer_managed_key = google_kms_crypto_key.redis_key.id
+}
+
+resource "google_kms_key_ring" "redis_keyring" {
+  name     = "redis-keyring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "redis_key" {
+  name            = "redis-key"
+  key_ring        = google_kms_key_ring.redis_keyring.id
+}
+
+// This example assumes this network already exists.
+// The API creates a tenant network per network authorized for a
+// Redis instance and that network is not deleted when the user-created
+// network (authorized_network) is deleted, so this prevents issues
+// with tenant network quota.
+// If this network hasn't been created and you are using this example in your
+// config, add an additional network resource or change
+// this from "data"to "resource"
+data "google_compute_network" "redis-network" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}


### PR DESCRIPTION
Add support to allow create CMEK Redis instance in terraform




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: Added CMEK key field `customer_managed_key` in `google_redis_instance `
```
