### PR TITLE
Update self-managed Cert Manager fields

### DIFF
--- a/mmv1/products/certificatemanager/api.yaml
+++ b/mmv1/products/certificatemanager/api.yaml
@@ -172,14 +172,14 @@ objects:
           certificates before they expire remains the user's responsibility.
         properties:
           - !ruby/object:Api::Type::String
-            name: certificatePem
+            name: pemCertificate
             required: true
             description: |
               The certificate chain in PEM-encoded form.
 
               Leaf certificate comes first, followed by intermediate ones if any.
           - !ruby/object:Api::Type::String
-            name: privateKeyPem
+            name: pemPrivateKey
             required: true
             description: |
               The private key of the leaf certificate in PEM-encoded form.

--- a/mmv1/products/certificatemanager/terraform.yaml
+++ b/mmv1/products/certificatemanager/terraform.yaml
@@ -49,9 +49,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # We don't support ignore_read on nested fields
         ignore_read: true
         custom_flatten: "templates/terraform/custom_flatten/certificate_manager_certificate_managed_dns_auth.go.erb"
-      selfManaged.certificatePem: !ruby/object:Overrides::Terraform::PropertyOverride
+      selfManaged.pemCertificate: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
-      selfManaged.privateKeyPem: !ruby/object:Overrides::Terraform::PropertyOverride
+      selfManaged.pemPrivateKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
       scope: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'certManagerDefaultScopeDiffSuppress'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

GCP API fields for self-managed certificates are `pemCertificate` and `pemPrivateKey` . However the existing terraform code refers to them as `certificatePem` and `privatekeyPem` ( https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.certificates#SelfManagedCertificate ) .

Terraform Issue: https://github.com/hashicorp/terraform-provider-google/issues/12091
Terraform PR:  https://github.com/hashicorp/terraform-provider-google/pull/12092

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
certificatemanager: updated public/private PEM fields `certificatePem` / `privatekeyPem` to `pemCertificate` / `pemPrivateKey` 
```
