### PR TITLE
GCP compute instance template fields are ForceNew

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -549,6 +549,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 						"instance_termination_action": {
 							Type:          schema.TypeString,
 							Optional:      true,
+							ForceNew:      true,
 							AtLeastOneOf:  schedulingInstTemplateKeys,
 							Description:  `Specifies the action GCE should take when SPOT VM is preempted.`,
 						},


### PR DESCRIPTION
* Compute instance template fields should ForceNew, GCP doesn't support update in place
* Fix "doesn't support update" error when trying to change the instance termination action

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed permadiff for `instance_termination_action` in `google_compute_instance_template`
```

Similar: https://github.com/GoogleCloudPlatform/magic-modules/pull/3493
Related: https://github.com/hashicorp/terraform-provider-google/issues/6317