### PR TITLE
Add instance_termination_action to instance and instance template for Spot VM

### DIFF
--- a/mmv1/templates/terraform/examples/spot_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/spot_instance_basic.tf.erb
@@ -15,6 +15,7 @@ resource "google_compute_instance" "<%= ctx[:primary_resource_id] %>" {
       preemptible = true
       automatic_restart = false
       provisioning_model = "SPOT"
+      instance_termination_action = "STOP"
   }
 
   network_interface {

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -51,6 +51,7 @@ var (
 		"scheduling.0.node_affinities",
 		"scheduling.0.min_node_cpus",
 		"scheduling.0.provisioning_model",
+		"scheduling.0.instance_termination_action",
 	}
 
 	shieldedInstanceConfigKeys = []string{
@@ -620,11 +621,13 @@ func resourceComputeInstance() *schema.Resource {
 							DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
 							Description:      `Specifies node affinities or anti-affinities to determine which sole-tenant nodes your instances and managed instance groups will use as host systems.`,
 						},
+						
 						"min_node_cpus": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							AtLeastOneOf: schedulingKeys,
 						},
+
 						"provisioning_model": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -632,6 +635,13 @@ func resourceComputeInstance() *schema.Resource {
 							ForceNew:     true,
 							AtLeastOneOf: schedulingKeys,
 							Description:  `Whether the instance is spot. If this is set as SPOT.`,
+						},
+
+						"instance_termination_action": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							AtLeastOneOf:  schedulingKeys,
+							Description:   `Specifies the action GCE should take when SPOT VM is preempted.`,
 						},
 					},
 				},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -30,6 +30,7 @@ var (
 		"scheduling.0.node_affinities",
 		"scheduling.0.min_node_cpus",
 		"scheduling.0.provisioning_model",
+                "scheduling.0.instance_termination_action",
 	}
 
 	shieldedInstanceTemplateConfigKeys = []string{
@@ -544,6 +545,12 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							ForceNew:     true,
 							AtLeastOneOf: schedulingInstTemplateKeys,
 							Description:  `Whether the instance is spot. If this is set as SPOT.`,
+						},
+						"instance_termination_action": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							AtLeastOneOf:  schedulingInstTemplateKeys,
+							Description:  `Specifies the action GCE should take when SPOT VM is preempted.`,
 						},
 					},
 				},

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1124,6 +1124,7 @@ func TestAccComputeInstanceTemplate_spot(t *testing.T) {
 					testAccCheckComputeInstanceTemplateAutomaticRestart(&instanceTemplate, false),
 					testAccCheckComputeInstanceTemplatePreemptible(&instanceTemplate, true),
 					testAccCheckComputeInstanceTemplateProvisioningModel(&instanceTemplate, "SPOT"),
+					testAccCheckComputeInstanceTemplateInstanceTerminationAction(&instanceTemplate, "STOP"),
 				),
 			},
 			{
@@ -1286,6 +1287,15 @@ func testAccCheckComputeInstanceTemplateProvisioningModel(instanceTemplate *comp
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.Scheduling.ProvisioningModel != provisioning_model {
 			return fmt.Errorf("Expected provisioning_model  %v, got %v", provisioning_model, instanceTemplate.Properties.Scheduling.ProvisioningModel)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceTemplateInstanceTerminationAction(instanceTemplate *compute.InstanceTemplate, instance_termination_action string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Scheduling.InstanceTerminationAction != instance_termination_action {
+			return fmt.Errorf("Expected instance_termination_action  %v, got %v", instance_termination_action, instanceTemplate.Properties.Scheduling.InstanceTerminationAction)
 		}
 		return nil
 	}
@@ -2860,6 +2870,7 @@ resource "google_compute_instance_template" "foobar" {
     preemptible       = true
     automatic_restart = false
     provisioning_model = "SPOT"
+    instance_termination_action = "STOP"
   }
 
   metadata = {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -2234,6 +2234,7 @@ func TestAccComputeInstance_spotVM(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceTerminationAction(&instance, "STOP"),
 				),
 			},
 			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
@@ -2583,6 +2584,23 @@ func testAccCheckComputeResourcePolicy(instance *compute.Instance, scheduleName 
 
 		if resourcePoliciesCountHave == 1 && !strings.Contains(instance.ResourcePolicies[0], scheduleName) {
 			return fmt.Errorf("got the wrong schedule: have: %s; want: %s", instance.ResourcePolicies[0], scheduleName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceTerminationAction(instance *compute.Instance, instanceTerminationActionWant string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instance == nil {
+			return fmt.Errorf("instance is nil")
+		}
+		if instance.Scheduling == nil {
+			return fmt.Errorf("no scheduling")
+		}
+
+		if instance.Scheduling.InstanceTerminationAction != instanceTerminationActionWant {
+			return fmt.Errorf("got the wrong instance termniation action: have: %s; want: %s",instance.Scheduling.InstanceTerminationAction, instanceTerminationActionWant)
 		}
 
 		return nil
@@ -6277,6 +6295,7 @@ resource "google_compute_instance" "foobar" {
     provisioning_model = "SPOT"
     automatic_restart = false
     preemptible = true
+		instance_termination_action = "STOP"
   }
 
 }

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -127,6 +127,10 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 		scheduling.ProvisioningModel = v.(string)
 		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "ProvisioningModel")
 	}
+	if v, ok := original["instance_termination_action"]; ok {
+		scheduling.InstanceTerminationAction = v.(string)
+		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "InstanceTerminationAction")
+	}
 	return scheduling, nil
 }
 
@@ -136,6 +140,7 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 		"preemptible":         resp.Preemptible,
 		"min_node_cpus":       resp.MinNodeCpus,
 		"provisioning_model":  resp.ProvisioningModel,
+		"instance_termination_action": resp.InstanceTerminationAction,
 	}
 
 	if resp.AutomaticRestart != nil {
@@ -481,8 +486,12 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 		return true
 	}
 
-        if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
-	        return true
+	if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
+		return true
+	}
+
+	if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
+			return true
 	}
 
 	return false


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
GCE now support Spot VMs termination action:
https://cloud.google.com/compute/docs/instances/spot
part of hashicorp/terraform-provider-google#12089




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
compute: added `instance_termination_action` field to `google_compute_instance` resource to support Spot VM termination action
```

```release-note:enhancement
compute: added `instance_termination_action` field to `google_compute_instance_template` resource to support Spot VM termination action```