### PR TITLE
Vcr - skip testAccComputeInstance_networkPerformanceConfig

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1266,9 +1266,9 @@ func TestAccComputeInstance_networkPerformanceConfig(t *testing.T) {
 	// It's been failing in teamcity for > 90d so there is no
 	// starting point or obvious reason to potentially pivot off
 	//
-	// For whoever decides to investigate this it looks like
-	// at the time the failure is due to a failure to restart
-	// the compute instance after config update. This results
+	// For whoever decides to investigate this. It looks like
+	// at the time the failure is due to a failure to start
+	// the compute instance after a config update. This results
 	// in it /unable to find the resource/ as the start operation
 	// never completes successful. I suspect a bad configuration
 	// but am unsure.

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1260,6 +1260,19 @@ func TestAccComputeInstance_private_image_family(t *testing.T) {
 }
 <% unless version == 'ga' -%>
 func TestAccComputeInstance_networkPerformanceConfig(t *testing.T) {
+	// This test /should/ be passing but the reason it's failing
+	// is very non-obvious and requires further investigation
+	//
+	// It's been failing in teamcity for > 90d so there is no
+	// starting point or obvious reason to potentially pivot off
+	//
+	// For whoever decides to investigate this it looks like
+	// at the time the failure is due to a failure to restart
+	// the compute instance after config update. This results
+	// in it /unable to find the resource/ as the start operation
+	// never completes successful. I suspect a bad configuration
+	// but am unsure.
+	skipIfVcr(t)
 	t.Parallel()
 
 	var instance compute.Instance


### PR DESCRIPTION
This test /should/ be passing but the reason it's failing is very non-obvious and requires further investigation. Time that I don't have unfortunately, but may have in the future.

filed https://github.com/hashicorp/terraform-provider-google/issues/12383
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
