### PR TITLE
Promote google_dataproc_metastore_service and related fields in google_dataproc_cluster to GA

### DIFF
--- a/mmv1/products/metastore/api.yaml
+++ b/mmv1/products/metastore/api.yaml
@@ -19,7 +19,7 @@ versions:
     base_url: https://metastore.googleapis.com/v1beta/
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://metastore.googleapis.com/beta/    
+    base_url: https://metastore.googleapis.com/v1/    
 scopes:
   - https://www.googleapis.com/auth/cloud-identity
 apis_required:

--- a/mmv1/products/metastore/api.yaml
+++ b/mmv1/products/metastore/api.yaml
@@ -222,6 +222,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'databaseType'
         input: true
+        default_value: :MYSQL
         description: |
           The database type that the Metastore service stores its data.
         values:

--- a/mmv1/products/metastore/api.yaml
+++ b/mmv1/products/metastore/api.yaml
@@ -17,6 +17,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://metastore.googleapis.com/v1beta/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://metastore.googleapis.com/beta/    
 scopes:
   - https://www.googleapis.com/auth/cloud-identity
 apis_required:
@@ -31,7 +34,6 @@ objects:
     self_link: "projects/{{project}}/locations/{{location}}/services/{{service_id}}"
     update_verb: :PATCH
     update_mask: true
-    min_version: beta
     description: |
       A managed metastore service that serves metadata queries.
     iam_policy: !ruby/object:Api::Resource::IamPolicy
@@ -75,7 +77,7 @@ objects:
         input: true
         default_value: global
         description: |
-          The  location where the autoscaling policy should reside.
+          The location where the metastore service should reside.
           The default value is `global`.
     properties:
       - !ruby/object:Api::Type::String
@@ -130,6 +132,7 @@ objects:
         description: |
           The one hour maintenance window of the metastore service.
           This specifies when the service can be restarted for maintenance purposes in UTC time.
+          Maintenance window is not needed for services with the `SPANNER` database type.
         properties:
           - !ruby/object:Api::Type::Integer
             name: 'hourOfDay'
@@ -151,14 +154,12 @@ objects:
               - :SUNDAY
       - !ruby/object:Api::Type::NestedObject
         name: 'encryptionConfig'
-        min_version: beta
         description: |
           Information used to configure the Dataproc Metastore service to encrypt
           customer data at rest.
         properties:
           - !ruby/object:Api::Type::String
             name: 'kmsKey'
-            min_version: beta
             description: |
               The fully qualified customer provided Cloud KMS key name to use for customer data encryption.
               Use the following format: `projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)`
@@ -169,6 +170,16 @@ objects:
         description: |
          Configuration information specific to running Hive metastore software as the metastore service.
         properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'endpointProtocol'
+            min_version: beta
+            input: true
+            default_value: :THRIFT
+            description: |
+              The protocol to use for the metastore service endpoint. If unspecified, defaults to `THRIFT`.
+            values:
+              - :THRIFT
+              - :GRPC         
           - !ruby/object:Api::Type::String
             name: 'version'
             input: true
@@ -208,3 +219,25 @@ objects:
                 required: true
                 description: |
                   A Cloud Storage URI that specifies the path to a krb5.conf file. It is of the form gs://{bucket_name}/path/to/krb5.conf, although the file does not need to be named krb5.conf explicitly.
+      - !ruby/object:Api::Type::Enum
+        name: 'databaseType'
+        input: true
+        description: |
+          The database type that the Metastore service stores its data.
+        values:
+          - :MYSQL
+          - :SPANNER
+      - !ruby/object:Api::Type::Enum
+        name: 'releaseChannel'
+        input: true
+        default_value: :STABLE
+        description: |
+          The release channel of the service. If unspecified, defaults to `STABLE`.
+        values:
+          - :CANARY
+          - :STABLE
+      - !ruby/object:Api::Type::String
+        name: 'uid'
+        output: true
+        description: |
+          The globally unique resource identifier of the metastore service.          

--- a/mmv1/products/metastore/terraform.yaml
+++ b/mmv1/products/metastore/terraform.yaml
@@ -19,13 +19,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_service_basic"
-        min_version: beta
+        primary_resource_name: "fmt.Sprintf(\"tf-test-metastore-srv%s\", context[\"random_suffix\"])"
         primary_resource_id: "default"
         vars:
           metastore_service_name: "metastore-srv"
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_service_cmek_test"
-        min_version: beta
         skip_docs: true
         primary_resource_id: "default"
         vars:
@@ -34,7 +33,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           keyring_name: "example-keyring"
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_service_cmek_example"
-        min_version: beta
         skip_test: true
         primary_resource_id: "default"
         vars:

--- a/mmv1/products/metastore/terraform.yaml
+++ b/mmv1/products/metastore/terraform.yaml
@@ -41,6 +41,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           keyring_name: "example-keyring"
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_service_endpoint"
+        min_version: beta
         skip_docs: true
         primary_resource_id: "endpoint"
         vars:

--- a/mmv1/products/metastore/terraform.yaml
+++ b/mmv1/products/metastore/terraform.yaml
@@ -39,6 +39,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           metastore_service_name: "example-service"
           key_name: "example-key"
           keyring_name: "example-keyring"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dataproc_metastore_service_endpoint"
+        skip_docs: true
+        primary_resource_id: "endpoint"
+        vars:
+          metastore_service_name: "metastore-endpoint"          
     properties:
       network: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
-  provider   = google-beta
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
   location   = "us-central1"
   port       = 9080

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_example.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_example.tf.erb
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
-  provider   = google-beta
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
   location   = "us-central1"
 

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_test.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_test.tf.erb
@@ -1,14 +1,9 @@
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
-data "google_storage_project_service_account" "gcs_account" {
-  provider = google-beta
-}
+data "google_storage_project_service_account" "gcs_account" {}
 
 
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
-  provider   = google-beta
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
   location   = "us-central1"
 
@@ -24,7 +19,6 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['key_name'] %>"
   key_ring = google_kms_key_ring.key_ring.id
 
@@ -32,13 +26,11 @@ resource "google_kms_crypto_key" "crypto_key" {
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['keyring_name'] %>"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
-  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.crypto_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_endpoint.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_endpoint.tf.erb
@@ -1,0 +1,11 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  hive_metastore_config {
+    endpoint_protocol = "GRPC"
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_endpoint.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_endpoint.tf.erb
@@ -2,10 +2,10 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
   provider   = google-beta
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
   location   = "us-central1"
-  port       = 9080
   tier       = "DEVELOPER"
 
   hive_metastore_config {
+    version           = "3.1.2"
     endpoint_protocol = "GRPC"
   }
 }

--- a/mmv1/third_party/terraform/data_sources/data_source_dataproc_metastore_service.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_dataproc_metastore_service.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
-
 import (
 	"fmt"
 
@@ -30,5 +28,3 @@ func dataSourceDataprocMetastoreServiceRead(d *schema.ResourceData, meta interfa
 	d.SetId(id)
 	return resourceDataprocMetastoreServiceRead(d, meta)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dataproc_metastore_service_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -46,6 +45,3 @@ data "google_dataproc_metastore_service" "my_metastore" {
 }
 `, name, tier)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_metastore_service_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -53,6 +52,3 @@ resource "google_dataproc_metastore_service" "my_metastore" {
 }
 `, name, tier)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/mmv1/third_party/terraform/utils/dataproc_metastore_service_diff_supress.go.erb
+++ b/mmv1/third_party/terraform/utils/dataproc_metastore_service_diff_supress.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"strings"
@@ -24,4 +23,3 @@ func dataprocMetastoreServiceOverrideSuppress(k, old, new string, d *schema.Reso
 	// For other keys, don't suppress diff.
 	return false
 }
-<% end -%>

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -243,9 +243,7 @@ func Provider() *schema.Provider {
 			"google_container_engine_versions":                 dataSourceGoogleContainerEngineVersions(),
 			"google_container_registry_image":                  dataSourceGoogleContainerImage(),
 			"google_container_registry_repository":             dataSourceGoogleContainerRepo(),
-			<% unless version == 'ga' -%>
 			"google_dataproc_metastore_service":                dataSourceDataprocMetastoreService(),
-			<% end -%>
 			"google_dns_keys":                                  dataSourceDNSKeys(),
 			"google_dns_managed_zone":                          dataSourceDnsManagedZone(),
 			"google_dns_record_set":                            dataSourceDnsRecordSet(),

--- a/mmv1/third_party/terraform/website/docs/d/data_source_dataproc_metastore_service.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/data_source_dataproc_metastore_service.markdown
@@ -11,9 +11,6 @@ description: |-
 
 Get a Dataproc Metastore service from Google Cloud by its id and location.
 
-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
-
 ## Example Usage
 
 ```tf


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Closes https://github.com/hashicorp/terraform-provider-google/issues/9938

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
metastore: promote `google_dataproc_metastore_service` to GA
```

```release-note:enhancement
metastore: add `databaseType`, `releaseChannel`, and `hiveMetastoreConfig.endpointProtocol` arguments
```
