### PR TITLE
potential fix for gke provider upgrade problem

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -4205,14 +4205,19 @@ func expandNodePoolDefaults(configured interface{}) *container.NodePoolDefaults 
 }
 
 func flattenNodePoolDefaults(c *container.NodePoolDefaults) []map[string]interface{} {
-        if c == nil {
+	if c == nil {
 		return nil
 	}
-        result := make(map[string]interface{})
-        if c.NodeConfigDefaults != nil && c.NodeConfigDefaults.GcfsConfig != nil {
-                result["node_config_defaults"] = flattenNodeConfigDefaults(c.NodeConfigDefaults)
-        }
-        return []map[string]interface{}{result}
+
+	result := make(map[string]interface{})
+	if c.NodeConfigDefaults != nil && c.NodeConfigDefaults.GcfsConfig != nil {
+			result["node_config_defaults"] = flattenNodeConfigDefaults(c.NodeConfigDefaults)
+	}
+	
+	if len(result) == 0 {
+		return nil
+	}
+	return []map[string]interface{}{result}
 }
 <% end -%>
 
@@ -4844,6 +4849,10 @@ func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]int
 	result := make(map[string]interface{})
 	if c.NetworkTags != nil {
 		result["network_tags"] = flattenNodePoolAutoConfigNetworkTags(c.NetworkTags)
+	}
+
+	if len(result) == 0 {
+		return nil
 	}
 	return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1055,7 +1055,7 @@ func resourceContainerCluster() *schema.Resource {
 			"node_pool_auto_config": {
 				Type:             schema.TypeList,
 				Optional:         true,
-				Computed:         true.
+				Computed:         true,
 				MaxItems:         1,
 				Description:      `Node pool configs that apply to all auto-provisioned node pools in autopilot clusters and node auto-provisioning enabled clusters.`,
 				Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -97,28 +97,28 @@ func clusterSchemaNodeConfig() *schema.Schema {
 // Defines default nodel pool settings for the entire cluster. These settings are
 // overridden if specified on the specific NodePool object.
 func clusterSchemaNodePoolDefaults() *schema.Schema {
-       return &schema.Schema{
+	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
-                DiffSuppressFunc: emptyOrUnsetBlockDiffSuppress,
-                Description: `The default nodel pool settings for the entire cluster.`,
-                MaxItems: 1,
-                Elem: &schema.Resource{
-                        Schema: map[string]*schema.Schema{
-                                "node_config_defaults": {
-                                        Type:        schema.TypeList,
-                                        Optional:    true,
+		Computed:    true,
+		Description: `The default nodel pool settings for the entire cluster.`,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"node_config_defaults": {
+					Type:        schema.TypeList,
+					Optional:    true,
 					Description: `Subset of NodeConfig message that has defaults.`,
-                                        MaxItems:    1,
-                                        Elem: &schema.Resource{
-                                                Schema: map[string]*schema.Schema{
-                                                        "gcfs_config": schemaGcfsConfig(false),
-                                                },
-                                        },
-                                },
-                        },
-                },
-       }
+					MaxItems:    1,
+					Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+									"gcfs_config": schemaGcfsConfig(false),
+							},
+					},
+				},
+			},
+		},
+	}
 }
 <% end -%>
 
@@ -1050,12 +1050,12 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 <% unless version == "ga" -%>
-                        "node_pool_defaults": clusterSchemaNodePoolDefaults(),
+			"node_pool_defaults": clusterSchemaNodePoolDefaults(),
 
 			"node_pool_auto_config": {
 				Type:             schema.TypeList,
 				Optional:         true,
-				DiffSuppressFunc: emptyOrUnsetBlockDiffSuppress,
+				Computed:         true.
 				MaxItems:         1,
 				Description:      `Node pool configs that apply to all auto-provisioned node pools in autopilot clusters and node auto-provisioning enabled clusters.`,
 				Elem: &schema.Resource{
@@ -4214,9 +4214,6 @@ func flattenNodePoolDefaults(c *container.NodePoolDefaults) []map[string]interfa
 			result["node_config_defaults"] = flattenNodeConfigDefaults(c.NodeConfigDefaults)
 	}
 	
-	if len(result) == 0 {
-		return nil
-	}
 	return []map[string]interface{}{result}
 }
 <% end -%>
@@ -4851,9 +4848,6 @@ func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]int
 		result["network_tags"] = flattenNodePoolAutoConfigNetworkTags(c.NetworkTags)
 	}
 
-	if len(result) == 0 {
-		return nil
-	}
 	return []map[string]interface{}{result}
 }
 

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -130,6 +130,10 @@ func emptyOrUnsetBlockDiffSuppressLogic(k, old, new string, o, n interface{}) bo
 		return false
 	}
 
+	if len(l) == 0 || l[0] == nil {
+		return true
+	}
+
 	contents, ok := l[0].(map[string]interface{})
 	if !ok {
 		return false

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -130,10 +130,6 @@ func emptyOrUnsetBlockDiffSuppressLogic(k, old, new string, o, n interface{}) bo
 		return false
 	}
 
-	if len(l) == 0 || l[0] == nil {
-		return true
-	}
-
 	contents, ok := l[0].(map[string]interface{})
 	if !ok {
 		return false


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Removed the DSF and set the fields to O+C. Tested it locally and it should fix the problem.

This resolves https://github.com/hashicorp/terraform-provider-google/issues/12422 and resolves https://github.com/hashicorp/terraform-provider-google/issues/12549



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed a bug where upgrading provider version breaks on `node_pool_auto_config` or `node_pool_defaults` 
```
