### PR TITLE
Updated some tests from debian-9 to debian-11

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_compute_image_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_image_test.go
@@ -82,7 +82,7 @@ func testAccDataSourceCheckPublicImage() resource.TestCheckFunc {
 
 		ds_attr := ds.Primary.Attributes
 		attrs_to_test := map[string]string{
-			"family": "debian-9",
+			"family": "debian-11",
 		}
 
 		for attr, expect_value := range attrs_to_test {
@@ -96,7 +96,7 @@ func testAccDataSourceCheckPublicImage() resource.TestCheckFunc {
 			}
 		}
 
-		selfLink := "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20171129"
+		selfLink := "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20220719"
 
 		if !compareSelfLinkOrResourceName("", ds_attr["self_link"], selfLink, nil) && ds_attr["self_link"] != selfLink {
 			return fmt.Errorf("self link does not match: %s vs %s", ds_attr["self_link"], selfLink)
@@ -109,7 +109,7 @@ func testAccDataSourceCheckPublicImage() resource.TestCheckFunc {
 var testAccDataSourcePublicImageConfig = `
 data "google_compute_image" "debian" {
   project = "debian-cloud"
-  name    = "debian-9-stretch-v20171129"
+  name    = "debian-11-bullseye-v20220719"
 }
 `
 

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
@@ -36,7 +36,7 @@ resource "google_compute_target_pool" "foo" {
 
 data "google_compute_image" "debian" {
   project = "debian-cloud"
-  name    = "debian-9-stretch-v20171129"
+  name    = "debian-11-bullseye-v20220719"
 }
 
 resource "google_compute_instance_template" "foo" {

--- a/mmv1/third_party/terraform/tests/resource_compute_attached_disk_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_attached_disk_test.go
@@ -204,7 +204,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 
@@ -234,7 +234,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 
@@ -265,7 +265,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -170,7 +170,7 @@ func TestAccComputeAutoscaler_scaleInControlFixed(t *testing.T) {
 func testAccComputeAutoscaler_scaffolding(itName, tpName, igmName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -959,7 +959,7 @@ func testAccComputeBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1016,7 +1016,7 @@ func testAccComputeBackendService_withBackendAndMaxUtilization(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1074,7 +1074,7 @@ func testAccComputeBackendService_withBackendAndIAP(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1283,7 +1283,7 @@ func testAccComputeBackendService_withMaxConnections(
 	serviceName, igName, itName, checkName string, maxConnections int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1340,7 +1340,7 @@ func testAccComputeBackendService_withMaxConnectionsPerInstance(
 	serviceName, igName, itName, checkName string, maxConnectionsPerInstance int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1413,7 +1413,7 @@ resource "google_compute_backend_service" "lipsum" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1491,7 +1491,7 @@ resource "google_compute_backend_service" "lipsum" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -1640,7 +1640,7 @@ resource "google_compute_url_map" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_resource_policy_attachment_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_resource_policy_attachment_test.go
@@ -43,7 +43,7 @@ func TestAccComputeDiskResourcePolicyAttachment_update(t *testing.T) {
 func testAccComputeDiskResourcePolicyAttachment_basic(diskName, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
