### PR TITLE
Dataproc cluster - metastore args - promote to GA

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -65,10 +65,10 @@ var (
 		"cluster_config.0.initialization_action",
 		"cluster_config.0.encryption_config",
 		"cluster_config.0.autoscaling_config",
+		"cluster_config.0.metastore_config",
 <% unless version == 'ga' -%>
 		"cluster_config.0.lifecycle_config",
 		"cluster_config.0.endpoint_config",
-		"cluster_config.0.metastore_config",
 <% end -%>
 	}
 )
@@ -643,6 +643,23 @@ by Dataproc`,
 								},
 							},
 						},
+						"metastore_config": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							AtLeastOneOf:     clusterConfigKeys,
+							MaxItems:         1,
+							Description:      `Specifies a Metastore configuration.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dataproc_metastore_service": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ForceNew:         true,
+										Description:      `Resource name of an existing Dataproc Metastore service.`,
+									},
+								},
+							},
+						},						
 <% unless version == 'ga' -%>
 						"lifecycle_config": {
 							Type:         schema.TypeList,
@@ -702,23 +719,6 @@ by Dataproc`,
 										Type:        schema.TypeMap,
 										Computed:    true,
 										Description: `The map of port descriptions to URLs. Will only be populated if enable_http_port_access is true.`,
-									},
-								},
-							},
-						},
-						"metastore_config": {
-							Type:             schema.TypeList,
-							Optional:         true,
-							AtLeastOneOf:     clusterConfigKeys,
-							MaxItems:         1,
-							Description:      `Specifies a Metastore configuration.`,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"dataproc_metastore_service": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ForceNew:         true,
-										Description:      `Resource name of an existing Dataproc Metastore service.`,
 									},
 								},
 							},
@@ -983,6 +983,10 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 		conf.AutoscalingConfig = expandAutoscalingConfig(cfg)
 	}
 
+	if cfg, ok := configOptions(d, "cluster_config.0.metastore_config"); ok {
+		conf.MetastoreConfig = expandMetastoreConfig(cfg)
+	}
+
 <% unless version == 'ga' -%>
 	if cfg, ok := configOptions(d, "cluster_config.0.lifecycle_config"); ok {
 		conf.LifecycleConfig = expandLifecycleConfig(cfg)
@@ -990,10 +994,6 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 
 	if cfg, ok := configOptions(d, "cluster_config.0.endpoint_config"); ok {
 		conf.EndpointConfig = expandEndpointConfig(cfg)
-	}
-
-	if cfg, ok := configOptions(d, "cluster_config.0.metastore_config"); ok {
-		conf.MetastoreConfig = expandMetastoreConfig(cfg)
 	}
 <% end -%>
 
@@ -1195,6 +1195,7 @@ func expandEndpointConfig(cfg map[string]interface{}) *dataproc.EndpointConfig {
 	}
 	return conf
 }
+<% end -%>
 
 func expandMetastoreConfig(cfg map[string]interface{}) *dataproc.MetastoreConfig {
 	conf := &dataproc.MetastoreConfig{}
@@ -1203,7 +1204,6 @@ func expandMetastoreConfig(cfg map[string]interface{}) *dataproc.MetastoreConfig
 	}
 	return conf
 }
-<% end -%>
 
 func expandInitializationActions(v interface{}) []*dataproc.NodeInitializationAction {
 	actionList := v.([]interface{})
@@ -1475,10 +1475,10 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		"autoscaling_config":        flattenAutoscalingConfig(d, cfg.AutoscalingConfig),
 		"security_config":           flattenSecurityConfig(d, cfg.SecurityConfig),
 		"preemptible_worker_config": flattenPreemptibleInstanceGroupConfig(d, cfg.SecondaryWorkerConfig),
+		"metastore_config":          flattenMetastoreConfig(d, cfg.MetastoreConfig),
 <% unless version == 'ga' -%>
 		"lifecycle_config": flattenLifecycleConfig(d, cfg.LifecycleConfig),
 		"endpoint_config":  flattenEndpointConfig(d, cfg.EndpointConfig),
-		"metastore_config": flattenMetastoreConfig(d, cfg.MetastoreConfig),
 <% end -%>
 	}
 
@@ -1586,6 +1586,7 @@ func flattenEndpointConfig(d *schema.ResourceData, ec *dataproc.EndpointConfig) 
 
 	return []map[string]interface{}{data}
 }
+<% end -%>
 
 func flattenMetastoreConfig(d *schema.ResourceData, ec *dataproc.MetastoreConfig) []map[string]interface{} {
 	if ec == nil {
@@ -1598,7 +1599,6 @@ func flattenMetastoreConfig(d *schema.ResourceData, ec *dataproc.MetastoreConfig
 
 	return []map[string]interface{}{data}
 }
-<% end -%>
 
 func flattenAccelerators(accelerators []*dataproc.AcceleratorConfig) interface{} {
 	acceleratorsTypeSet := schema.NewSet(schema.HashResource(acceleratorsSchema()), []interface{}{})

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -810,7 +810,6 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	t.Parallel()
 
@@ -844,7 +843,6 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func testAccCheckDataprocClusterDestroy(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1837,7 +1835,6 @@ resource "google_dataproc_autoscaling_policy" "asp" {
 `, rnd, rnd)
 }
 
-<% unless version == 'ga' -%>
 func testAccDataprocCluster_withMetastoreConfig(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
@@ -1899,4 +1896,3 @@ resource "google_dataproc_metastore_service" "ms" {
 }
 `, rnd)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -216,7 +216,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 * `endpoint_config` (Optional, Beta) The config settings for port access on the cluster.
    Structure [defined below](#nested_endpoint_config).
 
-* `metastore_config` (Optional, Beta) The config setting for metastore service with the cluster.
+* `metastore_config` (Optional) The config setting for metastore service with the cluster.
    Structure [defined below](#nested_metastore_config).
 - - -
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Relates https://github.com/hashicorp/terraform-provider-google/issues/9938

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataproc: promoted `metastore_config` in `google_dataproc_cluster` to GA
```
