### PR TITLE
Add `paused` attribute to `google_cloud_scheduler_job` resource

### DIFF
--- a/mmv1/products/cloudscheduler/api.yaml
+++ b/mmv1/products/cloudscheduler/api.yaml
@@ -76,6 +76,11 @@ objects:
         description: |
           State of the job.
         output: true
+      - !ruby/object:Api::Type::Boolean
+        name: paused
+        description: |
+          Sets the job to a paused state. Jobs default to being enabled when this property is not set.
+      - !ruby/object:Api::Type::String
         name: attemptDeadline
         description: |
           The deadline for job attempts. If the request handler does not respond by this deadline then the request is

--- a/mmv1/products/cloudscheduler/api.yaml
+++ b/mmv1/products/cloudscheduler/api.yaml
@@ -72,6 +72,10 @@ objects:
         required: false
         default_value: 'Etc/UTC'
       - !ruby/object:Api::Type::String
+        name: state
+        description: |
+          State of the job.
+        output: true
         name: attemptDeadline
         description: |
           The deadline for job attempts. If the request handler does not respond by this deadline then the request is

--- a/mmv1/products/cloudscheduler/terraform.yaml
+++ b/mmv1/products/cloudscheduler/terraform.yaml
@@ -35,6 +35,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           job_name: "test-job"
       - !ruby/object:Provider::Terraform::Examples
+        name: "scheduler_job_paused"
+        primary_resource_id: "job"
+        vars:
+          job_name: "test-job"
+      - !ruby/object:Provider::Terraform::Examples
         name: "scheduler_job_app_engine"
         primary_resource_id: "job"
         vars:

--- a/mmv1/products/cloudscheduler/terraform.yaml
+++ b/mmv1/products/cloudscheduler/terraform.yaml
@@ -18,6 +18,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/scheduler.erb
       resource_definition: templates/terraform/resource_definition/scheduler_auth.erb
+      encoder: templates/terraform/encoders/cloud_scheduler.go.erb
+      update_encoder: templates/terraform/update_encoder/cloud_scheduler.go.erb
+      post_create: templates/terraform/post_create/cloud_scheduler.go.erb
+      post_update: templates/terraform/post_update/cloud_scheduler.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "scheduler_job_pubsub"
@@ -52,6 +56,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      paused: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_value: false
+        custom_flatten: templates/terraform/custom_flatten/cloud_scheduler_paused.go.erb
       httpTarget.body: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateBase64String'

--- a/mmv1/templates/terraform/custom_flatten/cloud_scheduler_paused.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/cloud_scheduler_paused.go.erb
@@ -1,0 +1,10 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	state := d.Get("state");
+    if state == "PAUSED" {
+        return true
+    }
+    if state == "ENABLED" {
+        return false
+    }
+    return false
+}

--- a/mmv1/templates/terraform/encoders/cloud_scheduler.go.erb
+++ b/mmv1/templates/terraform/encoders/cloud_scheduler.go.erb
@@ -1,0 +1,2 @@
+delete(obj, "paused") // Field doesn't exist in API
+return obj, nil

--- a/mmv1/templates/terraform/examples/scheduler_job_paused.tf.erb
+++ b/mmv1/templates/terraform/examples/scheduler_job_paused.tf.erb
@@ -1,0 +1,18 @@
+resource "google_cloud_scheduler_job" "job" {
+  paused           = true
+  name             = "<%= ctx[:vars]['job_name'] %>"
+  description      = "test http job with updated fields"
+  schedule         = "*/8 * * * *"
+  time_zone        = "America/New_York"
+  attempt_deadline = "320s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://example.com/ping"
+    body        = base64encode("{\"foo\":\"bar\"}")
+  }
+}

--- a/mmv1/templates/terraform/post_create/cloud_scheduler.go.erb
+++ b/mmv1/templates/terraform/post_create/cloud_scheduler.go.erb
@@ -1,0 +1,21 @@
+endpoint := "resume" // Default to enabled
+logSuccessMsg := "Job state has been set to ENABLED"
+if paused, pausedOk := d.GetOk("paused"); pausedOk && paused.(bool) {
+	endpoint = "pause"
+	logSuccessMsg = "Job state has been set to PAUSED"
+}
+
+linkTmpl := fmt.Sprintf("{{CloudSchedulerBasePath}}projects/{{project}}/locations/{{region}}/jobs/{{name}}:%s", endpoint)
+url, err = replaceVars(d, config, linkTmpl)
+if err != nil {
+	return err
+}
+
+emptyReqBody := make(map[string]interface{})
+
+res, err = sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, emptyReqBody, d.Timeout(schema.TimeoutUpdate))
+if err != nil {
+	return fmt.Errorf("Error setting Cloud Scheduler Job status: %s", err)
+}
+
+log.Printf("[DEBUG] Finished updating Job %q status: %s", d.Id(), logSuccessMsg)

--- a/mmv1/templates/terraform/post_create/cloud_scheduler.go.erb
+++ b/mmv1/templates/terraform/post_create/cloud_scheduler.go.erb
@@ -13,7 +13,7 @@ if err != nil {
 
 emptyReqBody := make(map[string]interface{})
 
-res, err = sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, emptyReqBody, d.Timeout(schema.TimeoutUpdate))
+_, err = sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, emptyReqBody, d.Timeout(schema.TimeoutUpdate))
 if err != nil {
 	return fmt.Errorf("Error setting Cloud Scheduler Job status: %s", err)
 }

--- a/mmv1/templates/terraform/post_update/cloud_scheduler.go.erb
+++ b/mmv1/templates/terraform/post_update/cloud_scheduler.go.erb
@@ -1,0 +1,25 @@
+if d.HasChange("paused") {
+    endpoint := "resume" // Default to enabled
+    logSuccessMsg := "Job state has been set to ENABLED"
+    if paused, pausedOk := d.GetOk("paused"); pausedOk {
+        if paused.(bool) {
+            endpoint = "pause"
+            logSuccessMsg = "Job state has been set to PAUSED"
+        }
+    }
+
+    linkTmpl := fmt.Sprintf("{{CloudSchedulerBasePath}}projects/{{project}}/locations/{{region}}/jobs/{{name}}:%s", endpoint)
+    url, err = replaceVars(d, config, linkTmpl)
+    if err != nil {
+        return err
+    }
+
+    emptyReqBody := make(map[string]interface{})
+
+    res, err = sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, emptyReqBody, d.Timeout(schema.TimeoutUpdate))
+    if err != nil {
+        return fmt.Errorf("Error setting Cloud Scheduler Job status: %s", err)
+    }
+
+    log.Printf("[DEBUG] Finished updating Job %q status: %s", d.Id(), logSuccessMsg)
+}

--- a/mmv1/templates/terraform/post_update/cloud_scheduler.go.erb
+++ b/mmv1/templates/terraform/post_update/cloud_scheduler.go.erb
@@ -16,7 +16,7 @@ if d.HasChange("paused") {
 
     emptyReqBody := make(map[string]interface{})
 
-    res, err = sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, emptyReqBody, d.Timeout(schema.TimeoutUpdate))
+    _, err = sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, emptyReqBody, d.Timeout(schema.TimeoutUpdate))
     if err != nil {
         return fmt.Errorf("Error setting Cloud Scheduler Job status: %s", err)
     }

--- a/mmv1/templates/terraform/update_encoder/cloud_scheduler.go.erb
+++ b/mmv1/templates/terraform/update_encoder/cloud_scheduler.go.erb
@@ -1,0 +1,2 @@
+delete(obj, "paused") // Field doesn't exist in API
+return obj, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

**Closes https://github.com/hashicorp/terraform-provider-google/issues/7883**

This PR lets users control the state of the Cloud Scheduler Job as paused or enabled (default). If a Job is paused/resumed through the console that change made outside of Terraform isn't visible when creating plans.

I've added the [`state` of the job](https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs#state) as an output, and the new `paused` field controls calls to the [projects.locations.jobs.pause](https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs/pause) and [projects.locations.jobs.resume](https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs/resume) endpoints in post-create and post-update actions in the provider code to change the state.

My rationale for including `state` as an output was to allow users to see the job's state in scenarios where it is neither paused or enabled, e.g in an error state due to some factor outside the Terraform config. I believe if that happened the projects.locations.jobs.pause / projects.locations.jobs.resume API calls would return an error, so users would also be notified about any issues via that route too.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
**If this PR is for Terraform, I acknowledge that I have:**

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
scheduler: Added `state` output field to `google_cloud_scheduler_job`
```

```release-note:enhancement
scheduler: Added `paused` field to `google_cloud_scheduler_job`
```
