### PR TITLE
Update documentation for message_retention_duration in pubsub_topic

### DIFF
--- a/mmv1/products/pubsub/api.yaml
+++ b/mmv1/products/pubsub/api.yaml
@@ -109,7 +109,7 @@ objects:
           For instance, it allows any attached subscription to seek to a timestamp
           that is up to messageRetentionDuration in the past. If this field is not
           set, message retention is controlled by settings on individual subscriptions.
-          Cannot be more than 7 days or less than 10 minutes.
+          Cannot be more than 31 days or less than 10 minutes.
   - !ruby/object:Api::Resource
     name: 'Subscription'
     description: |


### PR DESCRIPTION
Update documentation for `message_retention_duration` in `pubsub_topic` to reflect new 31 day maximum. The API has already been updated to support this, as well as the GCP Console description:

<img width="525" alt="Screen Shot 2022-08-18 at 3 36 38 PM" src="https://user-images.githubusercontent.com/7943382/185479733-f2909176-3692-420c-ae67-5ade24a6b9ca.png">

Blog post announcing the extension (Dec 2021): https://cloud.google.com/blog/products/data-analytics/pubsub-launches-extended-message-storage-for-event-sourcing

b/229132847

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: updated documentation for `message_retention_duration` in `google_pubsub_topic` resource to reflect new 31 day maximum
```
