### PR TITLE
Add certificate_map to compute_target_ssl_proxy

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -15927,7 +15927,9 @@ objects:
           A list of SslCertificate resources that are used to authenticate
           connections between users and the load balancer. At least one
           SSL certificate must be specified.
-        required: true
+        exactly_one_of:
+          - sslCertificates
+          - certificateMap
         update_verb: :POST
         update_url: 'projects/{{project}}/global/targetSslProxies/{{name}}/setSslCertificates'
         item_type: !ruby/object:Api::Type::ResourceRef
@@ -15935,6 +15937,18 @@ objects:
           resource: 'SslCertificate'
           imports: 'selfLink'
           description: 'The SSL certificates used by this TargetSslProxy'
+      - !ruby/object:Api::Type::String
+        name: 'certificateMap'
+        description: |
+          A reference to the CertificateMap resource uri that identifies a certificate map
+          associated with the given target proxy. This field can only be set for global target proxies.
+          Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificateMaps/{resourceName}`.
+        exactly_one_of:
+          - sslCertificates
+          - certificateMap
+        update_verb: :POST
+        update_url:
+          'projects/{{project}}/global/targetSslProxies/{{name}}/setCertificateMap'
       - !ruby/object:Api::Type::ResourceRef
         name: 'sslPolicy'
         resource: 'SslPolicy'

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
@@ -1,18 +1,18 @@
+<% autogen_exception -%>
 package google
 
 import (
 	"fmt"
 	"testing"
 
-	"google3/third_party/golang/google_api/compute/v1/compute"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
 
-const (
-	canonicalSslCertificateTemplate = "https://www.googleapis.com/compute/v1/projects/%s/global/sslCertificates/%s"
-	canonicalCertificateMapTemplate = "//certificatemanager.googleapis.com/projects/%s/locations/global/certificateMaps/%s"
+<% if version == "ga" -%>
+	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
 )
 
 func TestAccComputeTargetSslProxy_update(t *testing.T) {
@@ -95,7 +95,7 @@ func testAccCheckComputeTargetSslProxyExists(t *testing.T, n string, proxy *comp
 func testAccCheckComputeTargetSslProxyHeader(t *testing.T, proxyHeader string, proxy *compute.TargetSslProxy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if proxy.ProxyHeader != proxyHeader {
-			return fmt.Errorf("Wrong proxy header. Expected '%s', got '%s'", proxyHeader, found.ProxyHeader)
+			return fmt.Errorf("Wrong proxy header. Expected '%s', got '%s'", proxyHeader, proxy.ProxyHeader)
 		}
 		return nil
 	}
@@ -121,7 +121,7 @@ func testAccCheckComputeTargetSslProxyHasCertificateMap(t *testing.T, certificat
 		config := googleProviderConfig(t)
 		wantCertMapURL := fmt.Sprintf(canonicalCertificateMapTemplate, config.Project, certificateMap)
 		gotCertMapURL := ConvertSelfLinkToV1(proxy.CertificateMap)
-		if wantCertMapUrl != gotCertMapUrl {
+		if wantCertMapURL != gotCertMapURL {
 			return fmt.Errorf("certificate map not found: got %q, want %q", gotCertMapURL, wantCertMapURL)
 		}
 		return nil

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
@@ -51,11 +51,19 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeTargetSslProxy_certificateMap(resourceSuffix),
+				Config: testAccComputeTargetSslProxy_certificateMap1(resourceSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetSslProxyExists(
 						t, "google_compute_target_ssl_proxy.with_certificate_map", &proxy),
-					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "certificatemap-test-"+resourceSuffix, &proxy),
+					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "certificatemap-test-1-"+resourceSuffix, &proxy),
+				),
+			},
+			{
+				Config: testAccComputeTargetSslProxy_certificateMap2(resourceSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeTargetSslProxyExists(
+						t, "google_compute_target_ssl_proxy.with_certificate_map", &proxy),
+					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "certificatemap-test-2-"+resourceSuffix, &proxy),
 				),
 			},
 		},
@@ -221,13 +229,13 @@ resource "google_compute_health_check" "zero" {
 `, target, sslPolicy, sslCert1, sslCert2, backend1, backend2, hc)
 }
 
-func testAccComputeTargetSslProxy_certificateMap(id string) string {
+func testAccComputeTargetSslProxy_certificateMap1(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_ssl_proxy" "with_certificate_map" {
   description      = "Resource created for Terraform acceptance testing"
   name             = "ssl-proxy-%s"
   backend_service  = google_compute_backend_service.foo.self_link
-	certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map.id}"
+	certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map1.id}"
 }
 
 resource "google_compute_backend_service" "foo" {
@@ -245,8 +253,66 @@ resource "google_compute_health_check" "zero" {
   }
 }
 
-resource "google_certificate_manager_certificate_map" "map" {
-  name = "certificatemap-test-%s"
+resource "google_certificate_manager_certificate_map" "map1" {
+  name = "certificatemap-test-1-%s"
+}
+resource "google_certificate_manager_certificate_map_entry" "map_entry" {
+  name         = "certificatemapentry-test-%s"
+  map          = google_certificate_manager_certificate_map.map.name
+  certificates = [google_certificate_manager_certificate.certificate.id]
+  matcher      = "PRIMARY"
+}
+
+resource "google_certificate_manager_certificate" "certificate" {
+  name        = "certificate-test-%s"
+  scope       = "DEFAULT"
+  managed {
+    domains = [
+      google_certificate_manager_dns_authorization.instance.domain,
+    ]
+    dns_authorizations = [
+      google_certificate_manager_dns_authorization.instance.id,
+    ]
+  }
+}
+
+resource "google_certificate_manager_dns_authorization" "instance" {
+  name   = "dnsauthorization-test-%s"
+  domain = "mysite.com"
+}
+`, id, id, id, id, id, id, id)
+}
+
+func testAccComputeTargetSslProxy_certificateMap2(id string) string {
+	return fmt.Sprintf(`
+resource "google_compute_target_ssl_proxy" "with_certificate_map" {
+  description      = "Resource created for Terraform acceptance testing"
+  name             = "ssl-proxy-%s"
+  backend_service  = google_compute_backend_service.foo.self_link
+	certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map2.id}"
+}
+
+resource "google_compute_backend_service" "foo" {
+  name          = "backend-service-%s"
+  protocol      = "SSL"
+  health_checks = [google_compute_health_check.zero.self_link]
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "health-check-%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "443"
+  }
+}
+
+resource "google_certificate_manager_certificate_map" "map1" {
+  name = "certificatemap-test-1-%s"
+}
+
+resource "google_certificate_manager_certificate_map" "map2" {
+  name = "certificatemap-test-2-%s"
 }
 
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
@@ -273,5 +339,5 @@ resource "google_certificate_manager_dns_authorization" "instance" {
   name   = "dnsauthorization-test-%s"
   domain = "mysite.com"
 }
-`, id, id, id, id, id, id, id)
+`, id, id, id, id, id, id, id, id)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
@@ -258,7 +258,7 @@ resource "google_certificate_manager_certificate_map" "map1" {
 }
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
   name         = "certificatemapentry-test-%s"
-  map          = google_certificate_manager_certificate_map.map.name
+  map          = google_certificate_manager_certificate_map.map1.name
   certificates = [google_certificate_manager_certificate.certificate.id]
   matcher      = "PRIMARY"
 }
@@ -317,7 +317,7 @@ resource "google_certificate_manager_certificate_map" "map2" {
 
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
   name         = "certificatemapentry-test-%s"
-  map          = google_certificate_manager_certificate_map.map.name
+  map          = google_certificate_manager_certificate_map.map1.name
   certificates = [google_certificate_manager_certificate.certificate.id]
   matcher      = "PRIMARY"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add certificate_map option to compute_target_ssl_proxy in order to support new certificate-manager (with wildcard support).

Similar PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/5991



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
compute: added `certificate_map` to `compute_target_ssl_proxy` resource
```
