### PR TITLE
Fix firebase rules vcr test

### DIFF
--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"bitbucket.org/creachadair/stringset"
 	dcl "github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
 	"github.com/golang/glog"
 )
@@ -519,4 +520,20 @@ func (sub *Variable) translateValue(isDocs bool) string {
 func (s Sample) PrimaryResourceName() string {
 	fileParts := strings.Split(*s.PrimaryResource, ".")
 	return fileParts[0]
+}
+
+// This is overbroad, but works for now.
+// This should only look for when a sample has a dependency on multiple *fine-grained*
+// resources, but we don't have a good way to identify fine-grained vs not currently
+func (s Sample) ShouldSkipVcr() bool {
+	uniqueResources := stringset.New()
+	
+	for _, d := range s.DependencyList {
+		if uniqueResources.Contains(d.TerraformResourceType) {
+			return true
+		}
+		uniqueResources.Add(d.TerraformResourceType)
+	}
+	return false
+
 }

--- a/tpgtools/templates/test_file.go.tmpl
+++ b/tpgtools/templates/test_file.go.tmpl
@@ -45,6 +45,9 @@ import (
 
 {{- range $s := $.TestSamples }}
 func TestAcc{{$.PathType}}_{{$s.TestSlug}}(t *testing.T) {
+{{- if $s.ShouldSkipVcr }}
+	skipIfVcr(t)
+{{- end }}
 	t.Parallel()
 
 	context := map[string]interface{} {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes this test by skipping in VCR as it has non-determinism



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
