### PR TITLE
Reverted secondary_zone being added to TFV test cases

### DIFF
--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.tf
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.tf
@@ -90,7 +90,6 @@ resource "google_sql_database_instance" "main" {
     location_preference {
       follow_gae_application = "test-follow_gae_application"
       zone                   = "us-central1-a"
-      secondary_zone         = "us-central1-b"
     }
     maintenance_window {
       day          = 42

--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.tfplan.json
@@ -123,8 +123,7 @@
                 "location_preference": [
                   {
                     "follow_gae_application": "test-follow_gae_application",
-                    "zone": "us-central1-a",
-                    "secondary_zone": "us-central1-b"
+                    "zone": "us-central1-a"
                   }
                 ],
                 "maintenance_window": [


### PR DESCRIPTION
This field can't yet be tested because it isn't in the released provider.

b/237821330

```release-note:none

```
