### PR TITLE
Added support to app engine for service account

### DIFF
--- a/mmv1/products/appengine/api.yaml
+++ b/mmv1/products/appengine/api.yaml
@@ -293,6 +293,11 @@ objects:
           The version of the API in the given runtime environment.
           Please see the app.yaml reference for valid values at `https://cloud.google.com/appengine/docs/standard/<language>/config/appref`\
           Substitute `<language>` with `python`, `java`, `php`, `ruby`, `go` or `nodejs`.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccount'
+        description: |
+          The identity that the deployed version will run as. Admin API will use the App Engine Appspot
+          service account as default if this field is neither provided in app.yaml file nor through CLI flag.
       - !ruby/object:Api::Type::Array
         name: 'handlers'
         description: |
@@ -492,7 +497,7 @@ objects:
             - :INBOUND_SERVICE_XMPP_MESSAGE
             - :INBOUND_SERVICE_XMPP_SUBSCRIBE
             - :INBOUND_SERVICE_XMPP_PRESENCE
-            - :INBOUND_SERVICE_CHANNEL_PRESENCE	
+            - :INBOUND_SERVICE_CHANNEL_PRESENCE
             - :INBOUND_SERVICE_WARMUP
       - !ruby/object:Api::Type::String
         name: 'instanceClass'
@@ -670,7 +675,7 @@ objects:
             - :INBOUND_SERVICE_XMPP_MESSAGE
             - :INBOUND_SERVICE_XMPP_SUBSCRIBE
             - :INBOUND_SERVICE_XMPP_PRESENCE
-            - :INBOUND_SERVICE_CHANNEL_PRESENCE	
+            - :INBOUND_SERVICE_CHANNEL_PRESENCE
             - :INBOUND_SERVICE_WARMUP
       - !ruby/object:Api::Type::String
         name: 'instanceClass'
@@ -794,6 +799,11 @@ objects:
           The version of the API in the given runtime environment.
           Please see the app.yaml reference for valid values at `https://cloud.google.com/appengine/docs/standard/<language>/config/appref`\
           Substitute `<language>` with `python`, `java`, `php`, `ruby`, `go` or `nodejs`.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccount'
+        description: |
+          The identity that the deployed version will run as. Admin API will use the App Engine Appspot
+          service account as default if this field is neither provided in app.yaml file nor through CLI flag.
       - !ruby/object:Api::Type::Array
         name: 'handlers'
         description: |

--- a/mmv1/products/appengine/terraform.yaml
+++ b/mmv1/products/appengine/terraform.yaml
@@ -153,66 +153,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           org_id: :ORG_ID
           billing_account: :BILLING_ACCT
-  FlexibleAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
-    import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
-    id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
-    mutex: "apps/{{project}}"
-    error_retry_predicates: ["isAppEngineRetryableError"]
-    parameters:
-      service: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-        required: false
-    virtual_fields:
-      - !ruby/object:Api::Type::Boolean
-        name: 'noop_on_destroy'
-        default_value: false
-        description: |
-          If set to `true`, the application version will not be deleted.
-      - !ruby/object:Api::Type::Boolean
-        name: 'delete_service_on_destroy'
-        default_value: false
-        description: |
-          If set to `true`, the service will be deleted if it is the last version.
-    custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/appversion_delete.go.erb
-      test_check_destroy: templates/terraform/custom_check_destroy/skip_delete_during_test.go.erb
-      encoder: templates/terraform/encoders/flex_app_version.go.erb
-    properties:
-      id: !ruby/object:Overrides::Terraform::PropertyOverride
-        name: 'version_id'
-      deployment: !ruby/object:Overrides::Terraform::PropertyOverride
-        custom_flatten: templates/terraform/custom_flatten/app_version.go.erb
-      deployment.container: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-      entrypoint: !ruby/object:Overrides::Terraform::PropertyOverride
-        ignore_read: true
-      envVariables: !ruby/object:Overrides::Terraform::PropertyOverride
-        description:
-          Environment variables available to the application.  As these are not returned
-          in the API request, Terraform will not detect any changes made outside of the Terraform config.
-        ignore_read: true
-      network.subnetworkName: !ruby/object:Overrides::Terraform::PropertyOverride
-        name: 'subnetwork'
-      betaSettings: !ruby/object:Overrides::Terraform::PropertyOverride
-        # https://issuetracker.google.com/issues/150157861
-        ignore_read: true
-        # default_from_api: true
-      # maxConcurrentRequests defaults to a runtime-specific value
-      automaticScaling.maxConcurrentRequests: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-      # runtimeApiVersion defaults to a runtime-specific value
-      runtimeApiVersion: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-      serviceAccount: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-      handlers: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-      inboundServices: !ruby/object:Overrides::Terraform::PropertyOverride
-        is_set: true
-    examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_flexible_app_version_sa"
-        primary_resource_id: "myapp_v1"
+        primary_resource_id: "myapp_sa_v1"
         ignore_read_extra:
           - "noop_on_destroy"
           - "deployment.0.zip"

--- a/mmv1/products/appengine/terraform.yaml
+++ b/mmv1/products/appengine/terraform.yaml
@@ -212,13 +212,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_flexible_app_version_sa"
-        primary_resource_id: "myapp_sa_v1"
+        primary_resource_id: "myapp_v1"
         ignore_read_extra:
           - "noop_on_destroy"
           - "deployment.0.zip"
         vars:
           bucket_name: "appengine-static-content"
-          project: "appeng-flex-sa"
+          project: "appeng-flx"
         test_env_vars:
           org_id: :ORG_ID
           billing_account: :BILLING_ACCT

--- a/mmv1/products/appengine/terraform.yaml
+++ b/mmv1/products/appengine/terraform.yaml
@@ -48,7 +48,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: 'delete_service_on_destroy'
         default_value: false
         description: |
-          If set to `true`, the service will be deleted if it is the last version.    
+          If set to `true`, the service will be deleted if it is the last version.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_delete: templates/terraform/custom_delete/appversion_delete.go.erb
       test_check_destroy: templates/terraform/custom_check_destroy/appengine.go.erb
@@ -63,6 +63,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
       threadsafe: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      serviceAccount: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       handlers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       # instanceClass defaults to a value based on the scaling method
@@ -77,11 +79,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "delete_service_on_destroy"
         vars:
+          project: "appeng-flex"
           project_id: "ae-project"
           bucket_name: "appengine-static-content"
           service_name: "ae-service"
         test_env_vars:
           org_id: :ORG_ID
+          billing_account: :BILLING_ACCT
   FlexibleAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
     id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
@@ -101,7 +105,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: 'delete_service_on_destroy'
         default_value: false
         description: |
-          If set to `true`, the service will be deleted if it is the last version.    
+          If set to `true`, the service will be deleted if it is the last version.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_delete: templates/terraform/custom_delete/appversion_delete.go.erb
       test_check_destroy: templates/terraform/custom_check_destroy/skip_delete_during_test.go.erb
@@ -131,6 +135,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       # runtimeApiVersion defaults to a runtime-specific value
       runtimeApiVersion: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      serviceAccount: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       handlers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/products/appengine/terraform.yaml
+++ b/mmv1/products/appengine/terraform.yaml
@@ -136,8 +136,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       # runtimeApiVersion defaults to a runtime-specific value
       runtimeApiVersion: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-      serviceAccount: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       handlers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       inboundServices: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -152,6 +150,75 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           bucket_name: "appengine-static-content"
           project: "appeng-flex"
+        test_env_vars:
+          org_id: :ORG_ID
+          billing_account: :BILLING_ACCT
+  FlexibleAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
+    id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
+    mutex: "apps/{{project}}"
+    error_retry_predicates: ["isAppEngineRetryableError"]
+    parameters:
+      service: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+        required: false
+    virtual_fields:
+      - !ruby/object:Api::Type::Boolean
+        name: 'noop_on_destroy'
+        default_value: false
+        description: |
+          If set to `true`, the application version will not be deleted.
+      - !ruby/object:Api::Type::Boolean
+        name: 'delete_service_on_destroy'
+        default_value: false
+        description: |
+          If set to `true`, the service will be deleted if it is the last version.
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_delete: templates/terraform/custom_delete/appversion_delete.go.erb
+      test_check_destroy: templates/terraform/custom_check_destroy/skip_delete_during_test.go.erb
+      encoder: templates/terraform/encoders/flex_app_version.go.erb
+    properties:
+      id: !ruby/object:Overrides::Terraform::PropertyOverride
+        name: 'version_id'
+      deployment: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: templates/terraform/custom_flatten/app_version.go.erb
+      deployment.container: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      entrypoint: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      envVariables: !ruby/object:Overrides::Terraform::PropertyOverride
+        description:
+          Environment variables available to the application.  As these are not returned
+          in the API request, Terraform will not detect any changes made outside of the Terraform config.
+        ignore_read: true
+      network.subnetworkName: !ruby/object:Overrides::Terraform::PropertyOverride
+        name: 'subnetwork'
+      betaSettings: !ruby/object:Overrides::Terraform::PropertyOverride
+        # https://issuetracker.google.com/issues/150157861
+        ignore_read: true
+        # default_from_api: true
+      # maxConcurrentRequests defaults to a runtime-specific value
+      automaticScaling.maxConcurrentRequests: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      # runtimeApiVersion defaults to a runtime-specific value
+      runtimeApiVersion: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      serviceAccount: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      handlers: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      inboundServices: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "app_engine_flexible_app_version_sa"
+        primary_resource_id: "myapp_sa_v1"
+        ignore_read_extra:
+          - "noop_on_destroy"
+          - "deployment.0.zip"
+        vars:
+          bucket_name: "appengine-static-content"
+          project: "appeng-flex-sa"
         test_env_vars:
           org_id: :ORG_ID
           billing_account: :BILLING_ACCT

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -51,6 +51,8 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
     port = "8080"
   }
 
+  service_account = google_service_account.default.email
+
   handlers {
     url_regex        = ".*\\/my-path\\/*"
     security_level   = "SECURE_ALWAYS"
@@ -71,6 +73,11 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
   }
 
   noop_on_destroy = true
+}
+
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
 }
 
 resource "google_storage_bucket" "bucket" {

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -5,11 +5,38 @@ resource "google_project" "my_project" {
   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
 }
 
+resource "google_app_engine_application" "app" {
+  project     = google_project.my_project.project_id
+  location_id = "us-central"
+}
+
 resource "google_project_service" "service" {
   project = google_project.my_project.project_id
   service = "appengineflex.googleapis.com"
 
   disable_dependent_services = false
+}
+
+resource "google_project_iam_member" "gae_api" {
+  project = google_project_service.service.project
+  role    = "roles/compute.networkUser"
+  member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
+}
+
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
+resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id] %>" {
+  version_id = "v1"
+  project    = google_project_iam_member.gae_api.project
+  service    = "default"
+  runtime    = "nodejs"
+
+  entrypoint {
+    shell = "node ./app.js"
+  }
 
   deployment {
     zip {
@@ -51,11 +78,6 @@ resource "google_project_service" "service" {
   }
 
   noop_on_destroy = true
-}
-
-resource "google_service_account" "default" {
-  account_id   = "service-account-id"
-  display_name = "Service Account"
 }
 
 resource "google_storage_bucket" "bucket" {

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -5,33 +5,11 @@ resource "google_project" "my_project" {
   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
 }
 
-resource "google_app_engine_application" "app" {
-  project     = google_project.my_project.project_id
-  location_id = "us-central"
-}
-
 resource "google_project_service" "service" {
   project = google_project.my_project.project_id
   service = "appengineflex.googleapis.com"
 
   disable_dependent_services = false
-}
-
-resource "google_project_iam_member" "gae_api" {
-  project = google_project_service.service.project
-  role    = "roles/compute.networkUser"
-  member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
-}
-
-resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id] %>" {
-  version_id = "v1"
-  project    = google_project_iam_member.gae_api.project
-  service    = "default"
-  runtime    = "nodejs"
-
-  entrypoint {
-    shell = "node ./app.js"
-  }
 
   deployment {
     zip {

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -23,11 +23,6 @@ resource "google_project_iam_member" "gae_api" {
   member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
 }
 
-resource "google_service_account" "default" {
-  account_id   = "service-account-id"
-  display_name = "Service Account"
-}
-
 resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id] %>" {
   version_id = "v1"
   project    = google_project_iam_member.gae_api.project
@@ -56,7 +51,62 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
     port = "8080"
   }
 
+  handlers {
+    url_regex        = ".*\\/my-path\\/*"
+    security_level   = "SECURE_ALWAYS"
+    login            = "LOGIN_REQUIRED"
+    auth_fail_action = "AUTH_FAIL_ACTION_REDIRECT"
+
+    static_files {
+      path = "my-other-path"
+      upload_path_regex = ".*\\/my-path\\/*"
+    }
+  }
+
+  automatic_scaling {
+    cool_down_period = "120s"
+    cpu_utilization {
+      target_utilization = 0.5
+    }
+  }
+
+  noop_on_destroy = true
+}
+
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
+resource "google_app_engine_flexible_app_version" "myapp_v2" {
+  version_id = "v2"
+  project    = google_project_iam_member.gae_api.project
+  service    = "default"
+  runtime    = "nodejs"
+
   service_account = google_service_account.default.email
+
+  entrypoint {
+    shell = "node ./app.js"
+  }
+
+  deployment {
+    zip {
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}"
+    }
+  }
+
+  liveness_check {
+    path = "/"
+  }
+
+  readiness_check {
+    path = "/"
+  }
+
+  env_variables = {
+    port = "8080"
+  }
 
   handlers {
     url_regex        = ".*\\/my-path\\/*"
@@ -79,6 +129,7 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
 
   noop_on_destroy = true
 }
+
 
 resource "google_storage_bucket" "bucket" {
   project  = google_project.my_project.project_id

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version_sa.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version_sa.tf.erb
@@ -23,6 +23,11 @@ resource "google_project_iam_member" "gae_api" {
   member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
 }
 
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
 resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id] %>" {
   version_id = "v1"
   project    = google_project_iam_member.gae_api.project
@@ -50,6 +55,8 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
   env_variables = {
     port = "8080"
   }
+
+  service_account = google_service_account.default.email
 
   handlers {
     url_regex        = ".*\\/my-path\\/*"

--- a/mmv1/templates/terraform/examples/app_engine_standard_app_version.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_standard_app_version.tf.erb
@@ -3,6 +3,8 @@ resource "google_app_engine_standard_app_version" "<%= ctx[:primary_resource_id]
   service    = "myapp"
   runtime    = "nodejs10"
 
+  service_account = google_service_account.default.email
+
   entrypoint {
     shell = "node ./app.js"
   }
@@ -59,6 +61,11 @@ resource "google_app_engine_standard_app_version" "myapp_v2" {
   }
 
   noop_on_destroy = true
+}
+
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
 }
 
 resource "google_storage_bucket" "bucket" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added support to app engine for service account.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
    Added `service_account` support to `app_engine_version` resource.
```
