### PR TITLE
add make serialize before upgrading the dcl

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -80,6 +80,7 @@ serialize:
 		mv -f temp.serial serialization.go
 
 upgrade-dcl:
+	make serialize
 	cd tpgtools && \
 		go mod edit -dropreplace=github.com/GoogleCloudPlatform/declarative-resource-client-library &&\
 		go mod edit -require=github.com/GoogleCloudPlatform/declarative-resource-client-library@$(FORCE_DCL) &&\


### PR DESCRIPTION
Within this workflow we need to run `make serialize` before upgrading the dcl. 
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
