### PR TITLE
Add vertical whitespace and google.rpc.Help.Link output

### DIFF
--- a/mmv1/third_party/terraform/utils/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation.go.erb
@@ -170,7 +170,7 @@ func (e ComputeOperationError) Error() string {
 	return buf.String()
 }
 
-const errMsgSep = "\n\n\n"
+const errMsgSep = "\n\n"
 
 func writeOperationError(w io.StringWriter, opError *compute.OperationErrorErrors) {
 	w.WriteString(opError.Message + "\n")

--- a/mmv1/third_party/terraform/utils/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation.go.erb
@@ -176,15 +176,19 @@ func writeOperationError(w io.StringWriter, opError *compute.OperationErrorError
 	w.WriteString(opError.Message + "\n")
 
 	var lm *compute.LocalizedMessage
-	var links []*compute.HelpLink
+	var link *compute.HelpLink
 
 	for _, ed := range opError.ErrorDetails {
 		if ed.LocalizedMessage != nil {
 			lm = ed.LocalizedMessage
 		}
 
-		if ed.Help != nil {
-			links = append(links, ed.Help.Links...)
+		if link == nil && ed.Help != nil && len(ed.Help.Links) > 0 {
+			link = ed.Help.Links[0]
+		}
+
+		if lm != nil && link != nil {
+			break
 		}
 	}
 
@@ -193,9 +197,15 @@ func writeOperationError(w io.StringWriter, opError *compute.OperationErrorError
 		w.WriteString(lm.Message + "\n")
 	}
 
-	for _, link := range links {
+	if link != nil {
 		w.WriteString(errMsgSep)
-		w.WriteString(link.Description + "\n")
-		w.WriteString(link.Url + "\n")
+
+		if link.Description != "" {
+			w.WriteString(link.Description + "\n")
+		}
+
+		if link.Url != "" {
+			w.WriteString(link.Url + "\n")
+		}
 	}
 }

--- a/mmv1/third_party/terraform/utils/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation.go.erb
@@ -170,12 +170,32 @@ func (e ComputeOperationError) Error() string {
 	return buf.String()
 }
 
+const errMsgSep = "\n\n\n"
+
 func writeOperationError(w io.StringWriter, opError *compute.OperationErrorErrors) {
 	w.WriteString(opError.Message + "\n")
 
+	var lm *compute.LocalizedMessage
+	var links []*compute.HelpLink
+
 	for _, ed := range opError.ErrorDetails {
-		if ed.LocalizedMessage != nil && ed.LocalizedMessage.Message != "" {
-			w.WriteString(ed.LocalizedMessage.Message + "\n")
+		if ed.LocalizedMessage != nil {
+			lm = ed.LocalizedMessage
 		}
+
+		if ed.Help != nil {
+			links = append(links, ed.Help.Links...)
+		}
+	}
+
+	if lm != nil && lm.Message != "" {
+		w.WriteString(errMsgSep)
+		w.WriteString(lm.Message + "\n")
+	}
+
+	for _, link := range links {
+		w.WriteString(errMsgSep)
+		w.WriteString(link.Description + "\n")
+		w.WriteString(link.Url + "\n")
 	}
 }

--- a/mmv1/third_party/terraform/utils/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation.go.erb
@@ -179,7 +179,7 @@ func writeOperationError(w io.StringWriter, opError *compute.OperationErrorError
 	var link *compute.HelpLink
 
 	for _, ed := range opError.ErrorDetails {
-		if ed.LocalizedMessage != nil {
+		if lm == nil && ed.LocalizedMessage != nil {
 			lm = ed.LocalizedMessage
 		}
 

--- a/mmv1/third_party/terraform/utils/compute_operation_test.go
+++ b/mmv1/third_party/terraform/utils/compute_operation_test.go
@@ -1,0 +1,295 @@
+package google
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+)
+
+var omitAlways = []string{
+	"LocalizedMessage2",
+	"Help1Link2 Description",
+	"https://help1.com/link2",
+	"Help2Link1 Description",
+	"https://help2.com/link1",
+	"Help2Link2 Description",
+	"https://help2.com/link2",
+}
+
+func TestComputeOperationError_Error(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          compute.OperationError
+		expectContains []string
+		expectOmits    []string
+	}{
+		{
+			name: "MessageOnly",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+			},
+			expectOmits: append(omitAlways, []string{
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			}...),
+		},
+		{
+			name: "WithLocalizedMessageAndNoHelp",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+							&compute.OperationErrorErrorsErrorDetails{
+								LocalizedMessage: &compute.LocalizedMessage{
+									Locale:  "en-US",
+									Message: "LocalizedMessage1 message",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+				"LocalizedMessage1",
+			},
+			expectOmits: append(omitAlways, []string{
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			}...),
+		},
+		{
+			name: "WithLocalizedMessageAndHelp",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+							&compute.OperationErrorErrorsErrorDetails{
+								LocalizedMessage: &compute.LocalizedMessage{
+									Locale:  "en-US",
+									Message: "LocalizedMessage1 message",
+								},
+							},
+							&compute.OperationErrorErrorsErrorDetails{
+								Help: &compute.Help{
+									Links: []*compute.HelpLink{
+										&compute.HelpLink{
+											Description: "Help1Link1 Description",
+											Url:         "https://help1.com/link1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			},
+			expectOmits: append(omitAlways, []string{}...),
+		},
+		{
+			name: "WithNoLocalizedMessageAndHelp",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+							&compute.OperationErrorErrorsErrorDetails{
+								Help: &compute.Help{
+									Links: []*compute.HelpLink{
+										&compute.HelpLink{
+											Description: "Help1Link1 Description",
+											Url:         "https://help1.com/link1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			},
+			expectOmits: append(omitAlways, []string{
+				"LocalizedMessage1",
+			}...),
+		},
+		{
+			name: "WithLocalizedMessageAndHelpWithTwoLinks",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+							&compute.OperationErrorErrorsErrorDetails{
+								LocalizedMessage: &compute.LocalizedMessage{
+									Locale:  "en-US",
+									Message: "LocalizedMessage1 message",
+								},
+							},
+							&compute.OperationErrorErrorsErrorDetails{
+								Help: &compute.Help{
+									Links: []*compute.HelpLink{
+										&compute.HelpLink{
+											Description: "Help1Link1 Description",
+											Url:         "https://help1.com/link1",
+										},
+										&compute.HelpLink{
+											Description: "Help1Link2 Description",
+											Url:         "https://help1.com/link2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			},
+			expectOmits: append(omitAlways, []string{}...),
+		},
+		// The case below should never happen because the server should just send multiple links
+		// but the protobuf defition would allow it, so testing anyway.
+		{
+			name: "WithLocalizedMessageAndTwoHelpsWithTwoLinks",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+							&compute.OperationErrorErrorsErrorDetails{
+								LocalizedMessage: &compute.LocalizedMessage{
+									Locale:  "en-US",
+									Message: "LocalizedMessage1 message",
+								},
+							},
+							&compute.OperationErrorErrorsErrorDetails{
+								Help: &compute.Help{
+									Links: []*compute.HelpLink{
+										&compute.HelpLink{
+											Description: "Help1Link1 Description",
+											Url:         "https://help1.com/link1",
+										},
+										&compute.HelpLink{
+											Description: "Help1Link2 Description",
+											Url:         "https://help1.com/link2",
+										},
+									},
+								},
+							},
+							&compute.OperationErrorErrorsErrorDetails{
+								Help: &compute.Help{
+									Links: []*compute.HelpLink{
+										&compute.HelpLink{
+											Description: "Help2Link1 Description",
+											Url:         "https://help2.com/link1",
+										},
+										&compute.HelpLink{
+											Description: "Help2Link2 Description",
+											Url:         "https://help2.com/link2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			},
+			expectOmits: append(omitAlways, []string{}...),
+		},
+		// This should never happen because the server should never respond with the messages for
+		// two locales at once, but should rather take the locale as input to the API and serve
+		// the appropriate message for that locale. However, the protobuf defition would allow it,
+		// so we'll test for it. The second message in the list would be ignored.
+		{
+			name: "WithTwoLocalizedMessageAndHelp",
+			input: compute.OperationError{
+				Errors: []*compute.OperationErrorErrors{
+					&compute.OperationErrorErrors{
+						Message: "Top-level message.",
+						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+							&compute.OperationErrorErrorsErrorDetails{
+								LocalizedMessage: &compute.LocalizedMessage{
+									Locale:  "en-US",
+									Message: "LocalizedMessage1 message",
+								},
+							},
+							&compute.OperationErrorErrorsErrorDetails{
+								LocalizedMessage: &compute.LocalizedMessage{
+									Locale:  "en-ES",
+									Message: "LocalizedMessage2 message",
+								},
+							},
+							&compute.OperationErrorErrorsErrorDetails{
+								Help: &compute.Help{
+									Links: []*compute.HelpLink{
+										&compute.HelpLink{
+											Description: "Help1Link1 Description",
+											Url:         "https://help1.com/link1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectContains: []string{
+				"Top-level",
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			},
+			expectOmits: append(omitAlways, []string{}...),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ComputeOperationError(tc.input)
+			str := err.Error()
+
+			for _, contains := range tc.expectContains {
+				if !strings.Contains(str, contains) {
+					t.Errorf("expected\n%s\nto contain, %q, and did not", str, contains)
+				}
+			}
+
+			for _, omits := range tc.expectOmits {
+				if strings.Contains(str, omits) {
+					t.Errorf("expected\n%s\nnot to contain, %q, and did not", str, omits)
+				}
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
@@ -1,10 +1,15 @@
+<% autogen_exception -%>
 package google
 
 import (
 	"strings"
 	"testing"
 
+<% if version == "ga" -%>
 	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
 )
 
 var omitAlways = []string{

--- a/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
@@ -13,16 +13,6 @@ import (
 <% end -%>
 )
 
-var omitAlways = []string{
-	"LocalizedMessage2",
-	"Help1Link2 Description",
-	"https://help1.com/link2",
-	"Help2Link1 Description",
-	"https://help2.com/link1",
-	"Help2Link2 Description",
-	"https://help2.com/link2",
-}
-
 const (
 	topLevelMsg             = "Top-level message."
 	localizedMsgTmpl        = "LocalizedMessage%d message"
@@ -66,6 +56,32 @@ func buildOperationError(numLocalizedMsg int, numHelpWithLinks []int) compute.Op
 
 }
 
+func omitAlways(numLocalizedMsg int, numHelpWithLinks []int) []string {
+	var omits []string
+
+	for n := 2; n <= numLocalizedMsg; n++ {
+		omits = append(omits, fmt.Sprintf("LocalizedMessage%d", n))
+	}
+
+	for i := 0; i < len(numHelpWithLinks); i++ {
+		for j := maxLinks(i); j < numHelpWithLinks[i]; j++ {
+			desc, url := formatLink(i+1, j+1)
+			omits = append(omits, desc, url)
+		}
+	}
+
+	return omits
+
+}
+
+func maxLinks(helpIndex int) int {
+	if helpIndex == 0 {
+		return 1
+	}
+
+	return 0
+}
+
 func formatLocalizedMsg(localizedMsgNum int) string {
 	return fmt.Sprintf(localizedMsgTmpl, localizedMsgNum)
 }
@@ -87,7 +103,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 			expectContains: []string{
 				"Top-level",
 			},
-			expectOmits: append(omitAlways, []string{
+			expectOmits: append(omitAlways(0, []int{}), []string{
 				"LocalizedMessage1",
 				"Help1Link1 Description",
 				"https://help1.com/link1",
@@ -100,7 +116,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"Top-level",
 				"LocalizedMessage1",
 			},
-			expectOmits: append(omitAlways, []string{
+			expectOmits: append(omitAlways(1, []int{}), []string{
 				"Help1Link1 Description",
 				"https://help1.com/link1",
 			}...),
@@ -114,7 +130,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"Help1Link1 Description",
 				"https://help1.com/link1",
 			},
-			expectOmits: append(omitAlways, []string{}...),
+			expectOmits: append(omitAlways(1, []int{1}), []string{}...),
 		},
 		{
 			name:  "WithNoLocalizedMessageAndHelp",
@@ -124,7 +140,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"Help1Link1 Description",
 				"https://help1.com/link1",
 			},
-			expectOmits: append(omitAlways, []string{
+			expectOmits: append(omitAlways(0, []int{1}), []string{
 				"LocalizedMessage1",
 			}...),
 		},
@@ -137,7 +153,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"Help1Link1 Description",
 				"https://help1.com/link1",
 			},
-			expectOmits: append(omitAlways, []string{}...),
+			expectOmits: append(omitAlways(1, []int{2}), []string{}...),
 		},
 		// The case below should never happen because the server should just send multiple links
 		// but the protobuf defition would allow it, so testing anyway.
@@ -150,7 +166,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"Help1Link1 Description",
 				"https://help1.com/link1",
 			},
-			expectOmits: append(omitAlways, []string{}...),
+			expectOmits: append(omitAlways(1, []int{2, 2}), []string{}...),
 		},
 		// This should never happen because the server should never respond with the messages for
 		// two locales at once, but should rather take the locale as input to the API and serve
@@ -165,7 +181,7 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"Help1Link1 Description",
 				"https://help1.com/link1",
 			},
-			expectOmits: append(omitAlways, []string{}...),
+			expectOmits: append(omitAlways(2, []int{1}), []string{}...),
 		},
 	}
 

--- a/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
@@ -2,6 +2,7 @@
 package google
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -22,6 +23,57 @@ var omitAlways = []string{
 	"https://help2.com/link2",
 }
 
+const (
+	topLevelMsg             = "Top-level message."
+	localizedMsgTmpl        = "LocalizedMessage%d message"
+	helpLinkDescriptionTmpl = "Help%dLink%d Description"
+	helpLinkUrlTmpl         = "https://help%d.com/link%d"
+)
+
+var locales = []string{"en-US", "es-US", "es-ES", "es-MX", "de-DE"}
+
+func buildOperationError(numLocalizedMsg int, numHelpWithLinks []int) compute.OperationError {
+	opError := &compute.OperationErrorErrors{Message: topLevelMsg}
+	opErrorErrors := []*compute.OperationErrorErrors{opError}
+
+	for n := 1; n <= numLocalizedMsg; n++ {
+		opError.ErrorDetails = append(opError.ErrorDetails,
+			&compute.OperationErrorErrorsErrorDetails{
+				LocalizedMessage: &compute.LocalizedMessage{
+					Locale:  locales[n-1%len(locales)],
+					Message: formatLocalizedMsg(n),
+				},
+			})
+	}
+
+	for i := 0; i < len(numHelpWithLinks); i++ {
+		errorDetail := &compute.OperationErrorErrorsErrorDetails{
+			Help: &compute.Help{},
+		}
+
+		for nLinks := 1; nLinks <= numHelpWithLinks[i]; nLinks++ {
+			desc, url := formatLink(i+1, nLinks)
+			errorDetail.Help.Links = append(errorDetail.Help.Links, &compute.HelpLink{
+				Description: desc,
+				Url:         url,
+			})
+		}
+
+		opError.ErrorDetails = append(opError.ErrorDetails, errorDetail)
+	}
+
+	return compute.OperationError{Errors: opErrorErrors}
+
+}
+
+func formatLocalizedMsg(localizedMsgNum int) string {
+	return fmt.Sprintf(localizedMsgTmpl, localizedMsgNum)
+}
+
+func formatLink(helpNum, linkNum int) (string, string) {
+	return fmt.Sprintf(helpLinkDescriptionTmpl, helpNum, linkNum), fmt.Sprintf(helpLinkUrlTmpl, helpNum, linkNum)
+}
+
 func TestComputeOperationError_Error(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -30,14 +82,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 		expectOmits    []string
 	}{
 		{
-			name: "MessageOnly",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-					},
-				},
-			},
+			name:  "MessageOnly",
+			input: buildOperationError(0, []int{}),
 			expectContains: []string{
 				"Top-level",
 			},
@@ -48,22 +94,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 			}...),
 		},
 		{
-			name: "WithLocalizedMessageAndNoHelp",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
-							&compute.OperationErrorErrorsErrorDetails{
-								LocalizedMessage: &compute.LocalizedMessage{
-									Locale:  "en-US",
-									Message: "LocalizedMessage1 message",
-								},
-							},
-						},
-					},
-				},
-			},
+			name:  "WithLocalizedMessageAndNoHelp",
+			input: buildOperationError(1, []int{}),
 			expectContains: []string{
 				"Top-level",
 				"LocalizedMessage1",
@@ -74,32 +106,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 			}...),
 		},
 		{
-			name: "WithLocalizedMessageAndHelp",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
-							&compute.OperationErrorErrorsErrorDetails{
-								LocalizedMessage: &compute.LocalizedMessage{
-									Locale:  "en-US",
-									Message: "LocalizedMessage1 message",
-								},
-							},
-							&compute.OperationErrorErrorsErrorDetails{
-								Help: &compute.Help{
-									Links: []*compute.HelpLink{
-										&compute.HelpLink{
-											Description: "Help1Link1 Description",
-											Url:         "https://help1.com/link1",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:  "WithLocalizedMessageAndHelp",
+			input: buildOperationError(1, []int{1}),
 			expectContains: []string{
 				"Top-level",
 				"LocalizedMessage1",
@@ -109,26 +117,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 			expectOmits: append(omitAlways, []string{}...),
 		},
 		{
-			name: "WithNoLocalizedMessageAndHelp",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
-							&compute.OperationErrorErrorsErrorDetails{
-								Help: &compute.Help{
-									Links: []*compute.HelpLink{
-										&compute.HelpLink{
-											Description: "Help1Link1 Description",
-											Url:         "https://help1.com/link1",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:  "WithNoLocalizedMessageAndHelp",
+			input: buildOperationError(0, []int{1}),
 			expectContains: []string{
 				"Top-level",
 				"Help1Link1 Description",
@@ -139,36 +129,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 			}...),
 		},
 		{
-			name: "WithLocalizedMessageAndHelpWithTwoLinks",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
-							&compute.OperationErrorErrorsErrorDetails{
-								LocalizedMessage: &compute.LocalizedMessage{
-									Locale:  "en-US",
-									Message: "LocalizedMessage1 message",
-								},
-							},
-							&compute.OperationErrorErrorsErrorDetails{
-								Help: &compute.Help{
-									Links: []*compute.HelpLink{
-										&compute.HelpLink{
-											Description: "Help1Link1 Description",
-											Url:         "https://help1.com/link1",
-										},
-										&compute.HelpLink{
-											Description: "Help1Link2 Description",
-											Url:         "https://help1.com/link2",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:  "WithLocalizedMessageAndHelpWithTwoLinks",
+			input: buildOperationError(1, []int{2}),
 			expectContains: []string{
 				"Top-level",
 				"LocalizedMessage1",
@@ -180,50 +142,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 		// The case below should never happen because the server should just send multiple links
 		// but the protobuf defition would allow it, so testing anyway.
 		{
-			name: "WithLocalizedMessageAndTwoHelpsWithTwoLinks",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
-							&compute.OperationErrorErrorsErrorDetails{
-								LocalizedMessage: &compute.LocalizedMessage{
-									Locale:  "en-US",
-									Message: "LocalizedMessage1 message",
-								},
-							},
-							&compute.OperationErrorErrorsErrorDetails{
-								Help: &compute.Help{
-									Links: []*compute.HelpLink{
-										&compute.HelpLink{
-											Description: "Help1Link1 Description",
-											Url:         "https://help1.com/link1",
-										},
-										&compute.HelpLink{
-											Description: "Help1Link2 Description",
-											Url:         "https://help1.com/link2",
-										},
-									},
-								},
-							},
-							&compute.OperationErrorErrorsErrorDetails{
-								Help: &compute.Help{
-									Links: []*compute.HelpLink{
-										&compute.HelpLink{
-											Description: "Help2Link1 Description",
-											Url:         "https://help2.com/link1",
-										},
-										&compute.HelpLink{
-											Description: "Help2Link2 Description",
-											Url:         "https://help2.com/link2",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:  "WithLocalizedMessageAndTwoHelpsWithTwoLinks",
+			input: buildOperationError(1, []int{2, 2}),
 			expectContains: []string{
 				"Top-level",
 				"LocalizedMessage1",
@@ -237,38 +157,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 		// the appropriate message for that locale. However, the protobuf defition would allow it,
 		// so we'll test for it. The second message in the list would be ignored.
 		{
-			name: "WithTwoLocalizedMessageAndHelp",
-			input: compute.OperationError{
-				Errors: []*compute.OperationErrorErrors{
-					&compute.OperationErrorErrors{
-						Message: "Top-level message.",
-						ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
-							&compute.OperationErrorErrorsErrorDetails{
-								LocalizedMessage: &compute.LocalizedMessage{
-									Locale:  "en-US",
-									Message: "LocalizedMessage1 message",
-								},
-							},
-							&compute.OperationErrorErrorsErrorDetails{
-								LocalizedMessage: &compute.LocalizedMessage{
-									Locale:  "en-ES",
-									Message: "LocalizedMessage2 message",
-								},
-							},
-							&compute.OperationErrorErrorsErrorDetails{
-								Help: &compute.Help{
-									Links: []*compute.HelpLink{
-										&compute.HelpLink{
-											Description: "Help1Link1 Description",
-											Url:         "https://help1.com/link1",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:  "WithTwoLocalizedMessageAndHelp",
+			input: buildOperationError(2, []int{1}),
 			expectContains: []string{
 				"Top-level",
 				"LocalizedMessage1",


### PR DESCRIPTION
Output repeated google.rpc.Help.Link "description" and "url".

For Compute Operation errors, add vertical whitespace between the Error message the LocalizedMessage.message and each Help.Link "description" and "url". 

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support documentation links to error messages for certain Compute Operation errors.
```
