### PR TITLE
fix two fields

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -834,12 +834,12 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("docker_repository") {
-		function.Runtime = d.Get("docker_repository").(string)
+		function.DockerRepository = d.Get("docker_repository").(string)
 		updateMaskArr = append(updateMaskArr, "dockerRepository")
 	}
 
 	if d.HasChange("kms_key_name") {
-		function.Runtime = d.Get("docker_repository").(string)
+		function.KmsKeyName = d.Get("kms_key_name").(string)
 		updateMaskArr = append(updateMaskArr, "kmsKeyName")
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -187,6 +187,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", randInt(t))
 	zipFilePath := createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
 	zipFileUpdatePath := createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerUpdatePath)
+	random_suffix := randString(t, 10)
 	defer os.Remove(zipFilePath) // clean up
 
 	vcrTest(t, resource.TestCase{
@@ -210,7 +211,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"build_environment_variables"},
 			},
 			{
-				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFileUpdatePath),
+				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFileUpdatePath, random_suffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudFunctionsFunctionExists(
 						t, funcResourceName, &function),
@@ -219,7 +220,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 					resource.TestCheckResourceAttr(funcResourceName,
 						"description", "test function updated"),
 					resource.TestCheckResourceAttr(funcResourceName,
-						"docker_registry", "CONTAINER_REGISTRY"),
+						"docker_registry", "ARTIFACT_REGISTRY"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"timeout", "91"),
 					resource.TestCheckResourceAttr(funcResourceName,
@@ -823,7 +824,7 @@ resource "google_cloudfunctions_function" "function" {
 `, bucketName, zipFilePath, functionName)
 }
 
-func testAccCloudFunctionsFunction_updated(functionName string, bucketName string, zipFilePath string) string {
+func testAccCloudFunctionsFunction_updated(functionName string, bucketName string, zipFilePath string, randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
@@ -839,7 +840,8 @@ resource "google_storage_bucket_object" "archive" {
 resource "google_cloudfunctions_function" "function" {
   name                         = "%s"
   description                  = "test function updated"
-  docker_registry              = "CONTAINER_REGISTRY"
+  docker_registry              = "ARTIFACT_REGISTRY"
+  docker_repository = google_artifact_registry_repository.my-repo.id
   available_memory_mb          = 256
   source_archive_bucket        = google_storage_bucket.bucket.name
   source_archive_object        = google_storage_bucket_object.archive.name
@@ -863,8 +865,16 @@ resource "google_cloudfunctions_function" "function" {
   }
   max_instances = 15
   min_instances = 5
+  region = "us-central1"
 }
-`, bucketName, zipFilePath, functionName)
+
+resource "google_artifact_registry_repository" "my-repo" {
+	location      = "us-central1"
+	repository_id = "tf-test-my-repository%s"
+	description   = "example docker repository with cmek"
+	format        = "DOCKER"
+}
+`, bucketName, zipFilePath, functionName, randomSuffix)
 }
 
 func testAccCloudFunctionsFunction_buildworkerpool(functionName string, bucketName string, zipFilePath string, location string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12457


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudfunction: fixed unable to update `docker_repository` and `kms_key_name` on `google_cloudfunctions_function`
```
