### PR TITLE
Added example for GFE3 global HTTP(S) LB--compute engine backend

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1136,6 +1136,25 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
         ignore_read_extra:
           - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "external_http_lb_mig_backend"
+        primary_resource_type: "google_compute_global_forwarding_rule"
+        primary_resource_id: "default"
+        vars:
+          lb_backend_template: "lb-backend-template"
+          lb_backend_example: "lb-backend-example"
+          fw_allow_health_check: "fw-allow-health-check"
+          lb_ipv4_1: "lb-ipv4-1"
+          http_basic_check: "http-basic-check"
+          web_backend_service: "web-backend-service"
+          web_map_http: "web-map-http"
+          http_lb_proxy: "http-lb-proxy"
+          http_content_rule: "http-content-rule"
+        skip_docs: true
+        skip_test: true # Very similar to external_http_lb_mig_backend_custom_header
+        ignore_read_extra:
+          - "metadata"
+          - "metadata_startup_script"
     properties:
       creationTimestamp: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/mmv1/templates/terraform/examples/external_http_lb_mig_backend.tf.erb
+++ b/mmv1/templates/terraform/examples/external_http_lb_mig_backend.tf.erb
@@ -1,0 +1,139 @@
+# External HTTP load balancer with an CDN-enabled managed instance group backend
+
+# [START cloudloadbalancing_ext_http_gce_instance_template]
+resource "google_compute_instance_template" "default" {
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disk-0"
+    mode         = "READ_WRITE"
+    source_image = "projects/debian-cloud/global/images/family/debian-9"
+    type         = "PERSISTENT"
+  }
+  labels = {
+    managed-by-cnrm = "true"
+  }
+  machine_type = "n1-standard-1"
+  metadata = {
+    startup-script = "#! /bin/bash\n     sudo apt-get update\n     sudo apt-get install apache2 -y\n     sudo a2ensite default-ssl\n     sudo a2enmod ssl\n     sudo vm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\n   http://169.254.169.254/computeMetadata/v1/instance/name)\"\n   sudo echo \"Page served from: $vm_hostname\" | \\\n   tee /var/www/html/index.html\n   sudo systemctl restart apache2"
+  }
+  name = "<%= ctx[:vars]['my_template'] %>"
+  network_interface {
+    access_config {
+      network_tier = "PREMIUM"
+    }
+    network            = "global/networks/default"
+    subnetwork         = "regions/us-east1/subnetworks/default"
+  }
+  region  = "us-east1"
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/pubsub", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+  }
+  tags = ["allow-health-check"]
+}
+# [END cloudloadbalancing_ext_http_gce_instance_template]
+
+# [START cloudloadbalancing_ext_http_gce_instance_mig]
+resource "google_compute_instance_group_manager" "default" {
+  name     = "<%= ctx[:vars]['lb_backend_example'] %>"
+  name     = "lb-backend-example"
+  zone     = "us-east1-b"
+  named_port {
+    name = "http"
+    port = 80
+  }
+  version {
+    instance_template = google_compute_instance_template.default.id
+    name              = "primary"
+  }
+  base_instance_name = "vm"
+  target_size        = 2
+}
+# [END cloudloadbalancing_ext_http_gce_instance_mig]
+
+
+# [START cloudloadbalancing_ext_http_gce_instance_firewall_rule]
+resource "google_compute_firewall" "default" {
+  allow {
+    ports    = ["80"]
+    protocol = "tcp"
+  }
+  direction     = "INGRESS"
+  name          = "<%= ctx[:vars]['fw_allow_health_check'] %>"
+  network       = "global/networks/default"
+  priority      = 1000
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["allow-health-check"]
+}
+# [END cloudloadbalancing_ext_http_gce_instance_firewall_rule]
+
+# [START cloudloadbalancing_ext_http_gce_instance_ip_address]
+resource "google_compute_global_address" "default" {
+  name       = "<%= ctx[:vars]['lb_ipv4_1'] %>"
+  ip_version = "IPV4"
+}
+# [END cloudloadbalancing_ext_http_gce_instance_ip_address]
+
+# [START cloudloadbalancing_ext_http_gce_instance_health_check]
+resource "google_compute_health_check" "default" {
+  check_interval_sec = 5
+  healthy_threshold  = 2
+  http_health_check {
+    port               = 80
+    port_specification = "USE_FIXED_PORT"
+    proxy_header       = "NONE"
+    request_path       = "/"
+  }
+  name                = "<%= ctx[:vars]['http_basic_check'] %>"
+  timeout_sec         = 5
+  unhealthy_threshold = 2
+}
+# [END cloudloadbalancing_ext_http_gce_instance_health_check]
+
+# [START cloudloadbalancing_ext_http_gce_instance_backend_service]
+resource "google_compute_backend_service" "default" {
+  connection_draining_timeout_sec = 0
+  health_checks                   = ["global/healthChecks/http-basic-check"]
+  load_balancing_scheme           = "EXTERNAL_MANAGED"
+  name                            = "<%= ctx[:vars]['web_backend_service'] %>"
+  port_name                       = "http"
+  protocol                        = "HTTP"
+  session_affinity                = "NONE"
+  timeout_sec                     = 30
+  backend {
+    group           = google_compute_instance_group_manager.default.instance_group
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+}
+# [END cloudloadbalancing_ext_http_gce_instance_backend_service]
+
+# [START cloudloadbalancing_ext_http_gce_instance_url_map]
+resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
+  default_service = google_compute_backend_service.default.id
+  name            = "<%= ctx[:vars]['web_map_http'] %>"
+}
+# [END cloudloadbalancing_ext_http_gce_instance_url_map]
+
+# [START cloudloadbalancing_ext_http_gce_instance_target_http_proxy]
+resource "google_compute_target_http_proxy" "default" {
+  name    = "<%= ctx[:vars]['http_lb_proxy'] %>"
+  url_map = google_compute_url_map.default.id
+}
+# [END cloudloadbalancing_ext_http_gce_instance_target_http_proxy]
+
+# [START cloudloadbalancing_ext_http_gce_instance_forwarding_rule]
+resource "google_compute_global_forwarding_rule" "default" {
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  name                  = "<%= ctx[:vars]['http_content_rule'] %>"
+  port_range            = "80-80"
+  target                = google_compute_target_http_proxy.default.id
+}
+# [END cloudloadbalancing_ext_http_gce_instance_forwarding_rule]


### PR DESCRIPTION
Intending for this page:

https://cloud.google.com/load-balancing/docs/https/setup-global-ext-https-compute

```release-note:none
```