### PR TITLE
Add json_custom_config field to compute_security_policy resource

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13911,6 +13911,35 @@ objects:
                       description: |
                         CIDR IP address range.
                       item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'advancedOptionsConfig'
+        description:
+          Advanced configuration options for this security policy.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'jsonParsing'
+            description: |
+              The JSON parsing behavior for this security policy.
+            values:
+              - :DISABLED
+              - :STANDARD
+          - !ruby/object:Api::Type::NestedObject
+            name: 'jsonCustomConfig'
+            description: |
+              Custom configuration to apply the JSON parsing. Only applicable when JSON parsing is set to STANDARD.
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'contentTypes'
+                description: |
+                  A list of custom Content-Type header values to apply the JSON parsing.
+                item_type: Api::Type::String
+          - !ruby/object:Api::Type::Enum
+            name: 'logLevel'
+            description: |
+              The level of detail to display for WAF logging.
+            values:
+              - :NORMAL
+              - :VERBOSE
   - !ruby/object:Api::Resource
     name: 'Snapshot'
     kind: 'compute#snapshot'

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13911,35 +13911,6 @@ objects:
                       description: |
                         CIDR IP address range.
                       item_type: Api::Type::String
-      - !ruby/object:Api::Type::NestedObject
-        name: 'advancedOptionsConfig'
-        description:
-          Advanced configuration options for this security policy.
-        properties:
-          - !ruby/object:Api::Type::Enum
-            name: 'jsonParsing'
-            description: |
-              The JSON parsing behavior for this security policy.
-            values:
-              - :DISABLED
-              - :STANDARD
-          - !ruby/object:Api::Type::NestedObject
-            name: 'jsonCustomConfig'
-            description: |
-              Custom configuration to apply the JSON parsing. Only applicable when JSON parsing is set to STANDARD.
-            properties:
-              - !ruby/object:Api::Type::Array
-                name: 'contentTypes'
-                description: |
-                  A list of custom Content-Type header values to apply the JSON parsing.
-                item_type: Api::Type::String
-          - !ruby/object:Api::Type::Enum
-            name: 'logLevel'
-            description: |
-              The level of detail to display for WAF logging.
-            values:
-              - :NORMAL
-              - :VERBOSE
   - !ruby/object:Api::Resource
     name: 'Snapshot'
     kind: 'compute#snapshot'

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -324,17 +324,35 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"json_parsing": {
 							Type: schema.TypeString,
-								Optional: true,
-								Computed: true,
-								ValidateFunc: validation.StringInSlice([]string{"DISABLED", "STANDARD"}, false),
-								Description: `JSON body parsing. Supported values include: "DISABLED", "STANDARD".`,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{"DISABLED", "STANDARD"}, false),
+							Description: `JSON body parsing. Supported values include: "DISABLED", "STANDARD".`,
+						},
+						"json_custom_config": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: `Custom configuration to apply the JSON parsing. Only applicable when JSON parsing is set to STANDARD.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"content_types": {
+										Type: schema.TypeSet,
+										Required: true,
+										MinItems: 1,
+										Elem: &schema.Schema{Type: schema.TypeString},
+										Description: `A list of custom Content-Type header values to apply the JSON parsing.`,
+									},
+								},
+							},
 						},
 						"log_level": {
 							Type: schema.TypeString,
-								Optional: true,
-								Computed: true,
-								ValidateFunc: validation.StringInSlice([]string{"NORMAL", "VERBOSE"}, false),
-								Description: `Logging level. Supported values include: "NORMAL", "VERBOSE".`,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{"NORMAL", "VERBOSE"}, false),
+							Description: `Logging level. Supported values include: "NORMAL", "VERBOSE".`,
 						},
 					},
 				},
@@ -797,8 +815,9 @@ func expandSecurityPolicyAdvancedOptionsConfig(configured []interface{}) *comput
 
 	data := configured[0].(map[string]interface{})
 	return &compute.SecurityPolicyAdvancedOptionsConfig{
-		JsonParsing: data["json_parsing"].(string),
-		LogLevel: data["log_level"].(string),
+		JsonParsing:      data["json_parsing"].(string),
+		JsonCustomConfig: expandSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(data["json_custom_config"].([]interface{})),
+		LogLevel:         data["log_level"].(string),
 	}
 }
 
@@ -808,8 +827,32 @@ func flattenSecurityPolicyAdvancedOptionsConfig(conf *compute.SecurityPolicyAdva
 	}
 
 	data := map[string]interface{}{
-		"json_parsing": conf.JsonParsing,
-		"log_level": conf.LogLevel,
+		"json_parsing":       conf.JsonParsing,
+		"json_custom_config": flattenSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(conf.JsonCustomConfig),
+		"log_level":          conf.LogLevel,
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func expandSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(configured []interface{}) *compute.SecurityPolicyAdvancedOptionsConfigJsonCustomConfig {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	data := configured[0].(map[string]interface{})
+	return &compute.SecurityPolicyAdvancedOptionsConfigJsonCustomConfig{
+		ContentTypes: convertStringArr(data["content_types"].(*schema.Set).List()),
+	}
+}
+
+func flattenSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(conf *compute.SecurityPolicyAdvancedOptionsConfigJsonCustomConfig) []map[string]interface{} {
+	if conf == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"content_types": schema.NewSet(schema.HashString, convertStringArrToInterface(conf.ContentTypes)),
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -340,7 +340,6 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 									"content_types": {
 										Type: schema.TypeSet,
 										Required: true,
-										MinItems: 1,
 										Elem: &schema.Schema{Type: schema.TypeString},
 										Description: `A list of custom Content-Type header values to apply the JSON parsing.`,
 									},
@@ -554,7 +553,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 
 	if d.HasChange("advanced_options_config") {
 		securityPolicy.AdvancedOptionsConfig = expandSecurityPolicyAdvancedOptionsConfig(d.Get("advanced_options_config").([]interface{}))
-		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "AdvancedOptionsConfig", "advancedOptionsConfig.jsonParsing", "advancedOptionsConfig.logLevel")
+		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "AdvancedOptionsConfig", "advancedOptionsConfig.jsonParsing", "advancedOptionsConfig.jsonCustomConfig", "advancedOptionsConfig.logLevel")
 	}
 
 	if d.HasChange("adaptive_protection_config") {
@@ -837,7 +836,8 @@ func flattenSecurityPolicyAdvancedOptionsConfig(conf *compute.SecurityPolicyAdva
 
 func expandSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(configured []interface{}) *compute.SecurityPolicyAdvancedOptionsConfigJsonCustomConfig {
 	if len(configured) == 0 || configured[0] == nil {
-		return nil
+		// If configuration is unset, return an empty JsonCustomConfig; this ensures the ContentTypes list can be cleared
+		return &compute.SecurityPolicyAdvancedOptionsConfigJsonCustomConfig{}
 	}
 
 	data := configured[0].(map[string]interface{})

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -425,6 +425,14 @@ resource "google_compute_security_policy" "policy" {
 
   advanced_options_config {
     json_parsing = "STANDARD"
+    json_custom_config {
+      content_types = [
+        "application/json",
+        "application/vnd.api+json",
+        "application/vnd.collection+json",
+        "application/vnd.hyper+json"
+      ]
+    }
     log_level    = "VERBOSE"
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -63,16 +63,7 @@ The following arguments are supported:
     security policy, a default rule with action "allow" will be added. Structure is [documented below](#nested_rule).
 
 * `advanced_options_config` - (Optional) [Advanced Configuration Options](https://cloud.google.com/armor/docs/security-policy-overview#json-parsing).
-
-<a name="nested_advanced_options_config"></a>The `advanced_options_config` block supports:
-
-* `json_parsing` - Whether or not to JSON parse the payload body. Defaults to `DISABLED`.
-  * DISABLED - Don't parse JSON payloads in POST bodies.
-  * STANDARD - Parse JSON payloads in POST bodies.
-
-* `log_level` - Log level to use. Defaults to `NORMAL`.
-  * NORMAL - Normal log level.
-  * VERBOSE - Verbose log level.
+    Structure is [documented below](#nested_advanced_options_config).
 
 * `adaptive_protection_config` - (Optional) Configuration for [Google Cloud Armor Adaptive Protection](https://cloud.google.com/armor/docs/adaptive-protection-overview?hl=en). Structure is [documented below](#nested_adaptive_protection_config).
 
@@ -82,6 +73,26 @@ The following arguments are supported:
   * CLOUD_ARMOR_EDGE - Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services
     (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage).
     They filter requests before the request is served from Google's cache.
+
+<a name="nested_advanced_options_config"></a>The `advanced_options_config` block supports:
+
+* `json_parsing` - Whether or not to JSON parse the payload body. Defaults to `DISABLED`.
+  * DISABLED - Don't parse JSON payloads in POST bodies.
+  * STANDARD - Parse JSON payloads in POST bodies.
+
+* `json_custom_config` - Custom configuration to apply the JSON parsing. Only applicable when
+    `json_parsing` is set to `STANDARD`. Structure is [documented below](#nested_json_custom_config).
+
+* `log_level` - Log level to use. Defaults to `NORMAL`.
+  * NORMAL - Normal log level.
+  * VERBOSE - Verbose log level.
+
+<a name="nested_json_custom_config"></a>The `json_custom_config` block supports:
+
+* `content_types` - A list of custom Content-Type header values to apply the JSON parsing. The
+    format of the Content-Type header values is defined in
+    [RFC 1341](https://www.ietf.org/rfc/rfc1341.txt). When configuring a custom Content-Type header
+    value, only the type/subtype needs to be specified, and the parameters should be excluded.
 
 <a name="nested_rule"></a>The `rule` block supports:
 


### PR DESCRIPTION
Adds the `json_custom_config` field to the `compute_security_policy` resource.

Since this is a handwritten resource, I updated the `api.yml` as well as the `resource_*.go.erb`, but I'm not sure if it's a good idea to be updating both. If there is a better way to do this please let me know.

b/190123207

Example:

```
resource "google_compute_security_policy" "policy" {
  ...
  advanced_options_config {
    json_parsing = "STANDARD"
    json_custom_config {
      content_types = [
        "application/json",
        "application/vnd.api+json",
        "application/vnd.collection+json",
        "application/vnd.hyper+json"
      ]
    }
  }
}
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `json_custom_config` field to `google_compute_security_policy` resource
```
