### PR TITLE
Add new sample for Cloud Run custom domain mapping

### DIFF
--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -316,7 +316,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         skip_docs: true
         vars:
           cloud_run_srv: "cloud-run-srv"
-        min_version: beta
       - !ruby/object:Provider::Terraform::Examples
         name: "cloudrun_custom_domain_mapping"
         primary_resource_id: "default"

--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -311,6 +311,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           cloud_run_srv: "cloud-run-srv"
         min_version: beta
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloudrun_custom_domain_mapping"
+        primary_resource_id: "default"
+        skip_docs: true
+        vars:
+          cloud_run_srv: "cloud-run-srv"
+          verified_domain: "verified-domain"
+        min_version: beta
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'autogenerate_revision_name'

--- a/mmv1/templates/terraform/examples/cloudrun_custom_domain_mapping.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrun_custom_domain_mapping.tf.erb
@@ -1,0 +1,31 @@
+# [START cloudrun_custom_domain_mapping_run_service]
+data "google_project" "project" {}
+
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]['cloud_run_srv'] %>"
+  location = "us-central1"
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+  }
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+# [END cloudrun_custom_domain_mapping_run_service]
+# [START cloudrun_custom_domain_mapping]
+resource "google_cloud_run_domain_mapping" "default" {
+  name     = "<%= ctx[:vars]['verified_domain'] %>"
+  location = google_cloud_run_service.default.location
+  metadata {
+    namespace = data.google_project.project.project_id
+  }
+  spec {
+    route_name = google_cloud_run_service.default.name
+  }
+}
+# [END cloudrun_custom_domain_mapping]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

To contribute to the following: https://cloud.google.com/run/docs/mapping-custom-domains


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
google_cloud_run_service: add sample for cloud run custom domain mapping

```
