### PR TITLE
feat: make it possible to deifine a feature in Vertex AI FeatureStore

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -347,22 +347,11 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'description'
         description: Description of the feature.
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'valueType'
         description: |
-          Type of Feature value. Immutable.
+          Type of Feature value. Immutable. https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.featurestores.entityTypes.features#ValueType
         required: true
-        values:
-          - VALUE_TYPE_UNSPECIFIED
-          - BOOL
-          - BOOL_ARRAY
-          - DOUBLE
-          - DOUBLE_ARRAY
-          - INT64
-          - INT64_ARRAY
-          - STRING
-          - STRING_ARRAY
-          - BYTES
 # Vertex ML Metadata
   - !ruby/object:Api::Resource
     name: MetadataStore

--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -277,6 +277,91 @@ objects:
                   Configuration of the snapshot analysis based monitoring pipeline running interval. The value is rolled up to full day.
 
                   A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+
+# Vertex AI Featurestore Entity Type Feature
+  - !ruby/object:Api::Resource
+    name: FeaturestoreEntitytypeFeature
+    base_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entityType}}/features'
+    create_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entityType}}/features?featureId={{name}}'
+    self_link: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entityType}}/features/{{name}}'
+    min_version: beta
+    update_verb: :PATCH
+    update_mask: true
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/vertex-ai/docs'
+      api: 'https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.featurestores.entityTypes.features'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+      Feature Metadata information that describes an attribute of an entity type. For example, apple is an entity type, and color is a feature that describes apple.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: entityType
+        description: The name of the Featurestore to use, in the format projects/{project}/locations/{location}/featurestores/{featurestore}/entityTypes/{entityTypes}.
+        url_param_only: true
+        input: true
+        required: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: The name of the feature. The feature can be up to 64 characters long and can consist only of ASCII Latin letters A-Z and a-z, underscore(_), and ASCII digits 0-9 starting with a letter. The value will be unique given an entity type.
+        input: true
+        url_param_only: true
+        pattern: '{{entityType}}/features/{{name}}'
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: Used to perform consistent read-modify-write updates.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        output: true
+        description: |
+          The timestamp of when the entity type was created in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        output: true
+        description: |
+           The timestamp when the entity type was most recently updated in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          A set of key/value label pairs to assign to the feature.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: Description of the feature.
+      - !ruby/object:Api::Type::Enum
+        name: 'valueType'
+        description: |
+          Type of Feature value. Immutable.
+        required: true
+        values:
+          - VALUE_TYPE_UNSPECIFIED
+          - BOOL
+          - BOOL_ARRAY
+          - DOUBLE
+          - DOUBLE_ARRAY
+          - INT64
+          - INT64_ARRAY
+          - STRING
+          - STRING_ARRAY
+          - BYTES
 # Vertex ML Metadata
   - !ruby/object:Api::Resource
     name: MetadataStore

--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -281,9 +281,9 @@ objects:
 # Vertex AI Featurestore Entity Type Feature
   - !ruby/object:Api::Resource
     name: FeaturestoreEntitytypeFeature
-    base_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features'
-    create_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features?featureId={{name}}'
-    self_link: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features/{{name}}'
+    base_url: '{{entitytype}}/features'
+    create_url: '{{entitytype}}/features?featureId={{name}}'
+    self_link: '{{entitytype}}/features/{{name}}'
     min_version: beta
     update_verb: :PATCH
     update_mask: true
@@ -309,6 +309,7 @@ objects:
       error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
+      include_project: true
     description: |-
       Feature Metadata information that describes an attribute of an entity type. For example, apple is an entity type, and color is a feature that describes apple.
     parameters:
@@ -324,7 +325,7 @@ objects:
         description: The name of the feature. The feature can be up to 64 characters long and can consist only of ASCII Latin letters A-Z and a-z, underscore(_), and ASCII digits 0-9 starting with a letter. The value will be unique given an entity type.
         input: true
         url_param_only: true
-        pattern: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features/{{name}}'
+        pattern: '{{entitytype}}/features/{{name}}'
       - !ruby/object:Api::Type::String
         name: 'etag'
         description: Used to perform consistent read-modify-write updates.

--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -281,9 +281,9 @@ objects:
 # Vertex AI Featurestore Entity Type Feature
   - !ruby/object:Api::Resource
     name: FeaturestoreEntitytypeFeature
-    base_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entityType}}/features'
-    create_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entityType}}/features?featureId={{name}}'
-    self_link: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entityType}}/features/{{name}}'
+    base_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features'
+    create_url: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features?featureId={{name}}'
+    self_link: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features/{{name}}'
     min_version: beta
     update_verb: :PATCH
     update_mask: true
@@ -313,8 +313,8 @@ objects:
       Feature Metadata information that describes an attribute of an entity type. For example, apple is an entity type, and color is a feature that describes apple.
     parameters:
       - !ruby/object:Api::Type::String
-        name: entityType
-        description: The name of the Featurestore to use, in the format projects/{project}/locations/{location}/featurestores/{featurestore}/entityTypes/{entityTypes}.
+        name: entitytype
+        description: The name of the Featurestore to use, in the format projects/{project}/locations/{location}/featurestores/{featurestore}/entityTypes/{entitytype}.
         url_param_only: true
         input: true
         required: true
@@ -324,7 +324,7 @@ objects:
         description: The name of the feature. The feature can be up to 64 characters long and can consist only of ASCII Latin letters A-Z and a-z, underscore(_), and ASCII digits 0-9 starting with a letter. The value will be unique given an entity type.
         input: true
         url_param_only: true
-        pattern: '{{entityType}}/features/{{name}}'
+        pattern: 'projects/{{project}}/locations/{{region}}/featurestores/{{featurestore}}/entityTypes/{{entitytype}}/features/{{name}}'
       - !ruby/object:Api::Type::String
         name: 'etag'
         description: Used to perform consistent read-modify-write updates.

--- a/mmv1/products/vertexai/terraform.yaml
+++ b/mmv1/products/vertexai/terraform.yaml
@@ -79,7 +79,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           billing_account: :BILLING_ACCT
         test_vars_overrides:
           kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
-
     properties:
       etag: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
@@ -89,6 +88,30 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pre_create: templates/terraform/constants/vertex_ai_featurestore_entitytype.go.erb
       pre_update: templates/terraform/constants/vertex_ai_featurestore_entitytype.go.erb
       pre_delete: templates/terraform/constants/vertex_ai_featurestore_entitytype.go.erb
+  FeaturestoreEntitytypeFeature:  !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["{{%entitytype}}/features/{{name}}"]
+    autogen_async: false
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "vertex_ai_featurestore_entitytype_feature"
+        primary_resource_id: "feature"
+        vars:
+          name: "terraform"
+          project: "vertex-ai"
+          kms_key_name: "kms-name"
+        test_env_vars:
+          org_id: :ORG_ID
+          billing_account: :BILLING_ACCT
+        test_vars_overrides:
+    properties:
+      etag: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      name: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      pre_create: templates/terraform/constants/vertex_ai_featurestore_entitytype_feature.go.erb
+      pre_update: templates/terraform/constants/vertex_ai_featurestore_entitytype_feature.go.erb
+      pre_delete: templates/terraform/constants/vertex_ai_featurestore_entitytype_feature.go.erb
   MetadataStore: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: false
     id_format: '{{name}}'

--- a/mmv1/templates/terraform/constants/vertex_ai_featurestore_entitytype_feature.go.erb
+++ b/mmv1/templates/terraform/constants/vertex_ai_featurestore_entitytype_feature.go.erb
@@ -1,0 +1,9 @@
+if v, ok := d.GetOk("entitytype"); ok {
+	re := regexp.MustCompile("projects/([a-zA-Z0-9-]*)/(?:locations|regions)/([a-zA-Z0-9-]*)")
+	switch {
+	case re.MatchString(v.(string)):
+		if res := re.FindStringSubmatch(v.(string)); len(res) == 3 && res[1] != "" {
+			project = res[1]
+		}
+	}
+}

--- a/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype_feature.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featurestore_entitytype_feature.tf.erb
@@ -1,0 +1,37 @@
+resource "google_vertex_ai_featurestore" "featurestore" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['name'] %>"
+  labels = {
+    foo = "bar"
+  }
+  region   = "us-central1"
+  online_serving_config {
+    fixed_node_count = 2
+  }
+}
+
+resource "google_vertex_ai_featurestore_entitytype" "entity" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['name'] %>"
+  labels = {
+    foo = "bar"
+  }
+  featurestore = google_vertex_ai_featurestore.featurestore.id
+  monitoring_config {
+    snapshot_analysis {
+      disabled = false
+      monitoring_interval = "86400s"
+    }
+  }
+}
+
+resource "google_vertex_ai_featurestore_entitytype_feature" "feature" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['name'] %>"
+  labels = {
+    foo = "bar"
+  }
+  entitytype = google_vertex_ai_featurestore_entitytype.entity.id
+
+  value_type = "INT64_ARRAY"
+}

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -63,12 +63,6 @@ import (
     timeouts ||= Api::Timeouts.new
 -%>
 
-<%  if object.async&.is_a? Api::OpAsync -%>
-    <%  if object.async.include_project -%>
-var project string
-    <%  end -%>
-<% end -%>
-
 func resource<%= resource_name -%>() *schema.Resource {
     return &schema.Resource{
         Create: resource<%= resource_name -%>Create,
@@ -166,6 +160,10 @@ func resource<%= resource_name -%><%= prop.name.camelize(:upper) -%>SetStyleDiff
 <% end -%>
 
 func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{}) error {
+<%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
+    var project string
+<% end -%>
+
     config := meta.(*Config)
 <%  if object.custom_code.custom_create -%>
     <%= lines(compile(pwd + '/' + object.custom_code.custom_create))  -%>
@@ -576,6 +574,11 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 
 <% if updatable?(object, object.root_properties) -%>
 func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{}) error {
+
+<%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
+    var project string
+<% end -%>
+
     config := meta.(*Config)
     userAgent, err := generateUserAgentString(d, config.userAgent)
     if err != nil {
@@ -835,6 +838,10 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <% end # if updatable? -%>
 
 func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{}) error {
+<%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
+    var project string
+<% end -%>
+
 <% if object.skip_delete -%>
     log.Printf("[WARNING] <%= object.__product.name + " " + object.name %> resources" +
     " cannot be deleted from Google Cloud. The resource %s will be removed from Terraform" +

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -163,7 +163,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
     var project string
 <% end -%>
-
     config := meta.(*Config)
 <%  if object.custom_code.custom_create -%>
     <%= lines(compile(pwd + '/' + object.custom_code.custom_create))  -%>
@@ -578,7 +577,6 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 <%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
     var project string
 <% end -%>
-
     config := meta.(*Config)
     userAgent, err := generateUserAgentString(d, config.userAgent)
     if err != nil {
@@ -841,7 +839,6 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 <%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
     var project string
 <% end -%>
-
 <% if object.skip_delete -%>
     log.Printf("[WARNING] <%= object.__product.name + " " + object.name %> resources" +
     " cannot be deleted from Google Cloud. The resource %s will be removed from Terraform" +

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -573,7 +573,6 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 
 <% if updatable?(object, object.root_properties) -%>
 func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{}) error {
-
 <%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project -%>
     var project string
 <% end -%>


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-provider-google/issues/9298
Part of https://github.com/hashicorp/terraform-provider-google/issues/12307

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add `vertex_ai_featurestore_entitytype_feature` to enable the google-beta provider to define a feature in Vertex AI FeatureStore. https://github.com/GoogleCloudPlatform/magic-modules/pull/6565 is a PR to promote the other featurestore resources to GA from beta. If we merge PR#6565 first, it'd be nice to update this PR to use GA instead of beta too.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
vertex_ai_featurestore_entitytype_feature
```
