### PR TITLE
Add missing output fields to Certificate resource.

### DIFF
--- a/mmv1/products/certificatemanager/api.yaml
+++ b/mmv1/products/certificatemanager/api.yaml
@@ -67,20 +67,6 @@ objects:
         name: 'description'
         description: |
           A human-readable description of the resource.
-      - !ruby/object:Api::Type::String
-        name: 'createTime'
-        output: true
-        description: |
-          Creation timestamp of a DNS Authorization. Timestamp in RFC3339 UTC "Zulu" format,
-          with nanosecond resolution and up to nine fractional digits.
-          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-      - !ruby/object:Api::Type::Time
-        name: 'updateTime'
-        description: |
-          Update timestamp of a DNS Authorization. Timestamp in RFC3339 UTC "Zulu" format,
-          with nanosecond resolution and up to nine fractional digits.
-          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: 'Set of label tags associated with the DNS Authorization resource.'
@@ -156,38 +142,14 @@ objects:
         name: 'description'
         description: |
           A human-readable description of the resource.
-      - !ruby/object:Api::Type::String
-        name: 'createTime'
-        output: true
-        description: |
-          Creation timestamp of a Certificate. Timestamp in RFC3339 UTC "Zulu" format,
-          with nanosecond resolution and up to nine fractional digits.
-          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-      - !ruby/object:Api::Type::Time
-        name: 'updateTime'
-        description: |
-          Update timestamp of a Certificate. Timestamp in RFC3339 UTC "Zulu" format,
-          with nanosecond resolution and up to nine fractional digits.
-          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: 'Set of label tags associated with the Certificate resource.'
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: scope
         input: true
         description: |
           The scope of the certificate.
-
-          Certificates with default scope are served from core Google data centers.
-          If unsure, choose this option.
-
-          Certificates with scope EDGE_CACHE are special-purposed certificates,
-          served from non-core Google data centers.
-          Currently allowed only for managed certificates.
-        values:
-          - :DEFAULT
-          - :EDGE_CACHE
         default_value: :DEFAULT
       - !ruby/object:Api::Type::NestedObject
         name: selfManaged
@@ -236,55 +198,22 @@ objects:
             description: |
               Authorizations that will be used for performing domain authorization
             item_type: Api::Type::String
-          - !ruby/object:Api::Type::Enum
+          - !ruby/object:Api::Type::String
             name: 'state'
             output: true
             description: |
               A state of this Managed Certificate.
-
-              The state is undefined.
-
-              Certificate Manager attempts to provision or renew the certificate.
-              If the process takes longer than expected, consult the
-              `provisioning_issue` field.
-
-              Multiple certificate provisioning attempts failed and Certificate
-              Manager gave up. To try again, delete and create a new managed
-              Certificate resource.
-              For details see the `provisioning_issue` field.
-
-              The certificate management is working, and a certificate has been
-              provisioned.
-            values:
-              - :STATE_UNSPECIFIED
-              - :PROVISIONING
-              - :FAILED
-              - :ACTIVE
           - !ruby/object:Api::Type::NestedObject
             name: 'provisioningIssue'
             output: true
             description: |
               Information about issues with provisioning this Managed Certificate.
             properties:
-              - !ruby/object:Api::Type::Enum
+              - !ruby/object:Api::Type::String
                 name: 'reason'
                 output: true
                 description: |
                   Reason for provisioning failures.
-
-                  The reason is undefined.
-
-                  Certificate provisioning failed due to an issue with one or more of
-                  the domains on the certificate.
-                  For details of which domains failed, consult the
-                  `authorization_attempt_info` field.
-
-                  Exceeded Certificate Authority quotas or internal rate limits of the
-                  system. Provisioning may take longer to complete.
-                values:
-                  - :REASON_UNSPECIFIED
-                  - :AUTHORIZATION_ISSUE
-                  - :RATE_LIMITED
               - !ruby/object:Api::Type::String
                 name: details
                 output: true
@@ -305,46 +234,16 @@ objects:
                   output: true
                   description: |
                     Domain name of the authorization attempt.
-                - !ruby/object:Api::Type::Enum
+                - !ruby/object:Api::Type::String
                   name: 'state'
                   output: true
                   description: |
                     State of the domain for managed certificate issuance.
-
-                    The State is undefined.
-
-                    Certificate provisioning for this domain is under way. GCP will
-                    attempt to authorize the domain.
-
-                    A managed certificate can be provisioned, no issues for this domain.
-
-                    Attempt to authorize the domain failed. This prevents the Managed
-                    Certificate from being issued.
-                    /See `failure_reason` and `details` fields for more information.
-                  values:
-                    - :STATE_UNSPECIFIED
-                    - :AUTHORIZING
-                    - :AUTHORIZED
-                    - :FAILED
-                - !ruby/object:Api::Type::Enum
+                - !ruby/object:Api::Type::String
                   name: 'failureReason'
                   output: true
                   description: |
                     Reason for failure of the authorization attempt for the domain.
-
-                    There was a problem with the user's DNS or load balancer
-                    configuration for this domain.
-
-                    Certificate issuance forbidden by an explicit CAA record for the
-                    domain or a failure to check CAA records for the domain.
-
-                    Reached a CA or internal rate-limit for the domain,
-                    e.g. for certificates per top-level private domain.
-                  values:
-                    - :FAILURE_REASON_UNSPECIFIED
-                    - :CONFIG
-                    - :CAA
-                    - :RATE_LIMITED
                 - !ruby/object:Api::Type::String
                   name: details
                   output: true
@@ -393,20 +292,6 @@ objects:
         name: 'description'
         description: |
           One or more paragraphs of text description of a certificate map entry.
-      - !ruby/object:Api::Type::String
-        name: 'createTime'
-        output: true
-        description: |
-          Creation timestamp of a Certificate Map. Timestamp is in RFC3339 UTC "Zulu" format,
-          accurate to nanoseconds with up to nine fractional digits.
-          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-      - !ruby/object:Api::Type::Time
-        name: 'updateTime'
-        description: |
-          Update timestamp of a Certificate Map. Timestamp is in RFC3339 UTC "Zulu" format,
-          accurate to nanoseconds with up to nine fractional digits.
-          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
@@ -496,20 +381,6 @@ objects:
           description: |
             CertificateMapEntry is a list of certificate configurations,
             that have been issued for a particular hostname
-        - !ruby/object:Api::Type::String
-          name: 'createTime'
-          output: true
-          description: |
-            Creation timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format,
-            with nanosecond resolution and up to nine fractional digits.
-            Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-        - !ruby/object:Api::Type::Time
-          name: 'updateTime'
-          description: |
-            Update timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format,
-            with nanosecond resolution and up to nine fractional digits.
-            Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-          output: true
         - !ruby/object:Api::Type::KeyValuePairs
           name: 'labels'
           description: |
@@ -524,21 +395,11 @@ objects:
             There can be defined up to fifteen certificates in each Certificate Map Entry.
             Each certificate must match pattern projects/*/locations/*/certificates/*.
           item_type: Api::Type::String
-        - !ruby/object:Api::Type::Enum
+        - !ruby/object:Api::Type::String
           name: 'state'
           output: true
           description: |
             A serving state of this Certificate Map Entry.
-
-            The status is undefined.
-
-            The configuration is serving.
-
-            Update is in progress. Some frontends may serve this configuration.
-          values:
-            - :SERVING_STATE_UNSPECIFIFED
-            - :ACTIVE
-            - :PENDING
         - !ruby/object:Api::Type::String
           name: 'hostname'
           description: |
@@ -548,14 +409,11 @@ objects:
           exactly_one_of:
             - hostname
             - matcher
-        - !ruby/object:Api::Type::Enum
+        - !ruby/object:Api::Type::String
           name: 'matcher'
           exactly_one_of:
             - hostname
             - matcher
           description: |
             A predefined matcher for particular cases, other than SNI selection
-          values:
-            - :MATCHER_UNSPECIFIED
-            - :PRIMARY
             

--- a/mmv1/products/certificatemanager/api.yaml
+++ b/mmv1/products/certificatemanager/api.yaml
@@ -150,7 +150,14 @@ objects:
         input: true
         description: |
           The scope of the certificate.
-        default_value: :DEFAULT
+
+          DEFAULT: Certificates with default scope are served from core Google data centers.
+          If unsure, choose this option.
+          
+          EDGE_CACHE: Certificates with scope EDGE_CACHE are special-purposed certificates,
+          served from non-core Google data centers.
+          Currently allowed only for managed certificates.
+        default_value: DEFAULT
       - !ruby/object:Api::Type::NestedObject
         name: selfManaged
         input: true
@@ -291,7 +298,21 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'description'
         description: |
-          One or more paragraphs of text description of a certificate map entry.
+          A human-readable description of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        output: true
+        description: |
+          Creation timestamp of a Certificate Map. Timestamp is in RFC3339 UTC "Zulu" format,
+          accurate to nanoseconds with up to nine fractional digits.
+          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+      - !ruby/object:Api::Type::Time
+        name: 'updateTime'
+        description: |
+          Update timestamp of a Certificate Map. Timestamp is in RFC3339 UTC "Zulu" format,
+          accurate to nanoseconds with up to nine fractional digits.
+          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
@@ -379,8 +400,21 @@ objects:
         - !ruby/object:Api::Type::String
           name: 'description'
           description: |
-            CertificateMapEntry is a list of certificate configurations,
-            that have been issued for a particular hostname
+            A human-readable description of the resource.
+        - !ruby/object:Api::Type::String
+          name: 'createTime'
+          output: true
+          description: |
+            Creation timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format, 
+            with nanosecond resolution and up to nine fractional digits. 
+            Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+        - !ruby/object:Api::Type::Time
+          name: 'updateTime'
+          description: |
+            Update timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format, 
+            with nanosecond resolution and up to nine fractional digits. 
+            Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+          output: true
         - !ruby/object:Api::Type::KeyValuePairs
           name: 'labels'
           description: |

--- a/mmv1/products/certificatemanager/api.yaml
+++ b/mmv1/products/certificatemanager/api.yaml
@@ -35,7 +35,7 @@ objects:
     update_verb: :PATCH
     update_mask: true
     description: |
-      DnsAuthorization represents a HTTP-reachable backend for an DnsAuthorization.
+      DnsAuthorization represents a HTTP-reachable backend for a DnsAuthorization.
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
@@ -67,9 +67,23 @@ objects:
         name: 'description'
         description: |
           A human-readable description of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        output: true
+        description: |
+          Creation timestamp of a DNS Authorization. Timestamp in RFC3339 UTC "Zulu" format,
+          with nanosecond resolution and up to nine fractional digits.
+          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+      - !ruby/object:Api::Type::Time
+        name: 'updateTime'
+        description: |
+          Update timestamp of a DNS Authorization. Timestamp in RFC3339 UTC "Zulu" format,
+          with nanosecond resolution and up to nine fractional digits.
+          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
-        description: 'Set of label tags associated with the EdgeCache resource.'
+        description: 'Set of label tags associated with the DNS Authorization resource.'
       - !ruby/object:Api::Type::String
         name: 'domain'
         input: true
@@ -91,6 +105,7 @@ objects:
             output: true
             description: |
               Fully qualified name of the DNS Resource Record.
+              E.g. `_acme-challenge.example.com`.
           - !ruby/object:Api::Type::String
             name: 'type'
             output: true
@@ -109,7 +124,7 @@ objects:
     update_verb: :PATCH
     update_mask: true
     description: |
-      Certificate represents a HTTP-reachable backend for an Certificate.
+      Certificate represents a HTTP-reachable backend for a Certificate.
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
@@ -141,9 +156,23 @@ objects:
         name: 'description'
         description: |
           A human-readable description of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        output: true
+        description: |
+          Creation timestamp of a Certificate. Timestamp in RFC3339 UTC "Zulu" format,
+          with nanosecond resolution and up to nine fractional digits.
+          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+      - !ruby/object:Api::Type::Time
+        name: 'updateTime'
+        description: |
+          Update timestamp of a Certificate. Timestamp in RFC3339 UTC "Zulu" format,
+          with nanosecond resolution and up to nine fractional digits.
+          Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
-        description: 'Set of label tags associated with the EdgeCache resource.'
+        description: 'Set of label tags associated with the Certificate resource.'
       - !ruby/object:Api::Type::Enum
         name: scope
         input: true
@@ -194,11 +223,6 @@ objects:
           Certificate Manager provisions and renews Managed Certificates
           automatically, for as long as it's authorized to do so.
         properties:
-          - !ruby/object:Api::Type::String
-            name: state
-            output: true
-            description: |
-              State of the managed certificate resource.
           - !ruby/object:Api::Type::Array
             name: domains
             input: true
@@ -212,6 +236,122 @@ objects:
             description: |
               Authorizations that will be used for performing domain authorization
             item_type: Api::Type::String
+          - !ruby/object:Api::Type::Enum
+            name: 'state'
+            output: true
+            description: |
+              A state of this Managed Certificate.
+
+              The state is undefined.
+
+              Certificate Manager attempts to provision or renew the certificate.
+              If the process takes longer than expected, consult the
+              `provisioning_issue` field.
+
+              Multiple certificate provisioning attempts failed and Certificate
+              Manager gave up. To try again, delete and create a new managed
+              Certificate resource.
+              For details see the `provisioning_issue` field.
+
+              The certificate management is working, and a certificate has been
+              provisioned.
+            values:
+              - :STATE_UNSPECIFIED
+              - :PROVISIONING
+              - :FAILED
+              - :ACTIVE
+          - !ruby/object:Api::Type::NestedObject
+            name: 'provisioningIssue'
+            output: true
+            description: |
+              Information about issues with provisioning this Managed Certificate.
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'reason'
+                output: true
+                description: |
+                  Reason for provisioning failures.
+
+                  The reason is undefined.
+
+                  Certificate provisioning failed due to an issue with one or more of
+                  the domains on the certificate.
+                  For details of which domains failed, consult the
+                  `authorization_attempt_info` field.
+
+                  Exceeded Certificate Authority quotas or internal rate limits of the
+                  system. Provisioning may take longer to complete.
+                values:
+                  - :REASON_UNSPECIFIED
+                  - :AUTHORIZATION_ISSUE
+                  - :RATE_LIMITED
+              - !ruby/object:Api::Type::String
+                name: details
+                output: true
+                description: |
+                  Human readable explanation about the issue. Provided to help address
+                  the configuration issues.
+                  Not guaranteed to be stable. For programmatic access use `reason` field.
+          - !ruby/object:Api::Type::Array
+            name: 'authorizationAttemptInfo'
+            output: true
+            description: |
+              Detailed state of the latest authorization attempt for each domain
+              specified for this Managed Certificate.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: domain
+                  output: true
+                  description: |
+                    Domain name of the authorization attempt.
+                - !ruby/object:Api::Type::Enum
+                  name: 'state'
+                  output: true
+                  description: |
+                    State of the domain for managed certificate issuance.
+
+                    The State is undefined.
+
+                    Certificate provisioning for this domain is under way. GCP will
+                    attempt to authorize the domain.
+
+                    A managed certificate can be provisioned, no issues for this domain.
+
+                    Attempt to authorize the domain failed. This prevents the Managed
+                    Certificate from being issued.
+                    /See `failure_reason` and `details` fields for more information.
+                  values:
+                    - :STATE_UNSPECIFIED
+                    - :AUTHORIZING
+                    - :AUTHORIZED
+                    - :FAILED
+                - !ruby/object:Api::Type::Enum
+                  name: 'failureReason'
+                  output: true
+                  description: |
+                    Reason for failure of the authorization attempt for the domain.
+
+                    There was a problem with the user's DNS or load balancer
+                    configuration for this domain.
+
+                    Certificate issuance forbidden by an explicit CAA record for the
+                    domain or a failure to check CAA records for the domain.
+
+                    Reached a CA or internal rate-limit for the domain,
+                    e.g. for certificates per top-level private domain.
+                  values:
+                    - :FAILURE_REASON_UNSPECIFIED
+                    - :CONFIG
+                    - :CAA
+                    - :RATE_LIMITED
+                - !ruby/object:Api::Type::String
+                  name: details
+                  output: true
+                  description: |
+                    Human readable explanation for reaching the state. Provided to help
+                    address the configuration issues.
+                    Not guaranteed to be stable. For programmatic access use `failure_reason` field.
   - !ruby/object:Api::Resource
     name: 'CertificateMap'
     base_url: 'projects/{{project}}/locations/global/certificateMaps'
@@ -360,14 +500,14 @@ objects:
           name: 'createTime'
           output: true
           description: |
-            Creation timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format, 
-            with nanosecond resolution and up to nine fractional digits. 
+            Creation timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format,
+            with nanosecond resolution and up to nine fractional digits.
             Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
         - !ruby/object:Api::Type::Time
           name: 'updateTime'
           description: |
-            Update timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format, 
-            with nanosecond resolution and up to nine fractional digits. 
+            Update timestamp of a Certificate Map Entry. Timestamp in RFC3339 UTC "Zulu" format,
+            with nanosecond resolution and up to nine fractional digits.
             Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
           output: true
         - !ruby/object:Api::Type::KeyValuePairs


### PR DESCRIPTION
Updated a couple of mistakes in fields descriptions. Changed type of
Certificate.Managed.State from String to Enum.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
certificatemanager: added `state`, `authorization_attempt_info` and `provisioning_issue` output fields to `google_certificate_manager_certificate`
```
