### PR TITLE
feat: add `exp` field to JWT if `expires_in` is set

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_service_account_jwt_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_service_account_jwt_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"fmt"
 
@@ -18,6 +19,7 @@ const (
 	jwtTestSubject          = "custom-subject"
 	jwtTestFoo              = "bar"
 	jwtTestComplexFooNested = "baz"
+	jwtTestExpiresIn        = 60
 )
 
 type jwtTestPayload struct {
@@ -28,6 +30,8 @@ type jwtTestPayload struct {
 	ComplexFoo struct {
 		Nested string `json:"nested"`
 	} `json:"complexFoo"`
+
+	Expiration int64 `json:"exp"`
 }
 
 func testAccCheckServiceAccountJwtValue(name, audience string) resource.TestCheckFunc {
@@ -78,6 +82,12 @@ func testAccCheckServiceAccountJwtValue(name, audience string) resource.TestChec
 			return fmt.Errorf("invalid 'foo', expected '%s', got '%s'", jwtTestComplexFooNested, payload.ComplexFoo.Nested)
 		}
 
+		expectedExpiration := dataSourceGoogleServiceAccountJwtNow().Add(jwtTestExpiresIn * time.Second).Unix()
+
+		if payload.Expiration != expectedExpiration {
+			return fmt.Errorf("invalid 'exp', expected '%d', got '%d'", expectedExpiration, payload.Expiration)
+		}
+
 		return nil
 	}
 }
@@ -88,6 +98,13 @@ func TestAccDataSourceGoogleServiceAccountJwt(t *testing.T) {
 	resourceName := "data.google_service_account_jwt.default"
 	serviceAccount := getTestServiceAccountFromEnv(t)
 	targetServiceAccountEmail := BootstrapServiceAccount(t, getTestProjectFromEnv(), serviceAccount)
+
+	staticTime := time.Now()
+
+	// Override the current time with one that will never change, to compare against later.
+	dataSourceGoogleServiceAccountJwtNow = func() time.Time {
+		return staticTime
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -115,6 +132,8 @@ data "google_service_account_jwt" "default" {
         nested: "%s"
       }
     })
+
+    expires_in = %d
 }
-`, targetServiceAccount, jwtTestSubject, jwtTestFoo, jwtTestComplexFooNested)
+`, targetServiceAccount, jwtTestSubject, jwtTestFoo, jwtTestComplexFooNested, jwtTestExpiresIn)
 }

--- a/mmv1/third_party/terraform/tests/data_source_google_service_account_jwt_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_service_account_jwt_test.go
@@ -101,7 +101,7 @@ func TestAccDataSourceGoogleServiceAccountJwt(t *testing.T) {
 
 	staticTime := time.Now()
 
-	// Override the current time with one that will never change, to compare against later.
+	// Override the current time with one that is set to a static value, to compare against later.
 	dataSourceGoogleServiceAccountJwtNow = func() time.Time {
 		return staticTime
 	}
@@ -111,6 +111,16 @@ func TestAccDataSourceGoogleServiceAccountJwt(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccCheckGoogleServiceAccountJwt(targetServiceAccountEmail),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceAccountJwtValue(resourceName, targetAudience),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Bump the hardcoded time to ensure terraform responds well to the JWT expiration changing.
+					staticTime = time.Now().Add(10 * time.Second)
+				},
 				Config: testAccCheckGoogleServiceAccountJwt(targetServiceAccountEmail),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceAccountJwtValue(resourceName, targetAudience),

--- a/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
@@ -23,6 +23,8 @@ data "google_service_account_jwt" "foo" {
     foo: "bar",
     sub: "subject",
   })
+
+  expires_in = 60
 }
 
 output "jwt" {
@@ -36,6 +38,7 @@ The following arguments are supported:
 
 * `target_service_account` (Required) - The email of the service account that will sign the JWT.
 * `payload` (Required) - The JSON-encoded JWT claims set to include in the self-signed JWT.
+* `expires_in` (Optional) - Number of seconds until the JWT expires. If set and non-zero an `exp` claim will be added to the payload derived from the current timestamp plus expires_in seconds.
 * `delegates` (Optional) - Delegate chain of approvals needed to perform full impersonation. Specify the fully qualified service account name.
 
 ## Attributes Reference


### PR DESCRIPTION
This commit adds the ability to add an `exp` field to the signed JWT. While Terraform has some time-related functions (e.g. `timestamp` and `formatdate`), there does not appear to be a Terraform-native way of generating a _unix_ timestamp for the current time. Without this feature it would be impossible for a user to set `exp` to a meaningful value themselves.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
google_service_account_jwt: added `expires_in` attribute for generating `exp` claim.
```
