### PR TITLE
Add warning about when to use legacy_name

### DIFF
--- a/mmv1/overrides/terraform/resource_override.rb
+++ b/mmv1/overrides/terraform/resource_override.rb
@@ -38,7 +38,7 @@ module Overrides
           # Note: This should not be used for vanity names for new products.
           # This was added to handle preexisting handwritten resources that
           # don't match the natural generated name exactly, and to support
-          # services with a mix of handwritten services.
+          # services with a mix of handwritten and generated resources.
           :legacy_name,
 
           # The Terraform resource id format used when calling #setId(...).

--- a/mmv1/overrides/terraform/resource_override.rb
+++ b/mmv1/overrides/terraform/resource_override.rb
@@ -35,6 +35,10 @@ module Overrides
           # i.e. 'google_project' for resourcemanager.Project
           # Use Provider::Terraform::Config.legacy_name to override just
           # product name.
+          # Note: This should not be used for vanity names for new products.
+          # This was added to handle preexisting handwritten resources that
+          # don't match the natural generated name exactly, and to support
+          # services with a mix of handwritten services.
           :legacy_name,
 
           # The Terraform resource id format used when calling #setId(...).

--- a/mmv1/provider/config.rb
+++ b/mmv1/provider/config.rb
@@ -28,6 +28,9 @@ module Provider
     # Some tool-specific names may be in use, and they won't all match;
     # For Terraform, some products use the API client name w/o spaces and
     # others use spaces. Eg: "app_engine" vs "appengine".
+    # Note: This should not be used for vanity names for new products.
+    # This was added for services with a mix of handwritten and generated
+    # resources.
     attr_reader :legacy_name
 
     # Some product names do not match their [golang] client name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
