### PR TITLE
Add support for IAM policies on Security Command Center sources

### DIFF
--- a/mmv1/products/securitycenter/api.yaml
+++ b/mmv1/products/securitycenter/api.yaml
@@ -36,7 +36,13 @@ objects:
       guides:
         'Official Documentation':
           'https://cloud.google.com/security-command-center/docs'
-      api: 'https://cloud.google.com/security-command-center/docs/reference/rest/v1beta1/organizations.sources'
+      api: 'https://cloud.google.com/security-command-center/docs/reference/rest/v1/organizations.sources'
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :POST
+      parent_resource_attribute: 'source'
+      base_url: organizations/{{organization}}/sources/{{source}}
+      import_format: ["organizations/{{organization}}/sources/{{source}}", "{{source}}"]
     parameters:
       - !ruby/object:Api::Type::String
         name: organization

--- a/mmv1/products/securitycenter/api.yaml
+++ b/mmv1/products/securitycenter/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://securitycenter.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://securitycenter.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:

--- a/mmv1/products/securitycenter/api.yaml
+++ b/mmv1/products/securitycenter/api.yaml
@@ -18,9 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://securitycenter.googleapis.com/v1/
-  - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://securitycenter.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:

--- a/mmv1/third_party/terraform/tests/iam_scc_source_test.go
+++ b/mmv1/third_party/terraform/tests/iam_scc_source_test.go
@@ -1,0 +1,219 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccSecurityCenterSourceIamBinding(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"role":          "roles/securitycenter.sourcesViewer",
+		"org_id":        getTestOrgFromEnv(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityCenterSourceIamBinding_basic(context),
+			},
+			{
+				ResourceName: "google_scc_source_iam_binding.foo",
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					// This has to be a function because sources only use numeric IDs
+					id := state.RootModule().Resources["google_scc_source.custom_source"].Primary.Attributes["id"]
+					return fmt.Sprintf("%s %s",
+						id,
+						context["role"],
+					), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test Iam Binding update
+				Config: testAccSecurityCenterSourceIamBinding_update(context),
+			},
+			{
+				ResourceName: "google_scc_source_iam_binding.foo",
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					// This has to be a function because sources only use numeric IDs
+					id := state.RootModule().Resources["google_scc_source.custom_source"].Primary.Attributes["id"]
+					return fmt.Sprintf("%s %s",
+						id,
+						context["role"],
+					), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSecurityCenterSourceIamMember(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"role":          "roles/securitycenter.sourcesViewer",
+		"org_id":        getTestOrgFromEnv(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Test Iam Member creation (no update for member, no need to test)
+				Config: testAccSecurityCenterSourceIamMember_basic(context),
+			},
+			{
+				ResourceName: "google_scc_source_iam_member.foo",
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					// This has to be a function because sources only use numeric IDs
+					id := state.RootModule().Resources["google_scc_source.custom_source"].Primary.Attributes["id"]
+					return fmt.Sprintf("%s %s user:admin@hashicorptest.com",
+						id,
+						context["role"],
+					), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSecurityCenterSourceIamPolicy(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"role":          "roles/securitycenter.sourcesViewer",
+		"org_id":        getTestOrgFromEnv(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityCenterSourceIamPolicy_basic(context),
+			},
+			{
+				ResourceName:      "google_scc_source_iam_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSecurityCenterSourceIamPolicy_emptyBinding(context),
+			},
+			{
+				ResourceName:      "google_scc_source_iam_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSecurityCenterSourceIamMember_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_scc_source" "custom_source" {
+  display_name = "tf-test-source%{random_suffix}"
+  organization = "%{org_id}"
+  description  = "My custom Cloud Security Command Center Finding Source"
+}
+
+resource "google_scc_source_iam_member" "foo" {
+  source       = google_scc_source.custom_source.id
+  organization = "%{org_id}"
+  role         = "%{role}"
+  member       = "user:admin@hashicorptest.com"
+}
+`, context)
+}
+
+func testAccSecurityCenterSourceIamPolicy_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_scc_source" "custom_source" {
+  display_name = "tf-test-source%{random_suffix}"
+  organization = "%{org_id}"
+  description  = "My custom Cloud Security Command Center Finding Source"
+}
+
+data "google_iam_policy" "foo" {
+  binding {
+    role    = "%{role}"
+    members = ["user:admin@hashicorptest.com"]
+  }
+}
+
+resource "google_scc_source_iam_policy" "foo" {
+  source       = google_scc_source.custom_source.id
+  organization = "%{org_id}"
+  policy_data  = data.google_iam_policy.foo.policy_data
+}
+`, context)
+}
+
+func testAccSecurityCenterSourceIamPolicy_emptyBinding(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_scc_source" "custom_source" {
+  display_name = "tf-test-source%{random_suffix}"
+  organization = "%{org_id}"
+  description  = "My custom Cloud Security Command Center Finding Source"
+}
+
+data "google_iam_policy" "foo" {
+}
+
+resource "google_scc_source_iam_policy" "foo" {
+  source       = google_scc_source.custom_source.id
+  organization = "%{org_id}"
+  policy_data  = data.google_iam_policy.foo.policy_data
+}
+`, context)
+}
+
+func testAccSecurityCenterSourceIamBinding_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_scc_source" "custom_source" {
+  display_name = "tf-test-source%{random_suffix}"
+  organization = "%{org_id}"
+  description  = "My custom Cloud Security Command Center Finding Source"
+}
+
+resource "google_scc_source_iam_binding" "foo" {
+  source       = google_scc_source.custom_source.id
+  organization = "%{org_id}"
+  role         = "%{role}"
+  members      = ["user:admin@hashicorptest.com"]
+}
+`, context)
+}
+
+func testAccSecurityCenterSourceIamBinding_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_scc_source" "custom_source" {
+  display_name = "tf-test-source%{random_suffix}"
+  organization = "%{org_id}"
+  description  = "My custom Cloud Security Command Center Finding Source"
+}
+
+resource "google_scc_source_iam_binding" "foo" {
+  source       = google_scc_source.custom_source.id
+  organization = "%{org_id}"
+  role         = "%{role}"
+  members      = ["user:admin@hashicorptest.com", "user:gterraformtest1@gmail.com"]
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). I consider this a very small change.
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). I didn't find any other examples for basic IAM resources, so I am unsure if this is needed here.
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Enable IAM resources for Security Command Center sources
```
