### PR TITLE
fixed diff on last slash of uri

### DIFF
--- a/mmv1/products/cloudscheduler/terraform.yaml
+++ b/mmv1/products/cloudscheduler/terraform.yaml
@@ -63,6 +63,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'authHeaderDiffSuppress'
       httpTarget.oidcToken: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'authHeaderDiffSuppress'
+      httpTarget.uri: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'lastSlashDiffSuppress'
       appEngineHttpTarget.headers: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/http_headers.erb'
         validation: !ruby/object:Provider::Terraform::Validation

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -213,3 +213,17 @@ func compareOptionalSubnet(_, old, new string, _ *schema.ResourceData) bool {
 	// otherwise compare as self links
 	return compareSelfLinkOrResourceName("", old, new, nil)
 }
+
+// Suppress diffs in below cases
+// "https://hello-rehvs75zla-uc.a.run.app/" -> "https://hello-rehvs75zla-uc.a.run.app"
+// "https://hello-rehvs75zla-uc.a.run.app" -> "https://hello-rehvs75zla-uc.a.run.app/"
+func lastSlashDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	if last := len(new) - 1; last >= 0 && new[last] == '/' {
+		new = new[:last]
+	}
+
+	if last := len(old) - 1; last >= 0 && old[last] == '/' {
+		old = old[:last]
+	}
+	return new == old
+}

--- a/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
@@ -285,3 +285,37 @@ func TestDurationDiffSuppress(t *testing.T) {
 		}
 	}
 }
+
+func TestLastSlashDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"locations to zones": {
+			Old:                "https://hello-rehvs75zla-uc.a.run.app/",
+			New:                "https://hello-rehvs75zla-uc.a.run.app",
+			ExpectDiffSuppress: true,
+		},
+		"regions to locations": {
+			Old:                "https://hello-rehvs75zla-uc.a.run.app",
+			New:                "https://hello-rehvs75zla-uc.a.run.app/",
+			ExpectDiffSuppress: true,
+		},
+		"locations to locations": {
+			Old:                "https://hello-rehvs75zla-uc.a.run.app/",
+			New:                "https://hello-rehvs75zla-uc.a.run.app/",
+			ExpectDiffSuppress: true,
+		},
+		"zones to regions": {
+			Old:                "https://x.a.run.app/",
+			New:                "https://y.a.run.app",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if lastSlashDiffSuppress("uri", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
@@ -307,8 +307,8 @@ func TestLastSlashDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: true,
 		},
 		"no slash to no slash": {
-			Old:                "https://hello-rehvs75zla-uc.a.run.app/",
-			New:                "https://hello-rehvs75zla-uc.a.run.app/",
+			Old:                "https://hello-rehvs75zla-uc.a.run.app",
+			New:                "https://hello-rehvs75zla-uc.a.run.app",
 			ExpectDiffSuppress: true,
 		},
 		"different domains": {

--- a/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress_test.go.erb
@@ -291,22 +291,27 @@ func TestLastSlashDiffSuppress(t *testing.T) {
 		Old, New           string
 		ExpectDiffSuppress bool
 	}{
-		"locations to zones": {
+		"slash to no slash": {
 			Old:                "https://hello-rehvs75zla-uc.a.run.app/",
 			New:                "https://hello-rehvs75zla-uc.a.run.app",
 			ExpectDiffSuppress: true,
 		},
-		"regions to locations": {
+		"no slash to slash": {
 			Old:                "https://hello-rehvs75zla-uc.a.run.app",
 			New:                "https://hello-rehvs75zla-uc.a.run.app/",
 			ExpectDiffSuppress: true,
 		},
-		"locations to locations": {
+		"slash to slash": {
 			Old:                "https://hello-rehvs75zla-uc.a.run.app/",
 			New:                "https://hello-rehvs75zla-uc.a.run.app/",
 			ExpectDiffSuppress: true,
 		},
-		"zones to regions": {
+		"no slash to no slash": {
+			Old:                "https://hello-rehvs75zla-uc.a.run.app/",
+			New:                "https://hello-rehvs75zla-uc.a.run.app/",
+			ExpectDiffSuppress: true,
+		},
+		"different domains": {
 			Old:                "https://x.a.run.app/",
 			New:                "https://y.a.run.app",
 			ExpectDiffSuppress: false,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11977


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudscheduler: fixed a diff on the last slash of uri on `google_cloud_scheduler_job`
```
