### PR TITLE
Update `google_iap_brand` documentation about import and name formats

### DIFF
--- a/mmv1/products/iap/api.yaml
+++ b/mmv1/products/iap/api.yaml
@@ -169,10 +169,10 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |
-          Output only. Identifier of the brand, in the format
-          `projects/{project_number}/brands/{brand_id}` or `projects/{project_id}/brands/{brand_id}`.
+          Output only. Identifier of the brand, in the format `projects/{project_number}/brands/{brand_id}`
+          NOTE: The name can also be expressed as `projects/{project_id}/brands/{brand_id}`, e.g. when importing.
           NOTE: The brand identification corresponds to the project number as only one
-          brand per project can be created.
+          brand can be created per project.
         output: true
     properties:
       - !ruby/object:Api::Type::String

--- a/mmv1/products/iap/api.yaml
+++ b/mmv1/products/iap/api.yaml
@@ -170,8 +170,8 @@ objects:
         name: 'name'
         description: |
           Output only. Identifier of the brand, in the format
-          `projects/{project_number}/brands/{brand_id}`. NOTE: The brand
-          identification corresponds to the project number as only one
+          `projects/{project_number}/brands/{brand_id}` or `projects/{project_id}/brands/{brand_id}`.
+          NOTE: The brand identification corresponds to the project number as only one
           brand per project can be created.
         output: true
     properties:

--- a/mmv1/products/iap/terraform.yaml
+++ b/mmv1/products/iap/terraform.yaml
@@ -190,7 +190,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       Destroying a Terraform-managed Brand will remove it from state 
       but *will not delete it from Google Cloud.*
     id_format: '{{name}}'
-    import_format: ['{{name}}']
+    import_format: ["projects/{{project_number}}/brands/{{brand_id}}", "projects/{{project_id}}/brands/{{brand_id}}"]
     skip_delete: true
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/templates/terraform/custom_import/iap_brand.go.erb
+++ b/mmv1/templates/terraform/custom_import/iap_brand.go.erb
@@ -22,12 +22,13 @@ if len(nameParts) == 4 {
 if len(nameParts) == 2 {
 	project = nameParts[0] // Different index
 
-	// Set `name` as a 4-part format so Read func produces valid URL
+	// Set `name` (and `id`) as a 4-part format so Read func produces valid URL
 	brand := nameParts[1]
 	name := fmt.Sprintf("projects/%s/brands/%s", project, brand)
 	if err := d.Set("name", name); err != nil {
 		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
+	d.SetId(name)
 }
 
 if err := d.Set("project", project); err != nil {

--- a/mmv1/templates/terraform/custom_import/iap_brand.go.erb
+++ b/mmv1/templates/terraform/custom_import/iap_brand.go.erb
@@ -6,15 +6,31 @@ if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
 }
 
 nameParts := strings.Split(d.Get("name").(string), "/")
-if len(nameParts) != 4 {
+if len(nameParts) != 4 && len(nameParts) != 2 {
 	return nil, fmt.Errorf(
-			"Saw %s when the name is expected to have shape %s",
+			"Saw %s when the name is expected to have either shape %s or %s",
 			d.Get("name"),
 			"projects/{{project}}/brands/{{name}}",
+			"{{project}}/{{name}}",
 		)
 }
 
-if err := d.Set("project", nameParts[1]); err != nil {
+var project string
+if len(nameParts) == 4 {
+	project = nameParts[1]
+}
+if len(nameParts) == 2 {
+	project = nameParts[0] // Different index
+
+	// Set `name` as a 4-part format so Read func produces valid URL
+	brand := nameParts[1]
+	name := fmt.Sprintf("projects/%s/brands/%s", project, brand)
+	if err := d.Set("name", name); err != nil {
+		return nil, fmt.Errorf("Error setting name: %s", err)
+	}
+}
+
+if err := d.Set("project", project); err != nil {
 	return nil, fmt.Errorf("Error setting project: %s", err)
 }
 return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/12600

PR makes the two possible import formats for the `google_iap_brand` resource more explicit.

I also updated the description of the `name` attribute as I thought it'd be good to make it clear that it can take the two forms (but I think API returns project number for Read operations). Relevant documentation : https://cloud.google.com/iap/docs/reference/rest/v1/projects.brands/get#body.PATH_PARAMETERS.name

When I generated the downstream locally I saw that a third import format is added automatically : `{{project_number}}/{{brand_id}}` I couldn't figure out how to stop this happening, so I implemented the ability to import with that format of ID.

I currently don't know how we'd make acceptance tests to test import with the different import formats, because we'd require knowledge of the the project number of the project made in the acceptance test.

For now, I've tested the import manually. See image below.
1. Removing the resource from state
2. Attempting import with the latest provider release
3. Attempting import with developer override using a build of this PR
    - The resource in state has an `id` of `{{project}}/{{brand_id}}` but the name is set as `projects/{{project}}/brands/{{brand_id}}`


<img width="1047" alt="Screenshot 2022-09-21 at 21 02 03" src="https://user-images.githubusercontent.com/15078782/191599675-d4c29b53-6963-40fe-bb6c-66804ac88e01.png">

----

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~ N/A
- [x] ~~[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~ N/A
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
iap: added ability to import `google_iap_brand` using ID in {{project}}/{{brand_id}} format
```
