### PR TITLE
Allow Private Worker Pool for Cloud Functions Cloud Builds.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -112,6 +112,12 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 				ValidateFunc: validateResourceCloudFunctionsFunctionName,
 			},
 
+			"build_worker_pool": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Name of the Cloud Build Custom Worker Pool that should be used to build the function.`,
+			},
+
 			"source_archive_bucket": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -489,6 +489,10 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 		function.Description = v.(string)
 	}
 
+	if v, ok := d.GetOk("build_worker_pool"); ok {
+		function.BuildWorkerPool = v.(string)
+	}
+
 	if v, ok := d.GetOk("entry_point"); ok {
 		function.EntryPoint = v.(string)
 	}
@@ -598,6 +602,9 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	if err := d.Set("description", function.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("build_worker_pool", function.BuildWorkerPool); err != nil {
+		return fmt.Errorf("Error setting build_worker_pool: %s", err)
 	}
 	if err := d.Set("entry_point", function.EntryPoint); err != nil {
 		return fmt.Errorf("Error setting entry_point: %s", err)
@@ -764,6 +771,11 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("description") {
 		function.Description = d.Get("description").(string)
 		updateMaskArr = append(updateMaskArr, "description")
+	}
+
+	if d.HasChange("build_worker_pool") {
+		function.BuildWorkerPool = d.Get("build_worker_pool").(string)
+		updateMaskArr = append(updateMaskArr, "build_worker_pool")
 	}
 
 	if d.HasChange("timeout") {

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -254,7 +254,11 @@ func TestAccCloudFunctionsFunction_buildworkerpool(t *testing.T) {
 	funcResourceName := "google_cloudfunctions_function.function"
 	functionName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", randInt(t))
+	location := "us-central1"
 	zipFilePath := createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
+	proj := getTestProjectFromEnv()
+
+
 	defer os.Remove(zipFilePath) // clean up
 
 	vcrTest(t, resource.TestCase{
@@ -263,13 +267,14 @@ func TestAccCloudFunctionsFunction_buildworkerpool(t *testing.T) {
 		CheckDestroy: testAccCheckCloudFunctionsFunctionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFunctionsFunction_buildworkerpool(functionName, bucketName, zipFilePath),
+				Config: testAccCloudFunctionsFunction_buildworkerpool(functionName, bucketName, zipFilePath, location),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudFunctionsFunctionExists(
 						t, funcResourceName, &function),
-					// TODO
 					resource.TestCheckResourceAttr(funcResourceName,
 						"name", functionName),
+					resource.TestCheckResourceAttr(funcResourceName,
+						"build_worker_pool", fmt.Sprintf("projects/%s/locations/%s/workerPools/pool-%s", proj, location, functionName)),
 				),
 			},
 			{
@@ -862,7 +867,7 @@ resource "google_cloudfunctions_function" "function" {
 `, bucketName, zipFilePath, functionName)
 }
 
-func testAccCloudFunctionsFunction_buildworkerpool(functionName string, bucketName string, zipFilePath string) string {
+func testAccCloudFunctionsFunction_buildworkerpool(functionName string, bucketName string, zipFilePath string, location string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
@@ -877,7 +882,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudbuild_worker_pool" "pool" {
   name     = "pool-%[3]s"
-  location = "us-central1"
+  location = "%s"
   worker_config {
     disk_size_gb   = 100
     machine_type   = "e2-standard-4"
@@ -896,7 +901,8 @@ resource "google_cloudfunctions_function" "function" {
   trigger_http          = true
   timeout               = 61
   entry_point           = "helloGET"
-}`, bucketName, zipFilePath, functionName)
+  build_worker_pool		= google_cloudbuild_worker_pool.pool.id
+}`, bucketName, zipFilePath, functionName, location)
 }
 
 func testAccCloudFunctionsFunction_pubsub(functionName string, bucketName string,

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -246,6 +246,42 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 	})
 }
 
+func TestAccCloudFunctionsFunction_buildworkerpool(t *testing.T) {
+	t.Parallel()
+
+	var function cloudfunctions.CloudFunction
+
+	funcResourceName := "google_cloudfunctions_function.function"
+	functionName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%d", randInt(t))
+	zipFilePath := createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
+	defer os.Remove(zipFilePath) // clean up
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFunctionsFunctionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudFunctionsFunction_buildworkerpool(functionName, bucketName, zipFilePath),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudFunctionsFunctionExists(
+						t, funcResourceName, &function),
+					// TODO
+					resource.TestCheckResourceAttr(funcResourceName,
+						"name", functionName),
+				),
+			},
+			{
+				ResourceName:            funcResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"build_environment_variables"},
+			},
+		},
+	})
+}
+
 func TestAccCloudFunctionsFunction_pubsub(t *testing.T) {
 	t.Parallel()
 
@@ -824,6 +860,43 @@ resource "google_cloudfunctions_function" "function" {
   min_instances = 5
 }
 `, bucketName, zipFilePath, functionName)
+}
+
+func testAccCloudFunctionsFunction_buildworkerpool(functionName string, bucketName string, zipFilePath string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "US"
+}
+
+resource "google_storage_bucket_object" "archive" {
+  name   = "index.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "%s"
+}
+
+resource "google_cloudbuild_worker_pool" "pool" {
+  name     = "pool-%[3]s"
+  location = "us-central1"
+  worker_config {
+    disk_size_gb   = 100
+    machine_type   = "e2-standard-4"
+    no_external_ip = false
+  }
+}
+
+resource "google_cloudfunctions_function" "function" {
+  name                  = "%[3]s"
+  runtime               = "nodejs10"
+  description           = "test function"
+  docker_registry       = "CONTAINER_REGISTRY"
+  available_memory_mb   = 128
+  source_archive_bucket = google_storage_bucket.bucket.name
+  source_archive_object = google_storage_bucket_object.archive.name
+  trigger_http          = true
+  timeout               = 61
+  entry_point           = "helloGET"
+}`, bucketName, zipFilePath, functionName)
 }
 
 func testAccCloudFunctionsFunction_pubsub(functionName string, bucketName string,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Allow Private Worker Pool for Cloud Functions Cloud Builds.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10897


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudfunctions: Added `build_worker_pool` to `google_cloudfunctions_function`
```
