### PR TITLE
Add data source for Serverless VPC Access Connector.

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
@@ -10,6 +10,7 @@ func dataSourceVPCAccessConnector() *schema.Resource {
 
 	dsSchema := datasourceSchemaFromResourceSchema(resourceVPCAccessConnector().Schema)
 	addRequiredFieldsToSchema(dsSchema, "name")
+	addOptionalFieldsToSchema(dsSchema, "project", "region")
 
 	return &schema.Resource{
 		Read:   dataSourceVPCAccessConnectorRead,

--- a/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceVPCAccessConnector() *schema.Resource {
+
+	dsSchema := datasourceSchemaFromResourceSchema(resourceVPCAccessConnector().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name")
+
+	return &schema.Resource{
+		Read:   dataSourceVPCAccessConnectorRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVPCAccessConnectorRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	id, err := replaceVars(d, config, "projects/{{project}}/locations/{{region}}/connectors/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+
+	d.SetId(id)
+
+	return resourceVPCAccessConnectorRead(d, meta)
+}

--- a/mmv1/third_party/terraform/tests/data_source_vpc_access_connector_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_vpc_access_connector_test.go
@@ -1,0 +1,48 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVPCAccessConnectorDatasource_basic(t *testing.T) {
+	t.Parallel()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCAccessConnectorDatasourceConfig(randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_vpc_access_connector.connector",
+						"google_vpc_access_connector.connector",
+						map[string]struct{}{
+							// Ignore fields not returned in response
+							"self_link": {},
+							"region":    {},
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccVPCAccessConnectorDatasourceConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_vpc_access_connector" "connector" {
+  name          = "vpc-con-test-%s"
+  ip_cidr_range = "10.8.0.0/28"
+  network       = "default"
+  region        = "us-central1"
+}
+
+data "google_vpc_access_connector" "connector" {
+  name = google_vpc_access_connector.connector.name
+}
+`, suffix)
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -308,6 +308,7 @@ func Provider() *schema.Provider {
 			"google_tags_tag_key":                              dataSourceGoogleTagsTagKey(),
 			"google_tags_tag_value":                            dataSourceGoogleTagsTagValue(),
 			"google_tpu_tensorflow_versions":                   dataSourceTpuTensorflowVersions(),
+			"google_vpc_access_connector":                      dataSourceVPCAccessConnector(),
 			"google_redis_instance":                            dataSourceGoogleRedisInstance(),
 			// ####### END datasources ###########
 		},

--- a/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Serverless VPC Access"
+page_title: "Google: google_vpc_access_connector"
+description: |-
+  Get a Serverless VPC Access connector.
+---
+
+# google\_vpc\_access\_connector
+
+Get a Serverless VPC Access connector.
+
+To get more information about Connector, see:
+
+* [API documentation](https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1/projects.locations.connectors)
+* How-to Guides
+    * [Configuring Serverless VPC Access](https://cloud.google.com/vpc/docs/configure-serverless-vpc-access)
+
+## Example Usage
+
+```hcl
+data "google_vpc_access_connector" "sample" {
+  name = "vpc-con"
+}
+
+resource "google_vpc_access_connector" "connector" {
+  name          = "vpc-con"
+  ip_cidr_range = "10.8.0.0/28"
+  network       = "default"
+  region        = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` -
+  (Required)
+  The name of the resource (Max 25 characters).
+
+* `network` -
+  (Optional)
+  Name or self_link of the VPC network. Required if `ip_cidr_range` is set.
+
+* `ip_cidr_range` -
+  (Optional)
+  The range of internal addresses that follows RFC 4632 notation. Example: `10.132.0.0/28`.
+
+* `min_throughput` -
+  (Optional)
+  Minimum throughput of the connector in Mbps. Default and min is 200.
+
+* `max_throughput` -
+  (Optional)
+  Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/locations/{{region}}/connectors/{{name}}`
+
+* `state` -
+  State of the VPC access connector.

--- a/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
@@ -36,6 +36,14 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the resource.
 
+- - -
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The region in which the resource belongs. If it
+    is not provided, the provider region is used.
+
 ## Attributes Reference
 
 See [google_vpc_access_connector](https://www.terraform.io/docs/providers/google/r/vpc_access_connector.html) resource for details of the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
@@ -34,32 +34,8 @@ resource "google_vpc_access_connector" "connector" {
 
 The following arguments are supported:
 
-* `name` -
-  (Required)
-  The name of the resource (Max 25 characters).
-
-* `network` -
-  (Optional)
-  Name or self_link of the VPC network. Required if `ip_cidr_range` is set.
-
-* `ip_cidr_range` -
-  (Optional)
-  The range of internal addresses that follows RFC 4632 notation. Example: `10.132.0.0/28`.
-
-* `min_throughput` -
-  (Optional)
-  Minimum throughput of the connector in Mbps. Default and min is 200.
-
-* `max_throughput` -
-  (Optional)
-  Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
-
+* `name` - (Required) Name of the resource.
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are exported:
-
-* `id` - an identifier for the resource with format `projects/{{project}}/locations/{{region}}/connectors/{{name}}`
-
-* `state` -
-  State of the VPC access connector.
+See [google_vpc_access_connector](https://www.terraform.io/docs/providers/google/r/vpc_access_connector.html) resource for details of the available attributes.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8827

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_vpc_access_connector`
```
