### PR TITLE
fix(resource_container_cluster): allow passing empty list to monitoring_config and logging_config

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -4121,14 +4121,19 @@ func expandDnsConfig(configured interface{}) *container.DNSConfig {
 
 func expandContainerClusterLoggingConfig(configured interface{}) *container.LoggingConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 || l[0] == nil {
+	if len(l) == 0 {
 		return nil
 	}
 
-	config := l[0].(map[string]interface{})
+	var components []string
+	if l[0] != nil {
+		config := l[0].(map[string]interface{})
+		components = convertStringArr(config["enable_components"].([]interface{}))
+	}
+
 	return &container.LoggingConfig{
 		ComponentConfig: &container.LoggingComponentConfig{
-			EnableComponents: convertStringArr(config["enable_components"].([]interface{})),
+			EnableComponents: components,
 		},
 	}
 }
@@ -4141,7 +4146,7 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	mc := &container.MonitoringConfig{}
 	config := l[0].(map[string]interface{})
 <%# In version == 'ga' enable_components will always be specified. %>
-	if v, ok := config["enable_components"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := config["enable_components"]; ok {
 		enable_components := v.([]interface{})
 		mc.ComponentConfig = &container.MonitoringComponentConfig{
 			EnableComponents: convertStringArr(enable_components),

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2319,6 +2319,7 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ResourceName:      "google_container_cluster.primary",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 <% if version == 'beta' -%>
 			{

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2258,6 +2258,14 @@ func TestAccContainerCluster_withLoggingConfig(t *testing.T) {
 				ImportStateVerify:   true,
 			},
 			{
+				Config: testAccContainerCluster_withLoggingConfigDisabled(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.primary",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
 				Config: testAccContainerCluster_withLoggingConfigUpdated(clusterName),
 			},
 			{
@@ -2298,13 +2306,21 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 			{
 				Config: testAccContainerCluster_withMonitoringConfigEnabled(clusterName),
 			},
-<% if version == 'beta' -%>
 			{
 				ResourceName:      "google_container_cluster.primary",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigDisabled(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+<% if version == 'beta' -%>
 			{
 				Config: testAccContainerCluster_withMonitoringConfigUpdated(clusterName),
 			},
@@ -6070,6 +6086,19 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
+func testAccContainerCluster_withLoggingConfigDisabled(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  logging_config {
+	  enable_components = []
+  }
+}
+`, name)
+}
+
 func testAccContainerCluster_withLoggingConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -6106,6 +6135,19 @@ resource "google_container_cluster" "primary" {
   min_master_version = "1.23.8-gke.1900"
   monitoring_config {
       enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER" ]
+  }
+}
+`, name)
+}
+
+func testAccContainerCluster_withMonitoringConfigDisabled(name string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
+      enable_components = []
   }
 }
 `, name)


### PR DESCRIPTION
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed allow passing empty list to monitoring_config and logging_config in `google_container_cluster`
```

## Description

Passing an empty list to `monitoring_config.enable_components` and `logging_config.enable_components` now disables logging.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12385


```
resource "google_container_cluster" "primary" {
  provider = google-beta

  name     = "cluster-1"
  location = "us-east1"

  monitoring_config {
    enable_components = []
  }
  
  logging_config {
    enable_components = []
  }
}
```
<img width="900" alt="image" src="https://user-images.githubusercontent.com/38879286/186669914-cf1288c1-0c55-42fd-9fe2-69efbdfaa318.png">

```
resource "google_container_cluster" "primary" {
  provider = google-beta

  name     = "cluster"
  location = "us-east1"

  monitoring_config {
    enable_components = []

    managed_prometheus {
      enabled = true
    }
  }
  
  logging_config {
    enable_components = []
  }
}
```
<img width="921" alt="image" src="https://user-images.githubusercontent.com/38879286/186669868-b1a9d674-eba7-42cf-8a92-a5c23b8186f4.png">

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12385