### PR TITLE
Support `jsonExtension: "GEOJSON"` for BigQuery job load configuration

### DIFF
--- a/mmv1/products/bigquery/api.yaml
+++ b/mmv1/products/bigquery/api.yaml
@@ -803,6 +803,12 @@ objects:
                   For orc, specify "ORC". [Beta] For Bigtable, specify "BIGTABLE".
                   The default value is CSV.
                 default_value: 'CSV'
+              - !ruby/object:Api::Type::String
+                name: 'jsonExtension'
+                description: |
+                  If sourceFormat is set to newline-delimited JSON, indicates whether it should be processed as a JSON variant such as GeoJSON.
+                  For a sourceFormat other than JSON, omit this field. If the sourceFormat is newline-delimited JSON: - for newline-delimited
+                  GeoJSON: set to GEOJSON.
               - !ruby/object:Api::Type::Boolean
                 name: 'allowJaggedRows'
                 description: |

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -184,11 +184,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           job_id: "job_load"
           bucket_name: "bq-geojson-sample"
-          geojson_path: "geojson-data.jsonl"
         test_env_vars:
           project: :PROJECT_NAME
-        test_vars_overrides:
-          geojson_path: "\"./test-fixtures/bigquery/geojson-data.jsonl\""
         ignore_read_extra:
           - "etag"
           - "status.0.state"

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -179,6 +179,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "etag"
           - "status.0.state"
       - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_job_load_geojson"
+        primary_resource_id: "job"
+        vars:
+          job_id: "job_load"
+        ignore_read_extra:
+          - "etag"
+          - "status.0.state"
+      - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_load_table_reference"
         primary_resource_id: "job"
         vars:

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -183,6 +183,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "job"
         vars:
           job_id: "job_load"
+          bucket_name: "bq-geojson-sample"
+          geojson_path: "geojson-data.jsonl"
+        test_vars_overrides:
+          geojson_path: "\"./test-fixtures/bigquery/geojson-data.jsonl\""
         ignore_read_extra:
           - "etag"
           - "status.0.state"

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -185,6 +185,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           job_id: "job_load"
           bucket_name: "bq-geojson-sample"
           geojson_path: "geojson-data.jsonl"
+        test_env_vars:
+          project: :PROJECT_NAME
         test_vars_overrides:
           geojson_path: "\"./test-fixtures/bigquery/geojson-data.jsonl\""
         ignore_read_extra:

--- a/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
@@ -1,3 +1,7 @@
+locals {
+  project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
+}
+
 resource "google_storage_bucket" "bucket" {
   name     = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
   location = "US"

--- a/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
@@ -11,7 +11,10 @@ resource "google_storage_bucket" "bucket" {
 resource "google_storage_bucket_object" "object" {
   name   = "geojson-data.jsonl"
   bucket = google_storage_bucket.bucket.name
-  source = "<%= ctx[:vars]['geojson_path'] %>"
+  content = <<EOF
+{"type":"Feature","properties":{"continent":"Europe","region":"Scandinavia"},"geometry":{"type":"Polygon","coordinates":[[[-30.94,53.33],[33.05,53.33],[33.05,71.86],[-30.94,71.86],[-30.94,53.33]]]}}
+{"type":"Feature","properties":{"continent":"Africa","region":"West Africa"},"geometry":{"type":"Polygon","coordinates":[[[-23.91,0],[11.95,0],[11.95,18.98],[-23.91,18.98],[-23.91,0]]]}}
+EOF
 }
 
 resource "google_bigquery_table" "foo" {
@@ -53,4 +56,6 @@ resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
     source_format = "NEWLINE_DELIMITED_JSON"
     json_extension = "GEOJSON"
   }
+
+  depends_on = ["google_storage_bucket_object.object"]
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
@@ -48,9 +48,6 @@ resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
       table_id   = google_bigquery_table.foo.table_id
     }
 
-    skip_leading_rows = 1
-    schema_update_options = ["ALLOW_FIELD_RELAXATION", "ALLOW_FIELD_ADDITION"]
-
     write_disposition = "WRITE_TRUNCATE"
     autodetect = true
     source_format = "NEWLINE_DELIMITED_JSON"

--- a/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
@@ -1,3 +1,15 @@
+resource "google_storage_bucket" "bucket" {
+  name     = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "geojson-data.jsonl"
+  bucket = google_storage_bucket.bucket.name
+  source = "<%= ctx[:vars]['geojson_path'] %>"
+}
+
 resource "google_bigquery_table" "foo" {
   deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
@@ -20,7 +32,7 @@ resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
 
   load {
     source_uris = [
-      "gs://BUCKET/REPLACE/SAMPLE/DATA.json",
+      "gs://${google_storage_bucket_object.object.bucket}/${google_storage_bucket_object.object.name}"
     ]
 
     destination_table {

--- a/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_geojson.tf.erb
@@ -1,0 +1,40 @@
+resource "google_bigquery_table" "foo" {
+  deletion_protection = false
+  dataset_id = google_bigquery_dataset.bar.dataset_id
+  table_id   = "<%= ctx[:vars]['job_id'] %>_table"
+}
+
+resource "google_bigquery_dataset" "bar" {
+  dataset_id                  = "<%= ctx[:vars]['job_id'] %>_dataset"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
+resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
+  job_id     = "<%= ctx[:vars]['job_id'] %>"
+
+  labels = {
+    "my_job" = "load"
+  }
+
+  load {
+    source_uris = [
+      "gs://BUCKET/REPLACE/SAMPLE/DATA.json",
+    ]
+
+    destination_table {
+      project_id = google_bigquery_table.foo.project
+      dataset_id = google_bigquery_table.foo.dataset_id
+      table_id   = google_bigquery_table.foo.table_id
+    }
+
+    skip_leading_rows = 1
+    schema_update_options = ["ALLOW_FIELD_RELAXATION", "ALLOW_FIELD_ADDITION"]
+
+    write_disposition = "WRITE_TRUNCATE"
+    autodetect = true
+    source_format = "NEWLINE_DELIMITED_JSON"
+    json_extension = "GEOJSON"
+  }
+}

--- a/mmv1/third_party/terraform/utils/test-fixtures/bigquery/geojson-data.jsonl
+++ b/mmv1/third_party/terraform/utils/test-fixtures/bigquery/geojson-data.jsonl
@@ -1,0 +1,2 @@
+{"type":"Feature","properties":{"continent":"Europe","region":"Scandinavia"},"geometry":{"type":"Polygon","coordinates":[[[-30.94,53.33],[33.05,53.33],[33.05,71.86],[-30.94,71.86],[-30.94,53.33]]]}}
+{"type":"Feature","properties":{"continent":"Africa","region":"West Africa"},"geometry":{"type":"Polygon","coordinates":[[[-23.91,0],[11.95,0],[11.95,18.98],[-23.91,18.98],[-23.91,0]]]}}

--- a/mmv1/third_party/terraform/utils/test-fixtures/bigquery/geojson-data.jsonl
+++ b/mmv1/third_party/terraform/utils/test-fixtures/bigquery/geojson-data.jsonl
@@ -1,2 +1,0 @@
-{"type":"Feature","properties":{"continent":"Europe","region":"Scandinavia"},"geometry":{"type":"Polygon","coordinates":[[[-30.94,53.33],[33.05,53.33],[33.05,71.86],[-30.94,71.86],[-30.94,53.33]]]}}
-{"type":"Feature","properties":{"continent":"Africa","region":"West Africa"},"geometry":{"type":"Polygon","coordinates":[[[-23.91,0],[11.95,0],[11.95,18.98],[-23.91,18.98],[-23.91,0]]]}}


### PR DESCRIPTION
The BigQuery REST API supports `jsonExtension: "GEOJSON"` for newline
delimited JSON, to import the data as GeoJSON (autodetecting the schema
and creating GEOGRAPHY fields for geo data).

Expose this in the job load configuration.

Fixes hashicorp/terraform-provider-google#12423.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `json_extension` field to the `load` block of `google_bigquery_job` resource
```
