### PR TITLE
Warn against using emptyOrUnsetBlockDiffSuppress

### DIFF
--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -109,9 +109,8 @@ func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 // to an empty block. This might occur in situations where removing a block completely
 // is impossible (if it's computed or part of an AtLeastOneOf), so instead the user sets
 // its values to empty.
-// NOTE: This DSF can have unintuitive results depending on the returned values from the
-// API. Using Optional + Computed is *strongly* preferred, as it's more well understood
-// and resilient to API changes.
+// NOTE: Using Optional + Computed is *strongly* preferred to this DSF, as it's
+// more well understood and resilient to API changes.
 func emptyOrUnsetBlockDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
 	return emptyOrUnsetBlockDiffSuppressLogic(k, old, new, o, n)

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -109,6 +109,9 @@ func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 // to an empty block. This might occur in situations where removing a block completely
 // is impossible (if it's computed or part of an AtLeastOneOf), so instead the user sets
 // its values to empty.
+// NOTE: This DSF can have unintuitive results depending on the returned values from the
+// API. Using Optional + Computed is *strongly* preferred, as it's more well understood
+// and resilient to API changes.
 func emptyOrUnsetBlockDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
 	return emptyOrUnsetBlockDiffSuppressLogic(k, old, new, o, n)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

After https://github.com/GoogleCloudPlatform/magic-modules/pull/6546 fixed some GKE problems, I dug into `emptyOrUnsetBlockDiffSuppress` a bit. I think we should recommend against using it- it's harder to understand, and is only used in two places so far.

I think what it _really_ does is allow a user to specify an empty block when the API returns `nil`, which is pretty different than what O+C does. But it reads like an O+C replacement initially (and it somewhat *is* one). Also, I think it behaves weirdly with some values returned from the API.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
