### PR TITLE
Updated some tests from debian-9 to debian-11 (9/?)

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_iam_test.go
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_iam_test.go
@@ -62,7 +62,7 @@ func testAccComputeInstanceIamPolicy_basic(zone, instanceName, roleId string) st
 
     boot_disk {
       initialize_params {
-        image = "debian-cloud/debian-9"
+        image = "debian-cloud/debian-11"
       }
     }
 

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_instance_group_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_instance_group_test.go.erb
@@ -199,7 +199,7 @@ func testAccCheckDataSourceGoogleComputeInstanceGroup(dataSourceName string) res
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfig(instanceName, igName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -242,7 +242,7 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort(instanceName, igName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -295,7 +295,7 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroup_fromIGM(igmName, secondIgmName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_from_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_from_template_test.go.erb
@@ -244,7 +244,7 @@ func testAccCheckComputeInstanceFromTemplateDestroyProducer(t *testing.T) func(s
 func testAccComputeInstanceFromTemplate_basic(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -318,7 +318,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_overrideBootDisk(templateDisk, overrideDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -383,7 +383,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideAttachedDisk(templateDisk, overrideDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -421,7 +421,7 @@ resource "google_compute_instance_template" "template" {
   }
 
   disk {
-    source_image = "debian-cloud/debian-9"
+    source_image = "debian-cloud/debian-11"
     auto_delete  = true
     boot         = false
   }
@@ -448,7 +448,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideScratchDisk(templateDisk, overrideDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -510,7 +510,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideScheduling(templateDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -561,7 +561,7 @@ func testAccComputeInstanceFromTemplate_012_removableFieldsTpl(template string) 
 
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -638,7 +638,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
