### PR TITLE
Add field cloud_logging_config to resource google_dns_managed_zone

### DIFF
--- a/mmv1/products/dns/api.yaml
+++ b/mmv1/products/dns/api.yaml
@@ -276,6 +276,14 @@ objects:
                 description: |
                   The fully qualified URL of the service directory namespace that should be
                   associated with the zone. Ignored for `public` visibility zones.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'cloudLoggingConfig'
+        description: 'Cloud logging configuration'
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enableLogging'
+            required: true
+            description: 'If set, enable query logging for this ManagedZone. False by default, making logging opt-in.'
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Managing Zones':

--- a/mmv1/products/dns/terraform.yaml
+++ b/mmv1/products/dns/terraform.yaml
@@ -67,6 +67,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           zone_name: "peering-zone"
           network_name: "network"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dns_managed_zone_cloud_logging"
+        primary_resource_id: "cloud-logging-enabled-zone"
+        vars:
+          zone_name: "cloud-logging-enabled-zone"
     properties:
       description: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
@@ -145,6 +150,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       reverseLookup: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
         custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
+      cloudLoggingConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'force_destroy'

--- a/mmv1/templates/terraform/examples/dns_managed_zone_cloud_logging.tf.erb
+++ b/mmv1/templates/terraform/examples/dns_managed_zone_cloud_logging.tf.erb
@@ -1,0 +1,12 @@
+resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['zone_name'] %>"
+  dns_name    = "services.example.com."
+  description = "Example cloud logging enabled DNS zone"
+  labels = {
+    foo = "bar"
+  }
+
+  cloud_logging_config {
+    enable_logging = true
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -152,6 +152,44 @@ func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 	})
 }
 
+func TestAccDNSManagedZone_cloudLoggingConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	zoneSuffix := randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsManagedZone_cloudLoggingConfig_basic(zoneSuffix),
+			},
+			{
+				ResourceName:      "google_dns_managed_zone.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsManagedZone_cloudLoggingConfig_update(zoneSuffix, true),
+			},
+			{
+				ResourceName:      "google_dns_managed_zone.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsManagedZone_cloudLoggingConfig_update(zoneSuffix, false),
+			},
+			{
+				ResourceName:      "google_dns_managed_zone.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 <% unless version.nil? || version == 'ga' -%>
 func TestAccDNSManagedZone_reverseLookup(t *testing.T) {
 	t.Parallel()
@@ -402,6 +440,36 @@ resource "google_compute_network" "network-1" {
   auto_create_subnetworks = false
 }
 `, suffix, first_nameserver, first_forwarding_path, second_nameserver, second_forwarding_path, suffix)
+}
+
+func testAccDnsManagedZone_cloudLoggingConfig_basic(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "foobar" {
+  name        = "mzone-test-%s"
+  dns_name    = "tf-acctest-%s.hashicorptest.com."
+  description = "Example DNS zone"
+  labels = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccDnsManagedZone_cloudLoggingConfig_update(suffix string, enableCloudLogging bool) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "foobar" {
+  name        = "mzone-test-%s"
+  dns_name    = "tf-acctest-%s.hashicorptest.com."
+  description = "Example DNS zone"
+  labels = {
+    foo = "bar"
+  }
+
+  cloud_logging_config {
+    enable_logging = %t
+  }
+}
+`, suffix, suffix, enableCloudLogging)
 }
 
 <% unless version.nil? || version == 'ga' -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add field cloud_logging_config to resource google_dns_managed_zone

Issue: https://github.com/hashicorp/terraform-provider-google/issues/10990
API: https://cloud.google.com/dns/docs/reference/v1/managedZones



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: Added general field `cloud_logging_config` to `google_dns_managed_zone`
```
