### PR TITLE
Fix incorrect formatting for `source_uris` attributes in documentation

### DIFF
--- a/mmv1/products/bigquery/api.yaml
+++ b/mmv1/products/bigquery/api.yaml
@@ -691,11 +691,11 @@ objects:
                 name: 'sourceUris'
                 description: |
                   The fully-qualified URIs that point to your data in Google Cloud.
-                  For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character
+                  For Google Cloud Storage URIs: Each URI can contain one '\*' wildcard character
                   and it must come after the 'bucket' name. Size limits related to load jobs apply
                   to external data sources. For Google Cloud Bigtable URIs: Exactly one URI can be
                   specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table.
-                  For Google Cloud Datastore backups: Exactly one URI can be specified. Also, the '*' wildcard character is not allowed.
+                  For Google Cloud Datastore backups: Exactly one URI can be specified. Also, the '\*' wildcard character is not allowed.
                 item_type: Api::Type::String
                 required: true
               - !ruby/object:Api::Type::NestedObject
@@ -1394,13 +1394,13 @@ objects:
             name: 'sourceUris'
             description: |
               The fully-qualified URIs that point to your data in Google Cloud.
-              For Google Cloud Storage URIs: Each URI can contain one '*'
+              For Google Cloud Storage URIs: Each URI can contain one '\*'
               wildcard character and it must come after the 'bucket' name. Size
               limits related to load jobs apply to external data sources. For
               Google Cloud Bigtable URIs: Exactly one URI can be specified and it
               has be a fully specified and valid HTTPS URL for a Google Cloud
               Bigtable table. For Google Cloud Datastore backups, exactly one
-              URI can be specified. Also, the '*' wildcard character is not
+              URI can be specified. Also, the '\*' wildcard character is not
               allowed.
             item_type: Api::Type::String
           - !ruby/object:Api::Type::NestedObject


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

As described in hashicorp/terraform-provider-google#12459, the documentation formatting is slightly wrong for `google_bigquery_job` `load` `source_uris`. This PR fixes that by escaping literal asterisks. Also, the same fix is applied for `google_bigquery_table` `external_data_configuration` `source_uris`.

Fixes hashicorp/terraform-provider-google#12459.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: fixed incorrect documentation formatting for `source_uris` attributes
```
