### PR TITLE
chore: fix region tags

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_static_outbound.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_static_outbound.tf.erb
@@ -75,7 +75,7 @@ resource "google_compute_router_nat" "default" {
 }
 # [END cloudrun_service_static_nat]
 
-# [START cloudrun_service_service]
+# [START cloudrun_service_static_service]
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   name     = "<%= ctx[:vars]['cloudrun_static_ip_service'] %>"
@@ -99,4 +99,4 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 }
-# [END cloudrun_service_service]
+# [END cloudrun_service_static_service]


### PR DESCRIPTION
```release-note:none
```

Fix typos in a(n ambiguous) region tag