### PR TITLE
Adding support for snapshot chain name

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -12944,6 +12944,13 @@ objects:
                   - snapshot_schedule_policy.0.snapshot_properties.0.guest_flush
                 description: |
                   Whether to perform a 'guest aware' snapshot.
+              - !ruby/object:Api::Type::String
+                name: 'chainName'
+                allow_empty_object: true
+                description: |
+                  Creates the new snapshot in the snapshot chain labeled with the 
+                  specified name. The chain name must be 1-63 characters long and comply 
+                  with RFC1035.
       - !ruby/object:Api::Type::NestedObject
         name: 'groupPlacementPolicy'
         conflicts:
@@ -14042,6 +14049,16 @@ objects:
         name: 'diskSizeGb'
         description: 'Size of the snapshot, specified in GB.'
         output: true
+      - !ruby/object:Api::Type::String
+        name: 'chainName'
+        allow_empty_object: true
+        description: |
+          Creates the new snapshot in the snapshot chain labeled with the 
+          specified name. The chain name must be 1-63 characters long and 
+          comply with RFC1035. This is an uncommon option only for advanced 
+          service owners who needs to create separate snapshot chains, for 
+          example, for chargeback tracking.  When you describe your snapshot 
+          resource, this field is visible only if it has a non-empty value.
       - !ruby/object:Api::Type::String
         name: 'name'
         required: true

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -12946,7 +12946,6 @@ objects:
                   Whether to perform a 'guest aware' snapshot.
               - !ruby/object:Api::Type::String
                 name: 'chainName'
-                allow_empty_object: true
                 description: |
                   Creates the new snapshot in the snapshot chain labeled with the 
                   specified name. The chain name must be 1-63 characters long and comply 
@@ -14051,7 +14050,6 @@ objects:
         output: true
       - !ruby/object:Api::Type::String
         name: 'chainName'
-        allow_empty_object: true
         description: |
           Creates the new snapshot in the snapshot chain labeled with the 
           specified name. The chain name must be 1-63 characters long and 

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2290,7 +2290,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "target"
           - "ip_address"
       - !ruby/object:Provider::Terraform::Examples
-        name: "regional-external-http-load-balancer"
+        name: "regional_external_http_load_balancer"
         primary_resource_type: "google_compute_region_url_map"
         primary_resource_id: "default"
         vars:

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2290,7 +2290,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "target"
           - "ip_address"
       - !ruby/object:Provider::Terraform::Examples
-        name: "regional_external_http_load_balancer"
+        name: "regional-external-http-load-balancer"
         primary_resource_type: "google_compute_region_url_map"
         primary_resource_id: "default"
         vars:
@@ -2361,6 +2361,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           name: "policy"
       - !ruby/object:Provider::Terraform::Examples
         name: "resource_policy_instance_schedule_policy"
+        primary_resource_id: "hourly"
+        vars:
+          name: "policy"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "resource_policy_snapshot_schedule_chain_name"
         primary_resource_id: "hourly"
         vars:
           name: "policy"
@@ -2688,6 +2693,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           snapshot_name: "my-snapshot"
           disk_name: "debian-disk"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "snapshot_chainname"
+        primary_resource_id: "snapshot"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-snapshot-chainname%s\", context[\"random_suffix\"])"
+        vars:
+          snapshot_name: "my-snapshot"
+          disk_name: "debian-disk"
+          chain_name: 'snapshot-chain'
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'snapshot_id'

--- a/mmv1/templates/terraform/examples/resource_policy_snapshot_schedule_chain_name.tf.erb
+++ b/mmv1/templates/terraform/examples/resource_policy_snapshot_schedule_chain_name.tf.erb
@@ -1,0 +1,25 @@
+resource "google_compute_resource_policy" "hourly" {
+  name   = "<%= ctx[:vars]['name'] %>"
+  region = "us-central1"
+  description = "chain name snapshot"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 20
+        start_time     = "23:00"
+      }
+    }
+    retention_policy {
+      max_retention_days    = 14
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+    snapshot_properties {
+      labels = {
+        my_label = "value"
+      }
+      storage_locations = ["us"]
+      guest_flush       = true
+      chain_name = "test-schedule-chain-name"
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/snapshot_chainname.tf.erb
+++ b/mmv1/templates/terraform/examples/snapshot_chainname.tf.erb
@@ -1,0 +1,23 @@
+resource "google_compute_snapshot" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['snapshot_name'] %>"
+  source_disk = google_compute_disk.persistent.id
+  zone        = "us-central1-a"
+  chain_name  = "<%= ctx[:vars]['chain_name'] %>"
+  labels = {
+    my_label = "value"
+  }
+  storage_locations = ["us-central1"]
+}
+
+data "google_compute_image" "debian" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "persistent" {
+  name  = "<%= ctx[:vars]['disk_name'] %>"
+  image = data.google_compute_image.debian.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}


### PR DESCRIPTION
Adding support for snapshot chain name in google_compute_snapshot and in google_compute_resource_policy.  This PR is for hashicorp/terraform-provider-google#12429

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `chain_name` to resource `google_compute_snapshot` 
```

```release-note:enhancement
compute: added field `chain_name` to resource `google_compute_resource_policy. snapshot_properties` 
```
