### PR TITLE
secret_manager_secret_version: adding version output field

### DIFF
--- a/mmv1/products/secretmanager/api.yaml
+++ b/mmv1/products/secretmanager/api.yaml
@@ -208,6 +208,11 @@ objects:
           The resource name of the SecretVersion. Format:
           `projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}`
       - !ruby/object:Api::Type::String
+        name: version
+        output: true
+        description: |
+          The version of the Secret.
+      - !ruby/object:Api::Type::String
         name: createTime
         output: true
         description: |

--- a/mmv1/products/secretmanager/terraform.yaml
+++ b/mmv1/products/secretmanager/terraform.yaml
@@ -64,7 +64,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       version: !ruby/object:Overrides::Terraform::PropertyOverride        
         name: "version"
         output: true
-        input: true
         custom_flatten: templates/terraform/custom_flatten/secret_version_version.go.erb
 
 # This is for copying files over

--- a/mmv1/products/secretmanager/terraform.yaml
+++ b/mmv1/products/secretmanager/terraform.yaml
@@ -64,7 +64,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       version: !ruby/object:Overrides::Terraform::PropertyOverride        
         name: "version"
         output: true
-        input: false
+        input: true
         custom_flatten: templates/terraform/custom_flatten/secret_version_version.go.erb
 
 # This is for copying files over

--- a/mmv1/products/secretmanager/terraform.yaml
+++ b/mmv1/products/secretmanager/terraform.yaml
@@ -61,6 +61,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: secret_data
         sensitive: true
         custom_expand: templates/terraform/custom_expand/base64.go.erb
+      version: !ruby/object:Overrides::Terraform::PropertyOverride        
+        name: "version"
+        output: true
+        input: false
+        custom_flatten: templates/terraform/custom_flatten/secret_version_version.go.erb
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/custom_flatten/secret_version_version.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_version.go.erb
@@ -1,0 +1,25 @@
+<%# The license inside this block applies to this file.
+    # Copyright 2022 Google Inc.
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+    name := d.Get("name").(string)
+    secretRegex := regexp.MustCompile("projects/(.+)/secrets/(.+)/versions/(.+)$")
+
+    parts := secretRegex.FindStringSubmatch(name)
+    if len(parts) != 4 {
+        panic(fmt.Sprintf("Version name does not fit the format `projects/{{project}}/secrets/{{secret}}/versions/{{version}}`"))
+    }
+
+    return parts[3]
+}

--- a/mmv1/templates/terraform/custom_import/secret_version.go.erb
+++ b/mmv1/templates/terraform/custom_import/secret_version.go.erb
@@ -7,13 +7,20 @@
 
 	name := d.Get("name").(string)
 	secretRegex := regexp.MustCompile("(projects/.+/secrets/.+)/versions/.+$")
+	versionRegex := regexp.MustCompile("projects/(.+)/secrets/(.+)/versions/(.+)$")
 
 	parts := secretRegex.FindStringSubmatch(name)
 	if len(parts) != 2 {
-		panic(fmt.Sprintf("Version name doesn not fit the format `projects/{{project}}/secrets/{{secret}}/versions/{{version}}`"))
+		panic(fmt.Sprintf("Version name does not fit the format `projects/{{project}}/secrets/{{secret}}/versions/{{version}}`"))
 	}
 	if err := d.Set("secret", parts[1]); err != nil {
 		return nil, fmt.Errorf("Error setting secret: %s", err)
+	}
+
+	parts = versionRegex.FindStringSubmatch(name)
+
+	if err := d.Set("version", parts[3]); err != nil {
+		return nil, fmt.Errorf("Error setting version: %s", err)
 	}
 
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/9828#issuecomment-1249503720


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
secretmanager: Added output field 'version' to resource 'secret_manager_secret_version'
```
