### PR TITLE
remove check on conflicts

### DIFF
--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -213,11 +213,6 @@ module Api
       check :conflicts, type: ::Array, default: [], item_type: ::String
 
       return if @conflicts.empty?
-
-      names = @__resource.all_user_properties.map(&:lineage)
-      @conflicts.each do |p|
-        raise "#{p} does not exist" unless names.include?(p)
-      end
     end
 
     # Returns list of properties that are in conflict with this property.

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -209,6 +209,8 @@ module Api
     end
 
     # Checks that all conflicting properties actually exist.
+    # This currently just returns if empty, because we don't want to do the check, since
+    # this list will have a full path for nested attributes.
     def check_conflicts
       check :conflicts, type: ::Array, default: [], item_type: ::String
 
@@ -219,8 +221,7 @@ module Api
     def conflicting
       return [] unless @__resource
 
-      (@__resource.all_user_properties.select { |p| @conflicts.include?(p.lineage) } +
-      @__resource.all_user_properties.select { |p| p.conflicts.include?(lineage) }).uniq
+      @conflicts
     end
 
     # Checks that all properties that needs at least one of their fields actually exist.

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -3786,6 +3786,8 @@ objects:
           connection does not need to match both properties for the firewall to
           apply. Only IPv4 is supported. For INGRESS traffic, one of `source_ranges`,
           `source_tags` or `source_service_accounts` is required.
+        conflicts:
+          - destination_ranges
         item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'sourceServiceAccounts'
@@ -3821,6 +3823,10 @@ objects:
           to match both properties for the firewall to apply. For INGRESS traffic,
           one of `source_ranges`, `source_tags` or `source_service_accounts` is required.
         item_type: Api::Type::String
+        conflicts:
+          - source_service_accounts
+          - destination_ranges
+          - target_service_accounts
       - !ruby/object:Api::Type::Array
         name: 'targetServiceAccounts'
         description: |
@@ -3843,6 +3849,9 @@ objects:
           If no targetTags are specified, the firewall rule applies to all
           instances on the specified network.
         item_type: Api::Type::String
+        conflicts:
+          - source_service_accounts
+          - target_service_accounts
   - !ruby/object:Api::Resource
     name: 'ForwardingRule'
     kind: 'compute#forwardingRule'

--- a/mmv1/templates/terraform/schema_property.erb
+++ b/mmv1/templates/terraform/schema_property.erb
@@ -168,8 +168,7 @@
     Default: <%= go_literal(property.default_value) -%>,
 <% end -%>
 <% unless property.conflicting().empty? -%>
-<% conflicting_props = property.conflicting().map(&:name).map(&:underscore) -%>
-    ConflictsWith: <%= go_literal(conflicting_props.map {|sp| get_property_schema_path(sp, object) }.compact) -%>,
+    ConflictsWith: <%= go_literal(property.conflicting.map  {|sp| get_property_schema_path(sp, object) }.compact) -%>,
 <% end -%>
 <% unless property.at_least_one_of_list().empty? -%>
     AtLeastOneOf: <%= go_literal(property.at_least_one_of_list.map {|sp| get_property_schema_path(sp, object) }.compact) -%>,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12052
Removing the check on `conflicts` in magic-modules to allow for nested objects. This aligns with how `at_least_one_of` and `exactly_one_of` work. This allows us to add the path in the check `parent.0.child`

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
