### PR TITLE
feat: add data_source_google_service_account_jwt

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_jwt.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_jwt.go
@@ -1,0 +1,81 @@
+package google
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	iamcredentials "google.golang.org/api/iamcredentials/v1"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleServiceAccountJwt() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleServiceAccountJwtRead,
+		Schema: map[string]*schema.Schema{
+			"payload": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `A JWT Claims Set that will be included in the signed JWT.`,
+			},
+			"target_service_account": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateRegexp("(" + strings.Join(PossibleServiceAccountNames, "|") + ")"),
+			},
+			"delegates": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateRegexp(ServiceAccountLinkRegex),
+				},
+			},
+			"jwt": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleServiceAccountJwtRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("projects/-/serviceAccounts/%s", d.Get("target_service_account").(string))
+
+	payload, err := json.Marshal(d.Get("payload").(map[string]interface{}))
+
+	if err != nil {
+		return fmt.Errorf("error marshaling payload JSON: %w", err)
+	}
+
+	jwtRequest := &iamcredentials.SignJwtRequest{
+		Payload:   payload,
+		Delegates: convertStringSet(d.Get("delegates").(*schema.Set)),
+	}
+
+	service := config.NewIamCredentialsClient(userAgent)
+
+	jwtResponse, err := service.Projects.ServiceAccounts.SignJwt(name, jwtRequest).Do()
+
+	if err != nil {
+		return fmt.Errorf("error calling iamcredentials.SignJwt: %w", err)
+	}
+
+	d.SetId(name)
+
+	if err := d.Set("jwt", jwtResponse.SignedJwt); err != nil {
+		return fmt.Errorf("error setting jwt attribute: %w", err)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -291,6 +291,7 @@ func Provider() *schema.Provider {
 			"google_service_account":                           dataSourceGoogleServiceAccount(),
 			"google_service_account_access_token":              dataSourceGoogleServiceAccountAccessToken(),
 			"google_service_account_id_token":                  dataSourceGoogleServiceAccountIdToken(),
+			"google_service_account_jwt":                       dataSourceGoogleServiceAccountJwt(),
 			"google_service_account_key":                       dataSourceGoogleServiceAccountKey(),
 			"google_sourcerepo_repository":                     dataSourceGoogleSourceRepoRepository(),
 			"google_spanner_instance":                          dataSourceSpannerInstance(),

--- a/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud Platform"
+layout: "google"
+page_title: "Google: google_service_account_jwt"
+sidebar_current: "docs-google-service-account-jwt"
+description: |-
+  Produces an arbitrary self-signed JWT for service accounts
+---
+
+# google\_service\_account\_jwt
+
+This data source provides a [self-signed JWT](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-jwt).  Tokens issued from this data source are typically used to call external services that accept JWTs for authentication.
+
+## Example Usage
+
+Note: in order to use the following, the caller must have _at least_ `roles/iam.serviceAccountTokenCreator` on the `target_service_account`.
+
+```hcl
+data "google_service_account_jwt" "foo" {
+  target_service_account = "impersonated-account@project.iam.gserviceaccount.com"
+
+  payload = {
+    foo: "bar",
+    sub: "subject",
+  }
+}
+
+output "jwt" {
+  value = data.google_service_account_jwt.foo.jwt
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `target_service_account` (Required) - The email of the service account that will sign the JWT.
+* `payload` (Required) - The JWT Claims Set to include in the self-signed JWT.
+* `delegates` (Optional) - Delegate chain of approvals needed to perform full impersonation. Specify the fully qualified service account name.
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `jwt` - The signed JWT containing the JWT Claims Set from the `payload`.


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/6686.

This PR adds a `google_service_account_jwt` data source, similar to the `google_service_account_id_token` data source. The difference between this and the `id_token` resource is that the `jwt` data source can produce an _arbitrary_ JWT, e.g. with a custom `sub` field, etc.

We're interested in this in order to use our existing Google Cloud credentials to authenticate with other terraform providers that can trust JWTs signed by Google. The linked issue is for Vault, which is not our use-case, but would make sense as well.

Note: I've contributed to `terraform-provider-google` before, but this is my first time contributing to `magic-modules`! It definitely feels a little trickier, so let me know if you'd like anything else from me. I would like to add tests to this, but I wanted to at least get a temperature check on the PR before investing more time in it.

---

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_service_account_jwt`
```
