### PR TITLE
Add location to google_cloudbuild_trigger.

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -27,8 +27,8 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Trigger'
-    base_url: projects/{{project}}/triggers
-    self_link: projects/{{project}}/triggers/{{id}}
+    base_url: projects/{{project}}/locations/{{location}}/triggers
+    self_link: projects/{{project}}/locations/{{location}}/triggers/{{id}}
     update_verb: :PATCH
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
@@ -36,6 +36,16 @@ objects:
       api: 'https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers'
     description: |
       Configuration for an automated build in response to source repository changes.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: |
+          The [Cloud Build location](https://cloud.google.com/build/docs/locations) for the trigger.
+          If not specified, "global" is used.
+        required: false
+        default_value: global
+        input: true
+        url_param_only: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'id'

--- a/mmv1/products/cloudbuild/terraform.yaml
+++ b/mmv1/products/cloudbuild/terraform.yaml
@@ -19,9 +19,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       note: |
         You can retrieve the email of the Cloud Build Service Account used in jobs by using the `google_project_service_identity` resource.
     # import by default only works with old-style self links ending in a name
-    import_format: ["projects/{{project}}/triggers/{{trigger_id}}"]
-    id_format: 'projects/{{project}}/triggers/{{trigger_id}}'
-    self_link: 'projects/{{project}}/triggers/{{trigger_id}}'
+    import_format:
+      - "projects/{{project}}/triggers/{{trigger_id}}"
+      - "projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}"
+    # For global triggers, the id format is changed to projects/{{project}}/triggers/{{trigger_id}} via code overrides.
+    id_format: 'projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}'
+    self_link: 'projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloudbuild_trigger_filename"
@@ -47,6 +50,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "manual-trigger"
 
     properties:
+      location: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: emptyOrDefaultStringSuppress("global")
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'trigger_id'
       name: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -85,8 +90,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
         custom_flatten: templates/terraform/custom_flatten/cloudbuild_approval_required.go.erb
     custom_code: !ruby/object:Provider::Terraform::CustomCode
+      pre_read: templates/terraform/pre_read/cloudbuild_trigger.go.erb
+      pre_create: templates/terraform/pre_create/cloudbuild_trigger.go.erb
       post_create: templates/terraform/post_create/cloudbuild_trigger_id.go.erb
       pre_update: templates/terraform/pre_update/cloudbuild_trigger.go.erb
+      pre_delete: templates/terraform/pre_delete/cloudbuild_trigger.go.erb
+      post_import: templates/terraform/post_import/cloudbuild_trigger.go.erb
       constants: templates/terraform/constants/cloudbuild_trigger.erb
       resource_definition: templates/terraform/resource_definition/cloudbuild_trigger.go.erb
 # This is for copying files over

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
@@ -1,4 +1,6 @@
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location = "us-central1"
+
   trigger_template {
     branch_name = "main"
     repo_name   = "my-repo"

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_filename.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_filename.tf.erb
@@ -1,4 +1,6 @@
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location = "us-central1"
+
   trigger_template {
     branch_name = "main"
     repo_name   = "my-repo"

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_include_build_logs.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_include_build_logs.tf.erb
@@ -1,4 +1,5 @@
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location = "australia-southeast1"
   name     = "<%= ctx[:primary_resource_id] %>"
   filename = "cloudbuild.yaml"
 

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_manual.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_manual.tf.erb
@@ -1,5 +1,6 @@
 
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location    = "us-west4"
   name        = "manual-build"
 
   source_to_build {

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_service_account.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_service_account.tf.erb
@@ -1,6 +1,8 @@
 data "google_project" "project" {}
 
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location = "global"
+
   trigger_template {
     branch_name = "main"
     repo_name   = "my-repo"

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_webhook_config.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_webhook_config.tf.erb
@@ -36,10 +36,11 @@ resource "google_secret_manager_secret_iam_policy" "policy" {
 
 
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location    = "us-central1"
   name        = "webhook-trigger"
   description = "acceptance test example webhook build trigger"
  
- webhook_config {
+  webhook_config {
     secret = google_secret_manager_secret_version.webhook_trigger_secret_key_data.id
   }
 

--- a/mmv1/templates/terraform/post_create/cloudbuild_trigger_id.go.erb
+++ b/mmv1/templates/terraform/post_create/cloudbuild_trigger_id.go.erb
@@ -9,8 +9,11 @@ if err := d.Set("trigger_id", triggerId.(string)); err != nil {
 
 // Store the ID now. We tried to set it before and it failed because
 // trigger_id didn't exist yet.
-id, err = replaceVars(d, config, "projects/{{project}}/triggers/{{trigger_id}}")
+id, err = replaceVars(d, config, "projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}")
 if err != nil {
   return fmt.Errorf("Error constructing id: %s", err)
 }
+// Force legacy id format for global triggers
+id = strings.ReplaceAll(id, "/locations//", "/")
+id = strings.ReplaceAll(id, "/locations/global/", "/")
 d.SetId(id)

--- a/mmv1/templates/terraform/post_import/cloudbuild_trigger.go.erb
+++ b/mmv1/templates/terraform/post_import/cloudbuild_trigger.go.erb
@@ -1,5 +1,5 @@
 <%- # the license inside this block applies to this file
-	# Copyright 2018 Google Inc.
+	# Copyright 2022 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,6 +12,8 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-	obj["id"] = d.Get("trigger_id")
-	url = strings.ReplaceAll(url, "/locations//", "/locations/global/")
+	// Force legacy id format for global triggers.
+	id = strings.ReplaceAll(id, "/locations//", "/")
+	id = strings.ReplaceAll(id, "/locations/global/", "/")
+	d.SetId(id)
 

--- a/mmv1/templates/terraform/pre_create/cloudbuild_trigger.go.erb
+++ b/mmv1/templates/terraform/pre_create/cloudbuild_trigger.go.erb
@@ -1,5 +1,5 @@
 <%- # the license inside this block applies to this file
-	# Copyright 2018 Google Inc.
+	# Copyright 2022 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,6 +12,5 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-	obj["id"] = d.Get("trigger_id")
 	url = strings.ReplaceAll(url, "/locations//", "/locations/global/")
 

--- a/mmv1/templates/terraform/pre_delete/cloudbuild_trigger.go.erb
+++ b/mmv1/templates/terraform/pre_delete/cloudbuild_trigger.go.erb
@@ -1,5 +1,5 @@
 <%- # the license inside this block applies to this file
-	# Copyright 2018 Google Inc.
+	# Copyright 2022 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,6 +12,5 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-	obj["id"] = d.Get("trigger_id")
 	url = strings.ReplaceAll(url, "/locations//", "/locations/global/")
 

--- a/mmv1/templates/terraform/pre_read/cloudbuild_trigger.go.erb
+++ b/mmv1/templates/terraform/pre_read/cloudbuild_trigger.go.erb
@@ -1,5 +1,5 @@
 <%- # the license inside this block applies to this file
-	# Copyright 2018 Google Inc.
+	# Copyright 2022 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,6 +12,5 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-	obj["id"] = d.Get("trigger_id")
 	url = strings.ReplaceAll(url, "/locations//", "/locations/global/")
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Support for Cloud Build regional triggers by adding a parameter location. The parameter is optional and defaults to "global".

fixes https://github.com/hashicorp/terraform-provider-google/issues/11624

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Support location in `google_cloudbuild_trigger`.
```
