### PR TITLE
Added datastream private connection

### DIFF
--- a/mmv1/products/datastream/api.yaml
+++ b/mmv1/products/datastream/api.yaml
@@ -279,3 +279,60 @@ objects:
               SSH private key.
             conflicts:
               - forward_ssh_connectivity.private_key
+  - !ruby/object:Api::Resource
+    name: 'PrivateConnection'
+    base_url: "projects/{{project}}/locations/{{location}}/privateConnections"
+    create_url: "projects/{{project}}/locations/{{location}}/privateConnections?privateConnectionId={{private_connection_id}}"
+    self_link: "projects/{{project}}/locations/{{location}}/privateConnections/{{private_connection_id}}"
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration'
+      api: 'https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.privateConnections'
+    description: |
+      A set of reusable connection configurations to be used as a source or destination for a stream.
+    input: true
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: privateConnectionId
+        description: |-
+          The private connectivity identifier.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: |
+          The name of the location this repository is located in.
+        required: true
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        output: true
+        description: The resource's name.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: Labels.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        required: true
+        description: Display name.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'vpcPeeringConfig'
+        required: true
+        description: |
+          The VPC Peering configuration is used to create VPC peering
+          between Datastream and the consumer's VPC.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'vpc'
+            required: true
+            description: |
+              Fully qualified name of the VPC that Datastream will peer to.
+              Format: projects/{project}/global/{networks}/{name}
+          - !ruby/object:Api::Type::String
+            name: 'subnet'
+            required: true
+            description: |
+              A free subnet for peering. (CIDR of /29)

--- a/mmv1/products/datastream/api.yaml
+++ b/mmv1/products/datastream/api.yaml
@@ -289,7 +289,9 @@ objects:
         'Official Documentation': 'https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration'
       api: 'https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.privateConnections'
     description: |
-      A set of reusable connection configurations to be used as a source or destination for a stream.
+      The PrivateConnection resource is used to establish private connectivity between Datastream and a customer's network.
+
+
     input: true
     parameters:
       - !ruby/object:Api::Type::String

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -72,3 +72,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "true"
         # This is covered by the update tests.
         skip_test: true
+  PrivateConnection: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: projects/{{project}}/locations/{{location}}/privateConnections/{{private_connection_id}}
+    import_format: ["projects/{{project}}/locations/{{location}}/privateConnections/{{private_connection_id}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "datastream_private_connection_full"
+        primary_resource_id: "default"
+        vars:
+          private_connection_id: "my-connection"
+          network_name: "my-network"

--- a/mmv1/templates/terraform/examples/datastream_private_connection_full.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_private_connection_full.tf.erb
@@ -1,0 +1,18 @@
+resource "google_datastream_private_connection" "<%= ctx[:primary_resource_id] %>" {
+	display_name          = "Connection profile"
+	location              = "us-central1"
+	private_connection_id = "<%= ctx[:vars]['private_connection_id'] %>"
+
+	labels = {
+		key = "value"
+	}
+
+	vpc_peering_config {
+		vpc = google_compute_network.default.id
+		subnet = "10.0.0.0/29"
+	}
+}
+
+resource "google_compute_network" "default" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added support for datastream private connection resource. This PR only adds the resource. Adding support for private connections to the connection profile resource will happen in a separate PR.

Related to https://github.com/hashicorp/terraform-provider-google/issues/10810

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_datastream_private_connection`
```
