### PR TITLE
Add test for sql database secondary zone

### DIFF
--- a/mmv1/third_party/validator/sql_database_instance.go
+++ b/mmv1/third_party/validator/sql_database_instance.go
@@ -97,20 +97,20 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	_settings := configured[0].(map[string]interface{})
 	settings := &sqladmin.Settings{
 		// Version is unset in Create but is set during update
-		SettingsVersion:             int64(_settings["version"].(int)),
-		Tier:                        _settings["tier"].(string),
-		ForceSendFields:             []string{"StorageAutoResize"},
-		ActivationPolicy:            _settings["activation_policy"].(string),
-		AvailabilityType:            _settings["availability_type"].(string),
-		DataDiskSizeGb:              int64(_settings["disk_size"].(int)),
-		DataDiskType:                _settings["disk_type"].(string),
-		PricingPlan:                 _settings["pricing_plan"].(string),
-		UserLabels:                  convertStringMap(_settings["user_labels"].(map[string]interface{})),
-		BackupConfiguration:         expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
-		DatabaseFlags:               expandDatabaseFlags(_settings["database_flags"].([]interface{})),
-		IpConfiguration:             expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
-		LocationPreference:          expandLocationPreference(_settings["location_preference"].([]interface{})),
-		MaintenanceWindow:           expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),
+		SettingsVersion:     int64(_settings["version"].(int)),
+		Tier:                _settings["tier"].(string),
+		ForceSendFields:     []string{"StorageAutoResize"},
+		ActivationPolicy:    _settings["activation_policy"].(string),
+		AvailabilityType:    _settings["availability_type"].(string),
+		DataDiskSizeGb:      int64(_settings["disk_size"].(int)),
+		DataDiskType:        _settings["disk_type"].(string),
+		PricingPlan:         _settings["pricing_plan"].(string),
+		UserLabels:          convertStringMap(_settings["user_labels"].(map[string]interface{})),
+		BackupConfiguration: expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
+		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].([]interface{})),
+		IpConfiguration:     expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
+		LocationPreference:  expandLocationPreference(_settings["location_preference"].([]interface{})),
+		MaintenanceWindow:   expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),
 	}
 
 	// 1st Generation instances don't support the disk_autoresize parameter
@@ -173,6 +173,7 @@ func expandLocationPreference(configured []interface{}) *sqladmin.LocationPrefer
 	return &sqladmin.LocationPreference{
 		FollowGaeApplication: _locationPreference["follow_gae_application"].(string),
 		Zone:                 _locationPreference["zone"].(string),
+		SecondaryZone:        _locationPreference["secondary_zone"].(string),
 	}
 }
 

--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.json
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.json
@@ -68,7 +68,8 @@
           },
           "locationPreference": {
             "followGaeApplication": "test-follow_gae_application",
-            "zone": "us-central1-a"
+            "zone": "us-central1-a",
+            "secondaryZone": "us-central1-b"
           },
           "maintenanceWindow": {
             "day": 42,

--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.tf
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.tf
@@ -90,6 +90,7 @@ resource "google_sql_database_instance" "main" {
     location_preference {
       follow_gae_application = "test-follow_gae_application"
       zone                   = "us-central1-a"
+      secondary_zone         = "us-central1-b"
     }
     maintenance_window {
       day          = 42

--- a/mmv1/third_party/validator/tests/data/full_sql_database_instance.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/full_sql_database_instance.tfplan.json
@@ -123,7 +123,8 @@
                 "location_preference": [
                   {
                     "follow_gae_application": "test-follow_gae_application",
-                    "zone": "us-central1-a"
+                    "zone": "us-central1-a",
+                    "secondary_zone": "us-central1-b"
                   }
                 ],
                 "maintenance_window": [
@@ -309,7 +310,8 @@
               "location_preference": [
                 {
                   "follow_gae_application": "test-follow_gae_application",
-                  "zone": "us-central1-a"
+                  "zone": "us-central1-a",
+                  "secondary_zone": "us-central1-b"
                 }
               ],
               "maintenance_window": [
@@ -603,6 +605,9 @@
                     },
                     "zone": {
                       "constant_value": "us-central1-a"
+                    },
+                    "secondary_zone": {
+                      "constant_value": "us-central1-b"
                     }
                   }
                 ],

--- a/mmv1/third_party/validator/tests/source/environment_test.go
+++ b/mmv1/third_party/validator/tests/source/environment_test.go
@@ -21,7 +21,7 @@ const (
 	defaultOrganizationDomain = "meep.test.com"
 	defaultOrganizationTarget = "13579"
 	defaultProject            = "foobar"
-	defaultProviderVersion    = "4.20.0"
+	defaultProviderVersion    = "4.28.0"
 	defaultRegion             = "us-central1"
 	defaultServiceAccount     = "meep@foobar.iam.gserviceaccount.com"
 )


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

b/237821330 add secondary zone for sql database in tfv


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
