### PR TITLE
Add filestore_snapshot resource

### DIFF
--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -253,3 +253,77 @@ objects:
         input: true
         description: |
           KMS key name used for data encryption.
+  - !ruby/object:Api::Resource
+    name: 'Snapshot'
+    create_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/snapshots?snapshotId={{name}}
+    self_link: projects/{{project}}/locations/{{location}}/instances/{{instance}}/snapshots/{{name}}
+    base_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/snapshots
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      A Google Cloud Filestore snapshot.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/filestore/docs/snapshots'
+        'Creating Snapshots':
+          'https://cloud.google.com/filestore/docs/create-snapshots'
+      api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.snapshots/create'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: |
+          The name of the location of the instance. This can be a region for ENTERPRISE tier instances.
+        input: true
+        required: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'instance'
+        description: |
+          The resource name of the filestore instance.
+        input: true
+        required: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The resource name of the snapshot. The name must be unique within the specified instance.
+
+          The name must be 1-63 characters long, and comply with
+          RFC1035. Specifically, the name must be 1-63 characters long and match
+          the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+          first character must be a lowercase letter, and all following
+          characters must be a dash, lowercase letter, or digit, except the last
+          character, which cannot be a dash.
+        required: true
+        input: true
+        url_param_only: true
+        pattern: projects/{{project}}/locations/{{location}}/instances/{{instance}}/snapshots/{{name}}
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          A description of the snapshot with 2048 characters or less. Requests with longer descriptions will be rejected.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          The snapshot state.
+        values:
+          - :CREATING
+          - :READY
+          - :DELETING
+        output: true
+      - !ruby/object:Api::Type::Time
+        name: 'createTime'
+        description: |
+          The time when the snapshot was created in RFC3339 text format.
+        output: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Resource labels to represent user-provided metadata.
+      - !ruby/object:Api::Type::String
+        name: 'filesystemUsedBytes'
+        description: |
+          The amount of bytes needed to allocate a full copy of the snapshot content.
+        output: true

--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -268,7 +268,7 @@ objects:
           'https://cloud.google.com/filestore/docs/snapshots'
         'Creating Snapshots':
           'https://cloud.google.com/filestore/docs/create-snapshots'
-      api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.snapshots/create'
+      api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.snapshots'
     parameters:
       - !ruby/object:Api::Type::String
         name: 'location'

--- a/mmv1/products/filestore/terraform.yaml
+++ b/mmv1/products/filestore/terraform.yaml
@@ -53,6 +53,22 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/filestore.erb
       pre_create: templates/terraform/pre_create/filestore_instance.go.erb
+  Snapshot: !ruby/object:Overrides::Terraform::ResourceOverride
+    mutex: "filestore/{{project}}"
+    error_retry_predicates: ["isNotFilestoreQuotaError"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "filestore_snapshot_basic"
+        primary_resource_id: "snapshot"
+        vars:
+          snapshot_name: "test-snapshot"
+          instance_name: "test-instance-for-snapshot"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "filestore_snapshot_full"
+        primary_resource_id: "snapshot"
+        vars:
+          snapshot_name: "test-snapshot"
+          instance_name: "test-instance-for-snapshot"
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/examples/filestore_snapshot_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_snapshot_basic.tf.erb
@@ -1,0 +1,21 @@
+resource "google_filestore_snapshot" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]["snapshot_name"] %>"
+  instance = google_filestore_instance.instance.name
+  location = "us-central1"
+}
+
+resource "google_filestore_instance" "instance" {
+  name     = "<%= ctx[:vars]["instance_name"] %>"
+  location = "us-central1"
+  tier     = "ENTERPRISE"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+}

--- a/mmv1/templates/terraform/examples/filestore_snapshot_full.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_snapshot_full.tf.erb
@@ -1,0 +1,27 @@
+resource "google_filestore_snapshot" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]["snapshot_name"] %>"
+  instance = google_filestore_instance.instance.name
+  location = "us-central1"
+
+  description = "Snapshot of <%= ctx[:vars]["instance_name"] %>"
+
+  labels = {
+    my_label = "value"
+  }
+}
+
+resource "google_filestore_instance" "instance" {
+  name     = "<%= ctx[:vars]["instance_name"] %>"
+  location = "us-central1"
+  tier     = "ENTERPRISE"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+}


### PR DESCRIPTION
Adds the `filestore_snapshot` resource for taking snapshots of enterprise filestore instances

b/227499956

Example:
```
resource "google_filestore_snapshot" "my_snapshot" {
  name     = "my-snapshot"
  instance = google_filestore_instance.my_instance.name
  location = "us-central1"
}
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_filestore_snapshot
```
