### PR TITLE
Add inter-service auth sample

### DIFF
--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -178,6 +178,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           cloudrun_service_name: "ingress-service"
         min_version: beta
       - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_run_service_interservice"
+        primary_resource_type: "google_cloud_run_service"
+        primary_resource_id: "default"
+        skip_docs: true
+        vars:
+          private_service_name: "private_service_name"
+      - !ruby/object:Provider::Terraform::Examples
         name: "eventarc_basic_tf"
         primary_resource_id: "default"
         vars:

--- a/mmv1/templates/terraform/examples/cloud_run_service_interservice.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_interservice.tf.erb
@@ -1,0 +1,88 @@
+# Example of using a public Cloud Run service to call a private one
+
+# [START cloudrun_service_interservice_public]
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]['private_service_name'] %>"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        # TODO<developer>: replace this with a public service container
+        # (This service can be invoked by anyone on the internet)
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+        # Include a reference to the private Cloud Run
+        # service's URL as an environment variable.
+        env {
+          name = "URL"
+          value = google_cloud_run_service.<%= ctx[:primary_resource_id] %>_private.status[0].url
+        }
+      }
+
+      # Give the "public" Cloud Run service
+      # a service account's identity
+      service_account_name = google_service_account.default.email
+    }
+  }
+}
+
+data "google_iam_policy" "public" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "public" {
+  location    = google_cloud_run_service.<%= ctx[:primary_resource_id] %>.location
+  project     = google_cloud_run_service.<%= ctx[:primary_resource_id] %>.project
+  service     = google_cloud_run_service.<%= ctx[:primary_resource_id] %>.name
+
+  policy_data = data.google_iam_policy.public.policy_data
+}
+# [END cloudrun_service_interservice_public]
+
+# [START cloudrun_service_interservice_sa]
+resource "google_service_account" "default" {
+  account_id   = "cloud-run-interservice-id"
+  description  = "Identity used by a public Cloud Run service to call private Cloud Run services."
+  display_name = "cloud-run-interservice-id"
+}
+# [END cloudrun_service_interservice_sa]
+
+# [START cloudrun_service_interservice_private]
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>_private" {
+  name     = "<%= ctx[:vars]['private_service_name'] %>-private"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        // TODO<developer>: replace this with a private service container
+        // (This service should only be invocable by the public service)
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+      }
+    }
+  }
+}
+
+data "google_iam_policy" "private" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "serviceAccount:${google_service_account.default.email}",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "private" {
+  location    = google_cloud_run_service.<%= ctx[:primary_resource_id] %>_private.location
+  project     = google_cloud_run_service.<%= ctx[:primary_resource_id] %>_private.project
+  service     = google_cloud_run_service.<%= ctx[:primary_resource_id] %>_private.name
+
+  policy_data = data.google_iam_policy.private.policy_data
+}
+# [END cloudrun_service_interservice_private]


### PR DESCRIPTION
```release-note:none
```

Adds a sample for [Service-to-Service auth](https://cloud.google.com/run/docs/authenticating/service-to-service).

@pattishin FYI - I've used a default container (`us-docker.pkg.dev/cloudrun/container/hello`) and told end-users (via comments) to replace these with _their own_ containers.