### PR TITLE
add support for MatchesPrefix and MatchesSuffix conditions

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -208,6 +208,18 @@ func resourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Description: `Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.`,
 									},
+									"matches_prefix": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `One or more matching name prefixes to satisfy this condition.`,
+									},
+									"matches_suffix": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `One or more matching name suffixes to satisfy this condition.`,
+									},
 								},
 							},
 							Description: `The Lifecycle Rule's condition configuration.`,
@@ -996,6 +1008,8 @@ func flattenBucketLifecycleRuleCondition(condition *storage.BucketLifecycleRuleC
 		"days_since_custom_time":     int(condition.DaysSinceCustomTime),
 		"days_since_noncurrent_time": int(condition.DaysSinceNoncurrentTime),
 		"noncurrent_time_before":     condition.NoncurrentTimeBefore,
+		"matches_prefix":             convertStringArrToInterface(condition.MatchesPrefix),
+		"matches_suffix":             convertStringArrToInterface(condition.MatchesSuffix),
 	}
 	if condition.IsLive == nil {
 		ruleCondition["with_state"] = "ANY"
@@ -1211,6 +1225,25 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 		transformed.NoncurrentTimeBefore = v.(string)
 	}
 
+	if v, ok := condition["matches_prefix"]; ok {
+		prefixes := v.([]interface{})
+		transformedPrefixes := make([]string, 0, len(prefixes))
+
+		for _, v := range prefixes {
+			transformedPrefixes = append(transformedPrefixes, v.(string))
+		}
+		transformed.MatchesPrefix = transformedPrefixes
+	}
+	if v, ok := condition["matches_suffix"]; ok {
+		suffixes := v.([]interface{})
+		transformedSuffixes := make([]string, 0, len(suffixes))
+
+		for _, v := range suffixes {
+			transformedSuffixes = append(transformedSuffixes, v.(string))
+		}
+		transformed.MatchesSuffix = transformedSuffixes
+	}
+
 	return transformed, nil
 }
 
@@ -1274,6 +1307,19 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 
 	if v, ok := m["num_newer_versions"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	if v, ok := m["matches_prefix"]; ok {
+		matches_prefixes := v.([]interface{})
+		for _, matches_prefix := range matches_prefixes {
+			buf.WriteString(fmt.Sprintf("%s-", matches_prefix))
+		}
+	}
+	if v, ok := m["matches_suffix"]; ok {
+		matches_suffixes := v.([]interface{})
+		for _, matches_suffix := range matches_suffixes {
+			buf.WriteString(fmt.Sprintf("%s-", matches_suffix))
+		}
 	}
 
 	return hashcode(buf.String())

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -1381,6 +1381,24 @@ resource "google_storage_bucket" "bucket" {
       with_state = "ARCHIVED"
     }
   }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      matches_prefix = ["test"]
+      age            = 2
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      matches_suffix = ["test"]
+      age            = 2
+    }
+  }
 }
 `, bucketName)
 }
@@ -1444,6 +1462,24 @@ resource "google_storage_bucket" "bucket" {
     }
     condition {
       with_state = "ARCHIVED"
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      matches_prefix = ["test"]
+      age            = 2
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      matches_suffix = ["test"]
+      age            = 2
     }
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -125,6 +125,10 @@ The following arguments are supported:
 
 * `matches_storage_class` - (Optional) [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects to satisfy this condition. Supported values include: `STANDARD`, `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`, `DURABLE_REDUCED_AVAILABILITY`.
 
+* `matches_prefix` - (Optional) One or more matching name prefixes to satisfy this condition.
+
+* `matches_suffix` - (Optional) One or more matching name suffixes to satisfy this condition.
+
 * `num_newer_versions` - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
 
 * `custom_time_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.


### PR DESCRIPTION
part of: https://github.com/hashicorp/terraform-provider-google/issues/11990
Adds Support for [MatchesPrefix and MatchesSuffix](https://cloud.google.com/storage/docs/lifecycle#matchesprefix-suffix) 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bucket: added support for `matches_prefix` and `matches_suffix`` in `condition` of a `lifecycle_rule` in  `google_storage_bucket`
```
