### PR TITLE
Added example for GFE3 regional HTTP LB--compute engine backend

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2289,6 +2289,27 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "target"
           - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "regional-external-http-load-balancer"
+        primary_resource_type: "google_compute_region_url_map"
+        primary_resource_id: "default"
+        vars:
+          lb_network: "lb-network"
+          backend_subnet: "backend-subnet"
+          proxy_only_subnet: "proxy-only-subnet"
+          fw_allow_health_check: "fw-allow-health-check"
+          fw_allow_proxies: "fw-allow-proxies"
+          l7_xlb_backend_template: "l7-xlb-backend-template"
+          l7_xlb_backend_example: "l7-xlb-backend-example"
+          address_name: "address-name"
+          l7_xlb_basic_check: "l7-xlb-basic-check"
+          l7_xlb_backend_service: "l7-xlb-backend-service"
+          regional_l7_xlb_map: "regional-l7-xlb-map"
+          l7_xlb_proxy: "l7-xlb-proxy"
+          l7_xlb_forwarding_rule: "l7-xlb-forwarding-rule"
+        skip_docs: true
+        skip_test: true # Similar to other samples
+        min_version: beta
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/templates/terraform/examples/regional-external-http-load-balancer.tf.erb
+++ b/mmv1/templates/terraform/examples/regional-external-http-load-balancer.tf.erb
@@ -1,0 +1,204 @@
+# [START cloudloadbalancing_rllxlb_example]
+
+# [START cloudloadbalancing_vpc_network_rllxlb_example]
+resource "google_compute_network" "default" {
+  name                    = "<%= ctx[:vars]['lb_network'] %>"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+# [END cloudloadbalancing__vpc_network_rllxlb_example]
+
+# [START cloudloadbalancing_vpc_subnetwork_rllxlb_example]
+resource "google_compute_subnetwork" "default" {
+  name                       = "<%= ctx[:vars]['backend_subnet'] %>"
+  ip_cidr_range              = "10.1.2.0/24"
+  network                    = google_compute_network.default.id
+  private_ipv6_google_access = "DISABLE_GOOGLE_ACCESS"
+  purpose                    = "PRIVATE"
+  region                     = "us-west1"
+  stack_type                 = "IPV4_ONLY"
+}
+# [END cloudloadbalancing_vpc_subnetwork_rllxlb_example]
+
+# [START cloudloadbalancing_vpc_proxy_subnetwork_rllxlb_example]
+resource "google_compute_subnetwork" "proxy_only" {
+  name          = "<%= ctx[:vars]['proxy_only_subnet'] %>"
+  ip_cidr_range = "10.129.0.0/23"
+  network       = google_compute_network.default.id
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  region        = "us-west1"
+  role          = "ACTIVE"
+}
+# [END cloudloadbalancing_vpc_proxy_subnetwork_rllxlb_example]
+
+# [START cloudloadbalancing_health_firewall_rllxlb_example]
+resource "google_compute_firewall" "default" {
+  name = "<%= ctx[:vars]['fw_allow_health_check'] %>"
+  allow {
+    protocol = "tcp"
+  }
+  direction     = "INGRESS"
+  network       = google_compute_network.default.id
+  priority      = 1000
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["load-balanced-backend"]
+}
+# [END cloudloadbalancing_health_firewall_rllxlb_example]
+
+# [START cloudloadbalancing_proxy_firewall_rllxlb_example]
+resource "google_compute_firewall" "allow_proxy" {
+  name = "<%= ctx[:vars]['fw_allow_proxies'] %>"
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["80"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["8080"]
+    protocol = "tcp"
+  }
+  direction     = "INGRESS"
+  network       = google_compute_network.default.id
+  priority      = 1000
+  source_ranges = ["10.129.0.0/23"]
+  target_tags   = ["load-balanced-backend"]
+}
+# [END cloudloadbalancing_proxy_firewall_rllxlb_example]
+
+# [START cloudloadbalancing_instance_template_rllxlb_example]
+resource "google_compute_instance_template" "default" {
+  name = "<%= ctx[:vars]['l7_xlb_backend_template'] %>"
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disk-0"
+    mode         = "READ_WRITE"
+    source_image = "projects/debian-cloud/global/images/family/debian-10"
+    type         = "PERSISTENT"
+  }
+  labels = {
+    managed-by-cnrm = "true"
+  }
+  machine_type = "n1-standard-1"
+  metadata = {
+    startup-script = "#! /bin/bash\nsudo apt-get update\nsudo apt-get install apache2 -y\nsudo a2ensite default-ssl\nsudo a2enmod ssl\nsudo vm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\nhttp://169.254.169.254/computeMetadata/v1/instance/name)\"\nsudo echo \"Page served from: $vm_hostname\" | \\\ntee /var/www/html/index.html\nsudo systemctl restart apache2"
+  }
+  network_interface {
+    access_config {
+      network_tier = "PREMIUM"
+    }
+    network            = google_compute_network.default.id
+    subnetwork         = google_compute_subnetwork.default.id
+    subnetwork_project = "load-balancer-https"
+  }
+  region = "us-west1"
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/pubsub", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+  }
+  tags = ["load-balanced-backend"]
+}
+# [END cloudloadbalancing_instance_template_rllxlb_example]
+
+# [START cloudloadbalancing_instance_group_rllxlb_example]
+resource "google_compute_instance_group_manager" "default" {
+  name = "<%= ctx[:vars]['l7_xlb_backend_example'] %>"
+  zone = "us-west1-a"
+  named_port {
+    name = "http"
+    port = 80
+  }
+  version {
+    instance_template = google_compute_instance_template.default.id
+    name              = "primary"
+  }
+  base_instance_name = "vm"
+  target_size        = 2
+}
+# [END cloudloadbalancing_instance_group_rllxlb_example]
+
+# [START cloudloadbalancing_ip_address_rllxlb_example]
+resource "google_compute_address" "default" {
+  name         = "<%= ctx[:vars]['address_name'] %>"
+  address_type = "EXTERNAL"
+  network_tier = "STANDARD"
+  region       = "us-west1"
+}
+# [END cloudloadbalancing_ip_address_rllxlb_example]
+
+
+# [START cloudloadbalancing_health_check_rllxlb_example]
+resource "google_compute_region_health_check" "default" {
+  name               = "<%= ctx[:vars]['l7_xlb_basic_check'] %>"
+  check_interval_sec = 5
+  healthy_threshold  = 2
+  http_health_check {
+    port_specification = "USE_SERVING_PORT"
+    proxy_header       = "NONE"
+    request_path       = "/"
+  }
+  region              = "us-west1"
+  timeout_sec         = 5
+  unhealthy_threshold = 2
+}
+# [END cloudloadbalancing_health_check_rllxlb_example]
+
+# [START cloudloadbalancing_backend_service_rllxlb_example]
+resource "google_compute_region_backend_service" "default" {
+  name                            = "<%= ctx[:vars]['l7_xlb_backend_service'] %>"
+  region                          = "us-west1"
+  load_balancing_scheme           = "EXTERNAL_MANAGED"
+  health_checks                   = [google_compute_region_health_check.default.id]
+  protocol                        = "HTTP"
+  session_affinity                = "NONE"
+  timeout_sec                     = 30
+  backend {
+    group           = google_compute_instance_group_manager.default.instance_group
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+}
+# [END cloudloadbalancing_backend_service_rllxlb_example]
+
+# [START cloudloadbalancing_url_map_rllxlb_example]
+resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
+  name            = "<%= ctx[:vars]['regional_l7_xlb_map'] %>"
+  region          = "us-west1"
+  default_service = google_compute_region_backend_service.default.id
+}
+# [END cloudloadbalancing_url_map_rllxlb_example]
+
+# [START cloudloadbalancing_target_http_proxy_rllxlb_example]
+resource "google_compute_region_target_http_proxy" "default" {
+  name    = "<%= ctx[:vars]['l7_xlb_proxy'] %>"
+  region  = "us-west1"
+  url_map = google_compute_region_url_map.default.id
+}
+# [END cloudloadbalancing_target_http_proxy_rllxlb_example]
+
+# [START cloudloadbalancing_forwarding_rule_rllxlb_example]
+resource "google_compute_forwarding_rule" "default" {
+  name                  = "l7-xlb-forwarding-rule"
+  provider              = google-beta
+  depends_on            = [google_compute_subnetwork.proxy_only]
+  region                = "us-east1"
+
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  port_range            = "80"
+  target                = google_compute_region_target_http_proxy.default.id
+  network               = google_compute_network.default.id
+  ip_address            = google_compute_address.default.id
+  network_tier          = "STANDARD"
+}
+# [END cloudloadbalancing_forwarding_rule_rllxlb_example]
+
+# [END cloudloadbalancing_rllxlb_example]


### PR DESCRIPTION
Intending for this page:

https://cloud.google.com/load-balancing/docs/https/setting-up-reg-ext-https-lb

```release-note:none
```