### PR TITLE
Made kms crypto key import set id correctly

### DIFF
--- a/mmv1/templates/terraform/custom_import/kms_crypto_key.go.erb
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key.go.erb
@@ -17,4 +17,10 @@
 		return nil, fmt.Errorf("Error setting skip_initial_version_creation: %s", err)
 	}
 
+	id, err := replaceVars(d, config, "<%= id_format(object) -%>")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
 	return []*schema.ResourceData{d}, nil

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -187,6 +187,13 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test importing with a short id
+			{
+				ResourceName:      "google_kms_crypto_key.crypto_key",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s/%s/%s", projectId, location, keyRingName, cryptoKeyName),
+				ImportStateVerify: true,
+			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
 				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/12056

This should be backwards-compatible because it will only impact newly-imported resources. Basically, the problem is that if you import a crypto key with a short-form import id, that gets set as the resource id (instead of the [standard behavior of setting the id based on the resource data](https://github.com/GoogleCloudPlatform/magic-modules/blob/a9187c7dd0a8a741306084029ac4c26b58e65c6f/mmv1/templates/terraform/resource.erb#L957))

This PR brings the resource in line with the standard behavior.

I added an automated test for importing with the short id.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: fixed setting of resource id post-import for `google_kms_crypto_key`
```
