### PR TITLE
Switch to using blockquote to display VCR test execution summary

### DIFF
--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -163,7 +163,7 @@ comment+="Failed tests: \`$FAILED_TESTS_COUNT\` ${NEWLINE}${NEWLINE}"
 
 if [[ -n $FAILED_TESTS_PATTERN ]]; then
   comment+="#### Action taken ${NEWLINE}"
-  comment+="<details> <summary>Triggering VCR tests in RECORDING mode for the tests that failed during VCR. Click here to see the failed tests</summary> $FAILED_TESTS_PATTERN </details>"
+  comment+="<details> <summary>Triggering VCR tests in RECORDING mode for the tests that failed during VCR. Click here to see the failed tests</summary><blockquote>$FAILED_TESTS_PATTERN </blockquote></details>"
   add_comment "${comment}"
   # RECORDING mode
   export VCR_MODE=RECORDING


### PR DESCRIPTION

before
<img width="927" alt="Screen Shot 2022-08-15 at 1 57 21 PM" src="https://user-images.githubusercontent.com/9483464/184717058-9b8021b2-ba94-40c4-9f34-cbc7aef9fe75.png">

after
<img width="940" alt="Screen Shot 2022-08-15 at 1 56 49 PM" src="https://user-images.githubusercontent.com/9483464/184716964-549e242c-51ca-4010-9b80-b048868886a8.png">

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
