### PR TITLE
Add new Config entity to Identitytoolkit

### DIFF
--- a/mmv1/products/identityplatform/api.yaml
+++ b/mmv1/products/identityplatform/api.yaml
@@ -28,6 +28,36 @@ apis_required:
     url: https://console.cloud.google.com/marketplace/details/google-cloud-platform/customer-identity/
 objects:
   - !ruby/object:Api::Resource
+    name: 'Config'
+    base_url: 'projects/{{project}}/config'
+    self_link: 'projects/{{project}}/config'
+    create_url: 'projects/{{project}}/identityPlatform:initializeAuth'
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      Identity Platform configuration for a Cloud project. Identity Platform is an
+      end-to-end authentication system for third-party users to access apps
+      and services.
+  
+      This entity is created only once during intialization and cannot be deleted, 
+      individual Identity Providers may be disabled instead.  This resource may only
+      be created in billing-enabled projects.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/identity-platform/docs'
+      api: 'https://cloud.google.com/identity-platform/docs/reference/rest/v2/Config'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        output: true
+        description: |
+          The name of the Config resource
+      - !ruby/object:Api::Type::Boolean
+        name: 'autodeleteAnonymousUsers'
+        description: |
+          Whether anonymous users will be auto-deleted after a period of 30 days
+  - !ruby/object:Api::Resource
     name: 'DefaultSupportedIdpConfig'
     base_url: 'projects/{{project}}/defaultSupportedIdpConfigs'
     self_link: 'projects/{{project}}/defaultSupportedIdpConfigs/{{idp_id}}'

--- a/mmv1/products/identityplatform/terraform.yaml
+++ b/mmv1/products/identityplatform/terraform.yaml
@@ -13,6 +13,21 @@
 
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Config: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["projects/{{project}}/config", "projects/{{project}}", "{{project}}"]
+    skip_delete: true
+    skip_sweeper: true
+    examples: 
+      - !ruby/object:Provider::Terraform::Examples
+        name: "identity_platform_config_basic"
+        primary_resource_id: "default"
+        vars:
+          instance_name: "memory-cache"
+        test_env_vars:
+          org_id: :ORG_ID
+          billing_acct: :BILLING_ACCT
+        # Resource creation race
+        skip_vcr: true
   DefaultSupportedIdpConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/defaultSupportedIdpConfigs/{{idp_id}}"]
     examples:

--- a/mmv1/templates/terraform/examples/identity_platform_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/identity_platform_config_basic.tf.erb
@@ -1,0 +1,17 @@
+resource "google_project" "default" {
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account =  "<%= ctx[:test_env_vars]['billing_acct'] -%>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "identitytoolkit.googleapis.com"
+}
+
+
+resource "google_identity_platform_config" "default" {
+  project = google_project.default.project_id
+  autodelete_anonymous_users = true
+}


### PR DESCRIPTION
Introduce a minimal Config entity to indentitytoolkit that will allow it to be problematically enabled for Billed projects.  Addition of the various other Project Configuration fields will be left to a future PR.


If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_identity_platform_config`
```
