### PR TITLE
Stop reading data_disk_type value from API response into state of google_notebooks_instance resource

### DIFF
--- a/mmv1/products/notebooks/terraform.yaml
+++ b/mmv1/products/notebooks/terraform.yaml
@@ -80,7 +80,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       noRemoveDataDisk: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
       dataDiskType: !ruby/object:Overrides::Terraform::PropertyOverride
-        diff_suppress_func: 'emptyOrDefaultStringSuppress("DISK_TYPE_UNSPECIFIED")'
+        ignore_read: true
       diskEncryption: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'emptyOrDefaultStringSuppress("DISK_ENCRYPTION_UNSPECIFIED")'
       instanceOwners: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
# Description

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8485

That issue linked above describes a permadiff/permadelete situation where:
- the Terraform config defines a type of disk to use in `data_disk_type`
- the notebook resource is created
- after creation, TF reads the resource from the API and overwrites state
- The API response doesn't include the `data_disk_type` value, so it is set to `""` in state
- On the next plan TF identifies that the config has a non-zero value and the state has a zero value, so proposes a change
- The change is on a `ForceNew` field

**This PR stops the `data_disk_type` value being read from the API to overwrite state.**

This matches how the boot disk arguments are handled:

https://github.com/GoogleCloudPlatform/magic-modules/blob/ea34ac204ae9216682497593ad5e383a16585ff3/mmv1/products/notebooks/terraform.yaml#L70-L73

# List
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~ N/A
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
    - Tests starting `TestAccNotebooksInstance_` pass
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
notebooks: fixed perma-diff in `google_notebooks_instance`
```
