### PR TITLE
Bigtable: Increase timeout in table creation

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -17,6 +18,11 @@ func resourceBigtableTable() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: resourceBigtableTableImport,
+		},
+
+		// Set a longer timeout for table creation as adding column families can be slow.
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
 		},
 
 		// ----------------------------------------------------------------------
@@ -124,7 +130,12 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 			column := co.(map[string]interface{})
 
 			if v, ok := column["family"]; ok {
-				if err := c.CreateColumnFamily(ctx, name, v.(string)); err != nil {
+				// Set a longer timeout as adding column family can be slow. The current timeout
+				// in the Go client is less than one minute. This timeout should not be longer
+				// than the overall timeout.
+				ctxWithDeadline, cancel := context.WithTimeout(ctx, 5*time.Minute)
+				defer cancel() // Always call cancel.
+				if err := c.CreateColumnFamily(ctxWithDeadline, name, v.(string)); err != nil {
 					return fmt.Errorf("Error creating column family %s. %s", v, err)
 				}
 			}

--- a/mmv1/third_party/terraform/resources/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_table.go
@@ -133,9 +133,9 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 				// Set a longer timeout as adding column family can be slow. The current timeout
 				// in the Go client is less than one minute. This timeout should not be longer
 				// than the overall timeout.
-				ctxWithDeadline, cancel := context.WithTimeout(ctx, 5*time.Minute)
+				ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
 				defer cancel() // Always call cancel.
-				if err := c.CreateColumnFamily(ctxWithDeadline, name, v.(string)); err != nil {
+				if err := c.CreateColumnFamily(ctxWithTimeout, name, v.(string)); err != nil {
 					return fmt.Errorf("Error creating column family %s. %s", v, err)
 				}
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

When creating a table, Terraform first invokes Bigtable table creation and then follow and then adds column families. If a table is replicated, adding column families can be expansive and slow. When adding a column family times out, you will see an error like this "rpc error: code = Unavailable desc = The service is currently unavailable” while creating column family ???".

This PR sets overall timeout for table creation to 45 minutes and adds a longer timeout (5 minutes) when invoking ModifyColumnFamily API call.

fixes https://github.com/hashicorp/terraform-provider-google/issues/12443

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: increased timeout in table creation.
```
