### PR TITLE
Fix inconsistencies in how IAM policies are stored in state

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -173,26 +173,42 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 		iConditionOk := policy.Bindings[i].Condition != nil
 		jConditionOk := policy.Bindings[j].Condition != nil
 
-		// If both bindings lack conditions we cannot sort
-		if !iConditionOk && !jConditionOk {
+		// If both bindings lack conditions we cannot sort them further
+		if (iConditionOk == false) && (jConditionOk == false) {
 			return false
 		}
 
-		// Sort by presence of a condition on only one binding
-		if !iConditionOk && jConditionOk {
+		// Sort by presence of a condition on only one of the two bindings
+		if (iConditionOk == false) && jConditionOk {
 			return true
 		}
-		if iConditionOk && !jConditionOk {
+		if iConditionOk && (jConditionOk == false) {
 			return false
 		}
 
-		// Sort by both bindings' conditions' titles
-		if policy.Bindings[i].Condition.Title < policy.Bindings[j].Condition.Title {
-			return true
+		// At this point both bindings have conditions
+
+		sameExpression := policy.Bindings[i].Condition.Expression == policy.Bindings[j].Condition.Expression
+		sameTitle := policy.Bindings[i].Condition.Title == policy.Bindings[j].Condition.Title
+		sameDescription := policy.Bindings[i].Condition.Description == policy.Bindings[j].Condition.Description
+
+		// Don't sort if conditions are the same
+		if sameExpression && sameTitle && sameDescription {
+			return false
 		}
 
-		// Sort by both bindings' conditions' expressions
-		return policy.Bindings[i].Condition.Expression < policy.Bindings[j].Condition.Expression
+		// Sort by both bindings' conditions' expressions, if they're not equivalent
+		if sameExpression == false {
+			return policy.Bindings[i].Condition.Expression < policy.Bindings[j].Condition.Expression
+		}
+
+		// Sort by both bindings' conditions' titles, if they're not equivalent
+		if sameTitle == false {
+			return policy.Bindings[i].Condition.Title < policy.Bindings[j].Condition.Title
+		}
+
+		// Comparing conditions' descriptions is the last available way to sort
+		return policy.Bindings[i].Condition.Description < policy.Bindings[j].Condition.Description
 	})
 
 	// Sort members within each binding to get simpler diffs as it's what the API does

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -120,99 +120,50 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 	bset := d.Get("binding").(*schema.Set)
 	aset := d.Get("audit_config").(*schema.Set)
 
-	// All binding{} blocks will be converted and stored in an array
-	bindings = make([]*cloudresourcemanager.Binding, bset.Len())
-
 	// Convert each config binding into a cloudresourcemanager.Binding
-	for i, v := range bset.List() {
+	// and merge member lists of equivalent binding{} blocks from the config provided by the user
+	bindingMap := map[string]*cloudresourcemanager.Binding{}
+	for _, v := range bset.List() {
 		binding := v.(map[string]interface{})
 		members := convertStringSet(binding["members"].(*schema.Set))
 		condition := expandIamCondition(binding["condition"])
 
-		bindings[i] = &cloudresourcemanager.Binding{
-			Role:      binding["role"].(string),
-			Members:   members,
-			Condition: condition,
+		// Map keys are used to identify binding{} blocks that are identical except for the member lists
+		key := binding["role"].(string)
+		if condition != nil {
+			key += fmt.Sprintf("-[%s]-[%s]-[%s]-[%s]", condition.Expression, condition.Title, condition.Description, condition.Location)
 		}
-	}
+		key = strconv.Itoa(hashcode(key))
 
-	// TODO(SarahFrench) improve comments
-	// Collect bindings by combination of role + condition presence + condition expression combinations
-	foundCombos := map[string]*cloudresourcemanager.Binding{}
-	for _, v := range bindings {
-		v := v // Avoid reused iteration variables
-		id := v.Role
-		if v.Condition != nil {
-			id += fmt.Sprintf("-[%s]-[%s]-[%s]-[%s]", v.Condition.Expression, v.Condition.Title, v.Condition.Description, v.Condition.Location)
-		}
-		if val, ok := foundCombos[id]; ok {
-			m := append(val.Members, v.Members...)
-			binding := foundCombos[id]
+		if val, ok := bindingMap[key]; ok {
+			// Add members to existing cloudresourcemanager.Binding in the map
+			m := append(val.Members, members...)
+			binding := bindingMap[key]
 			binding.Members = m
-			foundCombos[id] = binding
+			bindingMap[key] = binding
 		} else {
-			foundCombos[id] = v
+			// Add new cloudresourcemanager.Binding to the map
+			bindingMap[key] = &cloudresourcemanager.Binding{
+				Role:      binding["role"].(string),
+				Members:   members,
+				Condition: condition,
+			}
 		}
 	}
 
-	// Assign deduplicated bindings to the cloudresourcemanager.Policy variable
-	dedupBindings := []*cloudresourcemanager.Binding{}
-	for _, v := range foundCombos {
-		v := v // Avoid reused iteration variables
-		dedupBindings = append(dedupBindings, v)
+	// All binding{} blocks, post conversion to cloudresourcemanager.Binding and combining of member lists, are stored in an array
+	bindings = []*cloudresourcemanager.Binding{}
+	for _, v := range bindingMap {
+		v := v
+		bindings = append(bindings, v)
 	}
-	policy.Bindings = dedupBindings
+	policy.Bindings = bindings
 
-	// Sort bindings to get simpler diffs as it's what the API does
-	sort.Slice(policy.Bindings, func(i, j int) bool {
-		// Sort bindings by role, if they're not the same
-		sameRole := policy.Bindings[i].Role == policy.Bindings[j].Role
-		if sameRole == false {
-			return policy.Bindings[i].Role < policy.Bindings[j].Role
-		}
+	// Sort bindings within the list to get simpler diffs, as it's what the API does
+	// Sorting is based on the role affected by the binding and any conditions
+	sort.Slice(policy.Bindings, iamPolicyBindingsLessFunction(policy))
 
-		iConditionOk := policy.Bindings[i].Condition != nil
-		jConditionOk := policy.Bindings[j].Condition != nil
-
-		// If both bindings lack conditions we cannot sort them further
-		if (iConditionOk == false) && (jConditionOk == false) {
-			return false
-		}
-
-		// Sort by presence of a condition on only one of the two bindings
-		if (iConditionOk == false) && jConditionOk {
-			return true
-		}
-		if iConditionOk && (jConditionOk == false) {
-			return false
-		}
-
-		// At this point both bindings have conditions
-
-		sameExpression := policy.Bindings[i].Condition.Expression == policy.Bindings[j].Condition.Expression
-		sameTitle := policy.Bindings[i].Condition.Title == policy.Bindings[j].Condition.Title
-		sameDescription := policy.Bindings[i].Condition.Description == policy.Bindings[j].Condition.Description
-
-		// Don't sort if conditions are the same
-		if sameExpression && sameTitle && sameDescription {
-			return false
-		}
-
-		// Sort by both bindings' conditions' expressions, if they're not equivalent
-		if sameExpression == false {
-			return policy.Bindings[i].Condition.Expression < policy.Bindings[j].Condition.Expression
-		}
-
-		// Sort by both bindings' conditions' titles, if they're not equivalent
-		if sameTitle == false {
-			return policy.Bindings[i].Condition.Title < policy.Bindings[j].Condition.Title
-		}
-
-		// Comparing conditions' descriptions is the last available way to sort
-		return policy.Bindings[i].Condition.Description < policy.Bindings[j].Condition.Description
-	})
-
-	// Sort members within each binding to get simpler diffs as it's what the API does
+	// Sort members within each binding in the list to get simpler diffs, as it's what the API does
 	for i := 0; i < len(policy.Bindings); i++ {
 		sort.Strings(policy.Bindings[i].Members)
 	}
@@ -257,4 +208,55 @@ func expandAuditConfig(set *schema.Set) []*cloudresourcemanager.AuditConfig {
 		})
 	}
 	return auditConfigs
+}
+
+func iamPolicyBindingsLessFunction(policy cloudresourcemanager.Policy) func(i, j int) bool {
+
+	return func(i, j int) bool {
+		// Sort bindings by role, if they're not the same
+		sameRole := policy.Bindings[i].Role == policy.Bindings[j].Role
+		if !sameRole {
+			return policy.Bindings[i].Role < policy.Bindings[j].Role
+		}
+
+		iConditionOk := policy.Bindings[i].Condition != nil
+		jConditionOk := policy.Bindings[j].Condition != nil
+
+		// If both bindings lack conditions we cannot sort them further
+		if !iConditionOk && !jConditionOk {
+			return false
+		}
+
+		// Sort by presence of a condition on only one of the two bindings
+		if !iConditionOk && jConditionOk {
+			return true
+		}
+		if iConditionOk && !jConditionOk {
+			return false
+		}
+
+		// At this point both bindings have conditions
+
+		sameExpression := policy.Bindings[i].Condition.Expression == policy.Bindings[j].Condition.Expression
+		sameTitle := policy.Bindings[i].Condition.Title == policy.Bindings[j].Condition.Title
+		sameDescription := policy.Bindings[i].Condition.Description == policy.Bindings[j].Condition.Description
+
+		// Don't sort if conditions are the same
+		if sameExpression && sameTitle && sameDescription {
+			return false
+		}
+
+		// Sort by both bindings' conditions' expressions, if they're not equivalent
+		if !sameExpression {
+			return policy.Bindings[i].Condition.Expression < policy.Bindings[j].Condition.Expression
+		}
+
+		// Sort by both bindings' conditions' titles, if they're not equivalent
+		if !sameTitle {
+			return policy.Bindings[i].Condition.Title < policy.Bindings[j].Condition.Title
+		}
+
+		// Comparing conditions' descriptions is the last available way to sort
+		return policy.Bindings[i].Condition.Description < policy.Bindings[j].Condition.Description
+	}
 }

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -17,20 +17,20 @@ import (
 // to express a Google Cloud IAM policy in a data resource. This is an example
 // of how the schema would be used in a config:
 //
-//	data "google_iam_policy" "admin" {
-//	  binding {
-//	    role = "roles/storage.objectViewer"
-//	    members = [
-//	      "user:evanbrown@google.com",
-//	    ]
-//	  }
-//	}
+// data "google_iam_policy" "admin" {
+//   binding {
+//     role = "roles/storage.objectViewer"
+//     members = [
+//       "user:evanbrown@google.com",
+//     ]
+//   }
+// }
 func dataSourceGoogleIamPolicy() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGoogleIamPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"binding": {
-				Type:     schema.TypeSet,
+				Type: schema.TypeSet,
 				// Binding is optional because a user may want to set an IAM policy with no bindings
 				// This allows users to ensure that no bindings were created outside of terraform
 				Optional: true,
@@ -43,11 +43,11 @@ func dataSourceGoogleIamPolicy() *schema.Resource {
 						"members": {
 							Type:     schema.TypeSet,
 							Required: true,
-							Elem:     &schema.Schema{
+							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile("^deleted:"), "Terraform does not support IAM policies for deleted principals"),
 							},
-							Set:      schema.HashString,
+							Set: schema.HashString,
 						},
 						"condition": {
 							Type:     schema.TypeList,

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -143,15 +143,13 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 		v := v // Avoid reused iteration variables
 		id := v.Role
 		if v.Condition != nil {
-			id += v.Condition.Expression
+			id += fmt.Sprintf("-[%s]-[%s]-[%s]-[%s]", v.Condition.Expression, v.Condition.Title, v.Condition.Description, v.Condition.Location)
 		}
-
 		if val, ok := foundCombos[id]; ok {
 			m := append(val.Members, v.Members...)
 			binding := foundCombos[id]
 			binding.Members = m
 			foundCombos[id] = binding
-
 		} else {
 			foundCombos[id] = v
 		}
@@ -165,9 +163,36 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 	}
 	policy.Bindings = dedupBindings
 
-	// Sort bindings by their role name to get simpler diffs as it's what the API does
+	// Sort bindings to get simpler diffs as it's what the API does
 	sort.Slice(policy.Bindings, func(i, j int) bool {
-		return policy.Bindings[i].Role < policy.Bindings[j].Role
+		// Sort bindings by role
+		if policy.Bindings[i].Role < policy.Bindings[j].Role {
+			return true
+		}
+
+		iConditionOk := policy.Bindings[i].Condition != nil
+		jConditionOk := policy.Bindings[j].Condition != nil
+
+		// If both bindings lack conditions we cannot sort
+		if !iConditionOk && !jConditionOk {
+			return false
+		}
+
+		// Sort by presence of a condition on only one binding
+		if !iConditionOk && jConditionOk {
+			return true
+		}
+		if iConditionOk && !jConditionOk {
+			return false
+		}
+
+		// Sort by both bindings' conditions' titles
+		if policy.Bindings[i].Condition.Title < policy.Bindings[j].Condition.Title {
+			return true
+		}
+
+		// Sort by both bindings' conditions' expressions
+		return policy.Bindings[i].Condition.Expression < policy.Bindings[j].Condition.Expression
 	})
 
 	// Sort members within each binding to get simpler diffs as it's what the API does

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -165,9 +165,10 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 
 	// Sort bindings to get simpler diffs as it's what the API does
 	sort.Slice(policy.Bindings, func(i, j int) bool {
-		// Sort bindings by role
-		if policy.Bindings[i].Role < policy.Bindings[j].Role {
-			return true
+		// Sort bindings by role, if they're not the same
+		sameRole := policy.Bindings[i].Role == policy.Bindings[j].Role
+		if sameRole == false {
+			return policy.Bindings[i].Role < policy.Bindings[j].Role
 		}
 
 		iConditionOk := policy.Bindings[i].Condition != nil

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -133,7 +133,6 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 		if condition != nil {
 			key += fmt.Sprintf("-[%s]-[%s]-[%s]-[%s]", condition.Expression, condition.Title, condition.Description, condition.Location)
 		}
-		key = strconv.Itoa(hashcode(key))
 
 		if val, ok := bindingMap[key]; ok {
 			// Add members to existing cloudresourcemanager.Binding in the map
@@ -160,7 +159,7 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 	policy.Bindings = bindings
 
 	// Sort bindings within the list to get simpler diffs, as it's what the API does
-	// Sorting is based on the role affected by the binding and any conditions
+	// Sorting is based on the binding's role + condition fields
 	sort.Slice(policy.Bindings, iamPolicyBindingsLessFunction(policy))
 
 	// Sort members within each binding in the list to get simpler diffs, as it's what the API does

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_policy.go.erb
@@ -122,7 +122,6 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 
 	// All binding{} blocks will be converted and stored in an array
 	bindings = make([]*cloudresourcemanager.Binding, bset.Len())
-	policy.Bindings = bindings
 
 	// Convert each config binding into a cloudresourcemanager.Binding
 	for i, v := range bset.List() {
@@ -130,20 +129,51 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 		members := convertStringSet(binding["members"].(*schema.Set))
 		condition := expandIamCondition(binding["condition"])
 
-		// Sort members to get simpler diffs as it's what the API does
-		sort.Strings(members)
-
-		policy.Bindings[i] = &cloudresourcemanager.Binding{
+		bindings[i] = &cloudresourcemanager.Binding{
 			Role:      binding["role"].(string),
 			Members:   members,
 			Condition: condition,
 		}
 	}
 
+	// TODO(SarahFrench) improve comments
+	// Collect bindings by combination of role + condition presence + condition expression combinations
+	foundCombos := map[string]*cloudresourcemanager.Binding{}
+	for _, v := range bindings {
+		v := v // Avoid reused iteration variables
+		id := v.Role
+		if v.Condition != nil {
+			id += v.Condition.Expression
+		}
+
+		if val, ok := foundCombos[id]; ok {
+			m := append(val.Members, v.Members...)
+			binding := foundCombos[id]
+			binding.Members = m
+			foundCombos[id] = binding
+
+		} else {
+			foundCombos[id] = v
+		}
+	}
+
+	// Assign deduplicated bindings to the cloudresourcemanager.Policy variable
+	dedupBindings := []*cloudresourcemanager.Binding{}
+	for _, v := range foundCombos {
+		v := v // Avoid reused iteration variables
+		dedupBindings = append(dedupBindings, v)
+	}
+	policy.Bindings = dedupBindings
+
 	// Sort bindings by their role name to get simpler diffs as it's what the API does
-	sort.Slice(bindings, func(i, j int) bool {
-		return bindings[i].Role < bindings[j].Role
+	sort.Slice(policy.Bindings, func(i, j int) bool {
+		return policy.Bindings[i].Role < policy.Bindings[j].Role
 	})
+
+	// Sort members within each binding to get simpler diffs as it's what the API does
+	for i := 0; i < len(policy.Bindings); i++ {
+		sort.Strings(policy.Bindings[i].Members)
+	}
 
 	// Convert each audit_config into a cloudresourcemanager.AuditConfig
 	policy.AuditConfigs = expandAuditConfig(aset)

--- a/mmv1/third_party/terraform/tests/data_source_google_iam_policy_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_iam_policy_test.go
@@ -135,30 +135,16 @@ func TestDataSourceGoogleIamPolicyRead(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 			// Arrange - Create schema.ResourceData variable as test input
+			// Need bindings info as slice of empty interfaces
 			bindings := make([]interface{}, len(tc.Bindings))
-
 			for i, b := range tc.Bindings {
-				// Handle binding conditions, if set
-				if b["condition"] != nil {
-					c := b["condition"].([]interface{})
-					// Avoid adding zero valued condition
-					if len(c) == 1 {
-						conditions := make([]interface{}, len(c))
-						for j, con := range c {
-							conditions[j] = con
-						}
-						b["condition"] = conditions
-					}
-				}
 				bindings[i] = b
 			}
-
 			rawData := map[string]interface{}{
 				"binding":      bindings,
 				"policy_data":  "",              // Not set
 				"audit_config": []interface{}{}, // Not set
 			}
-
 			d := schema.TestResourceDataRaw(t, dataSourceGoogleIamPolicy().Schema, rawData)
 
 			// Act - Update resource data using `dataSourceGoogleIamPolicyRead`

--- a/mmv1/third_party/terraform/tests/data_source_google_iam_policy_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_iam_policy_test.go
@@ -70,6 +70,59 @@ func TestDataSourceGoogleIamPolicyRead(t *testing.T) {
 			ExpectedBindingCount:     2,
 			ExpectedPolicyDataString: "{\"bindings\":[{\"members\":[\"user:a\"],\"role\":\"role/A\"},{\"condition\":{\"description\":\"description A\",\"expression\":\"expression A\",\"title\":\"title A\"},\"members\":[\"user:a\"],\"role\":\"role/A\"}]}",
 		},
+		"members in equivalent bindings are consolidated": {
+			Bindings: []map[string]interface{}{
+				{
+					"role": "role/A",
+					"members": []interface{}{
+						"user:a",
+					},
+				},
+				{
+					"role": "role/A",
+					"members": []interface{}{
+						"user:b",
+					},
+				},
+			},
+			ExpectedBindingCount:     1,
+			ExpectedPolicyDataString: "{\"bindings\":[{\"members\":[\"user:a\",\"user:b\"],\"role\":\"role/A\"}]}",
+		},
+		// "bindings for the same role with equivalent conditions are consolidated": {
+		// 	Bindings: []map[string]interface{}{
+		// 		{
+		// 			"role": "role/A",
+		// 			"members": []interface{}{
+		// 				"user:a",
+		// 			},
+		// 			"condition": map[string]interface{}{
+		// 				"description": "my description string",
+		// 				"expression":  "my expression string",
+		// 				"title":       "my title string",
+		// 			},
+		// 		},
+		// 		{
+		// 			"role": "role/A",
+		// 			"members": []interface{}{
+		// 				"user:b",
+		// 			},
+		// 			"condition": map[string]interface{}{
+		// 				"description": "my description string",
+		// 				"expression":  "my expression string",
+		// 				"title":       "my title string",
+		// 			},
+		// 		},
+		// 		// Should not be consolidated into the above as there's no condition
+		// 		{
+		// 			"role": "role/A",
+		// 			"members": []interface{}{
+		// 				"user:c",
+		// 			},
+		// 		},
+		// 	},
+		// 	ExpectedBindingCount:     2,
+		// 	ExpectedPolicyDataString: "{\"bindings\":[{\"members\":[\"user:a\",\"user:b\"],\"role\":\"role/A\"}]}",
+		// },
 	}
 
 	for tn, tc := range cases {

--- a/mmv1/third_party/terraform/tests/data_source_google_iam_policy_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_iam_policy_test.go
@@ -1,0 +1,129 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDataSourceGoogleIamPolicyRead(t *testing.T) {
+	cases := map[string]struct {
+		Bindings                 []map[string]interface{}
+		ExpectedPolicyDataString string
+		ExpectedBindingCount     int
+	}{
+		"members are sorted alphabetically within a single binding": {
+			Bindings: []map[string]interface{}{
+				{
+					"role": "role/A",
+					"members": []interface{}{
+						"user:c",
+						"user:a",
+						"user:b",
+					},
+				},
+			},
+			ExpectedBindingCount:     1,
+			ExpectedPolicyDataString: "{\"bindings\":[{\"members\":[\"user:a\",\"user:b\",\"user:c\"],\"role\":\"role/A\"}]}",
+		},
+		"bindings are sorted by role": {
+			Bindings: []map[string]interface{}{
+				{
+					"role": "role/B",
+					"members": []interface{}{
+						"user:a",
+					},
+				},
+				{
+					"role": "role/A",
+					"members": []interface{}{
+						"user:a",
+					},
+				},
+			},
+			ExpectedBindingCount:     2,
+			ExpectedPolicyDataString: "{\"bindings\":[{\"members\":[\"user:a\"],\"role\":\"role/A\"},{\"members\":[\"user:a\"],\"role\":\"role/B\"}]}",
+		},
+		"bindings with the same role are sorted by presence of a condition": {
+			Bindings: []map[string]interface{}{
+				{
+					"role": "role/A",
+					"members": []interface{}{
+						"user:a",
+					},
+					"condition": []interface{}{
+						map[string]interface{}{
+							"description": "description A",
+							"expression":  "expression A",
+							"title":       "title A",
+						},
+					},
+				},
+				// Binding with no condition should be placed first
+				{
+					"role": "role/A",
+					"members": []interface{}{
+						"user:a",
+					},
+				},
+			},
+			ExpectedBindingCount:     2,
+			ExpectedPolicyDataString: "{\"bindings\":[{\"members\":[\"user:a\"],\"role\":\"role/A\"},{\"condition\":{\"description\":\"description A\",\"expression\":\"expression A\",\"title\":\"title A\"},\"members\":[\"user:a\"],\"role\":\"role/A\"}]}",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange - Create schema.ResourceData variable as test input
+			bindings := make([]interface{}, len(tc.Bindings))
+
+			for i, b := range tc.Bindings {
+				// Handle binding conditions, if set
+				if b["condition"] != nil {
+					c := b["condition"].([]interface{})
+					// Avoid adding zero valued condition
+					if len(c) == 1 {
+						conditions := make([]interface{}, len(c))
+						for j, con := range c {
+							t.Logf("CONDITION IS %#v", con)
+							conditions[j] = con
+						}
+						b["condition"] = conditions
+					} else {
+						t.Logf("Condition length != 1, is %#v", c)
+					}
+
+				}
+				bindings[i] = b
+			}
+
+			rawData := map[string]interface{}{
+				"binding":      bindings,
+				"policy_data":  "",              // Not set
+				"audit_config": []interface{}{}, // Not set
+			}
+
+			d := schema.TestResourceDataRaw(t, dataSourceGoogleIamPolicy().Schema, rawData)
+
+			// Act - Update resource data using `dataSourceGoogleIamPolicyRead`
+			var meta interface{}
+			err := dataSourceGoogleIamPolicyRead(d, meta)
+			if err != nil {
+				t.Error(err)
+			}
+
+			// Assert
+			val, ok := d.GetOk("policy_data")
+			if !ok {
+				t.Errorf("expected `policy_data` to be gettable but it's not. Val is %#v", val)
+			}
+			if val != tc.ExpectedPolicyDataString {
+				t.Errorf("expected `policy_data` to be %s, got: %s", tc.ExpectedPolicyDataString, val)
+			}
+
+			if len(tc.Bindings) != tc.ExpectedBindingCount {
+				t.Errorf("expected there to be %d bindings, got: %d", tc.ExpectedBindingCount, len(tc.Bindings))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
# Description

Partially fixes https://github.com/hashicorp/terraform-provider-google/issues/8701

This PR changes how the `google_iam_policy` data source stores the user-entered data in its  computed `policy_data` attribute. It is addressing the first issue I describe in [this comment on the original issue](https://github.com/hashicorp/terraform-provider-google/issues/8701#issuecomment-1227543271).

I've updated how the `google_iam_policy` data source processes its `binding` blocks into a JSON string which it stores as the `policy_data` attribute. I've made this processing resemble what happens in the API, so there should not be a mismatch between the JSON of the policy in the data source's state and the resource's state.

# Manual tests

Using [the config I describe in this comment](https://github.com/hashicorp/terraform-provider-google/issues/8701#issuecomment-1227543271) I apply the first plan to create everything and then make this small edit 

```diff
-    description = "This one has a description"
+    description = "This one has a description and I edited it"
```

When I generate a plan with the latest provider version I see lots of unnecessary diffs as reported in the original issue:

![Screenshot 2022-08-25 at 17 10 03](https://user-images.githubusercontent.com/15078782/186743415-8afdf5c6-eec2-4343-af85-48f21be3535a.png)

When I generate a plan using this PR's changes the diff is much smaller:

![Screenshot 2022-08-25 at 17 20 06](https://user-images.githubusercontent.com/15078782/186743086-b1558b54-23e9-4825-98a4-6a1fc422a7ad.png)

**👆 The extra diffs for setting an empty description are another issue I'm thinking of handling in a separate PR to this one**
- Here: https://github.com/GoogleCloudPlatform/magic-modules/pull/6473

# Checklist
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~ N/A
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
    - I ran the `TestAccArtifactRegistryRepositoryIamPolicyGenerated` acceptance test that uses the `google_iam_policy` data source and it passed ok
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
iam: fixed diffs between `policy_data` from `google_iam_policy` data source and policy data in API responses
```
