### PR TITLE
bigqueryreservation: move beta to v1 + add fields

### DIFF
--- a/mmv1/products/bigqueryreservation/api.yaml
+++ b/mmv1/products/bigqueryreservation/api.yaml
@@ -72,6 +72,7 @@ objects:
           capacity specified above at most.
       - !ruby/object:Api::Type::Integer
         name: 'concurrency'
+        default_value: 0
         description: |
           Maximum number of queries that are allowed to run concurrently in this reservation. This is a soft limit due to asynchronous nature of the system and various optimizations for small queries. Default value is 0 which means that concurrency will be automatically set based on the reservation size.
       - !ruby/object:Api::Type::Boolean

--- a/mmv1/products/bigqueryreservation/api.yaml
+++ b/mmv1/products/bigqueryreservation/api.yaml
@@ -17,7 +17,7 @@ display_name: BigQuery Reservation
 versions:
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://bigqueryreservation.googleapis.com/v1beta1/
+    base_url: https://bigqueryreservation.googleapis.com/v1/
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://bigqueryreservation.googleapis.com/v1/
@@ -39,7 +39,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         "Introduction to Reservations": "https://cloud.google.com/bigquery/docs/reservations-intro"
-      api: "https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1beta1/projects.locations.reservations/create"
+      api: "https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1/projects.locations.reservations/create"
     parameters:
       - !ruby/object:Api::Type::String
         name: 'location'
@@ -70,3 +70,12 @@ objects:
           If false, any query using this reservation will use idle slots from other reservations within
           the same admin project. If true, a query using this reservation will execute with the slot
           capacity specified above at most.
+      - !ruby/object:Api::Type::Integer
+        name: 'concurrency'
+        description: |
+          Maximum number of queries that are allowed to run concurrently in this reservation. This is a soft limit due to asynchronous nature of the system and various optimizations for small queries. Default value is 0 which means that concurrency will be automatically set based on the reservation size.
+      - !ruby/object:Api::Type::Boolean
+        name: 'multiRegionAuxiliary'
+        description: |
+          Applicable only for reservations located within one of the BigQuery multi-regions (US or EU).
+          If set to true, this reservation is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this reservation is placed in the organization's default region.

--- a/mmv1/templates/terraform/examples/bigquery_reservation_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_basic.tf.erb
@@ -3,6 +3,7 @@ resource "google_bigquery_reservation" "<%= ctx[:primary_resource_id] %>" {
 	location       = "asia-northeast1"
 	// Set to 0 for testing purposes
 	// In reality this would be larger than zero
-	slot_capacity  = 0
+	slot_capacity     = 0
 	ignore_idle_slots = false
+	concurrency       = 0
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Closes https://github.com/hashicorp/terraform-provider-google/issues/12479

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigqueryreservation: add `concurrency` and `multiRegionAuxiliary` to `google_bigquery_reservation`
```
