### PR TITLE
examples: region tag cloud_run => cloudrun

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_secure_services.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secure_services.tf.erb
@@ -1,4 +1,4 @@
-# [START cloud_run_secure_services_backend]
+# [START cloudrun_secure_services_backend]
 resource "google_cloud_run_service" "renderer" {
   provider = google-beta
   name     = "<%= ctx[:vars]['renderer'] %>"
@@ -18,9 +18,9 @@ resource "google_cloud_run_service" "renderer" {
     latest_revision = true
   }
 }
-# [END cloud_run_secure_services_backend]
+# [END cloudrun_secure_services_backend]
 
-# [START cloud_run_secure_services_frontend]
+# [START cloudrun_secure_services_frontend]
 resource "google_cloud_run_service" "editor" {
   provider = google-beta
   name     = "<%= ctx[:vars]['editor'] %>"
@@ -44,25 +44,25 @@ resource "google_cloud_run_service" "editor" {
     latest_revision = true
   }
 }
-# [END cloud_run_secure_services_frontend]
+# [END cloudrun_secure_services_frontend]
 
-# [START cloud_run_secure_services_backend_identity]
+# [START cloudrun_secure_services_backend_identity]
 resource "google_service_account" "renderer" {
   provider     = google-beta
   account_id   = "renderer-identity"
   display_name = "Service identity of the Renderer (Backend) service."
 }
-# [END cloud_run_secure_services_backend_identity]
+# [END cloudrun_secure_services_backend_identity]
 
-# [START cloud_run_secure_services_frontend_identity]
+# [START cloudrun_secure_services_frontend_identity]
 resource "google_service_account" "editor" {
   provider     = google-beta
   account_id   = "editor-identity"
   display_name = "Service identity of the Editor (Frontend) service."
 }
-# [END cloud_run_secure_services_frontend_identity]
+# [END cloudrun_secure_services_frontend_identity]
 
-# [START cloud_run_secure_services_backend_invoker_access]
+# [START cloudrun_secure_services_backend_invoker_access]
 resource "google_cloud_run_service_iam_member" "editor_invokes_renderer" {
   provider = google-beta
   location = google_cloud_run_service.renderer.location
@@ -70,9 +70,9 @@ resource "google_cloud_run_service_iam_member" "editor_invokes_renderer" {
   role     = "roles/run.invoker"
   member   = "serviceAccount:${google_service_account.editor.email}"
 }
-# [END cloud_run_secure_services_backend_invoker_access]
+# [END cloudrun_secure_services_backend_invoker_access]
 
-# [START cloud_run_secure_services_frontend_access]
+# [START cloudrun_secure_services_frontend_access]
 data "google_iam_policy" "noauth" {
   provider = google-beta
   binding {
@@ -91,7 +91,7 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
 
   policy_data = data.google_iam_policy.noauth.policy_data
 }
-# [END cloud_run_secure_services_frontend_access]
+# [END cloudrun_secure_services_frontend_access]
 
 output "backend_url" {
   value = google_cloud_run_service.renderer.status[0].url


### PR DESCRIPTION
Fix the region tags for the Cloud Run secure services example to use the standard `cloudrun` prefix

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
