### PR TITLE
Added overwrite_when attribute in storage_transfer_job

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -642,7 +642,7 @@ func resourceStorageTransferJobUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Patched transfer job: %v\n\n", res.Name)
-	return resourceStorageTransferJobRead(d, meta)
+	return nil
 }
 
 func resourceStorageTransferJobDelete(d *schema.ResourceData, meta interface{}) error {

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -25,6 +25,7 @@ var (
 		"transfer_spec.0.transfer_options.0.overwrite_objects_already_existing_in_sink",
 		"transfer_spec.0.transfer_options.0.delete_objects_unique_in_sink",
 		"transfer_spec.0.transfer_options.0.delete_objects_from_source_after_transfer",
+		"transfer_spec.0.transfer_options.0.overwrite_when",
 	}
 
 	transferSpecDataSourceKeys = []string{
@@ -283,6 +284,13 @@ func transferOptionsSchema() *schema.Schema {
 					AtLeastOneOf:  transferOptionsKeys,
 					ConflictsWith: []string{"transfer_spec.transfer_options.delete_objects_unique_in_sink"},
 					Description:   `Whether objects should be deleted from the source after they are transferred to the sink. Note that this option and delete_objects_unique_in_sink are mutually exclusive.`,
+				},
+				"overwrite_when": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					AtLeastOneOf: transferOptionsKeys,
+					ValidateFunc: validation.StringInSlice([]string{"DIFFERENT", "NEVER", "ALWAYS"}, false),
+					Description:  `When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by overwriteObjectsAlreadyExistingInSink.`,
 				},
 			},
 		},
@@ -634,7 +642,7 @@ func resourceStorageTransferJobUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Patched transfer job: %v\n\n", res.Name)
-	return nil
+	return resourceStorageTransferJobRead(d, meta)
 }
 
 func resourceStorageTransferJobDelete(d *schema.ResourceData, meta interface{}) error {
@@ -995,6 +1003,7 @@ func expandTransferOptions(options []interface{}) *storagetransfer.TransferOptio
 		DeleteObjectsFromSourceAfterTransfer:  option["delete_objects_from_source_after_transfer"].(bool),
 		DeleteObjectsUniqueInSink:             option["delete_objects_unique_in_sink"].(bool),
 		OverwriteObjectsAlreadyExistingInSink: option["overwrite_objects_already_existing_in_sink"].(bool),
+		OverwriteWhen:                         option["overwrite_when"].(string),
 	}
 }
 
@@ -1003,6 +1012,7 @@ func flattenTransferOption(option *storagetransfer.TransferOptions) []map[string
 		"delete_objects_from_source_after_transfer":  option.DeleteObjectsFromSourceAfterTransfer,
 		"delete_objects_unique_in_sink":              option.DeleteObjectsUniqueInSink,
 		"overwrite_objects_already_existing_in_sink": option.OverwriteObjectsAlreadyExistingInSink,
+		"overwrite_when":                             option.OverwriteWhen,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccStorageTransferJob_basic(t *testing.T) {
+	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)
 	testDataSinkName := randString(t, 10)
@@ -67,6 +68,7 @@ func TestAccStorageTransferJob_basic(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_omitScheduleEndDate(t *testing.T) {
+	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)
 	testDataSinkName := randString(t, 10)
@@ -90,6 +92,7 @@ func TestAccStorageTransferJob_omitScheduleEndDate(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_posixSource(t *testing.T) {
+	t.Parallel()
 
 	testDataSinkName := randString(t, 10)
 	testTransferJobDescription := randString(t, 10)
@@ -112,6 +115,7 @@ func TestAccStorageTransferJob_posixSource(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_posixSink(t *testing.T) {
+	t.Parallel()
 
 	testDataSourceName := randString(t, 10)
 	testTransferJobDescription := randString(t, 10)
@@ -134,6 +138,7 @@ func TestAccStorageTransferJob_posixSink(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_transferOptions(t *testing.T) {
+	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)
 	testDataSinkName := randString(t, 10)

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccStorageTransferJob_basic(t *testing.T) {
-	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)
 	testDataSinkName := randString(t, 10)
@@ -68,7 +67,6 @@ func TestAccStorageTransferJob_basic(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_omitScheduleEndDate(t *testing.T) {
-	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)
 	testDataSinkName := randString(t, 10)
@@ -92,7 +90,6 @@ func TestAccStorageTransferJob_omitScheduleEndDate(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_posixSource(t *testing.T) {
-	t.Parallel()
 
 	testDataSinkName := randString(t, 10)
 	testTransferJobDescription := randString(t, 10)
@@ -115,7 +112,6 @@ func TestAccStorageTransferJob_posixSource(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_posixSink(t *testing.T) {
-	t.Parallel()
 
 	testDataSourceName := randString(t, 10)
 	testTransferJobDescription := randString(t, 10)
@@ -138,7 +134,6 @@ func TestAccStorageTransferJob_posixSink(t *testing.T) {
 }
 
 func TestAccStorageTransferJob_transferOptions(t *testing.T) {
-	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)
 	testDataSinkName := randString(t, 10)

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -159,7 +159,7 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStorageTransferJob_transferOptions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, false, false, false),
+				Config: testAccStorageTransferJob_transferOptions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, false, false, false, testOverwriteWhen[0]),
 			},
 			{
 				ResourceName:      "google_storage_transfer_job.transfer_job",
@@ -167,7 +167,7 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStorageTransferJob_transferOptions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, true, true, false),
+				Config: testAccStorageTransferJob_transferOptions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, true, true, false, testOverwriteWhen[1]),
 			},
 			{
 				ResourceName:      "google_storage_transfer_job.transfer_job",
@@ -175,31 +175,7 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStorageTransferJob_transferOptions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, true, false, true),
-			},
-			{
-				ResourceName:      "google_storage_transfer_job.transfer_job",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccStorageTransferJob_withOverwriteWhen(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testOverwriteWhen[0]),
-			},
-			{
-				ResourceName:      "google_storage_transfer_job.transfer_job",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccStorageTransferJob_withOverwriteWhen(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testOverwriteWhen[1]),
-			},
-			{
-				ResourceName:      "google_storage_transfer_job.transfer_job",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccStorageTransferJob_withOverwriteWhen(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testOverwriteWhen[2]),
+				Config: testAccStorageTransferJob_transferOptions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, true, false, true, testOverwriteWhen[2]),
 			},
 			{
 				ResourceName:      "google_storage_transfer_job.transfer_job",
@@ -571,7 +547,7 @@ resource "google_storage_transfer_job" "transfer_job" {
 `, project, dataSourceBucketName, project, transferJobDescription, project)
 }
 
-func testAccStorageTransferJob_transferOptions(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, overwriteObjectsAlreadyExistingInSink bool, deleteObjectsUniqueInSink bool, deleteObjectsFromSourceAfterTransfer bool) string {
+func testAccStorageTransferJob_transferOptions(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, overwriteObjectsAlreadyExistingInSink bool, deleteObjectsUniqueInSink bool, deleteObjectsFromSourceAfterTransfer bool, overwriteWhenVal string) string {
 	return fmt.Sprintf(`
 data "google_storage_transfer_project_service_account" "default" {
   project = "%s"
@@ -620,86 +596,6 @@ resource "google_storage_transfer_job" "transfer_job" {
       overwrite_objects_already_existing_in_sink = %t
       delete_objects_unique_in_sink = %t
       delete_objects_from_source_after_transfer = %t
-    }
-  }
-
-  schedule {
-    schedule_start_date {
-      year  = 2018
-      month = 10
-      day   = 1
-    }
-    schedule_end_date {
-      year  = 2019
-      month = 10
-      day   = 1
-    }
-    start_time_of_day {
-      hours   = 0
-      minutes = 30
-      seconds = 0
-      nanos   = 0
-    }
-	repeat_interval = "604800s"
-  }
-
-  depends_on = [
-    google_storage_bucket_iam_member.data_source,
-    google_storage_bucket_iam_member.data_sink,
-  ]
-}
-`, project, dataSourceBucketName, project, dataSinkBucketName, project, transferJobDescription, project, overwriteObjectsAlreadyExistingInSink, deleteObjectsUniqueInSink, deleteObjectsFromSourceAfterTransfer)
-}
-
-func testAccStorageTransferJob_withOverwriteWhen(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, overwriteWhenVal string) string {
-	return fmt.Sprintf(`
-data "google_storage_transfer_project_service_account" "default" {
-  project = "%s"
-}
-
-resource "google_storage_bucket" "data_source" {
-  name          = "%s"
-  project       = "%s"
-  location      = "US"
-  force_destroy = true
-}
-
-resource "google_storage_bucket_iam_member" "data_source" {
-  bucket = google_storage_bucket.data_source.name
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
-}
-
-resource "google_storage_bucket" "data_sink" {
-  name          = "%s"
-  project       = "%s"
-  location      = "US"
-  force_destroy = true
-}
-
-resource "google_storage_bucket_iam_member" "data_sink" {
-  bucket = google_storage_bucket.data_sink.name
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
-}
-
-resource "google_storage_transfer_job" "transfer_job" {
-  description = "%s"
-  project     = "%s"
-
-  transfer_spec {
-    gcs_data_source {
-      bucket_name = google_storage_bucket.data_source.name
-      path  = "foo/bar/"
-    }
-    gcs_data_sink {
-      bucket_name = google_storage_bucket.data_sink.name
-      path  = "foo/bar/"
-    }
-    transfer_options {
-      overwrite_objects_already_existing_in_sink = false
-      delete_objects_unique_in_sink = false
-      delete_objects_from_source_after_transfer = false
       overwrite_when = "%s"
     }
   }
@@ -729,5 +625,5 @@ resource "google_storage_transfer_job" "transfer_job" {
     google_storage_bucket_iam_member.data_sink,
   ]
 }
-`, project, dataSourceBucketName, project, dataSinkBucketName, project, transferJobDescription, project, overwriteWhenVal)
+`, project, dataSourceBucketName, project, dataSinkBucketName, project, transferJobDescription, project, overwriteObjectsAlreadyExistingInSink, deleteObjectsUniqueInSink, deleteObjectsFromSourceAfterTransfer, overwriteWhenVal)
 }

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -157,6 +157,8 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 
 * `delete_objects_from_source_after_transfer` - (Optional) Whether objects should be deleted from the source after they are transferred to the sink. Note that this option and `delete_objects_unique_in_sink` are mutually exclusive.
 
+* `overwrite_when` - (Optional) When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by `overwriteObjectsAlreadyExistingInSink`. Possible values: DIFFERENT, NEVER, ALWAYS.
+
 <a name="nested_gcs_data_sink"></a>The `gcs_data_sink` block supports:
 
 * `bucket_name` - (Required) Google Cloud Storage bucket name.

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -157,7 +157,7 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 
 * `delete_objects_from_source_after_transfer` - (Optional) Whether objects should be deleted from the source after they are transferred to the sink. Note that this option and `delete_objects_unique_in_sink` are mutually exclusive.
 
-* `overwrite_when` - (Optional) When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by `overwriteObjectsAlreadyExistingInSink`. Possible values: DIFFERENT, NEVER, ALWAYS.
+* `overwrite_when` - (Optional) When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by `overwriteObjectsAlreadyExistingInSink`. Possible values: ALWAYS, DIFFERENT, NEVER.
 
 <a name="nested_gcs_data_sink"></a>The `gcs_data_sink` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -157,7 +157,7 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 
 * `delete_objects_from_source_after_transfer` - (Optional) Whether objects should be deleted from the source after they are transferred to the sink. Note that this option and `delete_objects_unique_in_sink` are mutually exclusive.
 
-* `overwrite_when` - (Optional) When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by `overwriteObjectsAlreadyExistingInSink`. Possible values: ALWAYS, DIFFERENT, NEVER.
+* `overwrite_when` - (Optional) When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by `overwrite_objects_already_existing_in_sink`. Possible values: ALWAYS, DIFFERENT, NEVER.
 
 <a name="nested_gcs_data_sink"></a>The `gcs_data_sink` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added overwrite_when attribute in google_storage_transfer_job resource. 

fixes https://github.com/hashicorp/terraform-provider-google/issues/11854

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added support for `overwriteWhen` field to `transfer_options` in `google_storage_transfer_job` resource
```