### PR TITLE
Upgraded build containers to go 1.18

### DIFF
--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -3,7 +3,7 @@ from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 
 RUN go install golang.org/x/tools/cmd/goimports@d088b475e3360caabc032aaee1dc66351d4e729a
-RUN go install github.com/github/hub@2.14.2
+RUN go install github.com/github/hub@v2.11.2+incompatible
 
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -2,8 +2,8 @@ from golang:1.18-stretch as resource
 
 SHELL ["/bin/bash", "-c"]
 
-RUN go get golang.org/x/tools/cmd/goimports@d088b475e3360caabc032aaee1dc66351d4e729a
-RUN go get github.com/github/hub
+RUN go install golang.org/x/tools/cmd/goimports@d088b475e3360caabc032aaee1dc66351d4e729a
+RUN go install github.com/github/hub
 
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.16.3-stretch as resource
+from golang:1.18-stretch as resource
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -3,7 +3,7 @@ from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 
 RUN go install golang.org/x/tools/cmd/goimports@d088b475e3360caabc032aaee1dc66351d4e729a
-RUN go install github.com/github/hub
+RUN go install github.com/github/hub@2.14.2
 
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.16-stretch as resource
+from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-tester/Dockerfile
+++ b/.ci/containers/terraform-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.16-stretch as resource
+from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-validator-tester-integration/Dockerfile
+++ b/.ci/containers/terraform-validator-tester-integration/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.16-stretch as resource
+from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-validator-tester/Dockerfile
+++ b/.ci/containers/terraform-validator-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.16-stretch as resource
+from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/terraform-vcr-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.16-stretch as resource
+from golang:1.18-stretch as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upgraded build containers to go 1.18. This will allow us to later upgrade tpg / tpgb to go 1.18 if we want to.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
