### PR TITLE
Add support for evaluationMissingData in AlertPolicy

### DIFF
--- a/mmv1/products/monitoring/api.yaml
+++ b/mmv1/products/monitoring/api.yaml
@@ -347,6 +347,16 @@ objects:
                      The absolute number of time series
                      that must fail the predicate for the
                      condition to be triggered.
+              - !ruby/object:Api::Type::Enum
+                name: evaluationMissingData
+                description: |
+                  A condition control that determines how
+                  metric-threshold conditions are evaluated when
+                  data stops arriving.
+                values:
+                  - :EVALUATION_MISSING_DATA_INACTIVE
+                  - :EVALUATION_MISSING_DATA_ACTIVE
+                  - :EVALUATION_MISSING_DATA_NO_OP
            - !ruby/object:Api::Type::NestedObject
              name: conditionThreshold
              description: |
@@ -734,6 +744,16 @@ objects:
                   resource labels, and metric labels. This
                   field may not exceed 2048 Unicode characters
                   in length.
+              - !ruby/object:Api::Type::Enum
+                name: evaluationMissingData
+                description: |
+                  A condition control that determines how
+                  metric-threshold conditions are evaluated when
+                  data stops arriving.
+                values:
+                  - :EVALUATION_MISSING_DATA_INACTIVE
+                  - :EVALUATION_MISSING_DATA_ACTIVE
+                  - :EVALUATION_MISSING_DATA_NO_OP
            - !ruby/object:Api::Type::String
              name: displayName
              required: true

--- a/mmv1/products/monitoring/terraform.yaml
+++ b/mmv1/products/monitoring/terraform.yaml
@@ -25,6 +25,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "alert_policy"
         vars:
           alert_policy_display_name: "My Alert Policy"
+      - !ruby/object:Provider::Terraform::Examples
+        # skipping tests because the API is full of race conditions
+        skip_test: true
+        name: "monitoring_alert_policy_evaluation_missing_data"
+        primary_resource_id: "alert_policy"
+        vars:
+          alert_policy_display_name: "My Alert Policy"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/templates/terraform/examples/monitoring_alert_policy_evaluation_missing_data.tf.erb
+++ b/mmv1/templates/terraform/examples/monitoring_alert_policy_evaluation_missing_data.tf.erb
@@ -1,0 +1,21 @@
+resource "google_monitoring_alert_policy" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "<%= ctx[:vars]["alert_policy_display_name"] %>"
+  combiner     = "OR"
+  conditions {
+    display_name = "test condition"
+    condition_threshold {
+      filter     = "metric.type=\"compute.googleapis.com/instance/disk/write_bytes_count\" AND resource.type=\"gce_instance\""
+      duration   = "60s"
+      comparison = "COMPARISON_GT"
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+    }
+  }
+
+  user_labels = {
+    foo = "bar"
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolves https://github.com/hashicorp/terraform-provider-google/issues/11161, resolves https://github.com/hashicorp/terraform-provider-google/issues/11227.

This PR adds a support for [EvaluationMissingData](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#evaluationmissingdata).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added `evaluation_missing_data` field to `google_monitoring_alert_policy`
```

NOTE: I saw a weird diff after running `make terraform`:

```diff
$ git diff
diff --git a/google-beta/resource_compute_subnetwork.go b/google-beta/resource_compute_subnetwork.go
index 59dd5e28c..8a620b94f 100644
--- a/google-beta/resource_compute_subnetwork.go
+++ b/google-beta/resource_compute_subnetwork.go
@@ -22,7 +22,6 @@ import (
        "reflect"
        "time"

-       "github.com/apparentlymart/go-cidr/cidr"
        "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
        "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
```

This seems to be irrelevant to my change, so I ignored this change and reverted this file before running `make testacc`.