### PR TITLE
updated references to debian-9-stretch to instead reference debian-11-bullseye

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -3522,14 +3522,14 @@ objects:
 
           To create a disk with one of the public operating system images,
           specify the image by its family name. For example, specify
-          family/debian-9 to use the latest Debian 9 image:
+          family/debian-11 to use the latest Debian 11 image:
 
-          projects/debian-cloud/global/images/family/debian-9
+          projects/debian-cloud/global/images/family/debian-11
 
           Alternatively, use a specific version of a public operating system
           image:
 
-          projects/debian-cloud/global/images/debian-9-stretch-vYYYYMMDD
+          projects/debian-cloud/global/images/debian-11-bullseye-vYYYYMMDD
 
           To create a disk with a private image that you created, specify the
           image name in the following format:

--- a/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1057,7 +1057,7 @@ resource "google_compute_instance" "inspec-instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -97,7 +97,7 @@ instance_template:
   can_ip_forward: false
   scheduling_automatic_restart: true
   scheduling_on_host_maintenance: MIGRATE
-  disk_source_image: debian-cloud/debian-9
+  disk_source_image: debian-cloud/debian-11
   disk_auto_delete: true
   disk_boot: true
   network_interface_network: default

--- a/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
@@ -14,7 +14,7 @@ Get information about a Google Compute Image. Check that your service account ha
 
 ```hcl
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
@@ -52,7 +52,7 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
@@ -76,7 +76,7 @@ resource "google_compute_instance" "vm_instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 
@@ -205,7 +205,7 @@ resource "google_compute_instance" "vm_instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_2_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_2_upgrade.html.markdown
@@ -384,7 +384,7 @@ Use the `disk_encryption_key` block instead:
 
 ```hcl
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -484,7 +484,7 @@ Use the `snapshot_encryption_key` block instead:
 
 ```hcl
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -512,7 +512,7 @@ Use the `source_disk_encryption_key` block instead:
 
 ```hcl
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 resource "google_compute_disk" "my_disk" {

--- a/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
@@ -37,7 +37,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -29,7 +29,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -25,7 +25,7 @@ resource "google_compute_instance_template" "tpl" {
   machine_type = "e2-medium"
 
   disk {
-    source_image = "debian-cloud/debian-9"
+    source_image = "debian-cloud/debian-11"
     auto_delete  = true
     disk_size_gb = 100
     boot         = true

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -78,7 +78,7 @@ resource "google_compute_instance_group" "staging_group" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -42,7 +42,7 @@ resource "google_compute_instance_template" "default" {
 
   // Create a new boot disk from an image
   disk {
-    source_image      = "debian-cloud/debian-9"
+    source_image      = "debian-cloud/debian-11"
     auto_delete       = true
     boot              = true
     // backup the disk every day
@@ -73,7 +73,7 @@ resource "google_compute_instance_template" "default" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -106,7 +106,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -242,7 +242,7 @@ the template to use that specific image:
 
 ```tf
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -270,7 +270,7 @@ resource "google_compute_instance_template" "instance_template" {
 
   // boot disk
   disk {
-    source_image = "debian-cloud/debian-9"
+    source_image = "debian-cloud/debian-11"
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -34,7 +34,7 @@ resource "google_compute_instance" "frontend" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -50,7 +50,7 @@ resource "google_compute_instance" "my-logged-instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/validator/tests/data/example_compute_instance.json
+++ b/mmv1/third_party/validator/tests/data/example_compute_instance.json
@@ -16,7 +16,7 @@
             "autoDelete": true,
             "boot": true,
             "initializeParams": {
-              "sourceImage": "projects/debian-cloud/global/images/family/debian-9"
+              "sourceImage": "projects/debian-cloud/global/images/family/debian-11"
             },
             "mode": "READ_WRITE"
           },

--- a/mmv1/third_party/validator/tests/data/example_compute_instance.tf
+++ b/mmv1/third_party/validator/tests/data/example_compute_instance.tf
@@ -41,7 +41,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/validator/tests/data/full_compute_instance.json
+++ b/mmv1/third_party/validator/tests/data/full_compute_instance.json
@@ -28,7 +28,7 @@
             "initializeParams": {
               "diskSizeGb": "42",
               "diskType": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-standard",
-              "sourceImage": "projects/debian-cloud/global/images/debian-9"
+              "sourceImage": "projects/debian-cloud/global/images/debian-11"
             },
             "mode": "READ_WRITE",
             "source": "projects/{{.Provider.project}}/zones/us-central1-a/disks/test-source"

--- a/mmv1/third_party/validator/tests/data/full_compute_instance.tf
+++ b/mmv1/third_party/validator/tests/data/full_compute_instance.tf
@@ -37,7 +37,7 @@ resource "google_compute_instance" "full_list_default_1" {
     disk_encryption_key_raw = "test-disk_encryption_key_raw"
     initialize_params {
       # TODO: panic in google.resolveImageImageExists if it is not a global image
-      image = "projects/debian-cloud/global/images/debian-9"
+      image = "projects/debian-cloud/global/images/debian-11"
       size  = 42
       type  = "pd-standard"
     }

--- a/mmv1/third_party/validator/tests/data/full_compute_instance.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/full_compute_instance.tfplan.json
@@ -35,7 +35,7 @@
                 "disk_encryption_key_raw": "test-disk_encryption_key_raw",
                 "initialize_params": [
                   {
-                    "image": "projects/debian-cloud/global/images/debian-9",
+                    "image": "projects/debian-cloud/global/images/debian-11",
                     "size": 42,
                     "type": "pd-standard"
                   }
@@ -239,7 +239,7 @@
               "disk_encryption_key_raw": "test-disk_encryption_key_raw",
               "initialize_params": [
                 {
-                  "image": "projects/debian-cloud/global/images/debian-9",
+                  "image": "projects/debian-cloud/global/images/debian-11",
                   "size": 42,
                   "type": "pd-standard"
                 }
@@ -598,7 +598,7 @@
                 "initialize_params": [
                   {
                     "image": {
-                      "constant_value": "projects/debian-cloud/global/images/debian-9"
+                      "constant_value": "projects/debian-cloud/global/images/debian-11"
                     },
                     "size": {
                       "constant_value": 42


### PR DESCRIPTION
debian-9 has been retired and is no longer returned by the API

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
