### PR TITLE
Revert "updated two defaults"

### DIFF
--- a/mmv1/products/vpcaccess/api.yaml
+++ b/mmv1/products/vpcaccess/api.yaml
@@ -102,9 +102,9 @@ objects:
         min_version: beta
       - !ruby/object:Api::Type::Integer
         name: minThroughput
-        # its default in API doc is 200 but api returns 500 if it is not set
         description: |
-          Minimum throughput of the connector in Mbps. Default and min is 500.
+          Minimum throughput of the connector in Mbps. Default and min is 200.
+        default_value: 200
       - !ruby/object:Api::Type::Integer
         name: minInstances
         description: |
@@ -117,8 +117,12 @@ objects:
         min_version: beta
       - !ruby/object:Api::Type::Integer
         name: maxThroughput
+        # The API documentation says this will default to 200, but when I tried that I got an error that the minimum
+        # throughput must be lower than the maximum. The console defaults to 1000, so I changed it to that.
+        # API returns 300 if it is not sent
         description: |
-          Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 1000.
+          Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
+        default_value: 300
       - !ruby/object:Api::Type::String
         name: 'selfLink'
         description: |

--- a/mmv1/products/vpcaccess/terraform.yaml
+++ b/mmv1/products/vpcaccess/terraform.yaml
@@ -50,13 +50,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'compareResourceNames'
         default_from_api: true
       minThroughput: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(200, 1000)'
       minInstances: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       maxThroughput: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(200, 1000)'
       maxInstances: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/cloudrun_vpc_access_connector.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrun_vpc_access_connector.tf.erb
@@ -20,7 +20,7 @@ resource "google_vpc_access_connector" "<%= ctx[:primary_resource_id] %>" {
   provider      = google-beta
   region        = "us-west1"
   ip_cidr_range = "10.8.0.0/28"
-  max_throughput= 1000
+  max_throughput= 300
   network       = google_compute_network.default.name
   depends_on    = [google_project_service.vpcaccess_api]
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#6478

It seems the change in PR GoogleCloudPlatform/magic-modules#6478 causes a bunch of tests failed due to 
```
 provider_test.go:315: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error waiting to create Connector: Error waiting for Creating Connector: Error code 3, message: Operation failed: A Connector must specify either max_throughput or max_instances.
        
          with google_vpc_access_connector.connector,
          on terraform_plugin_test.tf line 2, in resource "google_vpc_access_connector" "connector":
           2: resource "google_vpc_access_connector" "connector" {
```

```release-note:none
```