### PR TITLE
Add retry util func with polling interval

### DIFF
--- a/mmv1/third_party/terraform/utils/retry_utils.go
+++ b/mmv1/third_party/terraform/utils/retry_utils.go
@@ -53,6 +53,7 @@ func isRetryableError(topErr error, customPredicates ...RetryErrorPredicateFunc)
 	return isRetryable
 }
 
+// The polling overrides the default backoff logic with max backoff of 10s. The poll interval can be greater than 10s.
 func retryWithPolling(retryFunc func() (interface{}, error), timeout time.Duration, pollInterval time.Duration, errorRetryPredicates ...RetryErrorPredicateFunc) (interface{}, error) {
 	refreshFunc := func() (interface{}, string, error) {
 		result, err := retryFunc()

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -617,7 +617,7 @@ func TestRetryWithPolling_notRetryable(t *testing.T) {
 
 func TestRetryWithPolling_retriedAndSucceeded(t *testing.T) {
 	retryCount := 0
-	// Retry once and succeed.
+	// Retry once and succeeds.
 	retryFunc := func() (interface{}, error) {
 		retryCount++
 		// Error code of 200 is retryable.
@@ -646,7 +646,7 @@ func TestRetryWithPolling_retriedAndSucceeded(t *testing.T) {
 
 func TestRetryWithPolling_retriedAndFailed(t *testing.T) {
 	retryCount := 0
-	// Retry once and succeed.
+	// Retry once and fails.
 	retryFunc := func() (interface{}, error) {
 		retryCount++
 		// Error code of 200 is retryable.

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -577,6 +577,101 @@ func TestRetryTimeDuration_URLTimeoutsShouldRetry(t *testing.T) {
 	}
 }
 
+func TestRetryWithPolling_noRetry(t *testing.T) {
+	retryCount := 0
+	retryFunc := func() (interface{}, error) {
+		retryCount++
+		return "", &googleapi.Error{
+			Code: 400,
+		}
+	}
+	result, err := retryWithPolling(retryFunc, time.Duration(1000)*time.Millisecond, time.Duration(100)*time.Millisecond)
+	if err == nil || err.(*googleapi.Error).Code != 400 || result.(string) != "" {
+		t.Errorf("unexpected error %v and result %v", err, result)
+	}
+	if retryCount != 1 {
+		t.Errorf("expected error function to be called exactly once, but was called %d times", retryCount)
+	}
+}
+
+func TestRetryWithPolling_notRetryable(t *testing.T) {
+	retryCount := 0
+	retryFunc := func() (interface{}, error) {
+		retryCount++
+		return "", &googleapi.Error{
+			Code: 400,
+		}
+	}
+	// Retryable if the error code is not 400.
+	isRetryableFunc := func(err error) (bool, string) {
+		return err.(*googleapi.Error).Code != 400, ""
+	}
+	result, err := retryWithPolling(retryFunc, time.Duration(1000)*time.Millisecond, time.Duration(100)*time.Millisecond, isRetryableFunc)
+	if err == nil || err.(*googleapi.Error).Code != 400 || result.(string) != "" {
+		t.Errorf("unexpected error %v and result %v", err, result)
+	}
+	if retryCount != 1 {
+		t.Errorf("expected error function to be called exactly once, but was called %d times", retryCount)
+	}
+}
+
+func TestRetryWithPolling_retriedAndSucceeded(t *testing.T) {
+	retryCount := 0
+	// Retry once and succeed.
+	retryFunc := func() (interface{}, error) {
+		retryCount++
+		// Error code of 200 is retryable.
+		if retryCount < 2 {
+			return "", &googleapi.Error{
+				Code: 200,
+			}
+		}
+		return "Ok", nil
+	}
+	// Retryable if the error code is not 400.
+	isRetryableFunc := func(err error) (bool, string) {
+		return err.(*googleapi.Error).Code != 400, ""
+	}
+	result, err := retryWithPolling(retryFunc, time.Duration(1000)*time.Millisecond, time.Duration(100)*time.Millisecond, isRetryableFunc)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if result.(string) != "Ok" {
+		t.Errorf("unexpected result %v", result)
+	}
+	if retryCount != 2 {
+		t.Errorf("expected error function to be called exactly twice, but was called %d times", retryCount)
+	}
+}
+
+func TestRetryWithPolling_retriedAndFailed(t *testing.T) {
+	retryCount := 0
+	// Retry once and succeed.
+	retryFunc := func() (interface{}, error) {
+		retryCount++
+		// Error code of 200 is retryable.
+		if retryCount < 2 {
+			return "", &googleapi.Error{
+				Code: 200,
+			}
+		}
+		return "", &googleapi.Error{
+			Code: 400,
+		}
+	}
+	// Retryable if the error code is not 400.
+	isRetryableFunc := func(err error) (bool, string) {
+		return err.(*googleapi.Error).Code != 400, ""
+	}
+	result, err := retryWithPolling(retryFunc, time.Duration(1000)*time.Millisecond, time.Duration(100)*time.Millisecond, isRetryableFunc)
+	if err == nil || err.(*googleapi.Error).Code != 400 || result.(string) != "" {
+		t.Errorf("unexpected error %v and result %v", err, result)
+	}
+	if retryCount != 2 {
+		t.Errorf("expected error function to be called exactly twice, but was called %d times", retryCount)
+	}
+}
+
 func TestConflictError(t *testing.T) {
 	confErr := &googleapi.Error{
 		Code: 409,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

We currently have an util to retry something with a timeout: retryTimeDuration().

This PR adds retryWithPolling() to allow retrying with a timeout and a polling interval.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
