### PR TITLE
Rework terraform test image to support the remove of the metalinter

### DIFF
--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -76,16 +76,20 @@ make
 lint_exit_code=$?
 test_exit_code=1
 
+# TODO: remove on 2022/08/18 or later.
+# note: maintain (degraded) backwards compatibility with the old lint rule which
+# needs tools run in advance
+# note: this will silently fail on newer makefiles, as we are in a +e block
 make tools
+
+make lint
 lint_exit_code=$(($lint_exit_code || $?))
 
-if [ $lint_exit_code -eq 0 ]; then
-    # only run lint & tests if the code compiled and tools downloaded
-    make lint
-    lint_exit_code=$(($lint_exit_code || $?))
-    make test
-    test_exit_code=$?
-fi
+# note: test has a dependency on lint (which runs fmtcheck and vet) so it will
+# run them a second time.
+make test
+test_exit_code=$?
+
 
 make docscheck
 lint_exit_code=$(($lint_exit_code || $?))


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Written to run against https://github.com/hashicorp/terraform-provider-google/pull/12259, other than the `make tools` line.

This should work against both old+new versions of the makefile, at least in theory. If I'm wrong we can probably just roll forward and look for folks to rebase.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
