### PR TITLE
Add support for Managed AD Peering

### DIFF
--- a/mmv1/products/activedirectory/api.yaml
+++ b/mmv1/products/activedirectory/api.yaml
@@ -18,9 +18,91 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://managedidentities.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://managedidentities.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:
+  - !ruby/object:Api::Resource
+    name: 'Peering'
+    kind: 'activedirectory#peering'
+    base_url: 'projects/{{project}}/locations/global/peerings'
+    min_version: beta
+    create_url: projects/{{project}}/locations/global/peerings?peeringId={{peering_id}}
+    delete_url: projects/{{project}}/locations/global/peerings/{{peering_id}}
+    update_verb: :PATCH
+    update_mask: false
+    self_link: '{{name}}'
+    description: Creates a Peering for Managed AD instance.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+          'Active Directory Domain Peering': 'https://cloud.google.com/managed-microsoft-ad/docs/domain-peering'
+      api: 'https://cloud.google.com/managed-microsoft-ad/reference/rest/v1beta1/projects.locations.global.peerings'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: true
+        allowed:
+          - true
+          - false
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: peeringId
+        required: true
+        url_param_only: true
+        input: true
+        description: ""
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        required: false
+        url_param_only: false
+        input: false
+        output: true
+        description: |
+          Unique name of the peering in this scope including projects and location using the form: projects/{projectId}/locations/global/peerings/{peeringId}.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: 'Resource labels that can contain user-provided metadata'
+      - !ruby/object:Api::Type::String
+        name: authorizedNetwork
+        required: true
+        url_param_only: false
+        input: true
+        description: |
+          The full names of the Google Compute Engine networks to which the instance is connected. Caller needs to make sure that CIDR subnets do not overlap between networks, else peering creation will fail.
+      - !ruby/object:Api::Type::String
+        name: domainResource
+        required: true
+        url_param_only: false
+        input: true
+        description: |
+          Full domain resource path for the Managed AD Domain involved in peering. The resource path should be in the form projects/{projectId}/locations/global/domains/{domainName}
+      - !ruby/object:Api::Type::String
+        name: status
+        required: false
+        url_param_only: true
+        input: false
+        description: |
+          The current state of this Peering.
+      - !ruby/object:Api::Type::String
+        name: statusMessage
+        required: false
+        url_param_only: true
+        input: false
+        description: |
+          Additional information about the current status of this peering, if available.
   - !ruby/object:Api::Resource
     name: 'Domain'
     kind: 'activedirectory#domain'

--- a/mmv1/products/activedirectory/api.yaml
+++ b/mmv1/products/activedirectory/api.yaml
@@ -66,9 +66,6 @@ objects:
     properties:
       - !ruby/object:Api::Type::String
         name: name
-        required: false
-        url_param_only: false
-        input: false
         output: true
         description: |
           Unique name of the peering in this scope including projects and location using the form: projects/{projectId}/locations/global/peerings/{peeringId}.
@@ -78,29 +75,23 @@ objects:
       - !ruby/object:Api::Type::String
         name: authorizedNetwork
         required: true
-        url_param_only: false
         input: true
         description: |
           The full names of the Google Compute Engine networks to which the instance is connected. Caller needs to make sure that CIDR subnets do not overlap between networks, else peering creation will fail.
       - !ruby/object:Api::Type::String
         name: domainResource
         required: true
-        url_param_only: false
         input: true
         description: |
           Full domain resource path for the Managed AD Domain involved in peering. The resource path should be in the form projects/{projectId}/locations/global/domains/{domainName}
       - !ruby/object:Api::Type::String
         name: status
-        required: false
         url_param_only: true
-        input: false
         description: |
           The current state of this Peering.
       - !ruby/object:Api::Type::String
         name: statusMessage
-        required: false
         url_param_only: true
-        input: false
         description: |
           Additional information about the current status of this peering, if available.
   - !ruby/object:Api::Resource

--- a/mmv1/products/activedirectory/api.yaml
+++ b/mmv1/products/activedirectory/api.yaml
@@ -91,7 +91,6 @@ objects:
           The current state of this Peering.
       - !ruby/object:Api::Type::String
         name: statusMessage
-        url_param_only: true
         description: |
           Additional information about the current status of this peering, if available.
   - !ruby/object:Api::Resource

--- a/mmv1/products/activedirectory/terraform.yaml
+++ b/mmv1/products/activedirectory/terraform.yaml
@@ -60,6 +60,23 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # we need to check destroy during a test step where the parent resource
         # still exists and we need to validate that child resource has been deleted
         skip_test: true
+  Peering: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "projects/{{project}}/locations/global/domains/{{peering_id}}"
+    exclude_import: true
+    autogen_async: true
+    properties:
+      status: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      statusMessage: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "active_directory_peering_basic"
+        primary_resource_id: "ad-domain-peering"
+        test_env_vars:
+          org_id: :ORG_ID
+          billing_account: :BILLING_ACCT
+        skip_import_test: true
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.

--- a/mmv1/templates/terraform/examples/active_directory_peering_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/active_directory_peering_basic.tf.erb
@@ -1,0 +1,39 @@
+resource "google_active_directory_peering" "ad-domain-peering" {
+    provider = google-beta
+    domain_resource = google_active_directory_domain.ad-domain.name
+    peering_id = "ad-domain-peering"
+    authorized_network = google_compute_network.peered-network.id
+}
+
+resource "google_active_directory_domain" "ad-domain" {
+    provider = google-beta
+    domain_name = "ad.test.d-%{random_suffix}.com"
+    locations = ["us-central1"]
+    reserved_ip_range = "192.168.255.0/24"
+    authorized_networks = [google_compute_network.source-network.id]
+}
+
+resource "google_compute_network" "peered-network" {
+    provider = google-beta
+    project = google_project_service.compute.project
+    name = "ad-peered-network"
+}
+
+resource "google_compute_network" "source-network" {
+    provider = google-beta
+    name = "ad-network"
+}
+
+resource "google_project_service" "compute" {
+    provider = google-beta
+    project = google_project.peered-project.project_id
+    service = "compute.googleapis.com"
+}
+
+resource "google_project" "peered-project" {
+    provider = google-beta
+    name = "peered-project-%{random_suffix}"
+    project_id = "peered-project-%{random_suffix}"
+    org_id = "<%= ctx[:test_env_vars]['org_id'] %>"
+    billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}

--- a/mmv1/templates/terraform/examples/active_directory_peering_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/active_directory_peering_basic.tf.erb
@@ -1,39 +1,42 @@
 resource "google_active_directory_peering" "ad-domain-peering" {
-    provider = google-beta
-    domain_resource = google_active_directory_domain.ad-domain.name
-    peering_id = "ad-domain-peering"
+    provider           = google-beta
+    domain_resource    = google_active_directory_domain.ad-domain.name
+    peering_id         = "ad-domain-peering"
     authorized_network = google_compute_network.peered-network.id
+    labels             = {
+        foo = "bar"
+    }
 }
 
 resource "google_active_directory_domain" "ad-domain" {
-    provider = google-beta
-    domain_name = "ad.test.d-%{random_suffix}.com"
-    locations = ["us-central1"]
-    reserved_ip_range = "192.168.255.0/24"
+    provider            = google-beta
+    domain_name         = "ad.test.d-%{random_suffix}.com"
+    locations           = ["us-central1"]
+    reserved_ip_range   = "192.168.255.0/24"
     authorized_networks = [google_compute_network.source-network.id]
 }
 
 resource "google_compute_network" "peered-network" {
     provider = google-beta
-    project = google_project_service.compute.project
-    name = "ad-peered-network"
+    project  = google_project_service.compute.project
+    name     = "ad-peered-network"
 }
 
 resource "google_compute_network" "source-network" {
     provider = google-beta
-    name = "ad-network"
+    name     = "ad-network"
 }
 
 resource "google_project_service" "compute" {
     provider = google-beta
-    project = google_project.peered-project.project_id
-    service = "compute.googleapis.com"
+    project  = google_project.peered-project.project_id
+    service  = "compute.googleapis.com"
 }
 
 resource "google_project" "peered-project" {
-    provider = google-beta
-    name = "peered-project-%{random_suffix}"
-    project_id = "peered-project-%{random_suffix}"
-    org_id = "<%= ctx[:test_env_vars]['org_id'] %>"
+    provider        = google-beta
+    name            = "peered-project-%{random_suffix}"
+    project_id      = "peered-project-%{random_suffix}"
+    org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
     billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Adds support for Managed Active Directory Domain Peering. Fixes https://github.com/hashicorp/terraform-provider-google/issues/12119

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests. **Note -- There appear to be lint errors, but they are in code paths that I did not modify**
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_active_directory_peering: Added support for [Domain Peering](https://cloud.google.com/managed-microsoft-ad/docs/domain-peering)(beta)
```
