### PR TITLE
Cloud NAT Rules and Configurable TCP Time Wait

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13551,6 +13551,11 @@ objects:
           Timeout (in seconds) for TCP transitory connections.
           Defaults to 30s if not set.
         default_value: 30
+      - !ruby/object:Api::Type::Integer
+        name: tcpTimeWaitTimeoutSec
+        description: |
+          Timeout (in seconds) for TCP connections that are in TIME_WAIT state. Defaults to 120s if not set.
+        default_value: 120        
       - !ruby/object:Api::Type::NestedObject
         name: logConfig
         description: |
@@ -13571,6 +13576,47 @@ objects:
               - :ERRORS_ONLY
               - :TRANSLATIONS_ONLY
               - :ALL
+      - !ruby/object:Api::Type::Array
+        name: rule
+        description: |
+          A list of rules associated with this NAT.
+        send_empty_value: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'ruleNumber'
+              description: |
+                An integer uniquely identifying a rule in the list. The rule number must be a positive value between 0 and 65000, and must be unique among rules within a NAT.
+              required: true
+            - !ruby/object:Api::Type::String
+              name: 'description'
+              description: |
+                An optional description of this rule.
+            - !ruby/object:Api::Type::String
+              name: 'match'
+              description: |
+                CEL expression that specifies the match condition that egress traffic from a VM is evaluated against. If it evaluates to true, the corresponding action is enforced.
+                The following examples are valid match expressions for public NAT:
+                "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
+                "destination.ip == '1.1.0.1' || destination.ip == '8.8.8.8'"
+                The following example is a valid match expression for private NAT:
+                "nexthop.hub == 'https://networkconnectivity.googleapis.com/v1alpha1/projects/my-project/global/hub/hub-1'"
+            - !ruby/object:Api::Type::Array
+              name: action
+              description: |
+                The action to be enforced for traffic that matches this rule.
+              send_empty_value: true
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'sourceNatActiveIps'
+                    description: |
+                      A list of URLs of the IP resources used for this NAT rule. These IP addresses must be valid static external IP addresses assigned to the project. This field is used for public NAT.
+                    required: true
+                  - !ruby/object:Api::Type::String
+                    name: 'sourceNatDrainIps'
+                    description: |
+                      A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT. These IPs should be used for updating/patching a NAT rule only. This field is used for public NAT.
       - !ruby/object:Api::Type::Boolean
         name: enableEndpointIndependentMapping
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13577,7 +13577,7 @@ objects:
               - :TRANSLATIONS_ONLY
               - :ALL
       - !ruby/object:Api::Type::Array
-        name: rule
+        name: rules
         description: |
           A list of rules associated with this NAT.
         send_empty_value: true
@@ -13594,6 +13594,7 @@ objects:
                 An optional description of this rule.
             - !ruby/object:Api::Type::String
               name: 'match'
+              required: true
               description: |
                 CEL expression that specifies the match condition that egress traffic from a VM is evaluated against. If it evaluates to true, the corresponding action is enforced.
                 The following examples are valid match expressions for public NAT:
@@ -13601,22 +13602,30 @@ objects:
                 "destination.ip == '1.1.0.1' || destination.ip == '8.8.8.8'"
                 The following example is a valid match expression for private NAT:
                 "nexthop.hub == 'https://networkconnectivity.googleapis.com/v1alpha1/projects/my-project/global/hub/hub-1'"
-            - !ruby/object:Api::Type::Array
+            - !ruby/object:Api::Type::NestedObject
               name: action
+              required: true
               description: |
                 The action to be enforced for traffic that matches this rule.
-              send_empty_value: true
-              item_type: !ruby/object:Api::Type::NestedObject
-                properties:
-                  - !ruby/object:Api::Type::String
-                    name: 'sourceNatActiveIps'
-                    description: |
-                      A list of URLs of the IP resources used for this NAT rule. These IP addresses must be valid static external IP addresses assigned to the project. This field is used for public NAT.
-                    required: true
-                  - !ruby/object:Api::Type::String
-                    name: 'sourceNatDrainIps'
-                    description: |
-                      A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT. These IPs should be used for updating/patching a NAT rule only. This field is used for public NAT.
+              properties:
+                - !ruby/object:Api::Type::Array
+                  name: 'sourceNatActiveIps'
+                  description: |
+                    A list of URLs of the IP resources used for this NAT rule. These IP addresses must be valid static external IP addresses assigned to the project. This field is used for public NAT.
+                  item_type: !ruby/object:Api::Type::ResourceRef
+                    name: 'address'
+                    resource: 'Address'
+                    imports: 'selfLink'
+                    description: 'A reference to an address associated with this NAT'
+                - !ruby/object:Api::Type::Array
+                  name: 'sourceNatDrainIps'
+                  description: |
+                    A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT. These IPs should be used for updating/patching a NAT rule only. This field is used for public NAT.
+                  item_type: !ruby/object:Api::Type::ResourceRef
+                    name: 'address'
+                    resource: 'Address'
+                    imports: 'selfLink'
+                    description: 'A reference to an address associated with this NAT'
       - !ruby/object:Api::Type::Boolean
         name: enableEndpointIndependentMapping
         description: |

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -1111,7 +1111,7 @@ resource "google_compute_router_nat" "foobar" {
 	rule_number = 2
 	match       = "inIpRange(destination.ip, '3.3.0.0/16') || inIpRange(destination.ip, '4.4.0.0/16')"
 	action {
-	  source_nat_active_ips = [google_compute_address.foobar2.id]
+	  source_nat_active_ips = [google_compute_address.foobar3.id]
 	}
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -80,6 +80,15 @@ func TestAccComputeRouterNat_rule(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeRouterNatRuleUpdate(routerName),
+			},
+			{
+				// implicitly full ImportStateId
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1012,4 +1021,66 @@ resource "google_compute_router_nat" "foobar" {
   }
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterNatRuleUpdate(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  name   = "%s-addr"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_address" "foobar2" {
+  name   = "%s-addr-2"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_address" "foobar3" {
+  name   = "%s-addr-3"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                                = "%s"
+  router                              = google_compute_router.foobar.name
+  region                              = google_compute_router.foobar.region
+  nat_ip_allocate_option              = "MANUAL_ONLY"
+  nat_ips                             = [google_compute_address.foobar.id]
+  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  enable_endpoint_independent_mapping = false
+
+  rules {
+	rule_number = 1
+	match       = "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '5.5.0.0/16')"
+	action {
+	  source_nat_active_ips = [google_compute_address.foobar2.id]
+	}
+  }
+
+  rules {
+	rule_number = 2
+	match       = "inIpRange(destination.ip, '3.3.0.0/16') || inIpRange(destination.ip, '4.4.0.0/16')"
+	action {
+	  source_nat_active_ips = [google_compute_address.foobar2.id]
+	}
+  }
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -3,9 +3,7 @@ package google
 
 import (
 	"fmt"
-<% unless version == "ga" -%>
 	"regexp"
-<% end -%>
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -61,6 +59,31 @@ func TestAccComputeRouterNat_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeRouterNat_rule(t *testing.T) {
+	t.Parallel()
+
+	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterNatRule(routerName),
+			},
+			{
+				// implicitly full ImportStateId
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 
 func TestAccComputeRouterNat_update(t *testing.T) {
 	t.Parallel()
@@ -226,7 +249,6 @@ func TestAccComputeRouterNat_withPortAllocationMethods(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 	t.Parallel()
 
@@ -274,8 +296,6 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 		},
 	})
 }
-
-<% end -%>
 
 func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -715,7 +735,6 @@ resource "google_compute_router_nat" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName, enableEndpointIndependentMapping, enableDynamicPortAllocation, minPortsPerVm, maxPortsPerVm)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRouterNatBaseResourcesWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -862,8 +881,6 @@ resource "google_compute_router_nat" "foobar" {
 `, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
 
-<% end -%>
-
 func testAccComputeRouterNatKeepRouter(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -946,4 +963,53 @@ resource "google_compute_router_nat" "foobar" {
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 `, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterNatRule(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  name   = "%s-addr"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_address" "foobar2" {
+  name   = "%s-addr-2"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                                = "%s"
+  router                              = google_compute_router.foobar.name
+  region                              = google_compute_router.foobar.region
+  nat_ip_allocate_option              = "MANUAL_ONLY"
+  nat_ips                             = [google_compute_address.foobar.id]
+  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  enable_endpoint_independent_mapping = false
+
+  rules {
+	rule_number = 1
+	match       = "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
+	action {
+	  source_nat_active_ips = [google_compute_address.foobar2.id]
+	}
+  }
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -60,6 +60,42 @@ func TestAccComputeRouterNat_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouterNat_tcpTimeWaitTimeoutSec(t *testing.T) {
+	t.Parallel()
+
+	project := getTestProjectFromEnv()
+	region := getTestRegionFromEnv()
+
+	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterNatTcpTimeWaitTimeoutSec(routerName, 180),
+			},
+			{
+				// implicitly full ImportStateId
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatTcpTimeWaitTimeoutSec(routerName, 150),
+			},
+			{
+				// implicitly full ImportStateId
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeRouterNat_rule(t *testing.T) {
 	t.Parallel()
 
@@ -1083,4 +1119,34 @@ resource "google_compute_router_nat" "foobar" {
   }
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterNatTcpTimeWaitTimeoutSec(routerName string, timeout int) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  tcp_time_wait_timeout_sec          = "%d"
+}
+`, routerName, routerName, routerName, routerName, timeout)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -63,9 +63,6 @@ func TestAccComputeRouterNat_basic(t *testing.T) {
 func TestAccComputeRouterNat_tcpTimeWaitTimeoutSec(t *testing.T) {
 	t.Parallel()
 
-	project := getTestProjectFromEnv()
-	region := getTestRegionFromEnv()
-
 	testId := randString(t, 10)
 	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Closes https://github.com/hashicorp/terraform-provider-google/issues/10666

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: add `rules` and `tcp_time_wait_timeout_sec` to `google_compute_router_nat`
```
