### PR TITLE
Allow subordinate CA data sources in all states

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_certificate_authority.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_certificate_authority.go
@@ -43,8 +43,8 @@ func dataSourcePrivatecaCertificateAuthorityRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	// pem_csr is only applicable for SUBORDINATE CertificateAuthorities
-	if d.Get("type") == "SUBORDINATE" {
+	// pem_csr is only applicable for SUBORDINATE CertificateAuthorities when their state is AWAITING_USER_ACTIVATION
+	if d.Get("type") == "SUBORDINATE" && d.Get("state") == "AWAITING_USER_ACTIVATION" {
 		url, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:fetch")
 		if err != nil {
 			return err

--- a/mmv1/third_party/terraform/website/docs/d/privateca_certificate_authority.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/privateca_certificate_authority.html.markdown
@@ -6,7 +6,7 @@ description: |-
 ---
 # google_privateca_certificate_authority
 
-Get info about a Google Cloud IAP Client.
+Get info about a Google CAS Certificate Authority.
 
 ## Example Usage
 
@@ -42,4 +42,4 @@ The following arguments are supported:
 
 See [google_privateca_certificate_authority](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/privateca_certificate_authority) resource for details of the available attributes.
 
-* `pem_csr` - The PEM-encoded signed certificate signing request (CSR). This is only set on subordinate certificate authorities.
+* `pem_csr` - The PEM-encoded signed certificate signing request (CSR). This is only set on subordinate certificate authorities that are awaiting user activation.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Resolves https://github.com/hashicorp/terraform-provider-google/issues/12432

Currently, attempting to use a `google_privateca_certificate_authority` for a `SUBORDINATE` CA in any state other than `AWAITING_USER_ACTIVATION` is impossible, because the Google API can only fetch the CSR in that state ([reference](https://cloud.google.com/certificate-authority-service/docs/reference/rest/v1/projects.locations.caPools.certificateAuthorities/fetch)). This prevents some really common use cases, like pulling an existing subordinate CA to issue leaf certs.

With this change, pulling a subordinate CA in any state other than `AWAITING_USER_ACTIVATION` will result in `pem_csr` simply being unset. If the subordinate CA is in `AWAITING_USER_ACTIVATION` and the CSR fetch fails, an error will still be thrown as expected.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
privateca: fixed an issue that blocked subordinate CA data sources when `state` was not `AWAITING_USER_ACTIVATION`
```
