### PR TITLE
Make Network Endpoint Port optional

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8227,7 +8227,6 @@ objects:
         name: 'port'
         description: |
           Port number of network endpoint.
-        required: true
       - !ruby/object:Api::Type::String
         name: 'ipAddress'
         description: |

--- a/mmv1/templates/terraform/pre_delete/compute_network_endpoint.go.erb
+++ b/mmv1/templates/terraform/pre_delete/compute_network_endpoint.go.erb
@@ -11,7 +11,9 @@ portProp, err := expandNestedComputeNetworkEndpointPort(d.Get("port"), d, config
 if err != nil {
 	return err
 }
-toDelete["port"] = portProp
+if portProp != 0 {
+	toDelete["port"] = portProp
+}
 
 ipAddressProp, err := expandNestedComputeNetworkEndpointIpAddress(d.Get("ip_address"), d, config)
 if err != nil {

--- a/mmv1/third_party/terraform/tests/resource_compute_network_endpoint_group_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_endpoint_group_test.go.erb
@@ -96,29 +96,29 @@ resource "google_compute_network" "internal" {
 }
 
 resource "google_compute_subnetwork" "internal"{
-	name                    = "tf-test-my-subnetwork%{random_suffix}"
-	network                 = google_compute_network.internal.id
-	ip_cidr_range           = "10.128.0.0/20"
-	region                  = "us-central1"
-	private_ip_google_access= true
+  name                    = "tf-test-my-subnetwork%{random_suffix}"
+  network                 = google_compute_network.internal.id
+  ip_cidr_range           = "10.128.0.0/20"
+  region                  = "us-central1"
+  private_ip_google_access= true
 }
 
 resource "google_compute_instance" "default" {
-	name         = "tf-test-neg-%{random_suffix}"
-	machine_type = "e2-medium"
+  name         = "tf-test-neg-%{random_suffix}"
+  machine_type = "e2-medium"
   
-	boot_disk {
-	  initialize_params {
-		image = "debian-8-jessie-v20160803"
-		}
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+   }
   
-	network_interface {
-	  subnetwork = google_compute_subnetwork.internal.self_link
-	  access_config {
-	  }
-	}
+  network_interface {
+    subnetwork = google_compute_subnetwork.internal.self_link
+    access_config {
+    }
+  }
 }
-  
+
 `, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_network_endpoint_group_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_endpoint_group_test.go.erb
@@ -32,6 +32,31 @@ func TestAccComputeNetworkEndpointGroup_networkEndpointGroup(t *testing.T) {
 	})
 }
 
+func TestAccComputeNetworkEndpointGroup_internalEndpoint(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeNetworkEndpointGroupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNetworkEndpointGroup_internalEndpoint(context),
+			},
+			{
+				ResourceName:            "google_compute_network_endpoint_group.neg",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"network", "subnetwork", "zone"},
+			},
+		},
+	})
+}
+
 func testAccComputeNetworkEndpointGroup_networkEndpointGroup(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network_endpoint_group" "neg" {
@@ -45,5 +70,55 @@ resource "google_compute_network" "default" {
   name                    = "tf-test-neg-network%{random_suffix}"
   auto_create_subnetworks = true
 }
+`, context)
+}
+
+func testAccComputeNetworkEndpointGroup_internalEndpoint(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network_endpoint_group" "neg" {
+  name                  = "tf-test-my-lb-neg%{random_suffix}"
+  network               = google_compute_network.internal.id
+  subnetwork            = google_compute_subnetwork.internal.id
+  zone                  = "us-central1-a"
+  network_endpoint_type = "GCE_VM_IP"
+}
+
+resource "google_compute_network_endpoint" "endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  #ip_address             = "127.0.0.1"
+  instance   = google_compute_instance.default.name
+  ip_address = google_compute_instance.default.network_interface[0].network_ip
+}
+
+resource "google_compute_network" "internal" {
+  name                    = "tf-test-neg-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "internal"{
+	name                    = "tf-test-my-subnetwork%{random_suffix}"
+	network                 = google_compute_network.internal.id
+	ip_cidr_range           = "10.128.0.0/20"
+	region                  = "us-central1"
+	private_ip_google_access= true
+}
+
+resource "google_compute_instance" "default" {
+	name         = "tf-test-neg-%{random_suffix}"
+	machine_type = "e2-medium"
+  
+	boot_disk {
+	  initialize_params {
+		image = "debian-8-jessie-v20160803"
+		}
+	}
+  
+	network_interface {
+	  subnetwork = google_compute_subnetwork.internal.self_link
+	  access_config {
+	  }
+	}
+}
+  
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



Closes https://github.com/hashicorp/terraform-provider-google/issues/11189
b/222103710

https://github.com/GoogleCloudPlatform/magic-modules/pull/6182 added `GCE_VM_IP` to NEGs, but NE's for NEG's of this type cannot have ports


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: made `port` optional in `google_compute_network_endpoint` to be associated with `GCE_VM_IP` network endpoint groups
```
