### PR TITLE
chore: remove slash-diff workaround

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_scheduled.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_scheduled.tf.erb
@@ -73,10 +73,7 @@ resource "google_cloud_scheduler_job" "default" {
 
   http_target {
     http_method = "POST"
-
-    # WORKAROUND: ensure this ends with a slash to prevent state-checking issues.
-    # See https://github.com/hashicorp/terraform-provider-google/issues/11977
-    uri         = "${google_cloud_run_service.default.status[0].url}/"
+    uri         = google_cloud_run_service.default.status[0].url
 
     oidc_token {
       service_account_email = google_service_account.default.email


### PR DESCRIPTION
```release-note:none
```

The merging of #6211 has rendered this workaround obsolete.