### PR TITLE
Suppress logrus entries that contain text related to `ListenSocket`

### DIFF
--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -98,9 +98,9 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	// - frequent transport spam
 	// - ListenSocket logs from gRPC
 	isTransportSpam := strings.Contains(entry.Message, "transport is closing")
-	grpcRegex := regexp.MustCompile(`\[Server #\d+( ListenSocket #\d+)*\]`) // Match patterns like `[Server #00]` or `[Server #00 ListenSocket #00]`
-	isGrpcLog := grpcRegex.MatchString(entry.Message)
-	if isTransportSpam || isGrpcLog {
+	listenSocketRegex := regexp.MustCompile(`\[Server #\d+( ListenSocket #\d+)*\]`) // Match patterns like `[Server #00]` or `[Server #00 ListenSocket #00]`
+	isListenSocketLog := listenSocketRegex.MatchString(entry.Message)
+	if isTransportSpam || isListenSocketLog {
 		return nil, nil
 	}
 

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -90,10 +90,20 @@ type Formatter struct {
 // Borrowed logic from https://github.com/sirupsen/logrus/blob/master/json_formatter.go and https://github.com/t-tomalak/logrus-easy-formatter/blob/master/formatter.go
 func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	// Suppress logs if TF_LOG is not DEBUG or TRACE
-	// Also suppress frequent transport spam
-	if !logging.IsDebugOrHigher() || strings.Contains(entry.Message, "transport is closing") {
+	if !logging.IsDebugOrHigher() {
 		return nil, nil
 	}
+
+	// Also suppress based on log content
+	// - frequent transport spam
+	// - ListenSocket logs from gRPC
+	isTransportSpam := strings.Contains(entry.Message, "transport is closing")
+	grpcRegex := regexp.MustCompile(`\[Server #\d+( ListenSocket #\d+)*\]`) // Match patterns like `[Server #00]` or `[Server #00 ListenSocket #00]`
+	isGrpcLog := grpcRegex.MatchString(entry.Message)
+	if isTransportSpam || isGrpcLog {
+		return nil, nil
+	}
+
 	output := f.LogFormat
 	entry.Level = logrus.DebugLevel // Force Entries to be Debug
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
# Description

This PR is a quick attempt at this issue : https://github.com/hashicorp/terraform-provider-google/issues/12159

My understanding was that this issue was to remove logs like below that appear in VCR test artefacts ([example](https://00f74ba44bfc4ebea122251d9884ae5bd22c3421d5-apidata.googleusercontent.com/download/storage/v1/b/ci-vcr-logs/o/beta%2Frefs%2Fheads%2Fauto-pr-6512%2Fartifacts%2F799fdd20-2b8e-4514-9966-7b3e8953681e%2Fbuild-log%2Frecording_build%2FTestAccComputeInstance_soleTenantNodeAffinities_recording_test.log?jk=AFshE3XeBv663KmO1j40CJZ60AcgMmsi_Mcx-vFGsAXCh4ghLhJQGGnCfd0tJvB6LVUX00MqJXj9I0NSWbzw5tqU91PKdxYNHF4vYbWUjzsR_G4ZBYzS9jQxRfnLyTtFC8lf5tTu-FFUvnahN8xsOiI86Fsd-CPPG1cBavyTJmNDW8eLbPy2GpHOL4IMlyxD4XpPiG_RCK92JEnsnvJNEDwxDCOHaT-pTljBwKSavf4-VMJlf69qTvs4IL9Grd46o29ALPMatjJ4BPQB1hc1PPth1YD6kE2iodYzRN5mils0EINjAIkjocdHLSM413EQhoEVvV8cFsUpLgJh6XWPr1YvrZ_VM-3n6fkb4_ir_XyBbdYz9dMxSWjfdBFmf6eh41hIQUbC3IoCaP3shawPmPP783a-nPyyAvF0bjEa_eqz_O0URNAg3jJWS_NVnTmJySzG7fZSP8Ut30_wrzNlHfa-fKgc8fCRt6-hB8eY-zSTReqf3jfdnFXfpAOtmR6va9DTFser71vKREr4CpdQiqU06fy5vzduTO1-DJ0c6Y7swPfabZIGfEWkNe5OWHJ3pc3xNghtFQbK1FObNQ8p_P3nupeYnby9xo03YA7xoqBvIMF9i4oZSqR7sLoLMo5ZE6gLyJcuU0UFAza0faDCvtBvwxvVRdhUYaWJmNoCuw9pG9WsAWS4yGjR7peW3IIaQBOvM4aj80zSkUCiBeJy07bCY6CfmZMVffUSbeT92Ic8Iv6hB5jFdB-Iz39e5P6dAwrRQoy7oZg81r0QMBKpWWP1mKyX7EyuPBd5TLcbqnznvxy9QqwHjT--r-k4yQ6tLHMLaYvDeam3Ug2jTt-Z2UP4xfxDtmfbZuVCj8IAL5dROz1-MP_SXUcjyUdaMZfNEXF6FPSXK-Fd682f04y_ZoDNDNsmjAtc0rYOW9YenrSrrRWvh7eorNKgogrjuA3LBAVmfThdTYZOEUDiANmfnSno7yleznyop00r4ODmjBuCkGAqcjLZe-Sk-pJ9JO62VoOZRs3G6ttyLQxxMVhJSQ47Qq0Yg1wJQeCsoOf5_NPI8XzhQKminAu9S0NGlO_S54yxBotuHm2ZnZHbWWwljs90r-n0zEf53rJCN8GCuqWs4gGcvp3jVpYwTKTjyWLfVSEOTWE2qUUxhbvqE69JY6wJh3XQ51B_UpU3PS-Jf_mGaYUdPQMg0Dr-67wWHH_rkYYCgfqpQmH72A&isca=1))

```
2022/09/06 12:14:19 [DEBUG] [core] [Server #19] Server created 
2022/09/06 12:14:19 [DEBUG] [core] [Server #19 ListenSocket #20] ListenSocket created 
2022/09/06 12:14:19 [DEBUG] [core] [Server #19 ListenSocket #20] ListenSocket deleted 
2022/09/06 12:14:19 [DEBUG] [core] [Server #23] Server created 
2022/09/06 12:14:19 [DEBUG] [core] [Server #23 ListenSocket #24] ListenSocket created 
2022/09/06 12:14:32 [DEBUG] [core] [Server #23 ListenSocket #24] ListenSocket deleted 
```

# Testing

I tested the PR by running the `TestAccDataSourceGoogleCloudFunctionsFunction_basic` acceptance test with and without this PRs changes, and I could only find `ListenSocket` in the logs when not using this PR.

- Are there better ways to test this?
- Should I make wrap the regex in a function and add a unit test to show how it should work?


# List 
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
    - I ran `TestAccDataSourceGoogleCloudFunctionsFunction_basic` with and without this PRs changes and can only see `ListenSocket` in the logs when not using this PR. No issues with the running of the test itself.
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
