### PR TITLE
dataproc: promote `lifecycle_config` and `endpoint_config` to ga

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -96,10 +96,8 @@ var (
 		"cluster_config.0.encryption_config",
 		"cluster_config.0.autoscaling_config",
 		"cluster_config.0.metastore_config",
-<% unless version == 'ga' -%>
 		"cluster_config.0.lifecycle_config",
 		"cluster_config.0.endpoint_config",
-<% end -%>
 	}
 )
 
@@ -973,7 +971,6 @@ by Dataproc`,
 								},
 							},
 						},						
-<% unless version == 'ga' -%>
 						"lifecycle_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -1036,7 +1033,6 @@ by Dataproc`,
 								},
 							},
 						},
-<% end -%>
 					},
 				},
 			},
@@ -1493,7 +1489,6 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 		conf.MetastoreConfig = expandMetastoreConfig(cfg)
 	}
 
-<% unless version == 'ga' -%>
 	if cfg, ok := configOptions(d, "cluster_config.0.lifecycle_config"); ok {
 		conf.LifecycleConfig = expandLifecycleConfig(cfg)
 	}
@@ -1501,7 +1496,6 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 	if cfg, ok := configOptions(d, "cluster_config.0.endpoint_config"); ok {
 		conf.EndpointConfig = expandEndpointConfig(cfg)
 	}
-<% end -%>
 
 	if cfg, ok := configOptions(d, "cluster_config.0.master_config"); ok {
 		log.Println("[INFO] got master_config")
@@ -1682,7 +1676,6 @@ func expandAutoscalingConfig(cfg map[string]interface{}) *dataproc.AutoscalingCo
 	return conf
 }
 
-<% unless version == 'ga' -%>
 func expandLifecycleConfig(cfg map[string]interface{}) *dataproc.LifecycleConfig {
 	conf := &dataproc.LifecycleConfig{}
 	if v, ok := cfg["idle_delete_ttl"]; ok {
@@ -1701,7 +1694,6 @@ func expandEndpointConfig(cfg map[string]interface{}) *dataproc.EndpointConfig {
 	}
 	return conf
 }
-<% end -%>
 
 func expandMetastoreConfig(cfg map[string]interface{}) *dataproc.MetastoreConfig {
 	conf := &dataproc.MetastoreConfig{}
@@ -1872,7 +1864,6 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		updMask = append(updMask, "config.autoscaling_config.policy_uri")
 	}
 
-<% unless version == 'ga' -%>
 	if d.HasChange("cluster_config.0.lifecycle_config.0.idle_delete_ttl") {
 		idleDeleteTtl := d.Get("cluster_config.0.lifecycle_config.0.idle_delete_ttl").(string)
 		cluster.Config.LifecycleConfig = &dataproc.LifecycleConfig{
@@ -1894,7 +1885,6 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 
 		updMask = append(updMask, "config.lifecycle_config.auto_delete_time")
 	}
-<% end -%>
 
 	if len(updMask) > 0 {
 		gracefulDecommissionTimeout := d.Get("graceful_decommission_timeout").(string)
@@ -2127,10 +2117,8 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		"security_config":           flattenSecurityConfig(d, cfg.SecurityConfig),
 		"preemptible_worker_config": flattenPreemptibleInstanceGroupConfig(d, cfg.SecondaryWorkerConfig),
 		"metastore_config":          flattenMetastoreConfig(d, cfg.MetastoreConfig),
-<% unless version == 'ga' -%>
-		"lifecycle_config": flattenLifecycleConfig(d, cfg.LifecycleConfig),
-		"endpoint_config":  flattenEndpointConfig(d, cfg.EndpointConfig),
-<% end -%>
+		"lifecycle_config":          flattenLifecycleConfig(d, cfg.LifecycleConfig),
+		"endpoint_config":           flattenEndpointConfig(d, cfg.EndpointConfig),
 	}
 
 	if len(cfg.InitializationActions) > 0 {
@@ -2211,7 +2199,6 @@ func flattenAutoscalingConfig(d *schema.ResourceData, ec *dataproc.AutoscalingCo
 	return []map[string]interface{}{data}
 }
 
-<% unless version == 'ga' -%>
 func flattenLifecycleConfig(d *schema.ResourceData, lc *dataproc.LifecycleConfig) []map[string]interface{} {
 	if lc == nil {
 		return nil
@@ -2237,7 +2224,6 @@ func flattenEndpointConfig(d *schema.ResourceData, ec *dataproc.EndpointConfig) 
 
 	return []map[string]interface{}{data}
 }
-<% end -%>
 
 func flattenMetastoreConfig(d *schema.ResourceData, ec *dataproc.MetastoreConfig) []map[string]interface{} {
 	if ec == nil {

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -9,9 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-<% unless version == "ga" -%>
 	"time"
-<% end -%>
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -644,7 +642,6 @@ func TestAccDataprocCluster_withOptionalComponents(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(t *testing.T) {
 	t.Parallel()
 
@@ -701,7 +698,6 @@ func TestAccDataprocCluster_withLifecycleConfigAutoDeletion(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccDataprocCluster_withLabels(t *testing.T) {
 	t.Parallel()
@@ -752,7 +748,6 @@ func TestAccDataprocCluster_withNetworkRefs(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccDataprocCluster_withEndpointConfig(t *testing.T) {
 	t.Parallel()
 
@@ -773,7 +768,6 @@ func TestAccDataprocCluster_withEndpointConfig(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccDataprocCluster_KMS(t *testing.T) {
 	t.Parallel()
@@ -1606,7 +1600,6 @@ resource "google_dataproc_cluster" "with_labels" {
 `, rnd)
 }
 
-<% unless version == 'ga' -%>
 func testAccDataprocCluster_withEndpointConfig(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_endpoint_config" {
@@ -1621,7 +1614,6 @@ resource "google_dataproc_cluster" "with_endpoint_config" {
 }
 `, rnd)
 }
-<% end -%>
 
 func testAccDataprocCluster_withImageVersion(rnd, version string) string {
 	return fmt.Sprintf(`
@@ -1653,7 +1645,6 @@ resource "google_dataproc_cluster" "with_opt_components" {
 `, rnd)
 }
 
-<% unless version == 'ga' -%>
 func testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, tm string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
@@ -1683,7 +1674,6 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
 }
 `, rnd, tm)
 }
-<% end -%>
 
 func testAccDataprocCluster_withServiceAcc(sa string, rnd string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -368,10 +368,10 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 * `encryption_config` (Optional) The Customer managed encryption keys settings for the cluster.
    Structure [defined below](#nested_encryption_config).
 
-* `lifecycle_config` (Optional, Beta) The settings for auto deletion cluster schedule.
+* `lifecycle_config` (Optional) The settings for auto deletion cluster schedule.
    Structure [defined below](#nested_lifecycle_config).
 
-* `endpoint_config` (Optional, Beta) The config settings for port access on the cluster.
+* `endpoint_config` (Optional) The config settings for port access on the cluster.
    Structure [defined below](#nested_endpoint_config).
 
 * `metastore_config` (Optional) The config setting for metastore service with the cluster.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ 
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataproc: promote `lifecycle_config` and `endpoint_config` to ga in `google_dataproc_cluster`
```
