### PR TITLE
Fix Hub Membership Import format

### DIFF
--- a/mmv1/products/gkehub/api.yaml
+++ b/mmv1/products/gkehub/api.yaml
@@ -33,7 +33,7 @@ objects:
     base_url: "projects/{{project}}/locations/global/memberships"
     create_url: "projects/{{project}}/locations/global/memberships?membershipId={{membership_id}}"
     update_url: "projects/{{project}}/locations/global/memberships/{{membership_id}}"
-    self_link: "{{name}}"
+    self_link: "projects/{{project}}/locations/global/memberships/{{membership_id}}"
     update_verb: :PATCH
     update_mask: true
     description: |

--- a/mmv1/products/gkehub/terraform.yaml
+++ b/mmv1/products/gkehub/terraform.yaml
@@ -32,8 +32,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
     # Skip sweeper gen since this is a child resource.
     skip_sweeper: true
-    id_format: "{{name}}"
-    import_format: ["{{%name}}"]
+    id_format: "projects/{{project}}/locations/global/memberships/{{membership_id}}"
+    import_format: ["projects/{{project}}/locations/global/memberships/{{membership_id}}"]
     properties:
       endpoint.gkeCluster.resourceLink: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: suppressGkeHubEndpointSelfLinkDiff


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes the import format for gke_hub_membership resource. The resource will be imported though project and membership_id, rather than name. 




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: added better support for import for `google_gke_hub_membership`
```
