### PR TITLE
Add version_info and authorization_code params to google_bigquery_data_transfer_config

### DIFF
--- a/mmv1/products/bigquerydatatransfer/api.yaml
+++ b/mmv1/products/bigquerydatatransfer/api.yaml
@@ -160,6 +160,16 @@ objects:
           reingests data for [today-10, today-1], rather than ingesting data for
           just [today-1]. Only valid if the data source supports the feature.
           Set the value to 0 to use the default value.
+      - !ruby/object:Api::Type::String
+        name: 'versionInfo'
+        description: |
+          Optional OAuth2 authorization code to use with this transfer configuration. This is required only if
+          data_source_id is 'youtube_channel' and new credentials are needed.
+      - !ruby/object:Api::Type::String
+        name: 'authorizationCode'
+        description: |
+          Optional version info. This is required only if data_source_id is not 'youtube_channel'
+          and new credentials are needed.
       - !ruby/object:Api::Type::Boolean
         name: 'disabled'
         description: |

--- a/mmv1/products/bigquerydatatransfer/api.yaml
+++ b/mmv1/products/bigquerydatatransfer/api.yaml
@@ -61,6 +61,16 @@ objects:
           Service account email. If this field is set, transfer config will
           be created with this service account credentials. It requires that
           requesting user calling this API has permissions to act as this service account.
+      - !ruby/object:Api::Type::String
+        name: 'versionInfo'
+        description: |
+          Optional OAuth2 authorization code to use with this transfer configuration. This is required only if
+          data_source_id is 'youtube_channel' and new credentials are needed.
+      - !ruby/object:Api::Type::String
+        name: 'authorizationCode'
+        description: |
+          Optional version info. This is required only if data_source_id is not 'youtube_channel'
+          and new credentials are needed.
     properties:
       - !ruby/object:Api::Type::String
         name: 'displayName'
@@ -160,16 +170,6 @@ objects:
           reingests data for [today-10, today-1], rather than ingesting data for
           just [today-1]. Only valid if the data source supports the feature.
           Set the value to 0 to use the default value.
-      - !ruby/object:Api::Type::String
-        name: 'versionInfo'
-        description: |
-          Optional OAuth2 authorization code to use with this transfer configuration. This is required only if
-          data_source_id is 'youtube_channel' and new credentials are needed.
-      - !ruby/object:Api::Type::String
-        name: 'authorizationCode'
-        description: |
-          Optional version info. This is required only if data_source_id is not 'youtube_channel'
-          and new credentials are needed.
       - !ruby/object:Api::Type::Boolean
         name: 'disabled'
         description: |

--- a/mmv1/products/bigquerydatatransfer/api.yaml
+++ b/mmv1/products/bigquerydatatransfer/api.yaml
@@ -65,12 +65,14 @@ objects:
         name: 'versionInfo'
         description: |
           Optional OAuth2 authorization code to use with this transfer configuration. This is required only if
-          data_source_id is 'youtube_channel' and new credentials are needed.
+          data_source_id is 'youtube_channel' and new credentials are needed. Note that this should not be set
+          when service_account_name is used to create the transfer config.
       - !ruby/object:Api::Type::String
         name: 'authorizationCode'
         description: |
           Optional version info. This is required only if data_source_id is not 'youtube_channel'
-          and new credentials are needed.
+          and new credentials are needed. Note that this should not be set when serviceAccountName is used to
+          create the transfer config.
     properties:
       - !ruby/object:Api::Type::String
         name: 'displayName'

--- a/mmv1/templates/terraform/examples/bigquerydatatransfer_config_scheduled_query.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquerydatatransfer_config_scheduled_query.tf.erb
@@ -12,6 +12,7 @@ resource "google_bigquery_data_transfer_config" "<%= ctx[:primary_resource_id] %
 
   display_name           = "<%= ctx[:vars]['display_name'] %>"
   location               = "asia-northeast1"
+  version_info           = "0.1"
   data_source_id         = "scheduled_query"
   schedule               = "first sunday of quarter 00:00"
   destination_dataset_id = google_bigquery_dataset.my_dataset.dataset_id


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The [gcloud REST API methods to manage BigQuery Data Transfer Configs](https://cloud.google.com/bigquery-transfer/docs/reference/datatransfer/rest/v1/projects.transferConfigs/create) specify two parameters which are not available in the google_bigquery_data_transfer_config resource: `versionInfo` and `authorizationCode`.

This seems like a fairly trivial correction to make; I have therefore made the relevant modifications to magic-modules to be downstreamed to terraform-provider-google.

Fixes [https://github.com/hashicorp/terraform-provider-google/issues/11886](https://github.com/hashicorp/terraform-provider-google/issues/11886).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `version_info` and `authorization_code` fields to `google_bigquery_data_transfer_config` resource
```
