### PR TITLE
Added support for google_datastream_connection_profile.bigquery_profile field

### DIFF
--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -216,7 +216,7 @@ module Api
     def all_nested_properties(props)
       nested = props
       props.each do |prop|
-        if !prop.flatten_object && prop.nested_properties?
+        if !prop.flatten_object && !prop.nested_properties.nil?
           nested += all_nested_properties(prop.nested_properties)
         end
       end
@@ -449,7 +449,7 @@ module Api
           rrefs.concat(resourcerefs_for_properties(p.resource_ref
                                                     .required_properties,
                                                    original_obj))
-        elsif p.nested_properties?
+        elsif !p.nested_properties.nil?
           rrefs.concat(resourcerefs_for_properties(p.nested_properties, original_obj))
         elsif p.is_a? Api::Type::Array
           if p.item_type.is_a? Api::Type::ResourceRef

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -319,11 +319,7 @@ module Api
 
     # Returns nested properties for this property.
     def nested_properties
-      []
-    end
-
-    def nested_properties?
-      !nested_properties.empty?
+      nil
     end
 
     def removed?

--- a/mmv1/overrides/runner.rb
+++ b/mmv1/overrides/runner.rb
@@ -132,7 +132,7 @@ module Overrides
         new_prop = build_primitive_property(old_property,
                                             property_overrides["#{prefix}#{old_property.name}"],
                                             override_classes)
-        if !old_property.nested_properties.nil?
+        unless old_property.nested_properties.nil?
           new_props = old_property.nested_properties.map do |p|
             build_property(p, property_overrides, override_classes,
                            "#{prefix}#{old_property.name}.")

--- a/mmv1/overrides/runner.rb
+++ b/mmv1/overrides/runner.rb
@@ -56,6 +56,7 @@ module Overrides
 
         validator = Overrides::Validator.new(api, overrides)
         validator.run
+
         build_product(api, overrides, resource: res_override_class, property: prop_override_class)
       end
 
@@ -131,7 +132,7 @@ module Overrides
         new_prop = build_primitive_property(old_property,
                                             property_overrides["#{prefix}#{old_property.name}"],
                                             override_classes)
-        if old_property.nested_properties?
+        if !old_property.nested_properties.nil?
           new_props = old_property.nested_properties.map do |p|
             build_property(p, property_overrides, override_classes,
                            "#{prefix}#{old_property.name}.")

--- a/mmv1/products/datastream/api.yaml
+++ b/mmv1/products/datastream/api.yaml
@@ -87,6 +87,7 @@ objects:
           - oracle_profile
           - gcs_profile
           - mysql_profile
+          - bigquery_profile
           - postgresql_profile
         description: |
           Oracle database profile.
@@ -125,6 +126,7 @@ objects:
           - oracle_profile
           - gcs_profile
           - mysql_profile
+          - bigquery_profile
           - postgresql_profile
         description: |
           Cloud Storage bucket profile.
@@ -144,6 +146,7 @@ objects:
           - oracle_profile
           - gcs_profile
           - mysql_profile
+          - bigquery_profile
           - postgresql_profile
         description: |
           MySQL database profile.
@@ -211,11 +214,25 @@ objects:
                 description: |
                   Indicates whether the clientKey field is set.
       - !ruby/object:Api::Type::NestedObject
+        name: 'bigqueryProfile'
+        send_empty_value: true
+        allow_empty_object: true
+        exactly_one_of:
+          - oracle_profile
+          - gcs_profile
+          - mysql_profile
+          - bigquery_profile
+          - postgresql_profile
+        description: |
+          BigQuery warehouse profile.
+        properties: []
+      - !ruby/object:Api::Type::NestedObject
         name: 'postgresqlProfile'
         exactly_one_of:
           - oracle_profile
           - gcs_profile
           - mysql_profile
+          - bigquery_profile
           - postgresql_profile
         description: |
           PostgreSQL database profile.

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -56,6 +56,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           connection_profile_id: "my-profile"
       - !ruby/object:Provider::Terraform::Examples
+        name: "datastream_connection_profile_bigquery"
+        primary_resource_id: "default"
+        vars:
+          connection_profile_id: "my-profile"
+      - !ruby/object:Provider::Terraform::Examples
         name: "datastream_connection_profile_full"
         primary_resource_id: "default"
         # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410

--- a/mmv1/provider/ansible/documentation.rb
+++ b/mmv1/provider/ansible/documentation.rb
@@ -49,7 +49,7 @@ module Provider
             'type' => python_type(prop),
             'aliases' => prop.aliases,
             'suboptions' => (
-                if prop.nested_properties?
+                if !prop.nested_properties.nil? && !prop.nested_properties.empty?
                   prop.nested_properties.reject(&:output).map { |p| documentation_for_property(p) }
                                         .reduce({}, :merge)
                 end
@@ -76,7 +76,7 @@ module Provider
             'returned' => 'success',
             'type' => type,
             'contains' => (
-              if prop.nested_properties?
+              if !prop.nested_properties.nil? && !prop.nested_properties.empty?
                 prop.nested_properties.map { |p| returns_for_property(p) }
                                       .reduce({}, :merge)
               end

--- a/mmv1/provider/ansible/module.rb
+++ b/mmv1/provider/ansible/module.rb
@@ -36,7 +36,7 @@ module Provider
             'elements' => (python_type(prop.item_type) \
               if prop.is_a?(Api::Type::Array) && python_type(prop.item_type)),
             'aliases' => prop.aliases,
-            'options' => (if prop.nested_properties?
+            'options' => (if !prop.nested_properties.nil? && !prop.nested_properties.empty?
                             prop.nested_properties.reject(&:output)
                                                   .map { |x| python_dict_for_property(x) }
                                                   .reduce({}, :merge)

--- a/mmv1/provider/ansible/request.rb
+++ b/mmv1/provider/ansible/request.rb
@@ -39,7 +39,7 @@ module Provider
       # This returns a list of properties that require classes being built out.
       def properties_with_classes(properties)
         properties.map do |p|
-          [p] + properties_with_classes(p.nested_properties) if p.nested_properties?
+          [p] + properties_with_classes(p.nested_properties) if !p.nested_properties.nil?
         end.compact.flatten
       end
 

--- a/mmv1/provider/ansible/request.rb
+++ b/mmv1/provider/ansible/request.rb
@@ -39,7 +39,7 @@ module Provider
       # This returns a list of properties that require classes being built out.
       def properties_with_classes(properties)
         properties.map do |p|
-          [p] + properties_with_classes(p.nested_properties) if !p.nested_properties.nil?
+          [p] + properties_with_classes(p.nested_properties) unless p.nested_properties.nil?
         end.compact.flatten
       end
 

--- a/mmv1/templates/inspec/nested_object.erb
+++ b/mmv1/templates/inspec/nested_object.erb
@@ -33,13 +33,13 @@ module GoogleInSpec
   module <%= product_ns %>
     module Property
       class <%= class_name -%>
-<% if property.nested_properties? -%>
+<% if !property.nested_properties.nil? -%>
 <% property.nested_properties.each do |prop| -%>
 
         attr_reader :<%= prop.out_name %>
 <% end # property.nested_properties.each -%>
 
-<% end # if property.nested_properties? -%>
+<% end # !property.nested_properties.nil? -%>
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_bigquery.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_bigquery.tf.erb
@@ -1,0 +1,7 @@
+resource "google_datastream_connection_profile" "<%= ctx[:primary_resource_id] %>" {
+	display_name          = "Connection profile"
+	location              = "us-central1"
+	connection_profile_id = "<%= ctx[:vars]['connection_profile_id'] %>"
+
+	bigquery_profile {}
+}

--- a/mmv1/templates/terraform/expand_property_method.erb
+++ b/mmv1/templates/terraform/expand_property_method.erb
@@ -98,7 +98,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 <%     if property.is_set -%>
   v = v.(*schema.Set).List()
 <%     end -%>
-<%     if property.nested_properties? -%>
+<%     if !property.nested_properties.nil? -%>
   l := v.([]interface{})
 <%       if property.is_a?(Api::Type::Array) -%>
   req := make([]interface{}, 0, len(l))
@@ -106,6 +106,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
     if raw == nil {
       continue
     }
+    original := raw.(map[string]interface{})
 <%       else -%>
 <%         if property.allow_empty_object -%>
   if len(l) == 0 {
@@ -116,14 +117,16 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
     transformed := make(map[string]interface{})
     return transformed, nil
   }
-<%       else -%>
+<%         else -%>
   if len(l) == 0 || l[0] == nil {
     return nil, nil
   }
 <%         end -%>
+<%         if !property.nested_properties.empty? -%>
   raw := l[0]
+  original := raw.(map[string]interface{})
+<%         end -%>
 <%       end -%>
-    original := raw.(map[string]interface{})
     transformed := make(map[string]interface{})
 
 <%       property.nested_properties.each do |prop| -%>
@@ -183,7 +186,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 }
 <%   end # tf_types.include?(property.class) -%>
 
-<% if property.nested_properties? -%>
+<% if !property.nested_properties.nil? -%>
 <%   property.nested_properties.each do |prop| -%>
 <%# Map is a map from {key -> object} in the API, but Terraform can't represent that
 so we treat the key as a property of the object in Terraform schema. %>

--- a/mmv1/templates/terraform/flatten_property_method.erb
+++ b/mmv1/templates/terraform/flatten_property_method.erb
@@ -24,11 +24,13 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
   if v == nil {
     return nil
   }
+  <% if !property.allow_empty_object -%>
   original := v.(map[string]interface{})
-  <% unless property.allow_empty_object -%>
   if len(original) == 0 {
     return nil
   }
+  <% elsif !property.properties.empty? -%>
+  original := v.(map[string]interface{})
   <% end -%>
   transformed := make(map[string]interface{})
   <% property.properties.each do |prop| -%>
@@ -131,7 +133,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
   return v
 <% end # property.is_a?(Api::Type::NestedObject) -%>
 }
-<% if property.nested_properties? -%>
+<% if !property.nested_properties.nil? -%>
   <% property.nested_properties.each do |prop| -%>
     <%= lines(build_flatten_method(prefix + titlelize_property(property), prop, object, pwd), 1) -%>
   <% end -%>

--- a/mmv1/templates/terraform/nested_property_documentation.erb
+++ b/mmv1/templates/terraform/nested_property_documentation.erb
@@ -4,7 +4,7 @@
 <%= lines(build_nested_property_documentation(prop, pwd)) -%>
 <% end -%>
 <%
-  elsif property.nested_properties?
+  elsif !property.nested_properties.nil? && !property.nested_properties.empty?
 -%>
 <a name="nested_<%= property.name.underscore -%>"></a>The `<%= property.name.underscore -%>` block <%= if property.output then "contains" else "supports" end -%>:
 <%- if property.is_a?(Api::Type::Map) %>

--- a/mmv1/templates/terraform/property_documentation.erb
+++ b/mmv1/templates/terraform/property_documentation.erb
@@ -32,6 +32,6 @@
 <% if property.sensitive -%>
   **Note**: This property is sensitive and will not be displayed in the plan.
 <% end -%>
-<% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
+<% if !property.flatten_object && !property.nested_properties.nil? && !property.nested_properties.empty? -%>
   Structure is [documented below](#nested_<%= property.name.underscore -%>).
 <% end -%>

--- a/mmv1/templates/terraform/schema_subresource.erb
+++ b/mmv1/templates/terraform/schema_subresource.erb
@@ -26,6 +26,8 @@ func <%= namespace_property_from_object(property, object) -%>Schema() *schema.Re
 }
 <% end %>
 
+<% if !property.nested_properties.nil? -%>
 <% property.nested_properties.each do |prop| -%>
 <%= lines(build_subresource_schema(prop, object, pwd), 1) -%>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-google/issues/10810

This required making some changes to compilation & templates to truly support completely empty "nested objects". I removed .nested_properties? in favor of more explicitly checking whether the nested properties are not specified or are present but empty.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datastream: Added field `bigquery_profile` to `google_datastream_connection_profile`
```
