### PR TITLE
Bigtable: add storage_target for autoscaling

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
@@ -107,6 +107,12 @@ func resourceBigtableInstance() *schema.Resource {
 										Required:    true,
 										Description: `The target CPU utilization for autoscaling. Value must be between 10 and 80.`,
 									},
+									"storage_target": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Computed:    true,
+										Description: `The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.`,
+									},
 								},
 							},
 						},
@@ -391,6 +397,7 @@ func flattenBigtableCluster(c *bigtable.ClusterInfo) map[string]interface{} {
 		autoscaling_config[0]["min_nodes"] = c.AutoscalingConfig.MinNodes
 		autoscaling_config[0]["max_nodes"] = c.AutoscalingConfig.MaxNodes
 		autoscaling_config[0]["cpu_target"] = c.AutoscalingConfig.CPUTargetPercent
+		autoscaling_config[0]["storage_target"] = c.AutoscalingConfig.StorageUtilizationPerNode
 	}
 	return cluster
 }
@@ -423,9 +430,10 @@ func expandBigtableClusters(clusters []interface{}, instanceID string, config *C
 		if len(autoscaling_configs) > 0 {
 			autoscaling_config := autoscaling_configs[0].(map[string]interface{})
 			cluster_config.AutoscalingConfig = &bigtable.AutoscalingConfig{
-				MinNodes:         autoscaling_config["min_nodes"].(int),
-				MaxNodes:         autoscaling_config["max_nodes"].(int),
-				CPUTargetPercent: autoscaling_config["cpu_target"].(int),
+				MinNodes:                  autoscaling_config["min_nodes"].(int),
+				MaxNodes:                  autoscaling_config["max_nodes"].(int),
+				CPUTargetPercent:          autoscaling_config["cpu_target"].(int),
+				StorageUtilizationPerNode: autoscaling_config["storage_target"].(int),
 			}
 		}
 		results = append(results, cluster_config)

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -121,7 +121,8 @@ for a `DEVELOPMENT` instance.
 
   * `min_nodes` - (Required) The minimum number of nodes for autoscaling.
   * `max_nodes` - (Required) The maximum number of nodes for autoscaling.
-  * `cpu_target` - (Required) The CPU utilization target in percentage. Must be between 10 and 80.
+  * `cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.
+  * `storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.
 
 !> **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count.
 

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -117,7 +117,7 @@ Bigtable instances are noted on the [Cloud Bigtable locations page](https://clou
 Required, with a minimum of `1` for a `PRODUCTION` instance. Must be left unset
 for a `DEVELOPMENT` instance.
 
-* `autoscaling_config` - (Optional) Autoscaling config for the cluster, contains the following arguments:
+* `autoscaling_config` - (Optional) [Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:
 
   * `min_nodes` - (Required) The minimum number of nodes for autoscaling.
   * `max_nodes` - (Required) The maximum number of nodes for autoscaling.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Bigtable: add storage target support for the autoscaling feature.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
bigtable: added support for `autoscaling_config.storage_target` to `google_bigtable_instance`
```
