### PR TITLE
google_dns_managed_zone: add zone ID attribute

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_managed_zone.go
@@ -26,6 +26,12 @@ func dataSourceDnsManagedZone() *schema.Resource {
 				Computed: true,
 			},
 
+			"managed_zone_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Unique identifier for the resource; defined by the server.`,
+			},
+
 			"name_servers": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -69,17 +75,20 @@ func dataSourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) erro
 		return handleNotFoundError(err, d, fmt.Sprintf("dataSourceDnsManagedZone %q", name))
 	}
 
-	if err := d.Set("name_servers", zone.NameServers); err != nil {
-		return fmt.Errorf("Error setting name_servers: %s", err)
+	if err := d.Set("dns_name", zone.DnsName); err != nil {
+		return fmt.Errorf("Error setting dns_name: %s", err)
 	}
 	if err := d.Set("name", zone.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("dns_name", zone.DnsName); err != nil {
-		return fmt.Errorf("Error setting dns_name: %s", err)
-	}
 	if err := d.Set("description", zone.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("managed_zone_id", zone.Id); err != nil {
+		return fmt.Errorf("Error setting managed_zone_id: %s", err)
+	}
+	if err := d.Set("name_servers", zone.NameServers); err != nil {
+		return fmt.Errorf("Error setting name_servers: %s", err)
 	}
 	if err := d.Set("visibility", zone.Visibility); err != nil {
 		return fmt.Errorf("Error setting visibility: %s", err)

--- a/mmv1/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -28,7 +28,6 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 						"forwarding_config.#":         {},
 						"force_destroy":               {},
 						"labels.#": 				   {},
-						"managed_zone_id": 			   {},
 						"creation_time": 			   {},
 <% unless version == "ga" -%>
 						"reverse_lookup":         {},


### PR DESCRIPTION
In [the data source for DNS managed zones](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone), include a new "managed_zone_id" attribute reporting the zone's ID, matching the corresponding [`google_dns_managed_zone` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone)'s [output attribute with the same name](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone#managed_zone_id).

While we're here, revise the order in which we transcribe the fields from the fetched object to the data source's attributes to match the declaration order in the schema.

Supersedes hashicorp/terraform-provider-google#12301.
Relates to #6186.
Fixes hashicorp/terraform-provider-google#7128.

---
I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers).
- [ ] Ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
dns: added `managed_zone_id` attribute to `google_dns_managed_zone` data source
```