### PR TITLE
Update resource_gke_hub_feature_membership_test for fields added in DCL 1.14.2

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
@@ -258,6 +258,29 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   }
   provider = google-beta
 }
+
+resource "google_gke_hub_feature_membership" "feature_member_4" {
+  project = google_project.project.project_id
+  location = "global"
+  feature = google_gke_hub_feature.feature.name
+  membership = google_gke_hub_membership.membership_fourth.membership_id
+  configmanagement {
+    version = "1.12.0"
+    policy_controller {
+      enabled = true
+      audit_interval_seconds = "100"
+      template_library_installed = true
+      mutation_enabled = true
+      monitoring {
+        backends = ["CLOUD_MONITORING", "PROMETHEUS"]
+      }
+    }
+  }
+  provider = google-beta
+}
+
+
+
 `, context)
 }
 
@@ -579,6 +602,16 @@ resource "google_container_cluster" "tertiary" {
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
+
+resource "google_container_cluster" "quarternary" {
+  name               = "tf-test-cl4%{random_suffix}"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  project = google_project.project.project_id
+  provider = google-beta
+  depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
+}
+
 resource "google_gke_hub_membership" "membership" {
   project = google_project.project.project_id
   membership_id = "tf-test1%{random_suffix}"
@@ -609,6 +642,18 @@ resource "google_gke_hub_membership" "membership_third" {
   endpoint {
     gke_cluster {
       resource_link = "//container.googleapis.com/${google_container_cluster.tertiary.id}"
+    }
+  }
+  description = "test resource."
+  provider = google-beta
+}
+
+resource "google_gke_hub_membership" "membership_fourth" {
+  project = google_project.project.project_id
+  membership_id = "tf-test4%{random_suffix}"
+  endpoint {
+    gke_cluster {
+      resource_link = "//container.googleapis.com/${google_container_cluster.quarternary.id}"
     }
   }
   description = "test resource."


### PR DESCRIPTION

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This adds a test for the `mutation_enabled` and `monitoring` fields added in https://github.com/GoogleCloudPlatform/declarative-resource-client-library/releases/tag/v1.14.2 which address [TPG #11618](https://github.com/hashicorp/terraform-provider-google/issues/11618).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
  - Test passes when ran locally: https://screenshot.googleplex.com/6JLQqrhkf7oq7V8

- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**
None, N/A, this just adds a test

```release-note:none

```