### PR TITLE
suppress dataplex labels

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -82,6 +82,8 @@ func resourceStorageBucket() *schema.Resource {
 			"labels": {
 				Type:        schema.TypeMap,
 				Optional:    true,
+				// GCP (Dataplex) automatically adds labels
+				DiffSuppressFunc: resourceDataplexLabelDiffSuppress,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `A set of key/value label pairs to assign to the bucket.`,
 			},
@@ -374,6 +376,22 @@ func resourceStorageBucket() *schema.Resource {
 		},
 		UseJSONNumber: true,
 	}
+}
+
+const resourceDataplexGoogleProvidedLabelPrefix = "labels.goog-dataplex"
+
+func resourceDataplexLabelDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if strings.HasPrefix(k, resourceDataplexGoogleProvidedLabelPrefix) && new == "" {
+		return true
+	}
+
+	// Let diff be determined by labels (above)
+	if strings.HasPrefix(k, "labels.%") {
+		return true
+	}
+
+	// For other keys, don't suppress diff.
+	return false
 }
 
 // Is the old bucket retention policy locked?

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -991,10 +991,10 @@ func TestLabelDiffSuppress(t *testing.T) {
 			New:                "",
 			ExpectDiffSuppress: true,
 		},
-		"explicit missing goog-dataplex-asset-id": {
+		"explicit goog-dataplex-asset-id": {
 			K:                  "labels.goog-dataplex-asset-id",
 			Old:                "test-bucket",
-			New:                "test-bucket",
+			New:                "test-bucket-1",
 			ExpectDiffSuppress: false,
 		},
 		"missing goog-dataplex-lake-id": {
@@ -1006,7 +1006,7 @@ func TestLabelDiffSuppress(t *testing.T) {
 		"explicit goog-dataplex-lake-id": {
 			K:                  "labels.goog-dataplex-lake-id",
 			Old:                "test-lake",
-			New:                "test-lake",
+			New:                "test-lake-1",
 			ExpectDiffSuppress: false,
 		},
 		"missing goog-dataplex-project-id": {
@@ -1018,7 +1018,7 @@ func TestLabelDiffSuppress(t *testing.T) {
 		"explicit goog-dataplex-project-id": {
 			K:                  "labels.goog-dataplex-project-id",
 			Old:                "test-project-12345",
-			New:                "test-project-12345",
+			New:                "test-project-12345-1",
 			ExpectDiffSuppress: false,
 		},
 		"missing goog-dataplex-zone-id": {
@@ -1030,7 +1030,7 @@ func TestLabelDiffSuppress(t *testing.T) {
 		"explicit goog-dataplex-zone-id": {
 			K:                  "labels.goog-dataplex-zone-id",
 			Old:                "test-zone1",
-			New:                "test-zone1",
+			New:                "test-zone1-1",
 			ExpectDiffSuppress: false,
 		},
 		"labels.%": {

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -1054,7 +1054,7 @@ func TestLabelDiffSuppress(t *testing.T) {
 		},
 	}
 	for tn, tc := range cases {
-		if resourceDataplexLabelDiffSuppress(tc.K, tc.Old, tc.New) != tc.ExpectDiffSuppress {
+		if resourceDataplexLabelDiffSuppress(tc.K, tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
 			t.Errorf("bad: %s, %q: %q => %q expect DiffSuppress to return %t", tn, tc.K, tc.Old, tc.New, tc.ExpectDiffSuppress)
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"testing"
 	"time"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"testing"
 	"time"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -978,6 +979,109 @@ func TestAccStorageBucket_retentionPolicyLocked(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestLabelDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		K, Old, New        string
+		ExpectDiffSuppress bool
+	}{
+		"missing goog-dataplex-asset-id": {
+			K:                  "labels.goog-dataplex-asset-id",
+			Old:                "test-bucket",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"explicit missing goog-dataplex-asset-id": {
+			K:                  "labels.goog-dataplex-asset-id",
+			Old:                "test-bucket",
+			New:                "test-bucket",
+			ExpectDiffSuppress: false,
+		},
+		"missing goog-dataplex-lake-id": {
+			K:                  "labels.goog-dataplex-lake-id",
+			Old:                "test-lake",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"explicit goog-dataplex-lake-id": {
+			K:                  "labels.goog-dataplex-lake-id",
+			Old:                "test-lake",
+			New:                "test-lake",
+			ExpectDiffSuppress: false,
+		},
+		"missing goog-dataplex-project-id": {
+			K:                  "labels.goog-dataplex-project-id",
+			Old:                "test-project-12345",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"explicit goog-dataplex-project-id": {
+			K:                  "labels.goog-dataplex-project-id",
+			Old:                "test-project-12345",
+			New:                "test-project-12345",
+			ExpectDiffSuppress: false,
+		},
+		"missing goog-dataplex-zone-id": {
+			K:                  "labels.goog-dataplex-zone-id",
+			Old:                "test-zone1",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"explicit goog-dataplex-zone-id": {
+			K:                  "labels.goog-dataplex-zone-id",
+			Old:                "test-zone1",
+			New:                "test-zone1",
+			ExpectDiffSuppress: false,
+		},
+		"labels.%": {
+			K:                  "labels.%",
+			Old:                "5",
+			New:                "1",
+			ExpectDiffSuppress: true,
+		},
+		"deleted custom key": {
+			K:                  "labels.my-label",
+			Old:                "my-value",
+			New:                "",
+			ExpectDiffSuppress: false,
+		},
+		"added custom key": {
+			K:                  "labels.my-label",
+			Old:                "",
+			New:                "my-value",
+			ExpectDiffSuppress: false,
+		},
+	}
+	for tn, tc := range cases {
+		if testLabelDiffSuppress(tc.K, tc.Old, tc.New) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, %q: %q => %q expect DiffSuppress to return %t", tn, tc.K, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
+var googleProvidedLabels = []string{
+	"goog-dataplex-asset-id",
+	"goog-dataplex-lake-id",
+	"goog-dataplex-project-id",
+	"goog-dataplex-zone-id",
+}
+
+func testLabelDiffSuppress(k, old, new string) bool {
+	// Suppress diffs for the labels provided by Google
+	for _, label := range googleProvidedLabels {
+		if strings.Contains(k, label) && new == "" {
+			return true
+		}
+	}
+
+	// Let diff be determined by labels (above)
+	if strings.Contains(k, "labels.%") {
+		return true
+	}
+
+	// For other keys, don't suppress diff.
+	return false
 }
 
 func testAccCheckStorageBucketExists(t *testing.T, n string, bucketName string, bucket *storage.Bucket) resource.TestCheckFunc {

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -1054,34 +1054,10 @@ func TestLabelDiffSuppress(t *testing.T) {
 		},
 	}
 	for tn, tc := range cases {
-		if testLabelDiffSuppress(tc.K, tc.Old, tc.New) != tc.ExpectDiffSuppress {
+		if resourceDataplexLabelDiffSuppress(tc.K, tc.Old, tc.New) != tc.ExpectDiffSuppress {
 			t.Errorf("bad: %s, %q: %q => %q expect DiffSuppress to return %t", tn, tc.K, tc.Old, tc.New, tc.ExpectDiffSuppress)
 		}
 	}
-}
-
-var googleProvidedLabels = []string{
-	"goog-dataplex-asset-id",
-	"goog-dataplex-lake-id",
-	"goog-dataplex-project-id",
-	"goog-dataplex-zone-id",
-}
-
-func testLabelDiffSuppress(k, old, new string) bool {
-	// Suppress diffs for the labels provided by Google
-	for _, label := range googleProvidedLabels {
-		if strings.Contains(k, label) && new == "" {
-			return true
-		}
-	}
-
-	// Let diff be determined by labels (above)
-	if strings.Contains(k, "labels.%") {
-		return true
-	}
-
-	// For other keys, don't suppress diff.
-	return false
 }
 
 func testAccCheckStorageBucketExists(t *testing.T, n string, bucketName string, bucket *storage.Bucket) resource.TestCheckFunc {


### PR DESCRIPTION
Suppress automatically added Dataplex Labels, when running tf plan.
Dataplex Labels added by the system led to an inconsistent tf state.

Closes [#12449](https://github.com/hashicorp/terraform-provider-google/issues/12449)

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:bug
storage: fixed a bug where user specified labels get overwritten by Dataplex auto generated labels
```
