### PR TITLE
vcr detect provider version

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_secure_services.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secure_services.tf.erb
@@ -1,6 +1,5 @@
 # [START cloud_run_secure_services_backend]
 resource "google_cloud_run_service" "renderer" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['renderer'] %>"
   location = "us-central1"
   template {

--- a/mmv1/templates/terraform/examples/cloud_run_service_secure_services.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secure_services.tf.erb
@@ -1,5 +1,6 @@
 # [START cloud_run_secure_services_backend]
 resource "google_cloud_run_service" "renderer" {
+  provider = google-beta
   name     = "<%= ctx[:vars]['renderer'] %>"
   location = "us-central1"
   template {

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -287,7 +287,7 @@ func googleProviderConfig(t *testing.T) *Config {
 	return testAccProvider.Meta().(*Config)
 }
 
-func getTestAccProviders(testName string) map[string]*schema.Provider {
+func getTestAccProviders(testName string, c resource.TestCase) map[string]*schema.Provider {
 	prov := Provider()
 	if isVcrEnabled() {
 		old := prov.ConfigureContextFunc
@@ -297,9 +297,15 @@ func getTestAccProviders(testName string) map[string]*schema.Provider {
 	} else {
 		log.Print("[DEBUG] VCR_PATH or VCR_MODE not set, skipping VCR")
 	}
+	var testProvider string
+	providerMapKeys := reflect.ValueOf(c.Providers).MapKeys()
+	if strings.Contains(providerMapKeys[0].String(), "google-beta") {
+		testProvider = "google-beta"
+	} else {
+		testProvider = "google"
+	}
 	return map[string]*schema.Provider{
-		"google": prov,
-		"google-beta": prov,
+		testProvider: prov,
 	}
 }
 

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -319,7 +319,7 @@ func isVcrEnabled() bool {
 // Can be called when VCR is not enabled, and it will behave as normal
 func vcrTest(t *testing.T, c resource.TestCase) {
 	if isVcrEnabled() {
-		providers := getTestAccProviders(t.Name())
+		providers := getTestAccProviders(t.Name(), c)
 		c.Providers = providers
 		defer closeRecorder(t)
 	} else if isReleaseDiffEnabled() {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Previously, beta-only tests without `provider = google-beta` in config would not fail in VCR due to VCR not detect test provider version correctly. This PR enables VCR to catch such errors.  

This provider version related failed tests detected in this PR will be resolved in a separate PR https://github.com/GoogleCloudPlatform/magic-modules/pull/6452


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
