### PR TITLE
fix VCR build logs and test status

### DIFF
--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -174,10 +174,22 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   test_exit_code=0
   for failed_test in $FAILED_TESTS
   do
-      TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel 1 -v -run=$failed_test -timeout 90m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" >> recording_test.log &
-      test_exit_code=$(($test_exit_code || $?))
+      TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -parallel 1 -v -run=$failed_test -timeout 90m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" > ${failed_test}_recording_test.log & pids+=($!)
   done
-  wait
+
+  # Check if any process fails 
+  for pid in ${pids[*]}; do
+    if ! wait $pid; then
+        test_exit_code=1
+    fi
+  done
+
+  # Concatenate recording build logs to one file
+  # Note: build logs are different from debug logs
+  for failed_test in $FAILED_TESTS
+  do
+    cat ${failed_test}_recording_test.log >> recording_test.log
+  done
 
   # store cassettes
   gsutil -m -q cp fixtures/* gs://ci-vcr-cassettes/beta/refs/heads/auto-pr-$pr_number/fixtures/


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR fixes:
-  Multiple test logs write into a single build log at the same time and it makes the build log hard to read(e.g. [build log](https://00f74ba44bafda96412994e0d87d8759bd1b0c6efc-apidata.googleusercontent.com/download/storage/v1/b/ci-vcr-logs/o/beta%2Frefs%2Fheads%2Fauto-pr-6270%2Fartifacts%2F3cbbe9f4-a090-4073-98d4-01c90461ca06%2Fbuild-log%2Frecording_test.log?jk=AFshE3WhkqryyWe4OSWS-P37GHOsnQtMnb5ZrxpdLa3SqJrOvUCYjQoSt3MEAGrJa15lrqyjCYaBEX8m0gLGCiAo7Kb7rR809gsat366UonEy_3qpLtOWy2TbQO9bAw5CXELLNSUjwNzmM_MZnzdaHjPUoDGE-F8CJ4RE71sIZ2nv901VhgQgX5vFrkGQvoJiesdyl8qO4lnKedx0AWAF1hFknQxc4fPER5hhTEOUhWLZqs94DrIJCZpmZ5LCVb0i1DszdAABYsQopiRsewQ8FRK4ljSIlnT20FtzJxiMx-f5GRxZEP4D1ptO5Qq6lhgZoMxE-jE_T3UK8e9Vb4P2ocR1ksZB0CpDSfIVMthva_xlAdB8UxYNvTxfg3JeBmwtdoFG3zAzyNj9SkktBnAdbWUnx8vA4tEEDjZtD8KvpNpnnlsB4wMfy-63io-8qZHQBDLKYgfyMceuPss9YbExmZcx33j9mINQqPCBgtMdphIL__mneHvt5eWkofhIM0hqD4mOfg28FloYiaXoUx-eioHlxcWa2qA574VEVR_xgFlXCJzv11yEy3f6RREkzmMbDIlqDiWtX1ICKDLeH70jXjqXVN4xDEtXWlL1x7O-pJy786f71svlSWZ_c-2CxRsbT1y5qITZM8dxf33PD3jU3HOSbxvHDuQgZwRtGHnB8ryT5lzNSsm1IACQHjk5j6ounxjSFHPeaTo-SLu6PfSkKpS4Sr3rFVaN7gHo6eARuwTT7yByi3iJJJZdwhPb8Ag0qnKJin9Qtc7m-XeOIJuKZixeewwvjhoANDJ_1ICgiT0ij57gwyMzoLGVXK6czRQFdafivQTxQpilAreK5iwCW6BR1BLxj3qejQEDCfHtqLfDP-kUKbKp8fkHP7n-HuGnP5apIP29fuBHwlCcFsNkkFa6ci_YyJp2uz8bFWzRso7AdBl7O02hXsW6qtrKjfC0SoAueasmpKLUnt3nUMcNWOGTGGyTs04C31xhUKykcdXwTj1jRoUDphTYnuvhGWCLYjbDk2BCYVeJovbvKwIW3B5QDub4-ivdqIevXzFe4zvYX3ftF-B6rHKQwKrkBfwLRXZA0p5PCR-Rjuo0xXhcWPpBRlQUNdOuejzES-kd24YAvvAqCVT2A&isca=1))
- Test status of VCR recording tests is not generated correctly (e.g. multiple tests failed during VCR recording https://github.com/GoogleCloudPlatform/magic-modules/pull/6270#issuecomment-1207276365 but the VCR tests status got a green check)




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
