### PR TITLE
Bigtable: Validate gc policy top level

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -317,11 +317,11 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 	}
 
 	if gok {
-		var j map[string]interface{}
-		if err := json.Unmarshal([]byte(gcRules.(string)), &j); err != nil {
+		var topLevelPolicy map[string]interface{}
+		if err := json.Unmarshal([]byte(gcRules.(string)), &topLevelPolicy); err != nil {
 			return nil, err
 		}
-		return getGCPolicyFromJSON(j)
+		return getGCPolicyFromJSON(topLevelPolicy /*isTopLevel=*/, true)
 	}
 
 	if aok {
@@ -351,16 +351,17 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 	return policies[0], nil
 }
 
-func getGCPolicyFromJSON(topLevelPolicy map[string]interface{}) (bigtable.GCPolicy, error) {
+func getGCPolicyFromJSON(inputPolicy map[string]interface{}, isTopLevel bool) (bigtable.GCPolicy, error) {
 	policy := []bigtable.GCPolicy{}
 
-	if err := validateNestedPolicy(topLevelPolicy, true); err != nil {
+	// TODO: change from true to isTopLevel.
+	if err := validateNestedPolicy(inputPolicy, true); err != nil {
 		return nil, err
 	}
 
-	for _, p := range topLevelPolicy["rules"].([]interface{}) {
+	for _, p := range inputPolicy["rules"].([]interface{}) {
 		childPolicy := p.(map[string]interface{})
-		if err := validateNestedPolicy(childPolicy, false); err != nil {
+		if err := validateNestedPolicy(childPolicy /*isTopLevel=*/, false); err != nil {
 			return nil, err
 		}
 
@@ -379,7 +380,7 @@ func getGCPolicyFromJSON(topLevelPolicy map[string]interface{}) (bigtable.GCPoli
 		}
 
 		if childPolicy["mode"] != nil {
-			n, err := getGCPolicyFromJSON(childPolicy)
+			n, err := getGCPolicyFromJSON(childPolicy /*isTopLevel=*/, false)
 			if err != nil {
 				return nil, err
 			}
@@ -387,7 +388,7 @@ func getGCPolicyFromJSON(topLevelPolicy map[string]interface{}) (bigtable.GCPoli
 		}
 	}
 
-	switch topLevelPolicy["mode"] {
+	switch inputPolicy["mode"] {
 	case strings.ToLower(GCPolicyModeUnion):
 		return bigtable.UnionPolicy(policy...), nil
 	case strings.ToLower(GCPolicyModeIntersection):
@@ -397,7 +398,7 @@ func getGCPolicyFromJSON(topLevelPolicy map[string]interface{}) (bigtable.GCPoli
 	}
 }
 
-func validateNestedPolicy(p map[string]interface{}, topLevel bool) error {
+func validateNestedPolicy(p map[string]interface{}, isTopLevel bool) error {
 	if len(p) > 2 {
 		return fmt.Errorf("rules has more than 2 fields")
 	}
@@ -418,19 +419,19 @@ func validateNestedPolicy(p map[string]interface{}, topLevel bool) error {
 		return fmt.Errorf("`rules` need at least 2 GC rule when mode is specified")
 	}
 
-	if topLevel && !rulesOk {
+	if isTopLevel && !rulesOk {
 		return fmt.Errorf("invalid nested policy, need `rules`")
 	}
 
-	if topLevel && !modeOk && len(rules) != 1 {
+	if isTopLevel && !modeOk && len(rules) != 1 {
 		return fmt.Errorf("when `mode` is not specified, `rules` can only have 1 child rule")
 	}
 
-	if !topLevel && len(p) == 2 && (!modeOk || !rulesOk) {
+	if !isTopLevel && len(p) == 2 && (!modeOk || !rulesOk) {
 		return fmt.Errorf("need `mode` and `rules` for child nested policies")
 	}
 
-	if !topLevel && len(p) == 1 && !maxVersionOk && !maxAgeOk {
+	if !isTopLevel && len(p) == 1 && !maxVersionOk && !maxAgeOk {
 		return fmt.Errorf("need `max_version` or `max_age` for the rule")
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -354,8 +354,7 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 func getGCPolicyFromJSON(inputPolicy map[string]interface{}, isTopLevel bool) (bigtable.GCPolicy, error) {
 	policy := []bigtable.GCPolicy{}
 
-	// TODO: change from true to isTopLevel.
-	if err := validateNestedPolicy(inputPolicy, true); err != nil {
+	if err := validateNestedPolicy(inputPolicy, isTopLevel); err != nil {
 		return nil, err
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -280,12 +280,12 @@ var testUnitBigtableGCPolicyRulesTestCases = []testUnitBigtableGCPolicyJSONRules
 func TestUnitBigtableGCPolicy_getGCPolicyFromJSON(t *testing.T) {
 	for _, tc := range testUnitBigtableGCPolicyRulesTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var j map[string]interface{}
-			err := json.Unmarshal([]byte(tc.gcJSONString), &j)
+			var topLevelPolicy map[string]interface{}
+			err := json.Unmarshal([]byte(tc.gcJSONString), &topLevelPolicy)
 			if err != nil {
 				t.Fatalf("error unmarshalling JSON string: %v", err)
 			}
-			got, err := getGCPolicyFromJSON(j)
+			got, err := getGCPolicyFromJSON(topLevelPolicy /*isTopLevel=*/, true)
 			if tc.errorExpected && err == nil {
 				t.Fatal("expect error, got nil")
 			} else if !tc.errorExpected && err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`isTopeLevel` in getGCPolicyFromJSON() needs to be passed along correctly. In case of a recursive call, `isTopeLevel` can be false.

This doesn't cause any problem currently based on the code in validateNestedPolicy(), but could cause a problem later in the future if some logic that depends on `isTopeLevel`  is added.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: passed `isTopeLevel` in getGCPolicyFromJSON() instead of hardcoding it to true.
```
