### PR TITLE
Revert "google_project Datasource project_id Validated"

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_project.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project.go
@@ -12,7 +12,6 @@ func dataSourceGoogleProject() *schema.Resource {
 
 	addOptionalFieldsToSchema(dsSchema, "project_id")
 
-	dsSchema["project_id"].ValidateFunc = validateProjectID()
 	return &schema.Resource{
 		Read:   datasourceGoogleProjectRead,
 		Schema: dsSchema,


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#6542

```release-note:bug
project: Removed incorrect validation on `google_project` datasource
```

Resolved https://github.com/hashicorp/terraform-provider-google/issues/12603