### PR TITLE
Updated debian-9 to debian-11 for some examples

### DIFF
--- a/mmv1/templates/terraform/examples/instance_custom_hostname.tf.erb
+++ b/mmv1/templates/terraform/examples/instance_custom_hostname.tf.erb
@@ -10,7 +10,7 @@ resource "google_compute_instance" "<%= ctx[:primary_resource_id] %>" {
   
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
   network_interface {

--- a/mmv1/templates/terraform/examples/instance_virtual_display_enabled.tf.erb
+++ b/mmv1/templates/terraform/examples/instance_virtual_display_enabled.tf.erb
@@ -10,7 +10,7 @@ resource "google_compute_instance" "<%= ctx[:primary_resource_id] %>" {
   
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
   network_interface {

--- a/mmv1/templates/terraform/examples/instance_with_ip.tf.erb
+++ b/mmv1/templates/terraform/examples/instance_with_ip.tf.erb
@@ -3,7 +3,7 @@ resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/examples/kms_secret_ciphertext_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/kms_secret_ciphertext_basic.tf.erb
@@ -25,7 +25,7 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/templates/terraform/examples/machine_image_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/machine_image_basic.tf.erb
@@ -5,7 +5,7 @@ resource "google_compute_instance" "vm" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/templates/terraform/examples/network_endpoint.tf.erb
+++ b/mmv1/templates/terraform/examples/network_endpoint.tf.erb
@@ -7,7 +7,7 @@ resource "google_compute_network_endpoint" "<%= ctx[:primary_resource_id] %>" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_instances.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_instances.tf.erb
@@ -51,7 +51,7 @@ resource "google_compute_network" "vpc" {
 }
 
 data "google_compute_image" "debian_9" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 # [END networkmanagement_test_instances]

--- a/mmv1/templates/terraform/examples/os_config_guest_policies_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_guest_policies_basic.tf.erb
@@ -1,6 +1,6 @@
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_instance.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_instance.tf.erb
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -20,7 +20,7 @@ resource "google_compute_instance_template" "foobar" {
   machine_type = "e2-standard-4"
 
   disk {
-    source_image = "debian-cloud/debian-9"
+    source_image = "debian-cloud/debian-11"
     disk_size_gb = 250
   }
 
@@ -66,6 +66,6 @@ resource "google_compute_region_instance_group_manager" "foobar" {
 }
 
 data "google_compute_image" "debian_9" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/examples/region_backend_service_balancing_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/region_backend_service_balancing_mode.tf.erb
@@ -16,7 +16,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family   = "debian-9"
+  family   = "debian-11"
   project  = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/examples/region_disk_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/region_disk_basic.tf.erb
@@ -10,7 +10,7 @@ resource "google_compute_region_disk" "regiondisk" {
 
 resource "google_compute_disk" "disk" {
   name  = "<%= ctx[:vars]['disk_name'] %>"
-  image = "debian-cloud/debian-9"
+  image = "debian-cloud/debian-11"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"

--- a/mmv1/templates/terraform/examples/region_disk_resource_policy_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/region_disk_resource_policy_attachment_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_compute_region_disk_resource_policy_attachment" "<%= ctx[:prima
 
 resource "google_compute_disk" "disk" {
   name  = "<%= ctx[:vars]['base_disk_name'] %>"
-  image = "debian-cloud/debian-9"
+  image = "debian-cloud/debian-11"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -41,6 +41,6 @@ resource "google_compute_resource_policy" "policy" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/examples/snapshot_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/snapshot_basic.tf.erb
@@ -9,7 +9,7 @@ resource "google_compute_snapshot" "<%= ctx[:primary_resource_id] %>" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/examples/spot_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/spot_instance_basic.tf.erb
@@ -7,7 +7,7 @@ resource "google_compute_instance" "<%= ctx[:primary_resource_id] %>" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
   

--- a/mmv1/templates/terraform/examples/stateful_igm.tf.erb
+++ b/mmv1/templates/terraform/examples/stateful_igm.tf.erb
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -42,7 +42,7 @@ resource "google_compute_disk" "default" {
   name  = "test-disk-%{random_suffix}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "debian-9-stretch-v20200805"
+  image = "debian-11-bullseye-v20220719"
   physical_block_size_bytes = 4096
 }
 

--- a/mmv1/templates/terraform/examples/stateful_rigm.tf.erb
+++ b/mmv1/templates/terraform/examples/stateful_rigm.tf.erb
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -48,7 +48,7 @@ resource "google_compute_disk" "default" {
   name  = "test-disk-%{random_suffix}"
   type  = "pd-ssd"
   zone  = "us-central1-a"
-  image = "debian-9-stretch-v20200805"
+  image = "debian-11-bullseye-v20220719"
   physical_block_size_bytes = 4096
 }
 

--- a/mmv1/templates/terraform/examples/target_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/target_instance_basic.tf.erb
@@ -4,7 +4,7 @@ resource "google_compute_target_instance" "<%= ctx[:primary_resource_id] %>" {
 }
 
 data "google_compute_image" "vmimage" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
