### PR TITLE
Improve ruby installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ To get started, you'll need:
     instructions to set up Go: [YouTube video](https://www.youtube.com/watch?v=VQVyvulNnzs).
   * If you're using Cloud Shell, Go is already installed.
 * Ruby 2.6.0
-  * You can use `rbenv` to manage your Ruby version(s).
-  * To install `rbenv`, run `sudo apt install rbenv`.
+  * You can use [`rbenv`](https://github.com/rbenv/rbenv) to manage your Ruby version(s).
+  * To install `rbenv`:
+    * Homebrew: run `brew install rbenv ruby-build`
+    * Debian, Ubuntu, and their derivatives: run `sudo apt install rbenv`
   * Then run `rbenv install 2.6.0`. 
     * For M1 Mac users, run `RUBY_CFLAGS="-Wno-error=implicit-function-declaration" rbenv install 2.6.0`
 * [`Bundler`](https://github.com/bundler/bundler)


### PR DESCRIPTION
Tweaks the instructions for installing Ruby and `rbenv` to include a link to the official docs, and include the Homebrew command. Before, we only had the Debian command, which I assume is the less popular of the two amongst contributors.

Relates to b/244477101

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
