### PR TITLE
Fix new lint errors introduced in Go 1.19.0

### DIFF
--- a/mmv1/templates/terraform/constants/region_backend_service.go.erb
+++ b/mmv1/templates/terraform/constants/region_backend_service.go.erb
@@ -28,7 +28,7 @@ var backendServiceOnlyManagedFieldNames = []string{
 
 // validateManagedBackendServiceBackends ensures capacity_scaler is set for each backend in a managed
 // backend service. To prevent a permadiff, we decided to override the API behavior and require the
-//// capacity_scaler value in this case.
+// capacity_scaler value in this case.
 //
 // The API:
 // - requires the sum of the backends' capacity_scalers be > 0

--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -13,6 +13,7 @@
 # limitations under the License.
 -%>
 <%= lines(autogen_notice(:go, pwd)) -%>
+
 package google
 
 import (

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -3,6 +3,7 @@
   has_project = object.base_url.include?("{{project}}")
 -%>
 <%= lines(autogen_notice(:go, pwd)) -%>
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -17,14 +17,14 @@ import (
 // to express a Google Cloud IAM policy in a data resource. This is an example
 // of how the schema would be used in a config:
 //
-// data "google_iam_policy" "admin" {
-//   binding {
-//     role = "roles/storage.objectViewer"
-//     members = [
-//       "user:evanbrown@google.com",
-//     ]
-//   }
-// }
+//	data "google_iam_policy" "admin" {
+//	  binding {
+//	    role = "roles/storage.objectViewer"
+//	    members = [
+//	      "user:evanbrown@google.com",
+//	    ]
+//	  }
+//	}
 func dataSourceGoogleIamPolicy() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGoogleIamPolicyRead,

--- a/mmv1/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
@@ -14,11 +14,10 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
-
-	"sort"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -170,10 +169,9 @@ func dataSourceGoogleSignedUrlRead(d *schema.ResourceData, meta interface{}) err
 
 // loadJwtConfig looks for credentials json in the following places,
 // in order of preference:
-//   1. `credentials` attribute of the datasource
-//   2. `credentials` attribute in the provider definition.
-//   3. A JSON file whose path is specified by the
-//      GOOGLE_APPLICATION_CREDENTIALS environment variable.
+//  1. `credentials` attribute of the datasource
+//  2. `credentials` attribute in the provider definition.
+//  3. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable.
 func loadJwtConfig(d *schema.ResourceData, meta interface{}) (*jwt.Config, error) {
 	config := meta.(*Config)
 
@@ -249,7 +247,6 @@ type UrlData struct {
 // Example output:
 // -------------------
 // GET
-//
 //
 // 1388534400
 // bucket/objectname

--- a/mmv1/third_party/terraform/resources/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_table.go
@@ -276,7 +276,7 @@ func flattenColumnFamily(families []string) []map[string]interface{} {
 	return result
 }
 
-//TODO(rileykarson): Fix the stored import format after rebasing 3.0.0
+// TODO(rileykarson): Fix the stored import format after rebasing 3.0.0
 func resourceBigtableTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if err := parseImportId([]string{

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -2232,13 +2232,14 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 // issues when a count of `0` guest accelerators is desired. This may occur when
 // guest_accelerator support is controlled via a module variable. E.g.:
 //
-// 		guest_accelerators {
-//      	count = "${var.enable_gpu ? var.gpu_count : 0}"
-//          ...
-// 		}
+//	guest_accelerators {
+// 		count = "${var.enable_gpu ? var.gpu_count : 0}"
+// 		...
+//	}
+
 // After reconciling the desired and actual state, we would otherwise see a
-// perpetual resembling:
-// 		[] != [{"count":0, "type": "nvidia-tesla-k80"}]
+// perpetual diff resembling:
+//	[] != [{"count":0, "type": "nvidia-tesla-k80"}]
 func suppressEmptyGuestAcceleratorDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	oldi, newi := d.GetChange("guest_accelerator")
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1,4 +1,4 @@
-// <% autogen_exception -%>
+<% autogen_exception -%>
 
 package google
 

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -572,7 +572,7 @@ func TestAccContainerNodePool_withNodeConfigScopeAlias(t *testing.T) {
 	})
 }
 
-//This test exists to validate a regional node pool *and* and update to it.
+// This test exists to validate a regional node pool *and* and update to it.
 func TestAccContainerNodePool_regionalAutoscaling(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/tests/resource_kms_key_ring_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_key_ring_test.go
@@ -99,10 +99,8 @@ func TestAccKmsKeyRing_basic(t *testing.T) {
 	})
 }
 
-/*
-	KMS KeyRings cannot be deleted. This ensures that the KeyRing resource was removed from state,
-	even though the server-side resource was not removed.
-*/
+// KMS KeyRings cannot be deleted. This ensures that the KeyRing resource was removed from state,
+// even though the server-side resource was not removed.
 func testAccCheckGoogleKmsKeyRingWasRemovedFromState(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, ok := s.RootModule().Resources[resourceName]
@@ -115,10 +113,8 @@ func testAccCheckGoogleKmsKeyRingWasRemovedFromState(resourceName string) resour
 	}
 }
 
-/*
-	This test runs in its own project, otherwise the test project would start to get filled
-	with undeletable resources
-*/
+// This test runs in its own project, otherwise the test project would start to get filled
+// with undeletable resources
 func testGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -1,5 +1,4 @@
-// <% autogen_exception -%>
-
+<% autogen_exception -%>
 package google
 
 import (

--- a/mmv1/third_party/terraform/utils/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates.go
@@ -97,7 +97,7 @@ func isConnectionResetNetworkError(err error) (bool, string) {
 // Retry 409s because some APIs like Cloud SQL throw a 409 if concurrent calls
 // are being made.
 //
-//The only way right now to determine it is a retryable 409 due to
+// The only way right now to determine it is a retryable 409 due to
 // concurrent calls is to look at the contents of the error message.
 // See https://github.com/hashicorp/terraform-provider-google/issues/3279
 func is409OperationInProgressError(err error) (bool, string) {

--- a/mmv1/third_party/terraform/utils/image.go
+++ b/mmv1/third_party/terraform/utils/image.go
@@ -78,13 +78,18 @@ func sanityTestRegexMatches(expected int, got []string, regexType, name string) 
 // If it's in the form global/images/{image}, return it
 // If it's in the form global/images/family/{family}, return it
 // If it's in the form family/{family}, check if it's a family in the current project. If it is, return it as global/images/family/{family}.
-//    If not, check if it could be a GCP-provided family, and if it exists. If it does, return it as projects/{project}/global/images/family/{family}.
+//
+//	If not, check if it could be a GCP-provided family, and if it exists. If it does, return it as projects/{project}/global/images/family/{family}.
+//
 // If it's in the form {project}/{family-or-image}, check if it's an image in the named project. If it is, return it as projects/{project}/global/images/{image}.
-//    If not, check if it's a family in the named project. If it is, return it as projects/{project}/global/images/family/{family}.
+//
+//	If not, check if it's a family in the named project. If it is, return it as projects/{project}/global/images/family/{family}.
+//
 // If it's in the form {family-or-image}, check if it's an image in the current project. If it is, return it as global/images/{image}.
-//    If not, check if it could be a GCP-provided image, and if it exists. If it does, return it as projects/{project}/global/images/{image}.
-//    If not, check if it's a family in the current project. If it is, return it as global/images/family/{family}.
-//    If not, check if it could be a GCP-provided family, and if it exists. If it does, return it as projects/{project}/global/images/family/{family}
+//
+//	If not, check if it could be a GCP-provided image, and if it exists. If it does, return it as projects/{project}/global/images/{image}.
+//	If not, check if it's a family in the current project. If it is, return it as global/images/family/{family}.
+//	If not, check if it could be a GCP-provided family, and if it exists. If it does, return it as projects/{project}/global/images/family/{family}
 func resolveImage(c *Config, project, name, userAgent string) (string, error) {
 	var builtInProject string
 	for k, v := range imageMap {

--- a/mmv1/third_party/terraform/utils/transport.go.erb
+++ b/mmv1/third_party/terraform/utils/transport.go.erb
@@ -1,4 +1,4 @@
-// <% autogen_exception -%>
+<% autogen_exception -%>
 
 package google
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Go 1.19.0 appears to lint function and package headers expecting tabs in places where spaces were previously acceptable. Fix some templates to add a space between the package definition and code autogen header, and perform various other cleanups.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
