### PR TITLE
fixed bucket name validation

### DIFF
--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -527,26 +527,26 @@ func fake404(reasonResourceType, resourceName string) *googleapi.Error {
 	}
 }
 
-// validate name of the gcs bucket.
+// validate name of the gcs bucket. Guidelines are located at https://cloud.google.com/storage/docs/naming-buckets
+// this does not attempt to check for IP addresses or close misspellings of "google"
 func checkGCSName(name string) error {
-	MAX_LENGTH := 63
-	var err error
+	if strings.HasPrefix(name, "goog") {
+		return fmt.Errorf("error: bucket name %s cannot start with %q", name, "goog")
+	}
+
+	if strings.Contains(name, "google") {
+		return fmt.Errorf("error: bucket name %s cannot contain %q", name, "google")
+	}
+
+	valid, _ := regexp.MatchString("^[a-z0-9][a-z0-9_.-]{1,220}[a-z0-9]$", name)
+	if !valid {
+		return fmt.Errorf("error: bucket name validation failed %v", name)
+	}
+
 	for _, str := range strings.Split(name, ".") {
-		strLen := len(str)
-		fmt.Println(str)
-		if strLen > MAX_LENGTH {
-			return fmt.Errorf("error: maximum length exceeded %v\n", str)
-		}
-		valid, _ := regexp.MatchString("^[a-z0-9_]+(-[a-z0-9]+)*$", str)
+		valid, _ := regexp.MatchString("^[a-z0-9_-]{1,63}$", str)
 		if !valid {
-			return fmt.Errorf("error: string validation failed %v\n", str)
-		}
-		gPrefix := strings.HasPrefix(str, "goog")
-		if gPrefix {
-			return fmt.Errorf("error: string cannot start with %q %v\n", "goog", str)
-		}
-		if err != nil {
-			break
+			return fmt.Errorf("error: bucket name validation failed %v", str)
 		}
 	}
 	return nil

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -540,7 +540,7 @@ func checkGCSName(name string) error {
 
 	valid, _ := regexp.MatchString("^[a-z0-9][a-z0-9_.-]{1,220}[a-z0-9]$", name)
 	if !valid {
-		return fmt.Errorf("error: bucket name validation failed %v", name)
+		return fmt.Errorf("error: bucket name validation failed %v. See https://cloud.google.com/storage/docs/naming-buckets", name)
 	}
 
 	for _, str := range strings.Split(name, ".") {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12226

Rewrote validation logic and added much-needed unit testing. Invalid cases were tested against the API

[Requirements ](https://cloud.google.com/storage/docs/naming-buckets) implemented:

- Bucket names can only contain lowercase letters, numeric characters, dashes (-), underscores (_), and dots (.). Spaces are not allowed.
- Bucket names must start and end with a number or letter.
- Bucket names must contain 3-63 characters. Names containing dots can contain up to 222 characters, but each dot-separated component can be no longer than 63 characters.
- Bucket names cannot begin with the "goog" prefix.
- Bucket names cannot contain "google" 

NOT implemented:
- Names containing dots require [verification](https://cloud.google.com/storage/docs/domain-name-verification).
- Bucket names cannot be represented as an IP address in dotted-decimal notation (for example, 192.168.5.4).
- Bucket names cannot contain close misspellings of "google", such as "g00gle".

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed a bug in `google_storage_bucket` where `name` was incorrectly validated.
```
