### PR TITLE
Adding in validation for trailing dot at end of DNS record name

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/resources/resource_dns_record_set.go
@@ -88,10 +88,11 @@ func resourceDnsRecordSet() *schema.Resource {
 			},
 
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The DNS name this record set will apply to.`,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRecordNameTrailingDot,
+				Description:  `The DNS name this record set will apply to.`,
 			},
 
 			"rrdatas": {
@@ -619,4 +620,19 @@ func flattenDnsRecordSetRoutingPolicyGEO(geo *dns.RRSetRoutingPolicyGeoPolicy) [
 		ris = append(ris, ri)
 	}
 	return ris
+}
+
+func validateRecordNameTrailingDot(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+	len_value := len(value)
+	if len_value == 0 {
+		errors = append(errors, fmt.Errorf("the empty string is not a valid name field value"))
+		return nil, errors
+	}
+	last1 := value[len_value-1:]
+	if last1 != "." {
+		errors = append(errors, fmt.Errorf("%q (%q) doesn't end with %q, name field must end with trailing dot, for example test.example.com. (note the trailing dot)", k, value, "."))
+		return nil, errors
+	}
+	return nil, nil
 }

--- a/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
@@ -11,6 +11,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func TestValidateRecordNameTrailingDot(t *testing.T) {
+	cases := []StringValidationTestCase{
+		// No errors
+		{TestName: "trailing dot", Value: "test-record.hashicorptest.com."},
+
+		// With errors
+		{TestName: "empty string", Value: "", ExpectError: true},
+		{TestName: "no trailing dot", Value: "test-record.hashicorptest.com", ExpectError: true},
+	}
+
+	es := testStringValidationCases(cases, validateRecordNameTrailingDot)
+	if len(es) > 0 {
+		t.Errorf("Failed to validate DNS Record name with value: %v", es)
+	}
+}
+
 func TestIpv6AddressDiffSuppress(t *testing.T) {
 	cases := map[string]struct {
 		Old, New       []string
@@ -534,4 +550,3 @@ resource "google_dns_record_set" "foobar" {
 }
 `, zoneName, zoneName, zoneName)
 }
-


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Potential fix for issue #9074 I have added a validator to ensure the trailing dot is not missed during terraform plan
https://github.com/hashicorp/terraform-provider-google/issues/9074

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: Added in validation for trailing dot at end of DNS record name
```
