### PR TITLE
Added network and subnetwork fields to regional NEG resource

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8553,6 +8553,21 @@ objects:
         description: |
           The target service url used to set up private service connection to
           a Google API or a PSC Producer Service Attachment.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'network'
+        resource: 'Network'
+        imports: 'selfLink'
+        description: |
+          This field is only used for PSC.
+          The URL of the network to which all network endpoints in the NEG belong. Uses
+          "default" project network if unspecified.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'subnetwork'
+        resource: 'Subnetwork'
+        imports: 'selfLink'
+        description: |
+          This field is only used for PSC.
+          Optional URL of the subnetwork to which all network endpoints in the NEG belong.
       - !ruby/object:Api::Type::NestedObject
         name: 'cloudRun'
         conflicts:

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1646,6 +1646,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "psc_neg"
         vars:
           neg_name: "psc-neg"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "region_network_endpoint_group_psc_service_attachment"
+        primary_resource_id: "psc_neg_service_attachment"
+        vars:
+          neg_name: "psc-neg"
+          network_name: "psc-network"
+          subnetwork_name: "psc-subnetwork"
+          psc_subnetwork_name: "psc-subnetwork-nat"
+          backend_service_name: "psc-backend"
+          forwarding_rule_name: "psc-forwarding-rule"
+          service_attachment_name: "psc-service-attachment"
+          health_check_name: "psc-healthcheck"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_psc_service_attachment.tf.erb
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_psc_service_attachment.tf.erb
@@ -1,0 +1,67 @@
+resource "google_compute_network" "default" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "europe-west4"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_subnetwork" "psc_subnetwork" {
+  name          = "<%= ctx[:vars]['psc_subnetwork_name'] %>"
+  ip_cidr_range = "10.1.0.0/16"
+  region        = "europe-west4"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_health_check" "default" {
+  name = "<%= ctx[:vars]['health_check_name'] %>"
+
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+resource "google_compute_region_backend_service" "default" {
+  name   = "<%= ctx[:vars]['backend_service_name'] %>"
+  region = "europe-west4"
+
+  health_checks = [google_compute_health_check.default.id]
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name   = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  region = "europe-west4"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.default.id
+  all_ports             = true
+  network               = google_compute_network.default.name
+  subnetwork            = google_compute_subnetwork.default.name
+}
+
+resource "google_compute_service_attachment" "default" {
+  name        = "<%= ctx[:vars]['service_attachment_name'] %>"
+  region      = "europe-west4"
+  description = "A service attachment configured with Terraform"
+
+  enable_proxy_protocol = false
+  connection_preference = "ACCEPT_AUTOMATIC"
+  nat_subnets           = [google_compute_subnetwork.psc_subnetwork.self_link]
+  target_service        = google_compute_forwarding_rule.default.self_link
+}
+
+resource "google_compute_region_network_endpoint_group" "<%= ctx[:primary_resource_id] %>" {
+  name                  = "<%= ctx[:vars]['neg_name'] %>"
+  region                = "europe-west4"
+
+  network_endpoint_type = "PRIVATE_SERVICE_CONNECT"
+  psc_target_service    = google_compute_service_attachment.default.self_link
+
+  network               = google_compute_network.default.self_link
+  subnetwork            = google_compute_subnetwork.default.self_link
+}


### PR DESCRIPTION
Added `network` and `subnetwork` fields to `google_compute_region_network_endpoint_group` for PSC. These are required when creating a PSC-type NEG that points to a service attachment.
 
Link to GA API: https://cloud.google.com/compute/docs/reference/rest/v1/regionNetworkEndpointGroups/insert

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `network` and `subnetwork` fields to `google_compute_region_network_endpoint_group` for PSC.
```
