### PR TITLE
feat(google_container_cluster): support notification filter

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -901,6 +901,25 @@ func resourceContainerCluster() *schema.Resource {
 										Optional:    true,
 										Description: `The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster. Must be in the format: projects/{project}/topics/{topic}.`,
 									},
+									"filter": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										MaxItems:    1,
+										Description: `Allows filtering to one or more specific event types. If event types are present, those and only those event types will be transmitted to the cluster. Other types will be skipped. If no filter is specified, or no event types are present, all event types will be sent`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"event_type": {
+													Type:        schema.TypeList,
+													Required:    true,
+													Description: `Can be used to filter what notifications are sent. Valid values include include UPGRADE_AVAILABLE_EVENT, UPGRADE_EVENT and SECURITY_BULLETIN_EVENT`,
+													Elem: &schema.Schema{
+														Type:         schema.TypeString,
+														ValidateFunc: validation.StringInSlice([]string{"UPGRADE_AVAILABLE_EVENT", "UPGRADE_EVENT", "SECURITY_BULLETIN_EVENT"}, false),
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -3789,12 +3808,22 @@ func expandNotificationConfig(configured interface{}) *container.NotificationCon
 		if len(v.([]interface{})) > 0 {
 			pubsub := notificationConfig["pubsub"].([]interface{})[0].(map[string]interface{})
 
-			return &container.NotificationConfig{
+			nc := &container.NotificationConfig{
 				Pubsub: &container.PubSub{
 					Enabled: pubsub["enabled"].(bool),
 					Topic:   pubsub["topic"].(string),
 				},
 			}
+
+			if vv, ok := pubsub["filter"]; ok && len(vv.([]interface{})) > 0 {
+				filter := vv.([]interface{})[0].(map[string]interface{})
+				eventType := filter["event_type"].([]interface{})
+				nc.Pubsub.Filter = &container.Filter{
+					EventType: convertStringArr(eventType),
+				}
+			}
+
+			return nc
 		}
 	}
 
@@ -4246,12 +4275,33 @@ func flattenNotificationConfig(c *container.NotificationConfig) []map[string]int
 		return nil
 	}
 
+	if c.Pubsub.Filter != nil {
+		filter := []map[string]interface{}{}
+		if len(c.Pubsub.Filter.EventType) > 0 {
+			filter = append(filter, map[string]interface{}{
+				"event_type": c.Pubsub.Filter.EventType,
+			})
+		}
+
+		return []map[string]interface{}{
+			{
+				"pubsub": []map[string]interface{}{
+					{
+						"enabled": c.Pubsub.Enabled,
+						"topic":   c.Pubsub.Topic,
+						"filter":  filter,
+					},
+				},
+			},
+		}
+	}
+
 	return []map[string]interface{}{
 		{
 			"pubsub": []map[string]interface{}{
 				{
 					"enabled": c.Pubsub.Enabled,
-					"topic": c.Pubsub.Topic,
+					"topic":   c.Pubsub.Topic,
 				},
 			},
 		},

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -249,6 +249,46 @@ func TestAccContainerCluster_withNotificationConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withFilteredNotificationConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	topic := fmt.Sprintf("tf-test-topic-%s", randString(t, 10))
+	newTopic := fmt.Sprintf("tf-test-topic-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withFilteredNotificationConfig(clusterName, topic),
+			},
+			{
+				ResourceName:      "google_container_cluster.filtered_notification_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_withFilteredNotificationConfigUpdate(clusterName, newTopic),
+			},
+			{
+				ResourceName:      "google_container_cluster.filtered_notification_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_disableFilteredNotificationConfig(clusterName, newTopic),
+			},
+			{
+				ResourceName:      "google_container_cluster.filtered_notification_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withConfidentialNodes(t *testing.T) {
 	t.Parallel()
 
@@ -3471,7 +3511,7 @@ resource "google_container_cluster" "notification_config" {
   notification_config {
 	pubsub {
 	  enabled = true
-	  topic = google_pubsub_topic.%s.id
+	  topic   = google_pubsub_topic.%s.id
 	}
   }
 }
@@ -3491,6 +3531,78 @@ resource "google_container_cluster" "notification_config" {
   }
 }
 `, clusterName)
+}
+
+func testAccContainerCluster_withFilteredNotificationConfig(clusterName string, topic string) string {
+
+	return fmt.Sprintf(`
+
+resource "google_pubsub_topic" "%s" {
+  name = "%s"
+}
+
+resource "google_container_cluster" "filtered_notification_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  notification_config {
+	pubsub {
+	  enabled = true
+	  topic   = google_pubsub_topic.%s.id
+	  filter {
+		event_type = ["UPGRADE_EVENT", "SECURITY_BULLETIN_EVENT"]
+	  }
+	}
+  }
+}
+`, topic, topic, clusterName, topic)
+}
+
+func testAccContainerCluster_withFilteredNotificationConfigUpdate(clusterName string, topic string) string {
+
+	return fmt.Sprintf(`
+
+resource "google_pubsub_topic" "%s" {
+  name = "%s"
+}
+
+resource "google_container_cluster" "filtered_notification_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  notification_config {
+	pubsub {
+	  enabled = true
+	  topic   = google_pubsub_topic.%s.id
+	  filter {
+		event_type = ["UPGRADE_AVAILABLE_EVENT"]
+	  }
+	}
+  }
+}
+`, topic, topic, clusterName, topic)
+}
+
+func testAccContainerCluster_disableFilteredNotificationConfig(clusterName string, topic string) string {
+
+	return fmt.Sprintf(`
+
+resource "google_pubsub_topic" "%s" {
+  name = "%s"
+}
+
+resource "google_container_cluster" "filtered_notification_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  notification_config {
+	pubsub {
+	  enabled = true
+	  topic   = google_pubsub_topic.%s.id
+	}
+  }
+}
+`, topic, topic, clusterName, topic)
 }
 
 func testAccContainerCluster_withConfidentialNodes(clusterName string, npName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -886,6 +886,8 @@ The `pubsub` block supports:
 
 * `topic` (Optional) - The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster. Must be in the format: `projects/{project}/topics/{topic}`.
 
+* `filter` (Optional) - Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Structure is [documented below](#nested_notification_filter).
+
 ```hcl
 notification_config {
   pubsub {
@@ -894,6 +896,10 @@ notification_config {
   }
 }
 ```
+
+<a name="nested_notification_filter"></a> The `filter` block supports:
+
+* `event_type` (Optional) - Can be used to filter what notifications are sent. Accepted values are `UPGRADE_AVAILABLE_EVENT`, `UPGRADE_EVENT` and `SECURITY_BULLETIN_EVENT`. See [Filtering notifications](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-notifications#filtering) for more details.
 
 <a name="nested_confidential_nodes"></a> The `confidential_nodes` block supports:
 


### PR DESCRIPTION
Signed-off-by: toVersus <toversus2357@gmail.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/11166

This PR added support for cluster notification filter to `google_container_cluster` resource.

- [REST API doc](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.Filter)
- [Types of upgrade notifications](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-notifications#notification-types)

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `notification_config.pubsub.filter` field to `google_container_cluster`
```
