### PR TITLE
Add force_delete for notification channel

### DIFF
--- a/mmv1/products/monitoring/terraform.yaml
+++ b/mmv1/products/monitoring/terraform.yaml
@@ -63,6 +63,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   NotificationChannel: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{name}}"
     import_format: ["{{name}}"]
+    delete_url: 'v3/{{name}}?force={{force_delete}}'
     mutex: stackdriver/notifications/{{project}}
     error_retry_predicates: ["isMonitoringConcurrentEditError"]
     examples:
@@ -78,6 +79,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         skip_test: true
         vars:
           display_name: "Sensitive Notification Channel test"
+    virtual_fields:
+      - !ruby/object:Api::Type::Boolean
+        name: 'force_delete'
+        url_param_only: true
+        default_value: false
+        description: |
+          If true, the notification channel will be deleted regardless
+          of its use in alert policies (the policies will be updated
+          to remove the channel). If false, channels that are still
+          referenced by an existing alerting policy will fail to be
+          deleted in a delete operation.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       resource_definition: templates/terraform/resource_definition/monitoring_notification_channel.erb
       encoder: templates/terraform/encoders/monitoring_notification_channel.go.erb

--- a/mmv1/templates/terraform/examples/notification_channel_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/notification_channel_basic.tf.erb
@@ -4,4 +4,5 @@ resource "google_monitoring_notification_channel" "<%= ctx[:primary_resource_id]
   labels = {
     email_address = "fake_email@blahblah.com"
   }
+  force_delete = false
 }


### PR DESCRIPTION
Fix this issue: https://github.com/hashicorp/terraform-provider-google/issues/10337

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added `force_delete` field to `google_monitoring_notification_channel` resource
```
