### PR TITLE
updated two defaults

### DIFF
--- a/mmv1/products/vpcaccess/api.yaml
+++ b/mmv1/products/vpcaccess/api.yaml
@@ -105,7 +105,6 @@ objects:
         # its default in API doc is 200 but api returns 500 if it is not set
         description: |
           Minimum throughput of the connector in Mbps. Default and min is 500.
-        default_value: 500
       - !ruby/object:Api::Type::Integer
         name: minInstances
         description: |
@@ -120,7 +119,6 @@ objects:
         name: maxThroughput
         description: |
           Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 1000.
-        default_value: 1000
       - !ruby/object:Api::Type::String
         name: 'selfLink'
         description: |

--- a/mmv1/products/vpcaccess/api.yaml
+++ b/mmv1/products/vpcaccess/api.yaml
@@ -102,9 +102,10 @@ objects:
         min_version: beta
       - !ruby/object:Api::Type::Integer
         name: minThroughput
+        # its default in API doc is 200 but api returns 500 if it is not set
         description: |
-          Minimum throughput of the connector in Mbps. Default and min is 200.
-        default_value: 200
+          Minimum throughput of the connector in Mbps. Default and min is 500.
+        default_value: 500
       - !ruby/object:Api::Type::Integer
         name: minInstances
         description: |
@@ -117,12 +118,9 @@ objects:
         min_version: beta
       - !ruby/object:Api::Type::Integer
         name: maxThroughput
-        # The API documentation says this will default to 200, but when I tried that I got an error that the minimum
-        # throughput must be lower than the maximum. The console defaults to 1000, so I changed it to that.
-        # API returns 300 if it is not sent
         description: |
-          Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
-        default_value: 300
+          Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 1000.
+        default_value: 1000
       - !ruby/object:Api::Type::String
         name: 'selfLink'
         description: |

--- a/mmv1/products/vpcaccess/terraform.yaml
+++ b/mmv1/products/vpcaccess/terraform.yaml
@@ -50,11 +50,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'compareResourceNames'
         default_from_api: true
       minThroughput: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(200, 1000)'
       minInstances: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       maxThroughput: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(200, 1000)'
       maxInstances: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/cloudrun_vpc_access_connector.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrun_vpc_access_connector.tf.erb
@@ -20,7 +20,7 @@ resource "google_vpc_access_connector" "<%= ctx[:primary_resource_id] %>" {
   provider      = google-beta
   region        = "us-west1"
   ip_cidr_range = "10.8.0.0/28"
-  max_throughput= 300
+  max_throughput= 1000
   network       = google_compute_network.default.name
   depends_on    = [google_project_service.vpcaccess_api]
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12411


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vpcaccess: updated defaults for `minThroughput` and `maxThroughput` on `google_vpc_access_connector`
```
