### PR TITLE
Final updates from debian-9 to debian-11

### DIFF
--- a/mmv1/templates/terraform/constants/disk.erb
+++ b/mmv1/templates/terraform/constants/disk.erb
@@ -111,7 +111,7 @@ func diskImageEquals(oldImageName, newImageName string) bool {
 
 func diskImageFamilyEquals(imageName, familyName string) bool {
 	// Handles the case when the image name includes the family name
-	// e.g. image name: debian-11-drawfork-v20180109, family name: debian-11
+	// e.g. image name: debian-11-bullseye-v20220719, family name: debian-11
 	// We have to check for arm64 because of cases like:
 	// image name: opensuse-leap-15-4-v20220713-arm64, family name: opensuse-leap (should not suppress)
 	if strings.Contains(imageName, strings.TrimSuffix(familyName, "-arm64")) {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_test.go.erb
@@ -326,7 +326,7 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup 
 func testAccComputeInstanceGroup_basic(zone, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -381,7 +381,7 @@ resource "google_compute_instance_group" "empty" {
 func testAccComputeInstanceGroup_rename(instance, instanceGroup, backend, health string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -444,7 +444,7 @@ resource "google_compute_https_health_check" "healthcheck" {
 func testAccComputeInstanceGroup_update(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -487,7 +487,7 @@ resource "google_compute_instance_group" "update" {
 func testAccComputeInstanceGroup_update2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -530,7 +530,7 @@ resource "google_compute_instance_group" "update" {
 func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 
@@ -588,7 +588,7 @@ resource "google_compute_instance_group" "group" {
 func testAccComputeInstanceGroup_network(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-9"
+  family  = "debian-11"
   project = "debian-cloud"
 }
 

--- a/tpgtools/ignored_handwritten/disk_utils.go
+++ b/tpgtools/ignored_handwritten/disk_utils.go
@@ -120,7 +120,7 @@ func diskImageEquals(oldImageName, newImageName string) bool {
 
 func diskImageFamilyEquals(imageName, familyName string) bool {
 	// Handles the case when the image name includes the family name
-	// e.g. image name: debian-9-drawfork-v20180109, family name: debian-9
+	// e.g. image name: debian-11-bullseye-v20220719, family name: debian-11
 	if strings.Contains(imageName, familyName) {
 		return true
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Apparently missed a couple yesterday


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
