### PR TITLE
Auto-generate provider resources map for tpgtools resources.

### DIFF
--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -379,7 +379,6 @@ end     # products.each do
 				// ####### START handwritten resources ###########
 				"google_app_engine_application":                resourceAppEngineApplication(),
 				"google_bigquery_table":                        resourceBigQueryTable(),
-				"google_bigquery_reservation_assignment":       resourceBigqueryReservationAssignment(),
 				"google_bigtable_gc_policy":                    resourceBigtableGCPolicy(),
 				"google_bigtable_instance":                     resourceBigtableInstance(),
 				"google_bigtable_table":                        resourceBigtableTable(),
@@ -463,46 +462,6 @@ end     # products.each do
 				// ####### END handwritten resources ###########
 			},
 			map[string]*schema.Resource{
-				// ####### START tpgtools resources ###########
-				"google_apikeys_key":                           resourceApikeysKey(),
-				"google_assured_workloads_workload":            resourceAssuredWorkloadsWorkload(),
-				"google_cloudbuild_worker_pool":                resourceCloudbuildWorkerPool(),
-				"google_clouddeploy_delivery_pipeline":         resourceClouddeployDeliveryPipeline(),
-				"google_clouddeploy_target":                		resourceClouddeployTarget(),
-				"google_compute_firewall_policy_association":   resourceComputeFirewallPolicyAssociation(),
-				"google_compute_firewall_policy":               resourceComputeFirewallPolicy(),
-				"google_compute_firewall_policy_rule":          resourceComputeFirewallPolicyRule(),
-				"google_container_aws_cluster":                 resourceContainerAwsCluster(),
-				"google_container_aws_node_pool":               resourceContainerAwsNodePool(),
-				"google_container_azure_client":                resourceContainerAzureClient(),
-				"google_container_azure_cluster":               resourceContainerAzureCluster(),
-				"google_container_azure_node_pool":             resourceContainerAzureNodePool(),
-				"google_dataplex_lake":                         resourceDataplexLake(),
-				"google_dataplex_zone":                         resourceDataplexZone(),
-				"google_dataproc_workflow_template":            resourceDataprocWorkflowTemplate(),
-				"google_eventarc_trigger":                      resourceEventarcTrigger(),
-				"google_firebaserules_release":                 resourceFirebaserulesRelease(),
-				"google_firebaserules_ruleset":                 resourceFirebaserulesRuleset(),
-				<% unless version == 'ga' -%>
-				"google_gke_hub_feature":                       resourceGkeHubFeature(),
-				"google_gke_hub_feature_membership":            resourceGkeHubFeatureMembership(),
-				<% end -%>
-				"google_logging_log_view":                      resourceLoggingLogView(),
-				"google_monitoring_monitored_project":          resourceMonitoringMonitoredProject(),
-				"google_network_connectivity_hub":              resourceNetworkConnectivityHub(),
-				"google_network_connectivity_spoke":            resourceNetworkConnectivitySpoke(),
-				"google_org_policy_policy":                     resourceOrgPolicyPolicy(),
-				"google_os_config_os_policy_assignment":        resourceOsConfigOsPolicyAssignment(),
-				"google_privateca_certificate_template":        resourcePrivatecaCertificateTemplate(),
-				"google_recaptcha_enterprise_key":              resourceRecaptchaEnterpriseKey(),
-				<% if version == 'private' -%>
-				"google_vmware_private_cloud":                  resourceVmwarePrivateCloud(),
-				"google_vmware_cluster":                        resourceVmwareCluster(),
-				"google_cloud_run_job":                         resourceRunJob(),
-				<% end -%>
-				// ####### END tpgtools resources ###########
-			},
-			map[string]*schema.Resource{
 				// ####### START non-generated IAM resources ###########
 				"google_bigtable_instance_iam_binding":         ResourceIamBinding(IamBigtableInstanceSchema, NewBigtableInstanceUpdater, BigtableInstanceIdParseFunc),
 				"google_bigtable_instance_iam_member":          ResourceIamMember(IamBigtableInstanceSchema, NewBigtableInstanceUpdater, BigtableInstanceIdParseFunc),
@@ -566,6 +525,7 @@ end     # products.each do
 				"google_service_account_iam_policy":            ResourceIamPolicy(IamServiceAccountSchema, NewServiceAccountIamUpdater, ServiceAccountIdParseFunc),
 				// ####### END non-generated IAM resources ###########
 			},
+			dclResources,
 		)
 }
 

--- a/tpgtools/override.go
+++ b/tpgtools/override.go
@@ -44,6 +44,7 @@ const (
 	PreCreate                          = "PRE_CREATE_FUNCTION"
 	PostCreate                         = "POST_CREATE_FUNCTION"
 	PreDelete                          = "PRE_DELETE_FUNCTION"
+	SkipInProvider                     = "SKIP_IN_PROVIDER"
 	CustomResourceName                 = "CUSTOM_RESOURCE_NAME"
 	NoSweeper                          = "NO_SWEEPER"
 	CustomImport                       = "CUSTOM_IMPORT_FUNCTION"

--- a/tpgtools/overrides/compute/beta/forwarding_rule.yaml
+++ b/tpgtools/overrides/compute/beta/forwarding_rule.yaml
@@ -5,6 +5,7 @@
   location: region
 - type: EXCLUDE
   field: id
+- type: SKIP_IN_PROVIDER
 - type: CUSTOM_RESOURCE_NAME
   details:
     title: global_forwarding_rule

--- a/tpgtools/overrides/compute/forwarding_rule.yaml
+++ b/tpgtools/overrides/compute/forwarding_rule.yaml
@@ -5,6 +5,7 @@
   location: region
 - type: EXCLUDE
   field: id
+- type: SKIP_IN_PROVIDER
 - type: CUSTOM_RESOURCE_NAME
   details:
     title: global_forwarding_rule

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -56,6 +56,10 @@ type Resource struct {
 	// replacing one substring with another.
 	ReplaceInBasePath BasePathReplacement
 
+	// SkipInProvider is true when the resource shouldn't be included in the dclResources
+	// map for the provider. This is usually because it was already included through mmv1.
+	SkipInProvider bool
+
 	// title is the name of the resource in snake_case. For example,
 	// "instance", "backend_service".
 	title SnakeCaseTerraformResourceName
@@ -426,6 +430,10 @@ func createResource(schema *openapi.Schema, info *openapi.Info, typeFetcher *Typ
 		res.InsertTimeoutMinutes = ctd.TimeoutMinutes
 		res.UpdateTimeoutMinutes = ctd.TimeoutMinutes
 		res.DeleteTimeoutMinutes = ctd.TimeoutMinutes
+	}
+
+	if overrides.ResourceOverride(SkipInProvider, location) {
+		res.SkipInProvider = true
 	}
 
 	crname := CustomResourceNameDetails{}

--- a/tpgtools/templates/provider_dcl_resources.go.tmpl
+++ b/tpgtools/templates/provider_dcl_resources.go.tmpl
@@ -34,7 +34,9 @@ import (
 
 var dclResources = map[string]*schema.Resource{
 {{- range $res := . }}
+	{{- if not $res.SkipInProvider }}
 	"{{$res.TerraformName}}": resource{{$res.PathType}}(),
+	{{- end }}
 {{- end }}
 }
 

--- a/tpgtools/templates/provider_dcl_resources.go.tmpl
+++ b/tpgtools/templates/provider_dcl_resources.go.tmpl
@@ -1,4 +1,4 @@
-{{/* Copyright 2021 Google LLC. All Rights Reserved.
+{{/* Copyright 2022 Google LLC. All Rights Reserved.
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -29,35 +29,12 @@
 package google
 
 import (
-	"time"
-	dcl "github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
-{{range $index, $pkg := .}}
-	{{$pkg.PackageName}} "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/{{$pkg.PackageNameWithVersion}}"
-{{- end}}
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-{{range $index, $pkg := .}}
-func NewDCL{{$pkg.ProductName.ToTitle}}Client(config *Config, userAgent, billingProject string, timeout time.Duration) *{{$pkg.PackageName}}.Client {
-	configOptions := []dcl.ConfigOption{
-		dcl.WithHTTPClient(config.client),
-		dcl.WithUserAgent(userAgent),
-		dcl.WithLogger(dclLogger{}),
-		dcl.WithBasePath(config.{{$pkg.BasePathIdentifier.ToTitle}}BasePath),
-	}
-
-	if (timeout != 0){
-		configOptions = append(configOptions, dcl.WithTimeout(timeout))
-	}
-
-	if config.UserProjectOverride {
-		configOptions = append(configOptions, dcl.WithUserProjectOverride())
-		if billingProject != "" {
-			configOptions = append(configOptions, dcl.WithBillingProject(billingProject))
-		}
-	}
-
-	dclConfig := dcl.NewConfig(configOptions...)
-	return {{$pkg.PackageName}}.NewClient(dclConfig)
+var dclResources = map[string]*schema.Resource{
+{{- range $res := . }}
+	"{{$res.TerraformName}}": resource{{$res.PathType}}(),
+{{- end }}
 }
-{{end}}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
