### PR TITLE
Updated some tests from debian-9 to debian-11 (12/?)

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_instance_migrate_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_migrate_test.go.erb
@@ -97,7 +97,7 @@ func TestAccComputeInstanceMigrateState(t *testing.T) {
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 		},
@@ -169,7 +169,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 		},
@@ -237,7 +237,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 		},
@@ -299,7 +299,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	diskName := fmt.Sprintf("instance-test-%s", randString(t, 10))
 	disk := &compute.Disk{
 		Name:        diskName,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+		SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 		Zone:        zone,
 	}
 	op, err := config.NewComputeClient(config.userAgent).Disks.Insert(config.Project, zone, disk).Do()
@@ -320,7 +320,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
@@ -380,7 +380,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	diskName := fmt.Sprintf("instance-test-%s", randString(t, 10))
 	disk := &compute.Disk{
 		Name:        diskName,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+		SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 		Zone:        zone,
 	}
 	op, err := config.NewComputeClient(config.userAgent).Disks.Insert(config.Project, zone, disk).Do()
@@ -401,7 +401,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
@@ -464,13 +464,13 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{
 					RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -497,7 +497,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-9",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-11",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone":                              zone,
@@ -533,13 +533,13 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{
 					RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -566,7 +566,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-9",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-11",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone":                              zone,
@@ -601,19 +601,19 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
+					SourceImage: "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
 				},
 			},
 		},
@@ -637,9 +637,9 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-9",
+		"disk.1.image":       "global/images/family/debian-11",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -674,19 +674,19 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
+					SourceImage: "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
 				},
 			},
 		},
@@ -710,9 +710,9 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-9",
+		"disk.1.image":       "global/images/family/debian-11",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -747,7 +747,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{
@@ -813,7 +813,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 				Boot:       true,
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-11",
 				},
 			},
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
