### PR TITLE
Update TagKeys to support purpose and purposeData

### DIFF
--- a/mmv1/products/tags/api.yaml
+++ b/mmv1/products/tags/api.yaml
@@ -99,6 +99,23 @@ objects:
 
           A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
         output: true
+      - !ruby/object:Api::Type::Enum
+        name: purpose
+        description: |
+          Optional. A purpose cannot be changed once set.
+          
+          A purpose denotes that this Tag is intended for use in policies of a specific policy engine, and will involve that policy engine in management operations involving this Tag.
+        values:
+          - :GCE_FIREWALL
+        input: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: purposeData
+        description: |
+          Optional. Purpose data cannot be changed once set.
+          
+          Purpose data corresponds to the policy system that the tag is intended for. For example, the GCE_FIREWALL purpose expects data in the following format: `network = "<project-name>/<vpc-name>"`.
+        input: true
+
   - !ruby/object:Api::Resource
     name: 'TagValue'
     base_url: tagValues

--- a/mmv1/products/tags/terraform.yaml
+++ b/mmv1/products/tags/terraform.yaml
@@ -28,6 +28,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       description: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.StringLenBetween(0, 256)'
+      purposeData: !ruby/object:Overrides::Terraform::PropertyOverride
+        # This property expects input like: network = "<project-id>/<vpc-name or vpc-id>" or selfLinkWithId (selfLink is not supported)
+        # However, the API response stored in Terraform state looks like: network = "https://www.googleapis.com/compute/v1/projects/<project-id>/global/networks/<vpc-id>"
+        # This results in persistent diffs, so we surpress them by using ignore_read. The API will reject incorrect references to non-existent or inaccessible VPCs.
+        # Since this property is configured as 'input: true', any modifications to this property will result in a forced replacement of the resource.
+        ignore_read: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "tag_key_basic"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds the additional properties `purpose` and `purposeData` to the `google_tags_tag_key` resource. These additional properties enable the ability to deploy Secure Tags, which can then be used by Firewall Policies.

Since both `purpose` and `purpose_data` cannot be modified once set, both resources have `input: true` set in their definitions. Additionally, the `ignore_read` override is set on `purpose_data`. This is because although `purpose_data` can accept input such as the following:
    - `{network = "[project-id]/[vpc-name]}`
    - `{network = "[project-id]/[vpc-id]"}`
    - `{network = "https://www.googleapis.com/compute/v1/projects/[project-id]/global/networks/[vpc-id]"}`

The API's response is always stored in the state as `{network = "https://www.googleapis.com/compute/v1/projects/[project-id]/global/networks/[vpc-id]"}` (also known as selfLinkWithId). As a result, persistent diffs would be generated without `ignore_read`, which stores the user input instead of the API's response. The API does validate that the referenced network (VPC) exists and is accessible, so using the `ignore_read` override will not result in a corrupted or broken state.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
tags: Added `purpose` and `purpose_data` properties to `google_tags_tag_key`
```
