### PR TITLE
Provider only tests need provider=google-beta

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_ingress.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_ingress.tf.erb
@@ -1,6 +1,7 @@
 # [START cloudrun_service_ingress]
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
-    name     = "<%= ctx[:vars]['cloudrun_service_name'] %>"
+  provider = google-beta
+  name     = "<%= ctx[:vars]['cloudrun_service_name'] %>"
     location = "us-central1"
 
     template {

--- a/mmv1/templates/terraform/examples/cloud_run_service_multiple_regions.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_multiple_regions.tf.erb
@@ -1,6 +1,7 @@
 # Cloud Run service replicated across multiple GCP regions
 
 resource "google_project_service" "compute_api" {
+  provider = google-beta
   project                    = "<%= ctx[:test_env_vars]['project'] %>"
   service                    = "compute.googleapis.com"
   disable_dependent_services = true
@@ -8,6 +9,7 @@ resource "google_project_service" "compute_api" {
 }
 
 resource "google_project_service" "run_api" {
+  provider = google-beta
   project                    = "<%= ctx[:test_env_vars]['project'] %>"
   service                    = "run.googleapis.com"
   disable_dependent_services = true
@@ -26,6 +28,7 @@ variable "run_regions" {
 }
 
 resource "google_compute_global_address" "lb_default" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['myservice_service_ip'] %>"
   project = "<%= ctx[:test_env_vars]['project'] %>"
 
@@ -36,6 +39,7 @@ resource "google_compute_global_address" "lb_default" {
 }
 
 resource "google_compute_backend_service" "lb_default" {
+  provider = google-beta
   name                  = "<%= ctx[:vars]['myservice_backend'] %>"
   project               = "<%= ctx[:test_env_vars]['project'] %>"
   load_balancing_scheme = "EXTERNAL_MANAGED"
@@ -60,6 +64,7 @@ resource "google_compute_backend_service" "lb_default" {
 
 
 resource "google_compute_url_map" "lb_default" {
+  provider = google-beta
   name            = "<%= ctx[:vars]['myservice_lb_urlmap'] %>"
   project         = "<%= ctx[:test_env_vars]['project'] %>"
   default_service = google_compute_backend_service.lb_default.id
@@ -78,6 +83,7 @@ resource "google_compute_url_map" "lb_default" {
 }
 
 resource "google_compute_managed_ssl_certificate" "lb_default" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['myservice_ssl_cert'] %>"
   project = "<%= ctx[:test_env_vars]['project'] %>"
 
@@ -87,6 +93,7 @@ resource "google_compute_managed_ssl_certificate" "lb_default" {
 }
 
 resource "google_compute_target_https_proxy" "lb_default" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['myservice_https_proxy'] %>"
   project = "<%= ctx[:test_env_vars]['project'] %>"
   url_map = google_compute_url_map.lb_default.id
@@ -99,6 +106,7 @@ resource "google_compute_target_https_proxy" "lb_default" {
 }
 
 resource "google_compute_global_forwarding_rule" "lb_default" {
+  provider = google-beta
   name                  = "<%= ctx[:vars]['myservice_lb_forwarding_rule'] %>"
   project               = "<%= ctx[:test_env_vars]['project'] %>"
   load_balancing_scheme = "EXTERNAL_MANAGED"
@@ -109,6 +117,7 @@ resource "google_compute_global_forwarding_rule" "lb_default" {
 }
 
 resource "google_compute_region_network_endpoint_group" "lb_default" {
+  provider = google-beta
   count                 = length(var.run_regions)
   project               = "<%= ctx[:test_env_vars]['project'] %>"
   name                  = "<%= ctx[:vars]['myservice_neg'] %>"
@@ -124,6 +133,7 @@ output "load_balancer_ip_addr" {
 }
 
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   count    = length(var.run_regions)
   project  = "<%= ctx[:test_env_vars]['project'] %>"
   name     = "<%= ctx[:vars]['myservice_run_app'] %>-${var.run_regions[count.index]}"
@@ -149,6 +159,7 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_cloud_run_service_iam_member" "run_allow_unauthenticated" {
+  provider = google-beta
   count    = length(var.run_regions)
   project  = "<%= ctx[:test_env_vars]['project'] %>"
   location = google_cloud_run_service.<%= ctx[:primary_resource_id] %>[count.index].location
@@ -158,6 +169,7 @@ resource "google_cloud_run_service_iam_member" "run_allow_unauthenticated" {
 }
 
 resource "google_compute_url_map" "https_default" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['myservice_https_urlmap'] %>"
   project = "<%= ctx[:test_env_vars]['project'] %>"
 
@@ -169,6 +181,7 @@ resource "google_compute_url_map" "https_default" {
 }
 
 resource "google_compute_target_http_proxy" "https_default" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['myservice_http_proxy'] %>"
   project = "<%= ctx[:test_env_vars]['project'] %>"
   url_map = google_compute_url_map.https_default.id
@@ -179,6 +192,7 @@ resource "google_compute_target_http_proxy" "https_default" {
 }
 
 resource "google_compute_global_forwarding_rule" "https_default" {
+  provider = google-beta
   name       = "<%= ctx[:vars]['myservice_https_forwarding_rule'] %>"
   project    = "<%= ctx[:test_env_vars]['project'] %>"
   target     = google_compute_target_http_proxy.https_default.id

--- a/mmv1/templates/terraform/examples/cloud_run_service_scheduled.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_scheduled.tf.erb
@@ -1,4 +1,5 @@
 resource "google_project_service" "run_api" {
+  provider = google-beta
   project                    = "<%= ctx[:test_env_vars]['project'] %>"
   service                    = "run.googleapis.com"
   disable_dependent_services = true
@@ -6,18 +7,21 @@ resource "google_project_service" "run_api" {
 }
 
 resource "google_project_service" "iam_api" {
+  provider = google-beta
   project                    = "<%= ctx[:test_env_vars]['project'] %>"
   service                    = "iam.googleapis.com"
   disable_on_destroy         = false
 }
 
 resource "google_project_service" "resource_manager_api" {
+  provider = google-beta
   project                    = "<%= ctx[:test_env_vars]['project'] %>"
   service                    = "cloudresourcemanager.googleapis.com"
   disable_on_destroy         = false
 }
 
 resource "google_project_service" "scheduler_api" {
+  provider = google-beta
   project                    = "<%= ctx[:test_env_vars]['project'] %>"
   service                    = "cloudscheduler.googleapis.com"
   disable_on_destroy         = false
@@ -25,6 +29,7 @@ resource "google_project_service" "scheduler_api" {
 
 # [START cloudrun_service_scheduled]
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   project  = "<%= ctx[:test_env_vars]['project'] %>"
   name     = "<%= ctx[:vars]['service_name'] %>"
   location = "us-central1"
@@ -49,6 +54,7 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_service_account" "default" {
+  provider = google-beta
   project      = "<%= ctx[:test_env_vars]['project'] %>"
   account_id   = "<%= ctx[:vars]['sa_name'] %>"
   description  = "Cloud Scheduler service account; used to trigger scheduled Cloud Run jobs."
@@ -61,6 +67,7 @@ resource "google_service_account" "default" {
 }
 
 resource "google_cloud_scheduler_job" "default" {
+  provider = google-beta
   name             = "<%= ctx[:vars]['scheduled_cloud_run_job'] %>"
   description      = "Invoke a Cloud Run container on a schedule."
   schedule         = "*/8 * * * *"


### PR DESCRIPTION
These tests are failing in team-city as they are beta only and therefore use `testAccProvidersOiCS`

https://ci-oss.hashicorp.engineering/viewLog.html?buildId=308700&buildTypeId=GoogleCloudBeta_ProviderGoogleCloudBetaGoogleProject#testNameId5456403734904197623
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
