### PR TITLE
bq sub for pubsub

### DIFF
--- a/mmv1/products/pubsub/api.yaml
+++ b/mmv1/products/pubsub/api.yaml
@@ -149,7 +149,37 @@ objects:
         description: |
           A set of key/value label pairs to assign to this Subscription.
       - !ruby/object:Api::Type::NestedObject
+        name: 'bigqueryConfig'
+        conflicts: 
+          - push_config
+        description: |
+          If delivery to BigQuery is used with this subscription, this field is used to configure it.
+          Either pushConfig or bigQueryConfig can be set, but not both.
+          If both are empty, then the subscriber will pull and ack messages using API methods.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'table'
+            description: |
+              The name of the table to which to write data, of the form {projectId}.{datasetId}.{tableId}
+            required: true
+          - !ruby/object:Api::Type::Boolean
+            name: 'useTopicSchema'
+            description: |
+              When true, use the topic's schema as the columns to write to in BigQuery, if it exists.
+          - !ruby/object:Api::Type::Boolean
+            name: 'writeMetadata'
+            description: |
+              When true, write the subscription name, messageId, publishTime, attributes, and orderingKey to additional columns in the table.
+              The subscription name, messageId, and publishTime fields are put in their own columns while all other message properties (other than data) are written to a JSON object in the attributes column.
+          - !ruby/object:Api::Type::Boolean
+            name: 'dropUnknownFields'
+            description: |
+              When true and useTopicSchema is true, any fields that are a part of the topic schema that are not part of the BigQuery table schema are dropped when writing to BigQuery.
+              Otherwise, the schemas must be kept in sync and any messages with extra fields are not written and remain in the subscription's backlog.
+      - !ruby/object:Api::Type::NestedObject
         name: 'pushConfig'
+        conflicts: 
+          - bigquery_config
         description: |
           If push delivery is used with this subscription, this field is used to
           configure it. An empty pushConfig signifies that the subscriber will

--- a/mmv1/products/pubsub/terraform.yaml
+++ b/mmv1/products/pubsub/terraform.yaml
@@ -111,6 +111,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           topic_name: "example-topic"
           subscription_name: "example-subscription"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "pubsub_subscription_push_bq"
+        primary_resource_id: "example"
+        vars:
+          topic_name: "example-topic"
+          subscription_name: "example-subscription"
+          dataset_id: "example_dataset"
+          table_id: "example_table"      
     docs: !ruby/object:Provider::Terraform::Docs
       note: |
         You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding 

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_bq.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_bq.tf.erb
@@ -1,0 +1,50 @@
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['subscription_name'] %>"
+  topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.name
+
+  bigquery_config {
+    table = "${google_bigquery_table.test.project}.${google_bigquery_table.test.dataset_id}.${google_bigquery_table.test.table_id}"
+  }
+
+  depends_on = [google_project_iam_member.viewer, google_project_iam_member.editor]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_project_iam_member" "viewer" {
+  project = data.google_project.project.project_id
+  role   = "roles/bigquery.metadataViewer"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "editor" {
+  project = data.google_project.project.project_id
+  role   = "roles/bigquery.dataEditor"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
+}
+
+resource "google_bigquery_table" "test" {
+  deletion_protection = false
+  table_id   = "<%= ctx[:vars]['table_id'] %>"
+  dataset_id = google_bigquery_dataset.test.dataset_id
+
+  schema = <<EOF
+[
+  {
+    "name": "data",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The data"
+  }
+]
+EOF
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/12199


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: add `bigquery_config` to `google_pubsub_subscription`
```
