### PR TITLE
Support serviceAccount field for AppEngine flex

### DIFF
--- a/mmv1/products/appengine/api.yaml
+++ b/mmv1/products/appengine/api.yaml
@@ -898,6 +898,11 @@ objects:
         name: 'runtimeMainExecutablePath'
         description: |
           The path or name of the app's main executable.
+      - !ruby/object:Api::Type::String
+          name: 'serviceAccount'
+          description: |
+            The identity that the deployed version will run as. Admin API will use the App Engine Appspot service account as
+            default if this field is neither provided in app.yaml file nor through CLI flag.
       - !ruby/object:Api::Type::NestedObject
         name: 'apiConfig'
         description: |

--- a/mmv1/products/appengine/terraform.yaml
+++ b/mmv1/products/appengine/terraform.yaml
@@ -27,7 +27,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "rule"
         vars:
           project_id: "ae-project"
-          account_id: "my-account"
         test_env_vars:
           org_id: :ORG_ID
   StandardAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
@@ -147,6 +146,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           bucket_name: "appengine-static-content"
           project: "appeng-flex"
+          account_id: "my-account"
         test_env_vars:
           org_id: :ORG_ID
           billing_account: :BILLING_ACCT

--- a/mmv1/products/appengine/terraform.yaml
+++ b/mmv1/products/appengine/terraform.yaml
@@ -27,6 +27,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "rule"
         vars:
           project_id: "ae-project"
+          account_id: "my-account"
         test_env_vars:
           org_id: :ORG_ID
   StandardAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -26,7 +26,13 @@ resource "google_service_account" "custom_service_account" {
 resource "google_project_iam_member" "gae_api" {
   project = google_project_service.service.project
   role    = "roles/compute.networkUser"
-  member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
+  member  = "serviceAccount:${google_service_account.custom_service_account.email}"
+}
+
+resource "google_project_iam_member" "logs_writer" {
+  project = google_project_service.service.project
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }
 
 resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -17,6 +17,11 @@ resource "google_project_service" "service" {
   disable_dependent_services = false
 }
 
+resource "google_service_account" "custom_service_account" {
+  account_id   = "<%= ctx[:vars]['account_id'] %>"
+  display_name = "Custom Service Account"
+}
+
 resource "google_project_iam_member" "gae_api" {
   project = google_project_service.service.project
   role    = "roles/compute.networkUser"
@@ -71,6 +76,7 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
   }
 
   noop_on_destroy = true
+  service_account = google_service_account.custom_service_account.id
 }
 
 resource "google_storage_bucket" "bucket" {

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -18,7 +18,7 @@ resource "google_project_service" "service" {
 }
 
 resource "google_service_account" "custom_service_account" {
-  account_id   = "<%= ctx[:vars]['account_id'] %>"
+  account_id   = "my-account"
   display_name = "Custom Service Account"
 }
 

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -35,6 +35,12 @@ resource "google_project_iam_member" "logs_writer" {
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }
 
+resource "google_project_iam_member" "storage_viewer" {
+  project = google_project_service.service.project
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.custom_service_account.email}"
+}
+
 resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id] %>" {
   version_id = "v1"
   project    = google_project_iam_member.gae_api.project

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -18,7 +18,7 @@ resource "google_project_service" "service" {
 }
 
 resource "google_service_account" "custom_service_account" {
-  project      = google_project_iam_member.gae_api.project
+  project      = google_project_service.service.project
   account_id   = "<%= ctx[:vars]['account_id'] %>"
   display_name = "Custom Service Account"
 }

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -18,7 +18,8 @@ resource "google_project_service" "service" {
 }
 
 resource "google_service_account" "custom_service_account" {
-  account_id   = "my-account"
+  project      = google_project_iam_member.gae_api.project
+  account_id   = "<%= ctx[:vars]['account_id'] %>"
   display_name = "Custom Service Account"
 }
 

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -77,7 +77,7 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
   }
 
   noop_on_destroy = true
-  service_account = google_service_account.custom_service_account.id
+  service_account = google_service_account.custom_service_account.email
 }
 
 resource "google_storage_bucket" "bucket" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/11813


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
appengine: Added field `serviceAccount` to `app_engine_flexible_app_version`
```
