### PR TITLE
Revert "Innocuous change to exercise docker image changes"

### DIFF
--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -90,7 +90,7 @@ type Formatter struct {
 // Borrowed logic from https://github.com/sirupsen/logrus/blob/master/json_formatter.go and https://github.com/t-tomalak/logrus-easy-formatter/blob/master/formatter.go
 func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	// Suppress logs if TF_LOG is not DEBUG or TRACE
-	// Also suppress frequent transport spam
+	// also suppress frequent transport spam
 	if !logging.IsDebugOrHigher() || strings.Contains(entry.Message, "transport is closing") {
 		return nil, nil
 	}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#6337 to exercise the ci pipeline again

```release-note:none
Release note
```