### PR TITLE
Clarify format of `limit` string in service quota override resources

### DIFF
--- a/mmv1/products/serviceusage/api.yaml
+++ b/mmv1/products/serviceusage/api.yaml
@@ -106,7 +106,6 @@ objects:
 
           ~> Make sure that `limit` is in a format that doesn't start with `1/` or contain curly braces.
           E.g. use `/project/user` instead of `1/{project}/{user}`.
-          The format used in the provider differs from format used by the gcloud CLI (due to the feature being in beta).
     properties:
       - !ruby/object:Api::Type::String
         name: 'overrideValue'
@@ -196,7 +195,6 @@ objects:
 
           ~> Make sure that `limit` is in a format that doesn't start with `1/` or contain curly braces.
           E.g. use `/project/user` instead of `1/{project}/{user}`.
-          The format used in the provider differs from format used by the gcloud CLI (due to the feature being in beta).
     properties:
       - !ruby/object:Api::Type::String
         name: 'overrideValue'

--- a/mmv1/products/serviceusage/api.yaml
+++ b/mmv1/products/serviceusage/api.yaml
@@ -103,6 +103,10 @@ objects:
         input: true
         description: |
           The limit on the metric, e.g. `/project/region`.
+
+          ~> Make sure that `limit` is in a format that doesn't start with `1/` or contain curly braces.
+          E.g. use `/project/user` instead of `1/{project}/{user}`.
+          The format used in the provider differs from format used by the gcloud CLI (due to the feature being in beta).
     properties:
       - !ruby/object:Api::Type::String
         name: 'overrideValue'
@@ -189,6 +193,10 @@ objects:
         input: true
         description: |
           The limit on the metric, e.g. `/project/region`.
+
+          ~> Make sure that `limit` is in a format that doesn't start with `1/` or contain curly braces.
+          E.g. use `/project/user` instead of `1/{project}/{user}`.
+          The format used in the provider differs from format used by the gcloud CLI (due to the feature being in beta).
     properties:
       - !ruby/object:Api::Type::String
         name: 'overrideValue'

--- a/mmv1/third_party/terraform/tests/resource_google_service_usage_consumer_quota_override_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_google_service_usage_consumer_quota_override_test.go.erb
@@ -1,0 +1,53 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccServiceUsageConsumerQuotaOverride_consumerQuotaOverrideCustomIncorrectLimitFormat(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        getTestOrgFromEnv(t),
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersOiCS,
+		CheckDestroy: testAccCheckServiceUsageConsumerQuotaOverrideDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccServiceUsageConsumerQuotaOverride_consumerQuotaOverrideCustomIncorrectLimitFormat(context),
+				ExpectError: regexp.MustCompile("No quota limit with limitId"),
+			},
+		},
+	})
+}
+
+func testAccServiceUsageConsumerQuotaOverride_consumerQuotaOverrideCustomIncorrectLimitFormat(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_project" "my_project" {
+  provider   = google-beta
+  name       = "tf-test-project"
+  project_id = "quota%{random_suffix}"
+  org_id     = "%{org_id}"
+}
+
+resource "google_service_usage_consumer_quota_override" "override" {
+  provider       = google-beta
+  project        = google_project.my_project.project_id
+  service        = urlencode("bigquery.googleapis.com")
+  metric         = urlencode("bigquery.googleapis.com/quota/query/usage")
+  limit          = urlencode("1/d/{project}/{user}") # Incorrect format for the API the provider uses, correct format for the gcloud CLI
+  override_value = "1"
+  force          = true
+}
+`, context)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

# Description

Relates to this issue : https://github.com/hashicorp/terraform-provider-google/issues/12253

The `google_service_usage_consumer_quota_override` resource uses a different version of the [customer quota metrics API](https://cloud.google.com/service-usage/docs/reference/rest/v1beta1/services.consumerQuotaMetrics.limits.consumerOverrides) than the gcloud CLI, and the format of the units used by the override differs between each API version.

This PR:
- Adds guidance to the resource's documentation, to help users avoid the issue
- Adds a test that asserts that the `1/{project}/{user}` format style is incorrect for the provider, to help people understand expected behaviour

I decided against adding validation on the `limit` field because what is 'wrong' now will eventually be correct once the resource is updated to use the newer API

# List

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~ N/A
- [x] ~~[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~ N/A
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```