### PR TITLE
update for support of CMEK for vertex ai resource

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -94,13 +94,13 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'kmsKeyName'
             description: |
-              Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. 
+              Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource.
               Has the form: projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key. The key needs to be in the same region as where the resource is created.
             input: true
       - !ruby/object:Api::Type::String
         name: 'metadataSchemaUri'
         required: true
-        input: true 
+        input: true
         description: |
           Points to a YAML file stored on Google Cloud Storage describing additional information about the Dataset. The schema is defined as an OpenAPI 3.0.2 Schema Object. The schema files that can be used here are found in gs://google-cloud-aiplatform/schema/dataset/metadata/.
 # Vertex AI Featurestores
@@ -151,7 +151,7 @@ objects:
         pattern: projects/{{project}}/locations/{{region}}/featurestores/{{name}}
       - !ruby/object:Api::Type::String
         name: 'etag'
-        description: Used to perform consistent read-modify-write updates. 
+        description: Used to perform consistent read-modify-write updates.
         output: true
       - !ruby/object:Api::Type::String
         name: 'createTime'
@@ -177,6 +177,17 @@ objects:
             required: true
             description: |
               The number of nodes for each cluster. The number of nodes will not scale automatically but can be scaled manually by providing different values when updating.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionSpec'
+        description: |
+           If set, both of the online and offline data storage will be secured by this key.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'kmsKeyName'
+            required: true
+            description: |
+              The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. Has the form: projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key. The key needs to be in the same region as where the compute resource is created.
+
 # Vertex AI Featurestore Entity Type
   - !ruby/object:Api::Resource
     name: FeaturestoreEntitytype
@@ -227,7 +238,7 @@ objects:
         pattern: '{featurestore}}/entityTypes/{{name}}'
       - !ruby/object:Api::Type::String
         name: 'etag'
-        description: Used to perform consistent read-modify-write updates. 
+        description: Used to perform consistent read-modify-write updates.
         output: true
       - !ruby/object:Api::Type::String
         name: 'createTime'
@@ -334,7 +345,7 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'kmsKeyName'
             description: |
-              Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. 
+              Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource.
               Has the form: projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key. The key needs to be in the same region as where the resource is created.
             input: true
       - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/vertexai/terraform.yaml
+++ b/mmv1/products/vertexai/terraform.yaml
@@ -40,9 +40,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           name: "terraform"
           project: "appeng-flex"
+          kms_key_name: "kms-name"
         test_env_vars:
           org_id: :ORG_ID
           billing_account: :BILLING_ACCT
+        test_vars_overrides:
+          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
         ignore_read_extra:
           - "force_destroy"
     properties:
@@ -70,9 +73,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           name: "terraform"
           project: "vertex-ai"
+          kms_key_name: "kms-name"
         test_env_vars:
           org_id: :ORG_ID
           billing_account: :BILLING_ACCT
+        test_vars_overrides:
+          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+
     properties:
       etag: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/products/vertexai/terraform.yaml
+++ b/mmv1/products/vertexai/terraform.yaml
@@ -39,9 +39,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "featurestore"
         vars:
           name: "terraform"
-          kms_key_name: "kms-key"
+          project: "appeng-flex"
         test_env_vars:
-          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+          org_id: :ORG_ID
+          billing_account: :BILLING_ACCT
         ignore_read_extra:
           - "force_destroy"
     properties:
@@ -68,9 +69,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "entity"
         vars:
           name: "terraform"
-          kms_key_name: "kms-key"
+          project: "vertex-ai"
         test_env_vars:
-          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+          org_id: :ORG_ID
+          billing_account: :BILLING_ACCT
     properties:
       etag: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/products/vertexai/terraform.yaml
+++ b/mmv1/products/vertexai/terraform.yaml
@@ -39,6 +39,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "featurestore"
         vars:
           name: "terraform"
+          kms_key_name: "kms-key"
+        test_env_vars:
+          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
         ignore_read_extra:
           - "force_destroy"
     properties:
@@ -65,6 +68,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "entity"
         vars:
           name: "terraform"
+          kms_key_name: "kms-key"
+        test_env_vars:
+          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     properties:
       etag: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore.tf.erb
@@ -1,20 +1,3 @@
-resource "google_kms_key_ring" "key_ring" {
-  provider = google-beta
-  name     = "key-ring"
-  location = "us-central1"
-}
-
-resource "google_kms_crypto_key" "crypto_key" {
-  provider = google-beta
-  name = "crypto-key"
-  key_ring = google_kms_key_ring.key_ring.id
-  purpose = "ENCRYPT_DECRYPT"
-
-  version_template {
-    algorithm = "GOOGLE_SYMMETRIC_ENCRYPTION"
-  }
-}
-
 resource "google_vertex_ai_featurestore" "featurestore" {
   provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
@@ -26,7 +9,7 @@ resource "google_vertex_ai_featurestore" "featurestore" {
     fixed_node_count = 2
   }
   encryption_spec {
-    kms_key_name = google_kms_crypto_key.crypto_key.id
+    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
   }
   force_destroy = true
 }

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore.tf.erb
@@ -1,3 +1,20 @@
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+  name     = "key-ring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
+  name = "crypto-key"
+  key_ring = google_kms_key_ring.key_ring.id
+  purpose = "ENCRYPT_DECRYPT"
+
+  version_template {
+    algorithm = "GOOGLE_SYMMETRIC_ENCRYPTION"
+  }
+}
+
 resource "google_vertex_ai_featurestore" "featurestore" {
   provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
@@ -9,7 +26,7 @@ resource "google_vertex_ai_featurestore" "featurestore" {
     fixed_node_count = 2
   }
   encryption_spec {
-    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+    kms_key_name = google_kms_crypto_key.crypto_key.id
   }
   force_destroy = true
 }

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore.tf.erb
@@ -8,5 +8,8 @@ resource "google_vertex_ai_featurestore" "featurestore" {
   online_serving_config {
     fixed_node_count = 2
   }
+  encryption_spec {
+    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+  }
   force_destroy = true
 }

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype.tf.erb
@@ -8,6 +8,9 @@ resource "google_vertex_ai_featurestore" "featurestore" {
   online_serving_config {
     fixed_node_count = 2
   }
+  encryption_spec {
+    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+  }
 }
 
 resource "google_vertex_ai_featurestore_entitytype" "entity" {

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype.tf.erb
@@ -1,20 +1,3 @@
-resource "google_kms_key_ring" "key_ring" {
-  provider = google-beta
-  name     = "key-ring"
-  location = "us-central1"
-}
-
-resource "google_kms_crypto_key" "crypto_key" {
-  provider = google-beta
-  name = "crypto-key"
-  key_ring = google_kms_key_ring.key_ring.id
-  purpose = "ENCRYPT_DECRYPT"
-
-  version_template {
-    algorithm = "GOOGLE_SYMMETRIC_ENCRYPTION"
-  }
-}
-
 resource "google_vertex_ai_featurestore" "featurestore" {
   provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
@@ -26,7 +9,7 @@ resource "google_vertex_ai_featurestore" "featurestore" {
     fixed_node_count = 2
   }
   encryption_spec {
-    kms_key_name = google_kms_crypto_key.crypto_key.id
+    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
   }
 }
 

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype.tf.erb
@@ -1,3 +1,20 @@
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+  name     = "key-ring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
+  name = "crypto-key"
+  key_ring = google_kms_key_ring.key_ring.id
+  purpose = "ENCRYPT_DECRYPT"
+
+  version_template {
+    algorithm = "GOOGLE_SYMMETRIC_ENCRYPTION"
+  }
+}
+
 resource "google_vertex_ai_featurestore" "featurestore" {
   provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
@@ -9,7 +26,7 @@ resource "google_vertex_ai_featurestore" "featurestore" {
     fixed_node_count = 2
   }
   encryption_spec {
-    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+    kms_key_name = google_kms_crypto_key.crypto_key.id
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Added support to CMEK to vertexai resource featurestore.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vertexai: added `encryption_spec` field to `google_vertex_ai_featurestore` resource (beta)
```
