### PR TITLE
Bigtable: Update local gc_rules on read

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -261,7 +261,9 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 
 		d.SetId(fi.GCPolicy)
 		// Only set `gc_rules`` when the legacy fields are not set. We are not planning to support legacy fields.
-		if d.Get("mode") == "" && d.Get("max_age") == "" && d.Get("max_version") == "" {
+		maxAge := d.Get("max_age")
+		maxVersion := d.Get("max_version")
+		if d.Get("mode") == "" && len(maxAge.([]interface{})) == 0 && len(maxVersion.([]interface{})) == 0 {
 			gcRuleString, err := gcPolicyToGCRuleString(fi.FullGCPolicy, true)
 			if err != nil {
 				return err

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -260,6 +260,12 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		d.SetId(fi.GCPolicy)
+
+		// No GC Policy.
+		if fi.FullGCPolicy.String() == "" {
+			return nil
+		}
+
 		// Only set `gc_rules`` when the legacy fields are not set. We are not planning to support legacy fields.
 		maxAge := d.Get("max_age")
 		maxVersion := d.Get("max_version")

--- a/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigtable"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,7 +30,7 @@ func TestAccBigtableGCPolicy_basic(t *testing.T) {
 				Config: testAccBigtableGCPolicy(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policy"),
+						t, "google_bigtable_gc_policy.policy", false),
 				),
 			},
 		},
@@ -54,7 +55,7 @@ func TestAccBigtableGCPolicy_swapOffDeprecated(t *testing.T) {
 				Config: testAccBigtableGCPolicy_days(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policy"),
+						t, "google_bigtable_gc_policy.policy", false),
 					// Verify can write some data.
 					testAccBigtableCanWriteData(
 						t, "google_bigtable_gc_policy.policy", 10),
@@ -64,7 +65,7 @@ func TestAccBigtableGCPolicy_swapOffDeprecated(t *testing.T) {
 				Config: testAccBigtableGCPolicy(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policy"),
+						t, "google_bigtable_gc_policy.policy", false),
 					// Verify no data loss after the GC policy update.
 					testAccBigtableCanReadData(
 						t, "google_bigtable_gc_policy.policy", 10),
@@ -92,7 +93,7 @@ func TestAccBigtableGCPolicy_union(t *testing.T) {
 				Config: testAccBigtableGCPolicyUnion(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policy"),
+						t, "google_bigtable_gc_policy.policy", false),
 				),
 			},
 		},
@@ -118,11 +119,11 @@ func TestAccBigtableGCPolicy_multiplePolicies(t *testing.T) {
 				Config: testAccBigtableGCPolicy_multiplePolicies(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policyA"),
+						t, "google_bigtable_gc_policy.policyA", false),
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policyB"),
+						t, "google_bigtable_gc_policy.policyB", false),
 					testAccBigtableGCPolicyExists(
-						t, "google_bigtable_gc_policy.policyC"),
+						t, "google_bigtable_gc_policy.policyC", false),
 				),
 			},
 		},
@@ -148,7 +149,7 @@ func TestAccBigtableGCPolicy_gcRulesPolicy(t *testing.T) {
 			{
 				Config: testAccBigtableGCPolicy_gcRulesCreate(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccBigtableGCPolicyExists(t, "google_bigtable_gc_policy.policy"),
+					testAccBigtableGCPolicyExists(t, "google_bigtable_gc_policy.policy", true),
 					resource.TestCheckResourceAttr("google_bigtable_gc_policy.policy", "gc_rules", gcRulesOriginal),
 				),
 			},
@@ -157,7 +158,7 @@ func TestAccBigtableGCPolicy_gcRulesPolicy(t *testing.T) {
 			{
 				Config: testAccBigtableGCPolicy_gcRulesUpdate(instanceName, tableName, familyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccBigtableGCPolicyExists(t, "google_bigtable_gc_policy.policy"),
+					testAccBigtableGCPolicyExists(t, "google_bigtable_gc_policy.policy", true),
 					resource.TestCheckResourceAttr("google_bigtable_gc_policy.policy", "gc_rules", gcRulesUpdate),
 				),
 			},
@@ -293,7 +294,7 @@ func TestUnitBigtableGCPolicy_getGCPolicyFromJSON(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			} else {
 				if got != nil && got.String() != tc.want {
-					t.Errorf("error getting policy from JSON, got: %v, want: %v", tc.want, got)
+					t.Errorf("error getting policy from JSON, got: %v, want: %v", got, tc.want)
 				}
 			}
 		})
@@ -346,6 +347,96 @@ var testUnitBigtableGCPolicyCustomizeDiffTestcases = []testUnitBigtableGCPolicyC
 	},
 }
 
+type testUnitGcPolicyToGCRuleString struct {
+	name          string
+	policy        bigtable.GCPolicy
+	topLevel      bool
+	want          string
+	errorExpected bool
+}
+
+var testUnitGcPolicyToGCRuleStringTestCases = []testUnitGcPolicyToGCRuleString{
+	{
+		name:          "NoGcPolicy",
+		policy:        bigtable.NoGcPolicy(),
+		topLevel:      true,
+		want:          `{"rules":[{"max_version":1}]}`,
+		errorExpected: true,
+	},
+	{
+		name:          "MaxVersionPolicy",
+		policy:        bigtable.MaxVersionsPolicy(1),
+		topLevel:      true,
+		want:          `{"rules":[{"max_version":1}]}`,
+		errorExpected: false,
+	},
+	{
+		name:          "MaxAgePolicy",
+		policy:        bigtable.MaxAgePolicy(time.Hour),
+		topLevel:      true,
+		want:          `{"rules":[{"max_age":"1h"}]}`,
+		errorExpected: false,
+	},
+	{
+		name:          "UnionPolicy",
+		policy:        bigtable.UnionPolicy(bigtable.MaxVersionsPolicy(1), bigtable.MaxAgePolicy(time.Hour)),
+		topLevel:      true,
+		want:          `{"mode":"union","rules":[{"max_version":1},{"max_age":"1h"}]}`,
+		errorExpected: false,
+	},
+	{
+		name:          "IntersectionPolicy",
+		policy:        bigtable.IntersectionPolicy(bigtable.MaxVersionsPolicy(1), bigtable.MaxAgePolicy(time.Hour)),
+		topLevel:      true,
+		want:          `{"mode":"intersection","rules":[{"max_version":1},{"max_age":"1h"}]}`,
+		errorExpected: false,
+	},
+	{
+		name:          "NestedPolicy",
+		policy:        bigtable.UnionPolicy(bigtable.IntersectionPolicy(bigtable.MaxVersionsPolicy(1), bigtable.MaxAgePolicy(3*time.Hour)), bigtable.MaxAgePolicy(time.Hour)),
+		topLevel:      true,
+		want:          `{"mode":"union","rules":[{"mode":"intersection","rules":[{"max_version":1},{"max_age":"3h"}]},{"max_age":"1h"}]}`,
+		errorExpected: false,
+	},
+	{
+		name:          "MaxVersionPolicyNotTopeLevel",
+		policy:        bigtable.MaxVersionsPolicy(1),
+		topLevel:      false,
+		want:          `{"max_version":1}`,
+		errorExpected: false,
+	},
+	{
+		name:          "MaxAgePolicyNotTopeLevel",
+		policy:        bigtable.MaxAgePolicy(time.Hour),
+		topLevel:      false,
+		want:          `{"max_age":"1h"}`,
+		errorExpected: false,
+	},
+}
+
+func TestUnitBigtableGCPolicy_gcPolicyToGCRuleString(t *testing.T) {
+	for _, tc := range testUnitGcPolicyToGCRuleStringTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := gcPolicyToGCRuleString(tc.policy, tc.topLevel)
+			if tc.errorExpected && err == nil {
+				t.Fatal("expect error, got nil")
+			} else if !tc.errorExpected && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			} else {
+				if got != nil {
+					gcRuleJsonString, err := json.Marshal(got)
+					if err != nil {
+						t.Fatalf("Error marshaling GC policy to json: %s", err)
+					}
+					if string(gcRuleJsonString) != tc.want {
+						t.Errorf("Unexpected GC policy, got: %v, want: %v", string(gcRuleJsonString), tc.want)
+					}
+				}
+			}
+		})
+	}
+}
+
 func testAccCheckBigtableGCPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		var ctx = context.Background()
@@ -382,7 +473,7 @@ func testAccCheckBigtableGCPolicyDestroyProducer(t *testing.T) func(s *terraform
 	}
 }
 
-func testAccBigtableGCPolicyExists(t *testing.T, n string) resource.TestCheckFunc {
+func testAccBigtableGCPolicyExists(t *testing.T, n string, compareGcRules bool) resource.TestCheckFunc {
 	var ctx = context.Background()
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -406,9 +497,24 @@ func testAccBigtableGCPolicyExists(t *testing.T, n string) resource.TestCheckFun
 			return fmt.Errorf("Error retrieving table. Could not find %s in %s.", rs.Primary.Attributes["table"], rs.Primary.Attributes["instance_name"])
 		}
 
-		for _, i := range table.FamilyInfos {
-			if i.Name == rs.Primary.Attributes["column_family"] && i.GCPolicy == rs.Primary.ID {
-				return nil
+		for _, familyInfo := range table.FamilyInfos {
+			if familyInfo.Name == rs.Primary.Attributes["column_family"] && familyInfo.GCPolicy == rs.Primary.ID {
+				// Ensure the remote GC policy matches the local copy if `compareGcRules` is set to true.
+				if !compareGcRules {
+					return nil
+				}
+				gcRuleString, err := gcPolicyToGCRuleString(familyInfo.FullGCPolicy /*isTopLevel=*/, true)
+				if err != nil {
+					return fmt.Errorf("Error converting GC policy to JSON string: %s", err)
+				}
+				gcRuleJsonString, err := json.Marshal(gcRuleString)
+				if err != nil {
+					return fmt.Errorf("Error marshaling GC Policy to JSON: %s", err)
+				}
+				if string(gcRuleJsonString) == rs.Primary.Attributes["gc_rules"] {
+					return nil
+				}
+				return fmt.Errorf("Found differences in the local and the remote GC policies: %s vs %s", rs.Primary.Attributes["gc_rules"], string(gcRuleJsonString))
 			}
 		}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Currently when GCPolicy remote resource is updated not on TF (Pantheon, gcloud CLI, etc.), the gc_rules string are not updated on read. This PR fixes the issue by parsing the GC policy into JSON string that TF understands and set it in the local gc_rules. This hopefully will resolve the drift issue we have seen in KCC.

The original PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/6415 was created by [hoangpham95](https://github.com/hoangpham95).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: added drift detection on `gc_rules` for `google_bigtable_gc_policy`
```
