### PR TITLE
make provisioned_iops Computed true

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -633,6 +633,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      provisionedIops: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
       sourceImage: !ruby/object:Overrides::Terraform::PropertyOverride
         name: image
         diff_suppress_func: 'diskImageDiffSuppress'

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -442,6 +442,27 @@ func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
 	})
 }
 
+func TestProvisionedIopDisk_basic(t *testing.T) {
+	t.Parallel()
+
+	diskName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testProvisionedIopsDisk_basic(diskName),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 <% unless version == 'ga' -%>
 func TestAccComputeDisk_resourcePolicies(t *testing.T) {
 	t.Parallel()
@@ -773,6 +794,16 @@ resource "google_compute_instance_group_manager" "manager" {
   wait_for_instances = true
 }
 `, diskName, mgrName)
+}
+
+func testProvisionedIopsDisk_basic(diskName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+  name  = "%s"
+  type = "pd-extreme"
+  size = 1
+}
+`, diskName)
 }
 
 <% unless version == 'ga' -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -442,7 +442,7 @@ func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
 	})
 }
 
-func TestProvisionedIopDisk_basic(t *testing.T) {
+func TestAccComputeDisk_pdExtremeImplicitProvisionedIops(t *testing.T) {
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -452,7 +452,7 @@ func TestProvisionedIopDisk_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testProvisionedIopsDisk_basic(diskName),
+				Config: testAccComputeDisk_pdExtremeImplicitProvisionedIops(diskName),
 			},
 			{
 				ResourceName:      "google_compute_disk.foobar",
@@ -796,7 +796,7 @@ resource "google_compute_instance_group_manager" "manager" {
 `, diskName, mgrName)
 }
 
-func testProvisionedIopsDisk_basic(diskName string) string {
+func testAccComputeDisk_pdExtremeImplicitProvisionedIops(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
   name  = "%s"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12020


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed force recreation on `provisioned_iops` of `google_compute_disk`
```
