### PR TITLE
Configure the 'deletion protection' of Cloud SQL database instances

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -871,6 +871,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	if ok {
 		instance.Settings = desiredSettings
 	}
+	instance.Settings.DeletionProtectionEnabled = d.Get("deletion_protection").(bool)
 
 	instance.RootPassword = d.Get("root_password").(string)
 
@@ -1393,6 +1394,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	instance.Settings.SettingsVersion = int64(_settings["version"].(int))
 	// Collation cannot be included in the update request
 	instance.Settings.Collation = ""
+	instance.Settings.DeletionProtectionEnabled = d.Get("deletion_protection").(bool)
 
 	// Lock on the master_instance_name just in case updating any replica
 	// settings causes operations on the master.

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -505,6 +505,13 @@ is set to true.`,
 								},
 							},
 						},
+
+						"deletion_protection_enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: `Configuration to protect against accidental instance deletion.`,
+						},
 					},
 				},
 				Description: `The settings to use for the database. The configuration is detailed below.`,
@@ -871,7 +878,6 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	if ok {
 		instance.Settings = desiredSettings
 	}
-	instance.Settings.DeletionProtectionEnabled = d.Get("deletion_protection").(bool)
 
 	instance.RootPassword = d.Get("root_password").(string)
 
@@ -1023,25 +1029,26 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}) *sqladmin.Setti
 	_settings := configured[0].(map[string]interface{})
 	settings := &sqladmin.Settings{
 		// Version is unset in Create but is set during update
-		SettingsVersion:          int64(_settings["version"].(int)),
-		Tier:                     _settings["tier"].(string),
-		ForceSendFields:          []string{"StorageAutoResize"},
-		ActivationPolicy:         _settings["activation_policy"].(string),
-		ActiveDirectoryConfig:    expandActiveDirectoryConfig(_settings["active_directory_config"].([]interface{})),
-		SqlServerAuditConfig:     expandSqlServerAuditConfig(_settings["sql_server_audit_config"].([]interface{})),
-		AvailabilityType:         _settings["availability_type"].(string),
-		Collation:                _settings["collation"].(string),
-		DataDiskSizeGb:           int64(_settings["disk_size"].(int)),
-		DataDiskType:             _settings["disk_type"].(string),
-		PricingPlan:              _settings["pricing_plan"].(string),
-		UserLabels:               convertStringMap(_settings["user_labels"].(map[string]interface{})),
-		BackupConfiguration:      expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
-		DatabaseFlags:            expandDatabaseFlags(_settings["database_flags"].([]interface{})),
-		IpConfiguration:          expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
-		LocationPreference:       expandLocationPreference(_settings["location_preference"].([]interface{})),
-		MaintenanceWindow:        expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),
-		InsightsConfig:           expandInsightsConfig(_settings["insights_config"].([]interface{})),
-		PasswordValidationPolicy: expandPasswordValidationPolicy(_settings["password_validation_policy"].([]interface{})),
+		SettingsVersion:           int64(_settings["version"].(int)),
+		ActivationPolicy:          _settings["activation_policy"].(string),
+		ActiveDirectoryConfig:     expandActiveDirectoryConfig(_settings["active_directory_config"].([]interface{})),
+		AvailabilityType:          _settings["availability_type"].(string),
+		BackupConfiguration:       expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
+		Collation:                 _settings["collation"].(string),
+		DataDiskSizeGb:            int64(_settings["disk_size"].(int)),
+		DataDiskType:              _settings["disk_type"].(string),
+		DatabaseFlags:             expandDatabaseFlags(_settings["database_flags"].([]interface{})),
+		DeletionProtectionEnabled: _settings["deletion_protection_enabled"].(bool),
+		ForceSendFields:           []string{"StorageAutoResize"},
+		InsightsConfig:            expandInsightsConfig(_settings["insights_config"].([]interface{})),
+		IpConfiguration:           expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
+		LocationPreference:        expandLocationPreference(_settings["location_preference"].([]interface{})),
+		MaintenanceWindow:         expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),
+		PasswordValidationPolicy:  expandPasswordValidationPolicy(_settings["password_validation_policy"].([]interface{})),
+		PricingPlan:               _settings["pricing_plan"].(string),
+		SqlServerAuditConfig:      expandSqlServerAuditConfig(_settings["sql_server_audit_config"].([]interface{})),
+		Tier:                      _settings["tier"].(string),
+		UserLabels:                convertStringMap(_settings["user_labels"].(map[string]interface{})),
 	}
 
 	resize := _settings["disk_autoresize"].(bool)
@@ -1394,7 +1401,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	instance.Settings.SettingsVersion = int64(_settings["version"].(int))
 	// Collation cannot be included in the update request
 	instance.Settings.Collation = ""
-	instance.Settings.DeletionProtectionEnabled = d.Get("deletion_protection").(bool)
 
 	// Lock on the master_instance_name just in case updating any replica
 	// settings causes operations on the master.
@@ -1497,16 +1503,17 @@ func resourceSqlDatabaseInstanceImport(d *schema.ResourceData, meta interface{})
 
 func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
 	data := map[string]interface{}{
-		"version":                    settings.SettingsVersion,
-		"tier":                       settings.Tier,
-		"activation_policy":          settings.ActivationPolicy,
-		"availability_type":          settings.AvailabilityType,
-		"collation":                  settings.Collation,
-		"disk_type":                  settings.DataDiskType,
-		"disk_size":                  settings.DataDiskSizeGb,
-		"pricing_plan":               settings.PricingPlan,
-		"user_labels":                settings.UserLabels,
-		"password_validation_policy": settings.PasswordValidationPolicy,
+		"version":                     settings.SettingsVersion,
+		"tier":                        settings.Tier,
+		"activation_policy":           settings.ActivationPolicy,
+		"availability_type":           settings.AvailabilityType,
+		"collation":                   settings.Collation,
+		"deletion_protection_enabled": settings.DeletionProtectionEnabled,
+		"disk_type":                   settings.DataDiskType,
+		"disk_size":                   settings.DataDiskSizeGb,
+		"pricing_plan":                settings.PricingPlan,
+		"user_labels":                 settings.UserLabels,
+		"password_validation_policy":  settings.PasswordValidationPolicy,
 	}
 
 	if settings.ActiveDirectoryConfig != nil {


### PR DESCRIPTION
This allows to configure the "deletion protection" of Cloud SQL database instances.

fixes https://github.com/hashicorp/terraform-provider-google/issues/12344

This can be made a bit better, but it would require to pass the `d *schema.ResourceData` to `expandSqlDatabaseInstanceSettings` and set all the "settings" fields inside this function; but then it's not really an "expand" function anymore.
Let me know if you want to make this kind of change.

I haven't run the acceptance tests yet.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added the support for configuring "deletion protection" of Cloud SQL database instances
```
