### PR TITLE
Handle resources with no create method

### DIFF
--- a/tpgtools/main.go
+++ b/tpgtools/main.go
@@ -187,7 +187,7 @@ func loadAndModelResources() (map[Version][]*Resource, map[Version][]*ProductMet
 				}
 
 				overrides := loadOverrides(packagePath, resourceFile.Name())
-				if(len(overrides) > 0){
+				if len(overrides) > 0 {
 					glog.Infof("Loaded overrides for %s", resourceFile.Name())
 				}
 
@@ -509,11 +509,11 @@ func generateProductsFile(fileName string, products []*ProductMetadata) {
 }
 
 var TemplateFunctions = template.FuncMap{
-	"title":             strings.Title,
-	"patternToRegex":    PatternToRegex,
-	"replace":           strings.Replace,
-	"isLastIndex":       isLastIndex,
-	"escapeDescription": escapeDescription,
+	"title":                           strings.Title,
+	"patternToRegex":                  PatternToRegex,
+	"replace":                         strings.Replace,
+	"isLastIndex":                     isLastIndex,
+	"escapeDescription":               escapeDescription,
 	"shouldAllowForwardSlashInFormat": shouldAllowForwardSlashInFormat,
 }
 

--- a/tpgtools/names.go
+++ b/tpgtools/names.go
@@ -112,6 +112,9 @@ func (b BasePathOverrideNameSnakeCase) ToTitle() RenderedString {
 	if strings.HasPrefix(string(b), "gkehub") {
 		return RenderedString("GKEHub" + title[6:])
 	}
+	if strings.HasPrefix(string(b), "vertex_ai") {
+		return RenderedString("VertexAI" + title[8:])
+	}
 	return RenderedString(title)
 }
 

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -313,14 +313,10 @@ func (p Property) DefaultStateSetter() string {
 	case SchemaTypeMap:
 		return fmt.Sprintf("d.Set(%q, res.%s)", p.Name(), p.PackageName)
 	case SchemaTypeList, SchemaTypeSet:
-		if p.Type.typ.Items != nil && p.Type.typ.Items.Type == "string" {
+		if p.typ.Items != nil && ((p.typ.Items.Type == "string" && len(p.typ.Items.Enum) == 0) || p.typ.Items.Type == "integer") {
 			return fmt.Sprintf("d.Set(%q, res.%s)", p.Name(), p.PackageName)
 		}
-		if p.Type.typ.Items != nil && p.Type.typ.Items.Type == "integer" {
-			return fmt.Sprintf("d.Set(%q, res.%s)", p.Name(), p.PackageName)
-		}
-
-		if p.Type.typ.Items != nil && len(p.Properties) > 0 {
+		if p.typ.Items != nil && (len(p.Properties) > 0 || len(p.typ.Items.Enum) > 0) {
 			return fmt.Sprintf("d.Set(%q, flatten%s%sArray(res.%s))", p.Name(), p.resource.PathType(), p.PackagePath(), p.PackageName)
 		}
 	}

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -124,8 +124,11 @@ type Resource struct {
 	// location is one of "zone", "region", or "global".
 	location string
 
-	// HasProject tells us if the resource has a project field
+	// HasProject tells us if the resource has a project field.
 	HasProject bool
+
+	// HasCreate tells us if the resource has a create endpoint.
+	HasCreate bool
 
 	// HasSweeper says if this resource has a generated sweeper.
 	HasSweeper bool
@@ -563,6 +566,9 @@ func createResource(schema *openapi.Schema, info *openapi.Info, typeFetcher *Typ
 			}
 		}
 	}
+
+	// Determine if a resource has a create method.
+	res.HasCreate, _ = schema.Extension["x-dcl-has-create"].(bool)
 
 	// Determine if a resource can use a generated sweeper or not
 	// We only supply a certain set of parent values to sweepers, so only generate

--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -232,7 +232,7 @@ func (s Sample) ReplaceReferences(d *Dependency) error {
 
 	for _, match := range matches {
 		referenceFileName := match[1]
-		idField := match[2]
+		idField := dcl.TitleToSnakeCase(match[2])
 		var tfReference string
 		for _, dep := range s.DependencyList {
 			if dep.FileName == referenceFileName {

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -251,9 +251,12 @@ should be converted to use the DCL's ID method, so normalization can be uniform.
 	d.SetId(id)
 
 {{- if $.CustomCreateDirectiveFunction }}
-  createDirective := {{ $.CustomCreateDirectiveFunction }}(obj)
+	directive := {{ $.CustomCreateDirectiveFunction }}(obj)
+{{- else if $.HasCreate }}
+	directive := CreateDirective
 {{- else }}
-  createDirective := CreateDirective
+	{{/* Resource has no create method, so we skip the BlockModification parameter. */}}
+	directive := UpdateDirective
 {{- end }}
 	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
@@ -281,7 +284,7 @@ should be converted to use the DCL's ID method, so normalization can be uniform.
 	} else {
 		client.Config.BasePath = bp
 	}
-	res, err := client.Apply{{$.DCLTitle}}(context.Background(), obj, createDirective...)
+	res, err := client.Apply{{$.DCLTitle}}(context.Background(), obj, directive...)
 
 	if _, ok := err.(dcl.DiffAfterApplyError); ok {
 		log.Printf("[DEBUG] Diff after apply returned from the DCL: %s", err)
@@ -493,7 +496,7 @@ func resource{{$.PathType}}Delete(d *schema.ResourceData, meta interface{}) erro
 {{ end }}
 	}
 
-	{{- if $.Mutex }}
+{{- if $.Mutex }}
 	lockName, err := {{ $.IDFunction }}(d, config, "{{$.Mutex}}")
 	if err != nil {
 		return err
@@ -533,12 +536,12 @@ func resource{{$.PathType}}Delete(d *schema.ResourceData, meta interface{}) erro
 		billingProject = bp
 	}
 	client := NewDCL{{$.TitleCasePackageName}}Client(config, userAgent, billingProject, d.Timeout(schema.TimeoutDelete))
-	{{- if $.AppendToBasePath }}
+{{- if $.AppendToBasePath }}
 	client.Config.BasePath += "{{$.AppendToBasePath}}"
-	{{- end }}
-	{{- if $.ReplaceInBasePath.Present }}
+{{- end }}
+{{- if $.ReplaceInBasePath.Present }}
 	client.Config.BasePath = strings.ReplaceAll(client.Config.BasePath, "{{$.ReplaceInBasePath.Old}}", "{{$.ReplaceInBasePath.New}}")
-	{{- end }}
+{{- end }}
 	if bp, err := replaceVars(d, config, client.Config.BasePath); err != nil {
 		d.SetId("")
 		return fmt.Errorf("Could not format %q: %w", client.Config.BasePath, err)
@@ -717,6 +720,7 @@ func flatten{{$.PathType}}{{$v.PackagePath}}Array(obj []{{$.Package}}.{{$v.Objec
 	return items
 }
 
+	{{- if $v.Settable }}
 func expand{{$.PathType}}{{$v.PackagePath}}Array(o interface{}) []{{$.Package}}.{{$v.ObjectType}}Enum {
 	objs := o.([]interface{})
 	items := make([]{{$.Package}}.{{$v.ObjectType}}Enum, 0, len(objs))
@@ -726,5 +730,6 @@ func expand{{$.PathType}}{{$v.PackagePath}}Array(o interface{}) []{{$.Package}}.
 	}
   return items
 }
+	{{- end }}
 {{ end }}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
