### PR TITLE
Bigtable: Compare column family

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -246,7 +246,6 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	defer c.Close()
 
 	name := d.Get("table").(string)
-	columnFamily := d.Get("column_family").(string)
 	ti, err := c.TableInfo(ctx, name)
 	if err != nil {
 		log.Printf("[WARN] Removing %s because it's gone", name)
@@ -255,7 +254,7 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	for _, fi := range ti.FamilyInfos {
-		if fi.Name == columnFamily {
+		if fi.Name == name {
 			d.SetId(fi.GCPolicy)
 			break
 		}

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -246,6 +246,7 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	defer c.Close()
 
 	name := d.Get("table").(string)
+	columnFamily := d.Get("column_family").(string)
 	ti, err := c.TableInfo(ctx, name)
 	if err != nil {
 		log.Printf("[WARN] Removing %s because it's gone", name)
@@ -254,7 +255,7 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	for _, fi := range ti.FamilyInfos {
-		if fi.Name == name {
+		if fi.Name == columnFamily {
 			d.SetId(fi.GCPolicy)
 			break
 		}

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -406,7 +406,7 @@ func testAccBigtableGCPolicyExists(t *testing.T, n string) resource.TestCheckFun
 		}
 
 		for _, i := range table.FamilyInfos {
-			if i.Name == rs.Primary.Attributes["column_family"] && rs.Primary.ID != "" {
+			if i.Name == rs.Primary.Attributes["column_family"] && i.GCPolicy == rs.Primary.ID {
 				return nil
 			}
 		}

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -406,7 +406,7 @@ func testAccBigtableGCPolicyExists(t *testing.T, n string) resource.TestCheckFun
 		}
 
 		for _, i := range table.FamilyInfos {
-			if i.Name == rs.Primary.Attributes["column_family"] {
+			if i.Name == rs.Primary.Attributes["column_family"] && rs.Primary.ID != "" {
 				return nil
 			}
 		}

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -99,6 +99,7 @@ func TestAccBigtableGCPolicy_union(t *testing.T) {
 	})
 }
 
+// Testing multiple GC policies; one per column family.
 func TestAccBigtableGCPolicy_multiplePolicies(t *testing.T) {
 	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
@@ -621,14 +622,20 @@ resource "google_bigtable_table" "table" {
   instance_name = google_bigtable_instance.instance.id
 
   column_family {
-    family = "%s"
+    family = "%sA"
+  }
+  column_family {
+    family = "%sB"
+  }
+  column_family {
+    family = "%sC"
   }
 }
 
 resource "google_bigtable_gc_policy" "policyA" {
   instance_name = google_bigtable_instance.instance.id
   table         = google_bigtable_table.table.name
-  column_family = "%s"
+  column_family = "%sA"
 
   max_age {
     days = 30
@@ -638,7 +645,7 @@ resource "google_bigtable_gc_policy" "policyA" {
 resource "google_bigtable_gc_policy" "policyB" {
   instance_name = google_bigtable_instance.instance.id
   table         = google_bigtable_table.table.name
-  column_family = "%s"
+  column_family = "%sB"
 
   max_version {
     number = 8
@@ -648,7 +655,7 @@ resource "google_bigtable_gc_policy" "policyB" {
 resource "google_bigtable_gc_policy" "policyC" {
 	instance_name = google_bigtable_instance.instance.id
   table         = google_bigtable_table.table.name
-  column_family = "%s"
+  column_family = "%sC"
 
   max_age {
     days = 7
@@ -660,7 +667,7 @@ resource "google_bigtable_gc_policy" "policyC" {
 
   mode        = "UNION"
 }
-`, instanceName, instanceName, tableName, family, family, family, family)
+`, instanceName, instanceName, tableName, family, family, family, family, family, family)
 }
 
 func testAccBigtableGCPolicy_gcRulesCreate(instanceName, tableName, family string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix comparing the wrong name when reading a GC policy.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed comparing column family name when reading a GC policy.
```
