### PR TITLE
Fix vcr test testAccComputeInstance_networkPerformanceConfig

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -5039,6 +5039,9 @@ resource "google_compute_image" "foobar" {
   guest_os_features {
     type = "VIRTIO_SCSI_MULTIQUEUE"
   }
+	guest_os_features {
+    type = "UEFI_COMPATIBLE"
+   }
 }
 
 resource "google_compute_instance" "foobar" {


### PR DESCRIPTION
vcr test was failing due to api now not respecting the original creation defintion. Its setting a field that we are not.

```log
  | 
  |       - guest_os_features { # forces replacement
  |           - type = "UEFI_COMPATIBLE" -> null
  |         }
```

upstream issue: go/mb/102410839


```release-note:none

```
