### PR TITLE
Improve links to sections within the `composer_environment` docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -279,7 +279,7 @@ The following arguments are supported:
 
 * `node_config` -
   (Optional)
-  The configuration used for the Kubernetes Engine cluster.  Structure is [documented below](#nested_node_config).
+  The configuration used for the Kubernetes Engine cluster.  Structure is [documented below](#nested_node_config_1).
 
 * `software_config` -
   (Optional)
@@ -320,7 +320,7 @@ The following arguments are supported:
   Google Compute Engine Public IPs and Google Prod IPs. Structure is
   [documented below](#nested_master_authorized_networks_config).
 
-<a name="nested_node_config"></a>The `node_config` block supports:
+<a name="nested_node_config_1"></a>The `node_config` block supports:
 
 * `zone` -
   (Optional, Cloud Composer 1 only)
@@ -643,7 +643,7 @@ The following arguments are supported:
 
 * `node_config` -
   (Optional)
-  The configuration used for the Kubernetes Engine cluster. Structure is documented below.
+  The configuration used for the Kubernetes Engine cluster. Structure is [documented below](#nested_node_config_2).
 
 * `software_config` -
   (Optional)
@@ -684,7 +684,7 @@ The following arguments are supported:
   Google Compute Engine Public IPs and Google Prod IPs. Structure is
   documented below.
 
-The `node_config` block supports:
+<a name="nested_node_config_2"></a>The `node_config` block supports:
 
 * `network` -
   (Optional)

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -610,15 +610,15 @@ The `web_server_network_access_control` supports:
 
 The following arguments are supported:
 
-* `name` -
+* <a href="#name_2"><span id="name_2">`name`</span></a> -
   (Required)
   Name of the environment
 
-* `config` -
+* <a href="#config_2"><span id="config_2">`config`</span></a> -
   (Optional)
   Configuration parameters for this environment. Structure is [documented below](#nested_config_2).
 
-* `labels` -
+* <a href="#labels_2"><span id="labels_2">`labels`</span></a> -
   (Optional)
   User-defined labels for this environment. The labels map can contain
   no more than 64 entries. Entries of the labels map are UTF8 strings
@@ -630,52 +630,52 @@ The following arguments are supported:
   No more than 64 labels can be associated with a given environment.
   Both keys and values must be <= 128 bytes in size.
 
-* `region` -
+* <a href="#region_2"><span id="region_2">`region`</span></a> -
   (Optional)
   The location or Compute Engine region for the environment.
 
-* `project` -
+* <a href="#project_2"><span id="project_2">`project`</span></a> -
   (Optional) The ID of the project in which the resource belongs.
   If it is not provided, the provider project is used.
 
 <a name="nested_config_2"></a>The `config` block supports:
 
-* `node_config` -
+* <a href="#nested_config_2_node_config"><span id="nested_config_2_node_config">`node_config`</span></a> -
   (Optional)
   The configuration used for the Kubernetes Engine cluster. Structure is [documented below](#nested_node_config_2).
 
-* `software_config` -
+* <a href="#nested_config_2_software_config"><span id="nested_config_2_software_config">`software_config`</span></a> -
   (Optional)
   The configuration settings for software (Airflow) inside the environment. Structure is
   [documented below](#nested_software_config_2).
 
-* `private_environment_config` -
+* <a href="#nested_config_2_private_environment_config"><span id="nested_config_2_private_environment_config">`private_environment_config`</span></a> -
   (Optional)
   The configuration used for the Private IP Cloud Composer environment. Structure is documented
   below.
 
-* `encryption_config` -
+* <a href="#nested_config_2_encryption_config"><span id="nested_config_2_encryption_config">`encryption_config`</span></a> -
   (Optional)
   The encryption options for the Cloud Composer environment and its
   dependencies.
 
-* `maintenance_window` -
+* <a href="#nested_config_2_maintenance_window"><span id="nested_config_2_maintenance_window">`maintenance_window`</span></a> -
   (Optional)
   The configuration settings for Cloud Composer maintenance windows.
 
-* `workloads_config` -
+* <a href="#nested_config_2_workloads_config"><span id="nested_config_2_workloads_config">`workloads_config`</span></a> -
   (Optional, Cloud Composer 2 only)
   The Kubernetes workloads configuration for GKE cluster associated with the
   Cloud Composer environment.
 
-* `environment_size` -
+* <a href="#nested_config_2_environment_size"><span id="nested_config_2_environment_size">`environment_size`</span></a> -
   (Optional, Cloud Composer 2 only)
   The environment size controls the performance parameters of the managed
   Cloud Composer infrastructure that includes the Airflow database. Values for
   environment size are `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`,
   and `ENVIRONMENT_SIZE_LARGE`.
 
-* `master_authorized_networks_config` -
+* <a href="#nested_config_2_master_authorized_networks_config"><span id="nested_config_2_master_authorized_networks_config">`master_authorized_networks_config`</span></a> -
   (Optional)
   Configuration options for the master authorized networks feature. Enabled
   master authorized networks will disallow all external traffic to access
@@ -684,7 +684,7 @@ The following arguments are supported:
 
 <a name="nested_node_config_2"></a>The `node_config` block supports:
 
-* `network` -
+* <a href="#nested_node_config_2_network"><span id="nested_node_config_2_network">`network`</span></a> -
   (Optional)
   The Compute Engine network to be used for machine
   communications, specified as a self-link, relative resource name
@@ -693,14 +693,14 @@ The following arguments are supported:
   The network must belong to the environment's project. If unspecified, the "default" network ID in the environment's
   project is used. If a Custom Subnet Network is provided, subnetwork must also be provided.
 
-* `subnetwork` -
+* <a href="#nested_node_config_2_subnetwork"><span id="nested_node_config_2_subnetwork">`subnetwork`</span></a> -
   (Optional)
   The Compute Engine subnetwork to be used for machine
   communications, specified as a self-link, relative resource name (for example,
   "projects/{project}/regions/{region}/subnetworks/{subnetwork}"), or by name. If subnetwork is provided,
   network must also be provided and the subnetwork must belong to the enclosing environment's project and region.
 
-* `service_account` -
+* <a href="#nested_node_config_2_service_account"><span id="nested_node_config_2_service_account">`service_account`</span></a> -
   (Optional)
   The Google Cloud Platform Service Account to be used by the
   node VMs. If a service account is not specified, the "default"
@@ -708,13 +708,13 @@ The following arguments are supported:
   note that the service account must have `roles/composer.worker`
   for any GCP resources created under the Cloud Composer Environment.
 
-* `ip_allocation_policy` -
+* <a href="#nested_node_config_2_ip_allocation_policy"><span id="nested_node_config_2_ip_allocation_policy">`ip_allocation_policy`</span></a> -
   (Optional)
   Configuration for controlling how IPs are allocated in the GKE cluster.
   Structure is [documented below](#nested_ip_allocation_policy_2).
   Cannot be updated.
 
-* `enable_ip_masq_agent` -
+* <a href="#nested_node_config_2_enable_ip_masq_agent"><span id="nested_node_config_2_enable_ip_masq_agent">`enable_ip_masq_agent`</span></a> -
   (Optional)
   IP Masq Agent translates Pod IP addresses to node IP addresses, so that 
   destinations and services targeted from Airflow DAGs and tasks only receive 
@@ -723,7 +723,7 @@ The following arguments are supported:
 
 <a name="nested_software_config_2"></a>The `software_config` block supports:
 
-* `airflow_config_overrides` -
+* <a href="#nested_software_config_2_airflow_config_overrides"><span id="nested_software_config_2_airflow_config_overrides">`airflow_config_overrides`</span></a> -
   (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
   separated by a hyphen, for example "core-dags_are_paused_at_creation".
 
@@ -734,14 +734,14 @@ The following arguments are supported:
   property values are [blacklisted](https://cloud.google.com/composer/docs/concepts/airflow-configurations#airflow_configuration_blacklists),
   and cannot be overridden.
 
-* `pypi_packages` -
+* <a href="#nested_software_config_2_pypi_packages"><span id="nested_software_config_2_pypi_packages">`pypi_packages`</span></a> -
   (Optional)
   Custom Python Package Index (PyPI) packages to be installed
   in the environment. Keys refer to the lowercase package name (e.g. "numpy"). Values are the lowercase extras and
   version specifier (e.g. "==1.12.0", "[devel,gcp_api]", "[devel]>=1.8.2, <1.9.2"). To specify a package without
   pinning it to a version specifier, use the empty string as the value.
 
-* `env_variables` -
+* <a href="#nested_software_config_2_env_variables"><span id="nested_software_config_2_env_variables">`env_variables`</span></a> -
   (Optional)
   Additional environment variables to provide to the Apache Airflow scheduler, worker, and webserver processes.
   Environment variable names must match the regular expression `[a-zA-Z_][a-zA-Z0-9_]*`.
@@ -763,7 +763,7 @@ The following arguments are supported:
   SQL_USER
   ```
 
-* `image_version` -
+* <a href="#image_version_2"><span id="image_version_2">`image_version`</span></a> -
   (Required in Cloud Composer 2, optional in Cloud Composer 1)
 
   **In Cloud Composer 2, you must specify an image with Cloud Composer 2**. Otherwise, the default image for Cloud Composer 1 is used. For more information about Cloud Composer images, see
@@ -785,10 +785,10 @@ The following arguments are supported:
 
 See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. The `private_environment_config` block supports:
 
-* `enable_private_endpoint` -
+* <a href="#nested_private_environment_config_2_enable_private_endpoint"><span id="nested_private_environment_config_2_enable_private_endpoint">`enable_private_endpoint`</span></a> -
   If true, access to the public endpoint of the GKE cluster is denied.
 
-* `master_ipv4_cidr_block` -
+* <a href="#nested_private_environment_config_2_master_ipv4_cidr_block"><span id="nested_private_environment_config_2_master_ipv4_cidr_block">`master_ipv4_cidr_block`</span></a> -
   (Optional)
   The IP range in CIDR notation to use for the hosted master network. This range is used
   for assigning internal IP addresses to the cluster master or set of masters and to the
@@ -796,20 +796,20 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   in use within the cluster's network.
   If left blank, the default value of is used. See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip#defaults) for default values per region.
 
-* `cloud_sql_ipv4_cidr_block` -
+* <a href="#nested_private_environment_config_2_cloud_sql_ipv4_cidr_block"><span id="nested_private_environment_config_2_cloud_sql_ipv4_cidr_block">`cloud_sql_ipv4_cidr_block`</span></a> -
   (Optional)
   The CIDR block from which IP range in tenant project will be reserved for Cloud SQL. Needs to be disjoint from `web_server_ipv4_cidr_block`
 
-* `cloud_composer_network_ipv4_cidr_block"` -
+* <a href="#nested_private_environment_config_2_cloud_composer_network_ipv4_cidr_block"><span id="nested_private_environment_config_2_cloud_composer_network_ipv4_cidr_block">`cloud_composer_network_ipv4_cidr_block"`</span></a> -
   (Optional, Cloud Composer 2 only)
   The CIDR block from which IP range for Cloud Composer Network in tenant project will be reserved. Needs to be disjoint from private_cluster_config.master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.
 
-* `enable_privately_used_public_ips` -
+* <a href="#nested_private_environment_config_2_enable_privately_used_public_ips"><span id="nested_private_environment_config_2_enable_privately_used_public_ips">`enable_privately_used_public_ips`</span></a> -
   (Optional)
   When enabled, IPs from public (non-RFC1918) ranges can be used for
   `ip_allocation_policy.cluster_ipv4_cidr_block` and `ip_allocation_policy.service_ipv4_cidr_block`.
 
-* `cloud_composer_connection_subnetwork` -
+* <a href="#nested_private_environment_config_2_cloud_composer_connection_subnetwork"><span id="nested_private_environment_config_2_cloud_composer_connection_subnetwork">`cloud_composer_connection_subnetwork`</span></a> -
   (Optional)
   When specified, the environment will use Private Service Connect instead of VPC peerings to connect
   to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP
@@ -819,17 +819,17 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 <a name="nested_ip_allocation_policy_2"></a>The `ip_allocation_policy` block supports:
 
-* `cluster_secondary_range_name` -
+* <a href="#nested_ip_allocation_policy_2_cluster_secondary_range_name"><span id="nested_ip_allocation_policy_2_cluster_secondary_range_name">`cluster_secondary_range_name`</span></a> -
   (Optional)
   The name of the cluster's secondary range used to allocate IP addresses to pods.
   Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
 
-* `services_secondary_range_name` -
+* <a href="#nested_ip_allocation_policy_2_services_secondary_range_name"><span id="nested_ip_allocation_policy_2_services_secondary_range_name">`services_secondary_range_name`</span></a> -
   (Optional)
   The name of the services' secondary range used to allocate IP addresses to the cluster.
   Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
 
-* `cluster_ipv4_cidr_block` -
+* <a href="#nested_ip_allocation_policy_2_cluster_ipv4_cidr_block"><span id="nested_ip_allocation_policy_2_cluster_ipv4_cidr_block">`cluster_ipv4_cidr_block`</span></a> -
   (Optional)
   The IP address range used to allocate IP addresses to pods in the cluster.
   For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
@@ -839,7 +839,7 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
   Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
 
-* `services_ipv4_cidr_block` -
+* <a href="#nested_ip_allocation_policy_2_services_ipv4_cidr_block"><span id="nested_ip_allocation_policy_2_services_ipv4_cidr_block">`services_ipv4_cidr_block`</span></a> -
   (Optional)
   The IP address range used to allocate IP addresses in this cluster.
   For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
@@ -851,24 +851,24 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 <a name="nested_encryption_config_comp_2"></a>The `encryption_config` block supports:
 
-* `kms_key_name` -
+* <a href="#nested_encryption_config_comp_2_kms_key_name"><span id="nested_encryption_config_comp_2_kms_key_name">`kms_key_name`</span></a> -
   (Required)
   Customer-managed Encryption Key available through Google's Key Management Service. It must
   be the fully qualified resource name,
   i.e. projects/project-id/locations/location/keyRings/keyring/cryptoKeys/key. Cannot be updated.
 
-<a name="nested_maintenance_window_comp_2"></a>The `maintenance_window` block supports:
+<a name="nested_maintenance_window_2"></a>The `maintenance_window` block supports:
 
-* `start_time` -
+* <a href="#nested_maintenance_window_2_start_time"><span id="nested_maintenance_window_2_start_time">`start_time`</span></a> -
   (Required)
   Start time of the first recurrence of the maintenance window.
 
-* `end_time` -
+* <a href="#nested_maintenance_window_2_end_time"><span id="nested_maintenance_window_2_end_time">`end_time`</span></a> -
   (Required)
   Maintenance window end time. It is used only to calculate the duration of the maintenance window.
   The value for end-time must be in the future, relative to 'start_time'.
 
-* `recurrence` -
+* <a href="#nested_maintenance_window_2_recurrence"><span id="nested_maintenance_window_2_recurrence">`recurrence`</span></a> -
   (Required)
   Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
   The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
@@ -876,70 +876,70 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 The `workloads_config` block supports:
 
-* `scheduler` -
+* <a href="#nested_workloads_config_2_scheduler"><span id="nested_workloads_config_2_scheduler">`scheduler`</span></a> -
   (Optional)
   Configuration for resources used by Airflow schedulers.
 
-* `web_server` -
+* <a href="#nested_workloads_config_2_web_server"><span id="nested_workloads_config_2_web_server">`web_server`</span></a> -
   (Optional)
   Configuration for resources used by Airflow web server.
 
-* `worker` -
+* <a href="#nested_workloads_config_2_worker"><span id="nested_workloads_config_2_worker">`worker`</span></a> -
   (Optional)
   Configuration for resources used by Airflow workers.
 
 The `scheduler` block supports:
 
-* `cpu` -
+* <a href="#nested_scheduler_2_cpu"><span id="nested_scheduler_2_cpu">`cpu`</span></a> -
   (Optional)
   The number of CPUs for a single Airflow scheduler.
 
-* `memory_gb` -
+* <a href="#nested_scheduler_2_memory_gb"><span id="nested_scheduler_2_memory_gb">`memory_gb`</span></a> -
   (Optional)
   The amount of memory (GB) for a single Airflow scheduler.
 
-* `storage_gb` -
+* <a href="#nested_scheduler_2_storage_gb"><span id="nested_scheduler_2_storage_gb">`storage_gb`</span></a> -
   (Optional)
   The amount of storage (GB) for a single Airflow scheduler.
 
-* `count` -
+* <a href="#nested_scheduler_2_count"><span id="nested_scheduler_2_count">`count`</span></a> -
   (Optional)
   The number of schedulers.
 
 The `web_server` block supports:
 
-* `cpu` -
+* <a href="#nested_web_server_2_cpu"><span id="nested_web_server_2_cpu">`cpu`</span></a> -
   (Optional)
   The number of CPUs for the Airflow web server.
 
-* `memory_gb` -
+* <a href="#nested_web_server_2_memory_gb"><span id="nested_web_server_2_memory_gb">`memory_gb`</span></a> -
   (Optional)
   The amount of memory (GB) for the Airflow web server.
 
-* `storage_gb` -
+* <a href="#nested_web_server_2_storage_gb"><span id="nested_web_server_2_storage_gb">`storage_gb`</span></a> -
   (Optional)
   The amount of storage (GB) for the Airflow web server.
 
 The `worker` block supports:
 
-* `cpu` -
+* <a href="#nested_worker_2_cpu"><span id="nested_worker_2_cpu">`cpu`</span></a> -
   (Optional)
   The number of CPUs for a single Airflow worker.
 
-* `memory_gb` -
+* <a href="#nested_worker_2_memory_gb"><span id="nested_worker_2_memory_gb">`memory_gb`</span></a> -
   (Optional)
   The amount of memory (GB) for a single Airflow worker.
 
-* `storage_gb`
+* <a href="#nested_worker_2_storage_gb"><span id="nested_worker_2_storage_gb">`storage_gb`</span></a>
   (Optional)
   The amount of storage (GB) for a single Airflow worker.
 
-* `min_count` -
+* <a href="#nested_worker_2_min_count"><span id="nested_worker_2_min_count">`min_count`</span></a> -
   (Optional)
   The minimum number of Airflow workers that the environment can run. The number of workers in the
   environment does not go above this number, even if a lower number of workers can handle the load.
 
-* `max_count` -
+* <a href="#nested_worker_2_max_count"><span id="nested_worker_2_max_count">`max_count` -
   (Optional)
   The maximum number of Airflow workers that the environment can run. The number of workers in the
   environment does not go above this number, even if a higher number of workers is required to

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -249,7 +249,7 @@ The following arguments are supported:
 
 * `config` -
   (Optional)
-  Configuration parameters for this environment. Structure is [documented below](#nested_config_1).
+  Configuration parameters for this environment. Structure is [documented below](#nested_config).
 
 * `labels` -
   (Optional)
@@ -271,7 +271,7 @@ The following arguments are supported:
   (Optional) The ID of the project in which the resource belongs.
   If it is not provided, the provider project is used.
 
-<a name="nested_config_1"></a>The `config` block supports:
+<a name="nested_config"></a>The `config` block supports:
 
 * `node_count` -
   (Optional, Cloud Composer 1 only)
@@ -279,11 +279,11 @@ The following arguments are supported:
 
 * `node_config` -
   (Optional)
-  The configuration used for the Kubernetes Engine cluster.  Structure is [documented below](#nested_node_config_1).
+  The configuration used for the Kubernetes Engine cluster.  Structure is [documented below](#nested_node_config).
 
 * `software_config` -
   (Optional)
-  The configuration settings for software inside the environment.  Structure is [documented below](#nested_software_config_1).
+  The configuration settings for software inside the environment.  Structure is [documented below](#nested_software_config).
 
 * `private_environment_config` -
   (Optional)
@@ -319,7 +319,7 @@ The following arguments are supported:
   Kubernetes master through HTTPS except traffic from the given CIDR blocks,
   Google Compute Engine Public IPs and Google Prod IPs. Structure is [documented below](#nested_master_authorized_networks_config).
 
-<a name="nested_node_config_1"></a>The `node_config` block supports:
+<a name="nested_node_config"></a>The `node_config` block supports:
 
 * `zone` -
   (Optional, Cloud Composer 1 only)
@@ -380,7 +380,7 @@ The following arguments are supported:
 * `ip_allocation_policy` -
   (Optional)
   Configuration for controlling how IPs are allocated in the GKE cluster.
-  Structure is [documented below](#nested_ip_allocation_policy_1).
+  Structure is [documented below](#nested_ip_allocation_policy).
   Cannot be updated.
 
 * `max_pods_per_node` -
@@ -399,7 +399,7 @@ The following arguments are supported:
   all destination addresses, except between pods traffic.
   See the [documentation](https://cloud.google.com/composer/docs/enable-ip-masquerade-agent).
 
-<a name="nested_software_config_1"></a>The `software_config` block supports:
+<a name="nested_software_config"></a>The `software_config` block supports:
 
 * `airflow_config_overrides` -
   (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
@@ -509,7 +509,7 @@ The `web_server_network_access_control` supports:
   (Optional)
   A description of this ip range.
 
-<a name="nested_ip_allocation_policy_1"></a>The `ip_allocation_policy` block supports:
+<a name="nested_ip_allocation_policy"></a>The `ip_allocation_policy` block supports:
 
 * `use_ip_aliases` -
   (Optional, Cloud Composer 1 only)

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -317,8 +317,7 @@ The following arguments are supported:
   Configuration options for the master authorized networks feature. Enabled
   master authorized networks will disallow all external traffic to access
   Kubernetes master through HTTPS except traffic from the given CIDR blocks,
-  Google Compute Engine Public IPs and Google Prod IPs. Structure is
-  [documented below](#nested_master_authorized_networks_config).
+  Google Compute Engine Public IPs and Google Prod IPs. Structure is [documented below](#nested_master_authorized_networks_config).
 
 <a name="nested_node_config_1"></a>The `node_config` block supports:
 
@@ -681,8 +680,7 @@ The following arguments are supported:
   Configuration options for the master authorized networks feature. Enabled
   master authorized networks will disallow all external traffic to access
   Kubernetes master through HTTPS except traffic from the given CIDR blocks,
-  Google Compute Engine Public IPs and Google Prod IPs. Structure is
-  documented below.
+  Google Compute Engine Public IPs and Google Prod IPs. Structure is [documented above in the Cloud Composer 1 section](#nested_master_authorized_networks_config).
 
 <a name="nested_node_config_2"></a>The `node_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -283,7 +283,7 @@ The following arguments are supported:
 
 * `software_config` -
   (Optional)
-  The configuration settings for software inside the environment.  Structure is [documented below](#nested_software_config).
+  The configuration settings for software inside the environment.  Structure is [documented below](#nested_software_config_1).
 
 * `private_environment_config` -
   (Optional)
@@ -399,7 +399,7 @@ The following arguments are supported:
   all destination addresses, except between pods traffic.
   See the [documentation](https://cloud.google.com/composer/docs/enable-ip-masquerade-agent).
 
-<a name="nested_software_config"></a>The `software_config` block supports:
+<a name="nested_software_config_1"></a>The `software_config` block supports:
 
 * `airflow_config_overrides` -
   (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
@@ -647,7 +647,7 @@ The following arguments are supported:
 * `software_config` -
   (Optional)
   The configuration settings for software (Airflow) inside the environment. Structure is
-  documented below.
+  [documented below](#nested_software_config_2).
 
 * `private_environment_config` -
   (Optional)
@@ -721,7 +721,7 @@ The following arguments are supported:
   packets from node IP addresses instead of Pod IP addresses
   See the [documentation](https://cloud.google.com/composer/docs/enable-ip-masquerade-agent).
 
-The `software_config` block supports:
+<a name="nested_software_config_2"></a>The `software_config` block supports:
 
 * `airflow_config_overrides` -
   (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -380,7 +380,7 @@ The following arguments are supported:
 * `ip_allocation_policy` -
   (Optional)
   Configuration for controlling how IPs are allocated in the GKE cluster.
-  Structure is [documented below](#nested_ip_allocation_policy).
+  Structure is [documented below](#nested_ip_allocation_policy_1).
   Cannot be updated.
 
 * `max_pods_per_node` -
@@ -509,7 +509,7 @@ The `web_server_network_access_control` supports:
   (Optional)
   A description of this ip range.
 
-<a name="nested_ip_allocation_policy"></a>The `ip_allocation_policy` block supports:
+<a name="nested_ip_allocation_policy_1"></a>The `ip_allocation_policy` block supports:
 
 * `use_ip_aliases` -
   (Optional, Cloud Composer 1 only)
@@ -711,7 +711,7 @@ The following arguments are supported:
 * `ip_allocation_policy` -
   (Optional)
   Configuration for controlling how IPs are allocated in the GKE cluster.
-  Structure is documented below.
+  Structure is [documented below](#nested_ip_allocation_policy_2).
   Cannot be updated.
 
 * `enable_ip_masq_agent` -
@@ -817,7 +817,7 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   versions `composer-2.*.*-airflow-*.*.*` and newer.
 
 
-The `ip_allocation_policy` block supports:
+<a name="nested_ip_allocation_policy_2"></a>The `ip_allocation_policy` block supports:
 
 * `cluster_secondary_range_name` -
   (Optional)

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -249,7 +249,7 @@ The following arguments are supported:
 
 * `config` -
   (Optional)
-  Configuration parameters for this environment  Structure is [documented below](#nested_config).
+  Configuration parameters for this environment. Structure is [documented below](#nested_config_1).
 
 * `labels` -
   (Optional)
@@ -271,7 +271,7 @@ The following arguments are supported:
   (Optional) The ID of the project in which the resource belongs.
   If it is not provided, the provider project is used.
 
-<a name="nested_config"></a>The `config` block supports:
+<a name="nested_config_1"></a>The `config` block supports:
 
 * `node_count` -
   (Optional, Cloud Composer 1 only)
@@ -617,7 +617,7 @@ The following arguments are supported:
 
 * `config` -
   (Optional)
-  Configuration parameters for this environment. Structure is documented below.
+  Configuration parameters for this environment. Structure is [documented below](#nested_config_2).
 
 * `labels` -
   (Optional)
@@ -639,7 +639,7 @@ The following arguments are supported:
   (Optional) The ID of the project in which the resource belongs.
   If it is not provided, the provider project is used.
 
-The `config` block supports:
+<a name="nested_config_2"></a>The `config` block supports:
 
 * `node_config` -
   (Optional)

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -610,15 +610,15 @@ The `web_server_network_access_control` supports:
 
 The following arguments are supported:
 
-* <a href="#name_2"><span id="name_2">`name`</span></a> -
+* <a href="#name_2" name="name_2">`name`</a> -
   (Required)
   Name of the environment
 
-* <a href="#config_2"><span id="config_2">`config`</span></a> -
+* <a href="#config_2" name="config_2">`config`</a> -
   (Optional)
   Configuration parameters for this environment. Structure is [documented below](#nested_config_2).
 
-* <a href="#labels_2"><span id="labels_2">`labels`</span></a> -
+* <a href="#labels_2" name="labels_2">`labels`</a> -
   (Optional)
   User-defined labels for this environment. The labels map can contain
   no more than 64 entries. Entries of the labels map are UTF8 strings
@@ -630,52 +630,52 @@ The following arguments are supported:
   No more than 64 labels can be associated with a given environment.
   Both keys and values must be <= 128 bytes in size.
 
-* <a href="#region_2"><span id="region_2">`region`</span></a> -
+* <a href="#region_2" name="region_2">`region`</a> -
   (Optional)
   The location or Compute Engine region for the environment.
 
-* <a href="#project_2"><span id="project_2">`project`</span></a> -
+* <a href="#project_2" name="project_2">`project`</a> -
   (Optional) The ID of the project in which the resource belongs.
   If it is not provided, the provider project is used.
 
 <a name="nested_config_2"></a>The `config` block supports:
 
-* <a href="#nested_config_2_node_config"><span id="nested_config_2_node_config">`node_config`</span></a> -
+* <a href="#nested_config_2_node_config" name="nested_config_2_node_config">`node_config`</a> -
   (Optional)
   The configuration used for the Kubernetes Engine cluster. Structure is [documented below](#nested_node_config_2).
 
-* <a href="#nested_config_2_software_config"><span id="nested_config_2_software_config">`software_config`</span></a> -
+* <a href="#nested_config_2_software_config" name="nested_config_2_software_config">`software_config`</a> -
   (Optional)
   The configuration settings for software (Airflow) inside the environment. Structure is
   [documented below](#nested_software_config_2).
 
-* <a href="#nested_config_2_private_environment_config"><span id="nested_config_2_private_environment_config">`private_environment_config`</span></a> -
+* <a href="#nested_config_2_private_environment_config" name="nested_config_2_private_environment_config">`private_environment_config`</a> -
   (Optional)
   The configuration used for the Private IP Cloud Composer environment. Structure is documented
   below.
 
-* <a href="#nested_config_2_encryption_config"><span id="nested_config_2_encryption_config">`encryption_config`</span></a> -
+* <a href="#nested_config_2_encryption_config" name="nested_config_2_encryption_config">`encryption_config`</a> -
   (Optional)
   The encryption options for the Cloud Composer environment and its
   dependencies.
 
-* <a href="#nested_config_2_maintenance_window"><span id="nested_config_2_maintenance_window">`maintenance_window`</span></a> -
+* <a href="#nested_config_2_maintenance_window" name="nested_config_2_maintenance_window">`maintenance_window`</a> -
   (Optional)
   The configuration settings for Cloud Composer maintenance windows.
 
-* <a href="#nested_config_2_workloads_config"><span id="nested_config_2_workloads_config">`workloads_config`</span></a> -
+* <a href="#nested_config_2_workloads_config" name="nested_config_2_workloads_config">`workloads_config`</a> -
   (Optional, Cloud Composer 2 only)
   The Kubernetes workloads configuration for GKE cluster associated with the
   Cloud Composer environment.
 
-* <a href="#nested_config_2_environment_size"><span id="nested_config_2_environment_size">`environment_size`</span></a> -
+* <a href="#nested_config_2_environment_size" name="nested_config_2_environment_size">`environment_size`</a> -
   (Optional, Cloud Composer 2 only)
   The environment size controls the performance parameters of the managed
   Cloud Composer infrastructure that includes the Airflow database. Values for
   environment size are `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`,
   and `ENVIRONMENT_SIZE_LARGE`.
 
-* <a href="#nested_config_2_master_authorized_networks_config"><span id="nested_config_2_master_authorized_networks_config">`master_authorized_networks_config`</span></a> -
+* <a href="#nested_config_2_master_authorized_networks_config" name="nested_config_2_master_authorized_networks_config">`master_authorized_networks_config`</a> -
   (Optional)
   Configuration options for the master authorized networks feature. Enabled
   master authorized networks will disallow all external traffic to access
@@ -684,7 +684,7 @@ The following arguments are supported:
 
 <a name="nested_node_config_2"></a>The `node_config` block supports:
 
-* <a href="#nested_node_config_2_network"><span id="nested_node_config_2_network">`network`</span></a> -
+* <a href="#nested_node_config_2_network" name="nested_node_config_2_network">`network`</a> -
   (Optional)
   The Compute Engine network to be used for machine
   communications, specified as a self-link, relative resource name
@@ -693,14 +693,14 @@ The following arguments are supported:
   The network must belong to the environment's project. If unspecified, the "default" network ID in the environment's
   project is used. If a Custom Subnet Network is provided, subnetwork must also be provided.
 
-* <a href="#nested_node_config_2_subnetwork"><span id="nested_node_config_2_subnetwork">`subnetwork`</span></a> -
+* <a href="#nested_node_config_2_subnetwork" name="nested_node_config_2_subnetwork">`subnetwork`</a> -
   (Optional)
   The Compute Engine subnetwork to be used for machine
   communications, specified as a self-link, relative resource name (for example,
   "projects/{project}/regions/{region}/subnetworks/{subnetwork}"), or by name. If subnetwork is provided,
   network must also be provided and the subnetwork must belong to the enclosing environment's project and region.
 
-* <a href="#nested_node_config_2_service_account"><span id="nested_node_config_2_service_account">`service_account`</span></a> -
+* <a href="#nested_node_config_2_service_account" name="nested_node_config_2_service_account">`service_account`</a> -
   (Optional)
   The Google Cloud Platform Service Account to be used by the
   node VMs. If a service account is not specified, the "default"
@@ -708,13 +708,13 @@ The following arguments are supported:
   note that the service account must have `roles/composer.worker`
   for any GCP resources created under the Cloud Composer Environment.
 
-* <a href="#nested_node_config_2_ip_allocation_policy"><span id="nested_node_config_2_ip_allocation_policy">`ip_allocation_policy`</span></a> -
+* <a href="#nested_node_config_2_ip_allocation_policy" name="nested_node_config_2_ip_allocation_policy">`ip_allocation_policy`</a> -
   (Optional)
   Configuration for controlling how IPs are allocated in the GKE cluster.
   Structure is [documented below](#nested_ip_allocation_policy_2).
   Cannot be updated.
 
-* <a href="#nested_node_config_2_enable_ip_masq_agent"><span id="nested_node_config_2_enable_ip_masq_agent">`enable_ip_masq_agent`</span></a> -
+* <a href="#nested_node_config_2_enable_ip_masq_agent" name="nested_node_config_2_enable_ip_masq_agent">`enable_ip_masq_agent`</a> -
   (Optional)
   IP Masq Agent translates Pod IP addresses to node IP addresses, so that 
   destinations and services targeted from Airflow DAGs and tasks only receive 
@@ -723,7 +723,7 @@ The following arguments are supported:
 
 <a name="nested_software_config_2"></a>The `software_config` block supports:
 
-* <a href="#nested_software_config_2_airflow_config_overrides"><span id="nested_software_config_2_airflow_config_overrides">`airflow_config_overrides`</span></a> -
+* <a href="#nested_software_config_2_airflow_config_overrides" name="nested_software_config_2_airflow_config_overrides">`airflow_config_overrides`</a> -
   (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
   separated by a hyphen, for example "core-dags_are_paused_at_creation".
 
@@ -734,14 +734,14 @@ The following arguments are supported:
   property values are [blacklisted](https://cloud.google.com/composer/docs/concepts/airflow-configurations#airflow_configuration_blacklists),
   and cannot be overridden.
 
-* <a href="#nested_software_config_2_pypi_packages"><span id="nested_software_config_2_pypi_packages">`pypi_packages`</span></a> -
+* <a href="#nested_software_config_2_pypi_packages" name="nested_software_config_2_pypi_packages">`pypi_packages`</a> -
   (Optional)
   Custom Python Package Index (PyPI) packages to be installed
   in the environment. Keys refer to the lowercase package name (e.g. "numpy"). Values are the lowercase extras and
   version specifier (e.g. "==1.12.0", "[devel,gcp_api]", "[devel]>=1.8.2, <1.9.2"). To specify a package without
   pinning it to a version specifier, use the empty string as the value.
 
-* <a href="#nested_software_config_2_env_variables"><span id="nested_software_config_2_env_variables">`env_variables`</span></a> -
+* <a href="#nested_software_config_2_env_variables" name="nested_software_config_2_env_variables">`env_variables`</a> -
   (Optional)
   Additional environment variables to provide to the Apache Airflow scheduler, worker, and webserver processes.
   Environment variable names must match the regular expression `[a-zA-Z_][a-zA-Z0-9_]*`.
@@ -763,7 +763,7 @@ The following arguments are supported:
   SQL_USER
   ```
 
-* <a href="#image_version_2"><span id="image_version_2">`image_version`</span></a> -
+* <a href="#image_version_2" name="image_version_2">`image_version`</a> -
   (Required in Cloud Composer 2, optional in Cloud Composer 1)
 
   **In Cloud Composer 2, you must specify an image with Cloud Composer 2**. Otherwise, the default image for Cloud Composer 1 is used. For more information about Cloud Composer images, see
@@ -785,10 +785,10 @@ The following arguments are supported:
 
 See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. The `private_environment_config` block supports:
 
-* <a href="#nested_private_environment_config_2_enable_private_endpoint"><span id="nested_private_environment_config_2_enable_private_endpoint">`enable_private_endpoint`</span></a> -
+* <a href="#nested_private_environment_config_2_enable_private_endpoint" name="nested_private_environment_config_2_enable_private_endpoint">`enable_private_endpoint`</a> -
   If true, access to the public endpoint of the GKE cluster is denied.
 
-* <a href="#nested_private_environment_config_2_master_ipv4_cidr_block"><span id="nested_private_environment_config_2_master_ipv4_cidr_block">`master_ipv4_cidr_block`</span></a> -
+* <a href="#nested_private_environment_config_2_master_ipv4_cidr_block" name="nested_private_environment_config_2_master_ipv4_cidr_block">`master_ipv4_cidr_block`</a> -
   (Optional)
   The IP range in CIDR notation to use for the hosted master network. This range is used
   for assigning internal IP addresses to the cluster master or set of masters and to the
@@ -796,20 +796,20 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   in use within the cluster's network.
   If left blank, the default value of is used. See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip#defaults) for default values per region.
 
-* <a href="#nested_private_environment_config_2_cloud_sql_ipv4_cidr_block"><span id="nested_private_environment_config_2_cloud_sql_ipv4_cidr_block">`cloud_sql_ipv4_cidr_block`</span></a> -
+* <a href="#nested_private_environment_config_2_cloud_sql_ipv4_cidr_block" name="nested_private_environment_config_2_cloud_sql_ipv4_cidr_block">`cloud_sql_ipv4_cidr_block`</a> -
   (Optional)
   The CIDR block from which IP range in tenant project will be reserved for Cloud SQL. Needs to be disjoint from `web_server_ipv4_cidr_block`
 
-* <a href="#nested_private_environment_config_2_cloud_composer_network_ipv4_cidr_block"><span id="nested_private_environment_config_2_cloud_composer_network_ipv4_cidr_block">`cloud_composer_network_ipv4_cidr_block"`</span></a> -
+* <a href="#nested_private_environment_config_2_cloud_composer_network_ipv4_cidr_block" name="nested_private_environment_config_2_cloud_composer_network_ipv4_cidr_block">`cloud_composer_network_ipv4_cidr_block"`</a> -
   (Optional, Cloud Composer 2 only)
   The CIDR block from which IP range for Cloud Composer Network in tenant project will be reserved. Needs to be disjoint from private_cluster_config.master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.
 
-* <a href="#nested_private_environment_config_2_enable_privately_used_public_ips"><span id="nested_private_environment_config_2_enable_privately_used_public_ips">`enable_privately_used_public_ips`</span></a> -
+* <a href="#nested_private_environment_config_2_enable_privately_used_public_ips" name="nested_private_environment_config_2_enable_privately_used_public_ips">`enable_privately_used_public_ips`</a> -
   (Optional)
   When enabled, IPs from public (non-RFC1918) ranges can be used for
   `ip_allocation_policy.cluster_ipv4_cidr_block` and `ip_allocation_policy.service_ipv4_cidr_block`.
 
-* <a href="#nested_private_environment_config_2_cloud_composer_connection_subnetwork"><span id="nested_private_environment_config_2_cloud_composer_connection_subnetwork">`cloud_composer_connection_subnetwork`</span></a> -
+* <a href="#nested_private_environment_config_2_cloud_composer_connection_subnetwork" name="nested_private_environment_config_2_cloud_composer_connection_subnetwork">`cloud_composer_connection_subnetwork`</a> -
   (Optional)
   When specified, the environment will use Private Service Connect instead of VPC peerings to connect
   to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP
@@ -819,17 +819,17 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 <a name="nested_ip_allocation_policy_2"></a>The `ip_allocation_policy` block supports:
 
-* <a href="#nested_ip_allocation_policy_2_cluster_secondary_range_name"><span id="nested_ip_allocation_policy_2_cluster_secondary_range_name">`cluster_secondary_range_name`</span></a> -
+* <a href="#nested_ip_allocation_policy_2_cluster_secondary_range_name" name="nested_ip_allocation_policy_2_cluster_secondary_range_name">`cluster_secondary_range_name`</a> -
   (Optional)
   The name of the cluster's secondary range used to allocate IP addresses to pods.
   Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
 
-* <a href="#nested_ip_allocation_policy_2_services_secondary_range_name"><span id="nested_ip_allocation_policy_2_services_secondary_range_name">`services_secondary_range_name`</span></a> -
+* <a href="#nested_ip_allocation_policy_2_services_secondary_range_name" name="nested_ip_allocation_policy_2_services_secondary_range_name">`services_secondary_range_name`</a> -
   (Optional)
   The name of the services' secondary range used to allocate IP addresses to the cluster.
   Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
 
-* <a href="#nested_ip_allocation_policy_2_cluster_ipv4_cidr_block"><span id="nested_ip_allocation_policy_2_cluster_ipv4_cidr_block">`cluster_ipv4_cidr_block`</span></a> -
+* <a href="#nested_ip_allocation_policy_2_cluster_ipv4_cidr_block" name="nested_ip_allocation_policy_2_cluster_ipv4_cidr_block">`cluster_ipv4_cidr_block`</a> -
   (Optional)
   The IP address range used to allocate IP addresses to pods in the cluster.
   For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
@@ -839,7 +839,7 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
   Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
 
-* <a href="#nested_ip_allocation_policy_2_services_ipv4_cidr_block"><span id="nested_ip_allocation_policy_2_services_ipv4_cidr_block">`services_ipv4_cidr_block`</span></a> -
+* <a href="#nested_ip_allocation_policy_2_services_ipv4_cidr_block" name="nested_ip_allocation_policy_2_services_ipv4_cidr_block">`services_ipv4_cidr_block`</a> -
   (Optional)
   The IP address range used to allocate IP addresses in this cluster.
   For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
@@ -851,7 +851,7 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 <a name="nested_encryption_config_comp_2"></a>The `encryption_config` block supports:
 
-* <a href="#nested_encryption_config_comp_2_kms_key_name"><span id="nested_encryption_config_comp_2_kms_key_name">`kms_key_name`</span></a> -
+* <a href="#nested_encryption_config_comp_2_kms_key_name" name="nested_encryption_config_comp_2_kms_key_name">`kms_key_name`</a> -
   (Required)
   Customer-managed Encryption Key available through Google's Key Management Service. It must
   be the fully qualified resource name,
@@ -859,16 +859,16 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 <a name="nested_maintenance_window_2"></a>The `maintenance_window` block supports:
 
-* <a href="#nested_maintenance_window_2_start_time"><span id="nested_maintenance_window_2_start_time">`start_time`</span></a> -
+* <a href="#nested_maintenance_window_2_start_time" name="nested_maintenance_window_2_start_time">`start_time`</a> -
   (Required)
   Start time of the first recurrence of the maintenance window.
 
-* <a href="#nested_maintenance_window_2_end_time"><span id="nested_maintenance_window_2_end_time">`end_time`</span></a> -
+* <a href="#nested_maintenance_window_2_end_time" name="nested_maintenance_window_2_end_time">`end_time`</a> -
   (Required)
   Maintenance window end time. It is used only to calculate the duration of the maintenance window.
   The value for end-time must be in the future, relative to 'start_time'.
 
-* <a href="#nested_maintenance_window_2_recurrence"><span id="nested_maintenance_window_2_recurrence">`recurrence`</span></a> -
+* <a href="#nested_maintenance_window_2_recurrence" name="nested_maintenance_window_2_recurrence">`recurrence`</a> -
   (Required)
   Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
   The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
@@ -876,70 +876,70 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
 
 The `workloads_config` block supports:
 
-* <a href="#nested_workloads_config_2_scheduler"><span id="nested_workloads_config_2_scheduler">`scheduler`</span></a> -
+* <a href="#nested_workloads_config_2_scheduler" name="nested_workloads_config_2_scheduler">`scheduler`</a> -
   (Optional)
   Configuration for resources used by Airflow schedulers.
 
-* <a href="#nested_workloads_config_2_web_server"><span id="nested_workloads_config_2_web_server">`web_server`</span></a> -
+* <a href="#nested_workloads_config_2_web_server" name="nested_workloads_config_2_web_server">`web_server`</a> -
   (Optional)
   Configuration for resources used by Airflow web server.
 
-* <a href="#nested_workloads_config_2_worker"><span id="nested_workloads_config_2_worker">`worker`</span></a> -
+* <a href="#nested_workloads_config_2_worker" name="nested_workloads_config_2_worker">`worker`</a> -
   (Optional)
   Configuration for resources used by Airflow workers.
 
 The `scheduler` block supports:
 
-* <a href="#nested_scheduler_2_cpu"><span id="nested_scheduler_2_cpu">`cpu`</span></a> -
+* <a href="#nested_scheduler_2_cpu" name="nested_scheduler_2_cpu">`cpu`</a> -
   (Optional)
   The number of CPUs for a single Airflow scheduler.
 
-* <a href="#nested_scheduler_2_memory_gb"><span id="nested_scheduler_2_memory_gb">`memory_gb`</span></a> -
+* <a href="#nested_scheduler_2_memory_gb" name="nested_scheduler_2_memory_gb">`memory_gb`</a> -
   (Optional)
   The amount of memory (GB) for a single Airflow scheduler.
 
-* <a href="#nested_scheduler_2_storage_gb"><span id="nested_scheduler_2_storage_gb">`storage_gb`</span></a> -
+* <a href="#nested_scheduler_2_storage_gb" name="nested_scheduler_2_storage_gb">`storage_gb`</a> -
   (Optional)
   The amount of storage (GB) for a single Airflow scheduler.
 
-* <a href="#nested_scheduler_2_count"><span id="nested_scheduler_2_count">`count`</span></a> -
+* <a href="#nested_scheduler_2_count" name="nested_scheduler_2_count">`count`</a> -
   (Optional)
   The number of schedulers.
 
 The `web_server` block supports:
 
-* <a href="#nested_web_server_2_cpu"><span id="nested_web_server_2_cpu">`cpu`</span></a> -
+* <a href="#nested_web_server_2_cpu" name="nested_web_server_2_cpu">`cpu`</a> -
   (Optional)
   The number of CPUs for the Airflow web server.
 
-* <a href="#nested_web_server_2_memory_gb"><span id="nested_web_server_2_memory_gb">`memory_gb`</span></a> -
+* <a href="#nested_web_server_2_memory_gb" name="nested_web_server_2_memory_gb">`memory_gb`</a> -
   (Optional)
   The amount of memory (GB) for the Airflow web server.
 
-* <a href="#nested_web_server_2_storage_gb"><span id="nested_web_server_2_storage_gb">`storage_gb`</span></a> -
+* <a href="#nested_web_server_2_storage_gb" name="nested_web_server_2_storage_gb">`storage_gb`</a> -
   (Optional)
   The amount of storage (GB) for the Airflow web server.
 
 The `worker` block supports:
 
-* <a href="#nested_worker_2_cpu"><span id="nested_worker_2_cpu">`cpu`</span></a> -
+* <a href="#nested_worker_2_cpu" name="nested_worker_2_cpu">`cpu`</a> -
   (Optional)
   The number of CPUs for a single Airflow worker.
 
-* <a href="#nested_worker_2_memory_gb"><span id="nested_worker_2_memory_gb">`memory_gb`</span></a> -
+* <a href="#nested_worker_2_memory_gb" name="nested_worker_2_memory_gb">`memory_gb`</a> -
   (Optional)
   The amount of memory (GB) for a single Airflow worker.
 
-* <a href="#nested_worker_2_storage_gb"><span id="nested_worker_2_storage_gb">`storage_gb`</span></a>
+* <a href="#nested_worker_2_storage_gb" name="nested_worker_2_storage_gb">`storage_gb`</a>
   (Optional)
   The amount of storage (GB) for a single Airflow worker.
 
-* <a href="#nested_worker_2_min_count"><span id="nested_worker_2_min_count">`min_count`</span></a> -
+* <a href="#nested_worker_2_min_count" name="nested_worker_2_min_count">`min_count`</a> -
   (Optional)
   The minimum number of Airflow workers that the environment can run. The number of workers in the
   environment does not go above this number, even if a lower number of workers can handle the load.
 
-* <a href="#nested_worker_2_max_count"><span id="nested_worker_2_max_count">`max_count` -
+* <a href="#nested_worker_2_max_count" name="nested_worker_2_max_count">`max_count` -
   (Optional)
   The maximum number of Airflow workers that the environment can run. The number of workers in the
   environment does not go above this number, even if a higher number of workers is required to

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -930,7 +930,7 @@ The `worker` block supports:
   (Optional)
   The amount of memory (GB) for a single Airflow worker.
 
-* `float storage_gb`
+* `storage_gb`
   (Optional)
   The amount of storage (GB) for a single Airflow worker.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

# Description

Closes https://github.com/hashicorp/terraform-provider-google/issues/11773

This PR addresses the issue with this:
  - **Overrides links automatically added to argument names by the Registry** by adding `<a>` tags to the argument names with `name` values chosen to be unique to each argument (e.g. so each argument called `cpu` can be linked to separately)
  - ⚠️ I'm happy to drop this from the PR if it's introducing too much _stuff_ to maintain, but my rationale was that it's tolerable as it's limited to just the one file!

Bonus fixes:
- Fixes instances of the documentation saying `Structure is documented below.` without a linking to the section
- Updates `name` values used for links to 'nested' sections - where sections of the same name are present I've updated the values to have `_2` if they're in the [Cloud composer 2](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/composer_environment#argument-reference---cloud-composer-2) argument reference section.
    - I'm hoping this will allow linking to the arguments that would have been 'shadowed' by similarly named arguments higher up the page, while minimising the effect on any links to specific arguments on the page that exist elsewhere

## Overriding links

If you use the [Terraform Registry's doc preview tool](https://registry.terraform.io/tools/doc-preview) and put this in the form field:

```
* `foobar`
  *  Links to itself
* `foobar`
  *  Links to the top foobar
* `foobar`
  *  Links to the top foobar
```

 ...you can see that the bullet points are each turned into links, but they are the same link and would show the user the first instance of `foobar` only.

Changing it to something like this allows linking to specific arguments with the same name:

```
* `foobar`
  *  Links to itself
* `foobar`
  *  Links to the top foobar
* <a href="#foobar-special" name="foobar-special">`foobar`</a>
  *  Links to itself
```

This PR does this for each argument... and needed to get creative with the values of `name` for arguments in nested blocks. I chose to take the `name` value of the block and add the argument name at the end.

## List

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~ N/A
- [x] ~~[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~ N/A
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
