### PR TITLE
Revert "Cloud NAT Rules and Configurable TCP Time Wait"

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13566,11 +13566,6 @@ objects:
           Timeout (in seconds) for TCP transitory connections.
           Defaults to 30s if not set.
         default_value: 30
-      - !ruby/object:Api::Type::Integer
-        name: tcpTimeWaitTimeoutSec
-        description: |
-          Timeout (in seconds) for TCP connections that are in TIME_WAIT state. Defaults to 120s if not set.
-        default_value: 120        
       - !ruby/object:Api::Type::NestedObject
         name: logConfig
         description: |
@@ -13591,56 +13586,6 @@ objects:
               - :ERRORS_ONLY
               - :TRANSLATIONS_ONLY
               - :ALL
-      - !ruby/object:Api::Type::Array
-        name: rules
-        description: |
-          A list of rules associated with this NAT.
-        send_empty_value: true
-        item_type: !ruby/object:Api::Type::NestedObject
-          properties:
-            - !ruby/object:Api::Type::Integer
-              name: 'ruleNumber'
-              description: |
-                An integer uniquely identifying a rule in the list. The rule number must be a positive value between 0 and 65000, and must be unique among rules within a NAT.
-              required: true
-            - !ruby/object:Api::Type::String
-              name: 'description'
-              description: |
-                An optional description of this rule.
-            - !ruby/object:Api::Type::String
-              name: 'match'
-              required: true
-              description: |
-                CEL expression that specifies the match condition that egress traffic from a VM is evaluated against. If it evaluates to true, the corresponding action is enforced.
-                The following examples are valid match expressions for public NAT:
-                "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
-                "destination.ip == '1.1.0.1' || destination.ip == '8.8.8.8'"
-                The following example is a valid match expression for private NAT:
-                "nexthop.hub == 'https://networkconnectivity.googleapis.com/v1alpha1/projects/my-project/global/hub/hub-1'"
-            - !ruby/object:Api::Type::NestedObject
-              name: action
-              required: true
-              description: |
-                The action to be enforced for traffic that matches this rule.
-              properties:
-                - !ruby/object:Api::Type::Array
-                  name: 'sourceNatActiveIps'
-                  description: |
-                    A list of URLs of the IP resources used for this NAT rule. These IP addresses must be valid static external IP addresses assigned to the project. This field is used for public NAT.
-                  item_type: !ruby/object:Api::Type::ResourceRef
-                    name: 'address'
-                    resource: 'Address'
-                    imports: 'selfLink'
-                    description: 'A reference to an address associated with this NAT'
-                - !ruby/object:Api::Type::Array
-                  name: 'sourceNatDrainIps'
-                  description: |
-                    A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT. These IPs should be used for updating/patching a NAT rule only. This field is used for public NAT.
-                  item_type: !ruby/object:Api::Type::ResourceRef
-                    name: 'address'
-                    resource: 'Address'
-                    imports: 'selfLink'
-                    description: 'A reference to an address associated with this NAT'
       - !ruby/object:Api::Type::Boolean
         name: enableEndpointIndependentMapping
         description: |

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -3,7 +3,9 @@ package google
 
 import (
 	"fmt"
+<% unless version == "ga" -%>
 	"regexp"
+<% end -%>
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -59,73 +61,6 @@ func TestAccComputeRouterNat_basic(t *testing.T) {
 		},
 	})
 }
-
-func TestAccComputeRouterNat_tcpTimeWaitTimeoutSec(t *testing.T) {
-	t.Parallel()
-
-	testId := randString(t, 10)
-	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeRouterNatTcpTimeWaitTimeoutSec(routerName, 180),
-			},
-			{
-				// implicitly full ImportStateId
-				ResourceName: "google_compute_router_nat.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeRouterNatTcpTimeWaitTimeoutSec(routerName, 150),
-			},
-			{
-				// implicitly full ImportStateId
-				ResourceName: "google_compute_router_nat.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeRouterNat_rule(t *testing.T) {
-	t.Parallel()
-
-	testId := randString(t, 10)
-	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeRouterNatRule(routerName),
-			},
-			{
-				// implicitly full ImportStateId
-				ResourceName: "google_compute_router_nat.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeRouterNatRuleUpdate(routerName),
-			},
-			{
-				// implicitly full ImportStateId
-				ResourceName: "google_compute_router_nat.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 
 func TestAccComputeRouterNat_update(t *testing.T) {
 	t.Parallel()
@@ -291,6 +226,7 @@ func TestAccComputeRouterNat_withPortAllocationMethods(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 	t.Parallel()
 
@@ -338,6 +274,8 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 		},
 	})
 }
+
+<% end -%>
 
 func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -777,6 +715,7 @@ resource "google_compute_router_nat" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName, enableEndpointIndependentMapping, enableDynamicPortAllocation, minPortsPerVm, maxPortsPerVm)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeRouterNatBaseResourcesWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -923,6 +862,8 @@ resource "google_compute_router_nat" "foobar" {
 `, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
 
+<% end -%>
+
 func testAccComputeRouterNatKeepRouter(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -1005,145 +946,4 @@ resource "google_compute_router_nat" "foobar" {
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 `, routerName, routerName, routerName, routerName)
-}
-
-func testAccComputeRouterNatRule(routerName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-}
-
-resource "google_compute_address" "foobar" {
-  name   = "%s-addr"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_address" "foobar2" {
-  name   = "%s-addr-2"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_router_nat" "foobar" {
-  name                                = "%s"
-  router                              = google_compute_router.foobar.name
-  region                              = google_compute_router.foobar.region
-  nat_ip_allocate_option              = "MANUAL_ONLY"
-  nat_ips                             = [google_compute_address.foobar.id]
-  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  enable_endpoint_independent_mapping = false
-
-  rules {
-	rule_number = 1
-	match       = "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
-	action {
-	  source_nat_active_ips = [google_compute_address.foobar2.id]
-	}
-  }
-}
-`, routerName, routerName, routerName, routerName, routerName, routerName)
-}
-
-func testAccComputeRouterNatRuleUpdate(routerName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-}
-
-resource "google_compute_address" "foobar" {
-  name   = "%s-addr"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_address" "foobar2" {
-  name   = "%s-addr-2"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_address" "foobar3" {
-  name   = "%s-addr-3"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_router_nat" "foobar" {
-  name                                = "%s"
-  router                              = google_compute_router.foobar.name
-  region                              = google_compute_router.foobar.region
-  nat_ip_allocate_option              = "MANUAL_ONLY"
-  nat_ips                             = [google_compute_address.foobar.id]
-  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  enable_endpoint_independent_mapping = false
-
-  rules {
-	rule_number = 1
-	match       = "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '5.5.0.0/16')"
-	action {
-	  source_nat_active_ips = [google_compute_address.foobar2.id]
-	}
-  }
-
-  rules {
-	rule_number = 2
-	match       = "inIpRange(destination.ip, '3.3.0.0/16') || inIpRange(destination.ip, '4.4.0.0/16')"
-	action {
-	  source_nat_active_ips = [google_compute_address.foobar3.id]
-	}
-  }
-}
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
-}
-
-func testAccComputeRouterNatTcpTimeWaitTimeoutSec(routerName string, timeout int) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-}
-
-resource "google_compute_router_nat" "foobar" {
-  name                               = "%s"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  tcp_time_wait_timeout_sec          = "%d"
-}
-`, routerName, routerName, routerName, routerName, timeout)
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#6221

Looks like tests failed in some of our nightly runs with error:
```
provider_test.go:309: Step 3/4 error: After applying this test step, the plan was not empty.
stdout:
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# google_compute_router_nat.foobar will be updated in-place
~ resource "google_compute_router_nat" "foobar" {
id                                  = "ci-test-project-188019/us-central1/tf-test-router-nat-kal6esk7c1/tf-test-router-nat-kal6esk7c1"
name                                = "tf-test-router-nat-kal6esk7c1"
# (16 unchanged attributes hidden)
~ rules {
~ match       = "inIpRange(destination.ip, '3.3.0.0/16') || inIpRange(destination.ip, '4.4.0.0/16')" -> "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '5.5.0.0/16')"
~ rule_number = 2 -> 1
~ action {
~ source_nat_active_ips = [
- "https://www.googleapis.com/compute/v1/projects/ci-test-project-188019/regions/us-central1/addresses/tf-test-router-nat-kal6esk7c1-addr-3",
+ "projects/ci-test-project-188019/regions/us-central1/addresses/tf-test-router-nat-kal6esk7c1-addr-2",
]
# (1 unchanged attribute hidden)
}
}
~ rules {
~ match       = "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '5.5.0.0/16')" -> "inIpRange(destination.ip, '3.3.0.0/16') || inIpRange(destination.ip, '4.4.0.0/16')"
~ rule_number = 1 -> 2
~ action {
~ source_nat_active_ips = [
- "https://www.googleapis.com/compute/v1/projects/ci-test-project-188019/regions/us-central1/addresses/tf-test-router-nat-kal6esk7c1-addr-2",
+ "projects/ci-test-project-188019/regions/us-central1/addresses/tf-test-router-nat-kal6esk7c1-addr-3",
]
+ source_nat_drain_ips  = []
}
}
}
Plan: 0 to add, 1 to change, 0 to destroy.
```

```release-note:none
```