### PR TITLE
Add reservation affinity

### DIFF
--- a/mmv1/products/container/api.yaml
+++ b/mmv1/products/container/api.yaml
@@ -207,6 +207,32 @@ objects:
               Whether the nodes are created as preemptible VM instances. See:
               https://cloud.google.com/compute/docs/instances/preemptible for
               more information about preemptible VM instances.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'reservationAffinity'
+            description: |
+              ReservationAffinity is the configuration of desired reservation which instances could take capacity from.
+            input: true
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'consumeReservationType'
+                description: |
+                  Corresponds to the type of reservation consumption.
+                values:
+                  - "UNSPECIFIED"
+                  - "NO_RESERVATION"
+                  - "ANY_RESERVATION"
+                  - "SPECIFIC_RESERVATION"
+              - !ruby/object:Api::Type::String
+                name: 'key'
+                description: |
+                  Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name,
+                  specify "googleapis.com/reservation-name" as the key and specify the name of your reservation as 
+                  its value.
+              - !ruby/object:Api::Type::Array
+                name: 'values'
+                item_type: Api::Type::String
+                description: |
+                  Corresponds to the label value(s) of reservation resource(s).
           - !ruby/object:Api::Type::Array
             name: 'accelerators'
             description: |

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3917,13 +3917,26 @@ resource "google_container_cluster" "with_node_config" {
 
 func testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName string) string {
 	return fmt.Sprintf(`
+
+resource "google_compute_reservation" "gce_reservation" {
+  name = "gce-reservation"
+  zone = "us-central1-f"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type     = "n1-standard-1"
+    }
+  }
+}
+
 resource "google_container_cluster" "with_node_config" {
   name               = "%s"
   location           = "us-central1-f"
   initial_node_count = 1
 
   node_config {
-    machine_type    = "e2-medium"
+    machine_type    = "n1-standard-1"
     disk_size_gb    = 15
     disk_type       = "pd-ssd"
     oauth_scopes = [
@@ -3950,7 +3963,7 @@ resource "google_container_cluster" "with_node_config" {
       consume_reservation_type = "SPECIFIC_RESERVATION"
       key = "compute.googleapis.com/reservation-name"
       values = [
-        "cud-reservation"
+        google_compute_reservation.gce_reservation.name
       ]
     }
   }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3920,10 +3920,12 @@ func testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterNa
 
 resource "google_project_service" "compute" {
   service = "compute.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "container" {
   service = "container.googleapis.com"
+  disable_on_destroy = false
   depends_on = [google_project_service.compute]
 }
 

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1017,9 +1017,9 @@ func TestAccContainerCluster_withNodeConfigReservationAffinity(t *testing.T) {
 				Config: testAccContainerCluster_withNodeConfigReservationAffinity(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.#", "1"),
+						"node_config.0.reservation_affinity.#", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.0.consume_reservation_type", "ANY_RESERVATION"),
+						"node_config.0.reservation_affinity.0.consume_reservation_type", "ANY_RESERVATION"),
 				),
 			},
 			{
@@ -1045,15 +1045,15 @@ func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testin
 				Config: testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.#", "1"),
+						"node_config.0.reservation_affinity.#", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.0.consume_reservation_type", "SPECIFIC_RESERVATION"),
+						"node_config.0.reservation_affinity.0.consume_reservation_type", "SPECIFIC_RESERVATION"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.0.key", "compute.googleapis.com/reservation-name"),
+						"node_config.0.reservation_affinity.0.key", "compute.googleapis.com/reservation-name"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.0.values.#", "1"),
+						"node_config.0.reservation_affinity.0.values.#", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"reservation_affinity.0.values.0", "cud-reservation"),
+						"node_config.0.reservation_affinity.0.values.0", "cud-reservation"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3918,6 +3918,16 @@ resource "google_container_cluster" "with_node_config" {
 func testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName string) string {
 	return fmt.Sprintf(`
 
+resource "google_project_service" "compute" {
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "container" {
+  service = "container.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+
 resource "google_compute_reservation" "gce_reservation" {
   name = "gce-reservation"
   zone = "us-central1-f"
@@ -3928,6 +3938,9 @@ resource "google_compute_reservation" "gce_reservation" {
       machine_type     = "n1-standard-1"
     }
   }
+
+  specific_reservation_required = true
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_container_cluster" "with_node_config" {
@@ -3954,7 +3967,6 @@ resource "google_container_cluster" "with_node_config" {
       foo = "bar"
     }
     tags             = ["foo", "bar"]
-    preemptible      = true
 
     // Updatable fields
     image_type = "COS_CONTAINERD"
@@ -3967,6 +3979,7 @@ resource "google_container_cluster" "with_node_config" {
       ]
     }
   }
+  depends_on = [google_project_service.container]
 }
 `, clusterName)
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1003,6 +1003,68 @@ func TestAccContainerCluster_withNodeConfigShieldedInstanceConfig(t *testing.T) 
 	})
 }
 
+func TestAccContainerCluster_withNodeConfigReservationAffinity(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withNodeConfigReservationAffinity(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.0.consume_reservation_type", "ANY_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_node_config",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.0.consume_reservation_type", "SPECIFIC_RESERVATION"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.0.key", "compute.googleapis.com/reservation-name"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.0.values.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
+						"reservation_affinity.0.values.0", "cud-reservation"),
+				),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_node_config",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withWorkloadMetadataConfig(t *testing.T) {
 	t.Parallel()
 
@@ -3808,6 +3870,88 @@ resource "google_container_cluster" "with_node_config" {
     shielded_instance_config {
       enable_secure_boot          = true
       enable_integrity_monitoring = true
+    }
+  }
+}
+`, clusterName)
+}
+
+func testAccContainerCluster_withNodeConfigReservationAffinity(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_node_config" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  node_config {
+    machine_type    = "e2-medium"
+    disk_size_gb    = 15
+    disk_type       = "pd-ssd"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+    ]
+    service_account = "default"
+    metadata = {
+      foo                      = "bar"
+      disable-legacy-endpoints = "true"
+    }
+    labels = {
+      foo = "bar"
+    }
+    tags             = ["foo", "bar"]
+    preemptible      = true
+
+    // Updatable fields
+    image_type = "COS_CONTAINERD"
+
+    reservation_affinity {
+      consume_reservation_type = "ANY_RESERVATION"
+    }
+  }
+}
+`, clusterName)
+}
+
+func testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_node_config" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  node_config {
+    machine_type    = "e2-medium"
+    disk_size_gb    = 15
+    disk_type       = "pd-ssd"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+    ]
+    service_account = "default"
+    metadata = {
+      foo                      = "bar"
+      disable-legacy-endpoints = "true"
+    }
+    labels = {
+      foo = "bar"
+    }
+    tags             = ["foo", "bar"]
+    preemptible      = true
+
+    // Updatable fields
+    image_type = "COS_CONTAINERD"
+
+    reservation_affinity {
+      consume_reservation_type = "SPECIFIC_RESERVATION"
+      key = "compute.googleapis.com/reservation-name"
+      values = [
+        "cud-reservation"
+      ]
     }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1053,7 +1053,7 @@ func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testin
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
 						"node_config.0.reservation_affinity.0.values.#", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"node_config.0.reservation_affinity.0.values.0", "cud-reservation"),
+						"node_config.0.reservation_affinity.0.values.0", "gce-reservation"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1034,6 +1034,7 @@ func TestAccContainerCluster_withNodeConfigReservationAffinity(t *testing.T) {
 func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testing.T) {
 	t.Parallel()
 
+    reservationName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
@@ -1042,7 +1043,7 @@ func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testin
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName),
+				Config: testAccContainerCluster_withNodeConfigReservationAffinitySpecific(reservationName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
 						"node_config.0.reservation_affinity.#", "1"),
@@ -3915,7 +3916,7 @@ resource "google_container_cluster" "with_node_config" {
 `, clusterName)
 }
 
-func testAccContainerCluster_withNodeConfigReservationAffinitySpecific(clusterName string) string {
+func testAccContainerCluster_withNodeConfigReservationAffinitySpecific(reservation, clusterName string) string {
 	return fmt.Sprintf(`
 
 resource "google_project_service" "compute" {
@@ -3931,7 +3932,7 @@ resource "google_project_service" "container" {
 
 
 resource "google_compute_reservation" "gce_reservation" {
-  name = "gce-reservation"
+  name = "%s"
   zone = "us-central1-f"
 
   specific_reservation {
@@ -3983,7 +3984,7 @@ resource "google_container_cluster" "with_node_config" {
   }
   depends_on = [google_project_service.container]
 }
-`, clusterName)
+`, reservation, clusterName)
 }
 
 func testAccContainerCluster_withWorkloadMetadataConfig(clusterName string) string {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1034,7 +1034,7 @@ func TestAccContainerCluster_withNodeConfigReservationAffinity(t *testing.T) {
 func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testing.T) {
 	t.Parallel()
 
-    reservationName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+    reservationName := fmt.Sprintf("tf-test-reservation-%s", randString(t, 10))
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
@@ -1054,7 +1054,7 @@ func TestAccContainerCluster_withNodeConfigReservationAffinitySpecific(t *testin
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
 						"node_config.0.reservation_affinity.0.values.#", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_config",
-						"node_config.0.reservation_affinity.0.values.0", "gce-reservation"),
+						"node_config.0.reservation_affinity.0.values.0", reservationName),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -193,6 +193,70 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_withReservationAffinity(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withReservationAffinity(cluster, np),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.#", "1"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.0.consume_reservation_type", "ANY_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_reservation_affinity",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccContainerNodePool_withReservationAffinitySpecific(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	reservation := fmt.Sprintf("tf-test-reservation-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withReservationAffinitySpecific(cluster, reservation, np),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.#", "1"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.0.consume_reservation_type", "SPECIFIC_RESERVATION"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.0.key", "compute.googleapis.com/reservation-name"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.0.values.#", "1"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_reservation_affinity",
+						"node_config.0.reservation_affinity.0.values.0", reservation),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_reservation_affinity",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
 func TestAccContainerNodePool_withWorkloadIdentityConfig(t *testing.T) {
 	t.Parallel()
@@ -1535,6 +1599,86 @@ resource "google_container_node_pool" "np_with_node_config" {
   }
 }
 `, cluster, nodePool)
+}
+
+func testAccContainerNodePool_withReservationAffinity(cluster, np string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_container_node_pool" "with_reservation_affinity" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+    reservation_affinity {
+      consume_reservation_type = "ANY_RESERVATION"
+    }
+  }
+}
+`, cluster, np)
+}
+
+func testAccContainerNodePool_withReservationAffinitySpecific(cluster, reservation, np string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_compute_reservation" "gce_reservation" {
+  name = "%s"
+  zone = "us-central1-f"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type     = "n1-standard-1"
+    }
+  }
+
+  specific_reservation_required = true
+}
+
+resource "google_container_node_pool" "with_reservation_affinity" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+    reservation_affinity {
+      consume_reservation_type = "SPECIFIC_RESERVATION"
+      key = "compute.googleapis.com/reservation-name"
+      values = [
+        google_compute_reservation.gce_reservation.name
+      ]
+    }
+  }
+}
+`, cluster, np)
 }
 
 

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1678,7 +1678,7 @@ resource "google_container_node_pool" "with_reservation_affinity" {
     }
   }
 }
-`, cluster, np)
+`, cluster, reservation, np)
 }
 
 

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1620,6 +1620,7 @@ resource "google_container_node_pool" "with_reservation_affinity" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {
+    machine_type    = "n1-standard-1"
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
@@ -1647,7 +1648,7 @@ resource "google_container_cluster" "cluster" {
 
 resource "google_compute_reservation" "gce_reservation" {
   name = "%s"
-  zone = "us-central1-f"
+  zone = "us-central1-a"
 
   specific_reservation {
     count = 1
@@ -1665,6 +1666,7 @@ resource "google_container_node_pool" "with_reservation_affinity" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {
+    machine_type    = "n1-standard-1"
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -221,7 +221,39 @@ func schemaNodeConfig() *schema.Schema {
 					Default:  false,
 					Description: `Whether the nodes are created as preemptible VM instances.`,
 				},
-
+				"reservation_affinity": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: `The reservation affinity configuration for the node pool.`,
+					ForceNew:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"consume_reservation_type": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								Description:  `Corresponds to the type of reservation consumption.`,
+								ValidateFunc: validation.StringInSlice([]string{"UNSPECIFIED", "NO_RESERVATION", "ANY_RESERVATION", "SPECIFIC_RESERVATION"}, false),
+							},
+							"key": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								ForceNew:    true,
+								Description: `The label key of a reservation resource.`,
+							},
+							"values": {
+								Type:        schema.TypeSet,
+								Description: "The label values of the reservation resource.",
+								ForceNew:    true,
+                                Optional:    true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+						},
+					},
+				},
 				"spot": {
 					Type:        schema.TypeBool,
 					Optional:    true,
@@ -480,6 +512,21 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		}
 	}
 
+	if v, ok := nodeConfig["reservation_affinity"]; ok && len(v.([]interface{})) > 0 {
+		conf := v.([]interface{})[0].(map[string]interface{})
+		valuesSet := conf["values"].(*schema.Set)
+		values := make([]string, valuesSet.Len())
+		for i, value := range valuesSet.List() {
+			values[i] = value.(string)
+		}
+
+		nc.ReservationAffinity = &container.ReservationAffinity{
+			ConsumeReservationType: conf["consume_reservation_type"].(string),
+			Key:                    conf["key"].(string),
+			Values:                 values,
+		}
+	}
+
 	if scopes, ok := nodeConfig["oauth_scopes"]; ok {
 		scopesSet := scopes.(*schema.Set)
 		scopes := make([]string, scopesSet.Len())
@@ -677,6 +724,7 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 <% end -%>
 		"gcfs_config":              flattenGcfsConfig(c.GcfsConfig),
 		"gvnic":										flattenGvnic(c.Gvnic),
+		"reservation_affinity":     flattenGKEReservationAffinity(c.ReservationAffinity),
 		"service_account":          c.ServiceAccount,
 		"metadata":                 c.Metadata,
 		"image_type":               c.ImageType,
@@ -756,6 +804,18 @@ func flattenGvnic(c *container.VirtualNIC) []map[string]interface{} {
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"enabled": c.Enabled,
+		})
+	}
+	return result
+}
+
+func flattenGKEReservationAffinity(c *container.ReservationAffinity) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"consume_reservation_type": c.ConsumeReservationType,
+			"key":                      c.Key,
+			"values":                   c.Values,
 		})
 	}
 	return result

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -743,6 +743,8 @@ gvnic {
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
+* `reservation_affinity` (Optional) The configuration of the desired reservation which instances could take capacity from. Structure is [documented below](#nested_reservation_affinity).
+
 * `spot` - (Optional) A boolean that represents whether the underlying node VMs are spot.
     See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
     for more information. Defaults to false.
@@ -906,6 +908,19 @@ recommended that you omit the block entirely if the field is not set to `true`.
 
 * `enabled` (Optional) - Whether the cluster master is accessible globally or
 not.
+
+<a name="nested_reservation_affinity"></a>The `reservation_affinity` block supports:
+
+* `consume_reservation_type` (Required) The type of reservation consumption
+    Accepted values are:
+
+    * `"UNSPECIFIED"`: Default value. This should not be used.
+    * `"NO_RESERVATION"`: Do not consume from any reserved capacity.
+    * `"ANY_RESERVATION"`: Consume any reservation available.
+    * `"SPECIFIC_RESERVATION"`: Must consume from a specific reservation. Must specify key value fields for specifying the reservations.
+* `key` (Optional) The label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify "compute.googleapis.com/reservation-name" as the key and specify the name of your reservation as its value.
+* `values` (Optional) The list of label values of reservation resources. For example: the name of the specific reservation when using a key of "compute.googleapis.com/reservation-name"
+
 
 <a name="nested_sandbox_config"></a>The `sandbox_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds the reservation affinity block to the node config object. This allows users to add reservation affinity settings to their GKE node pools.

Usage:
```
resource "google_container_node_pool" "reservation_nodes_cud" {
  name = "np-reservation-test-cud"
  location = "europe-west1-b"
  cluster    = google_container_cluster.reservation_test.name
  node_count = 1

  node_config {
    machine_type = "n1-standard-2"
    reservation_affinity {
      consume_reservation_type = "ANY_RESERVATION"
    }
    local_ssd_count = 1
    oauth_scopes    = [
      "https://www.googleapis.com/auth/cloud-platform"
    ]
  }
}

```

Fixes:
- https://github.com/hashicorp/terraform-provider-google/issues/11597
- https://github.com/hashicorp/terraform-provider-google/issues/9556



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added general field `reservation_affinity` to `google_container_node_pool`
```
