### PR TITLE
make role_arn computed in storage transfer job

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -407,6 +407,7 @@ func awsS3DataSchema() *schema.Resource {
 			"role_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ExactlyOneOf: awsS3AuthKeys,
 				Description:  `The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.`,
 			},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/11535

The API can return an empty string for role ARN when not specified. Unable to replicate, but setting to `computed` should resolve

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storagetransfer: fixed a bug in `google_storage_transfer_job` that caused a permanent diff on `role_arn`
```
