### PR TITLE
Generalize IAM Conditions Tag policy

### DIFF
--- a/mmv1/templates/terraform/examples/sql_instance_iam_condition.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_instance_iam_condition.tf.erb
@@ -14,7 +14,7 @@ data "google_iam_policy" "sql_iam_policy" {
       "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
     ]
     condition {
-      expression  = "resource.name == 'google_sql_database_instance.default.id' && resource.type == 'sqladmin.googleapis.com/Instance'"
+      expression  = "resource.name == 'google_sql_database_instance.default.id' && resource.service == 'sqladmin.googleapis.com'"
       title       = "created"
       description = "Cloud SQL instance creation"
     }


### PR DESCRIPTION
Update for this page:

https://cloud.google.com/sql/docs/mysql/iam-conditions#terraform

The current conditional IAM policy binding is correct, but it's too specific. We don't need to specify the 'Instance resource'; in some cases, it leads to overspecification of permissions. Instead, we need only specify the service.

```release-note:none
```