### PR TITLE
Adding DiffSuppress for pd-ssd and pd-hdd

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -312,6 +312,7 @@ is set to true.`,
 							Type:     schema.TypeString,
 							Optional: true,
 							Default: "PD_SSD",
+							DiffSuppressFunc: caseDiffDashSuppress,
 							Description: `The type of data disk: PD_SSD or PD_HDD.`,
 						},
 						"ip_configuration": {
@@ -1835,14 +1836,7 @@ func sqlDatabaseInstanceRestoreFromBackup(d *schema.ResourceData, config *Config
 	return nil
 }
 
-
-// The core logic is to split on a reguar expression provided as an arugment to the function for both old and new value
-// Then convert the arrays back to strings with join back on a space to then set to upper case and compare to see if equal
-func caseDiffWithMultiDelimitSuppress(delimit string) schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		expr := regexp.MustCompile(delimit)
-		postSplitOld := strings.Join(expr.Split(old, -1), " ")
-		postSplitNew := strings.Join(expr.Split(new, -1), " ")
-		return strings.ToUpper(postSplitOld) == strings.ToUpper(postSplitNew)
-	}
+func caseDiffDashSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	postReplaceNew := strings.Replace(new, "-", "_", -1)
+	return strings.ToUpper(postReplaceNew) == strings.ToUpper(old)
 }

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -1834,3 +1834,15 @@ func sqlDatabaseInstanceRestoreFromBackup(d *schema.ResourceData, config *Config
 
 	return nil
 }
+
+
+// The core logic is to split on a reguar expression provided as an arugment to the function for both old and new value
+// Then convert the arrays back to strings with join back on a space to then set to upper case and compare to see if equal
+func caseDiffWithMultiDelimitSuppress(delimit string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		expr := regexp.MustCompile(delimit)
+		postSplitOld := strings.Join(expr.Split(old, -1), " ")
+		postSplitNew := strings.Join(expr.Split(new, -1), " ")
+		return strings.ToUpper(postSplitOld) == strings.ToUpper(postSplitNew)
+	}
+}

--- a/mmv1/third_party/terraform/tests/resource_sql_database_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_test.go
@@ -10,6 +10,40 @@ import (
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
+func TestCaseDiffDashSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"PD_HDD": {
+			Old:                "PD_HDD",
+			New:                "pd-hdd",
+			ExpectDiffSuppress: true,
+		},
+		"PD_SSD": {
+			Old:                "PD_SSD",
+			New:                "pd-ssd",
+			ExpectDiffSuppress: true,
+		},
+		"pd-hdd": {
+			Old:                "pd-hdd",
+			New:                "PD_HDD",
+			ExpectDiffSuppress: false,
+		},
+		"pd-ssd": {
+			Old:                "pd-ssd",
+			New:                "PD_SSD",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if caseDiffDashSuppress(tn, tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
 func TestAccSqlDatabase_basic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Potential fix for Issue #10492  google_sql_database_instance permanent diff when disk_type is set to pd-ssd
https://github.com/hashicorp/terraform-provider-google/issues/10492


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
google_sql_database_instance: fixed a bug causing a perma-diff on disk_type due to API values being downcased
```
