### PR TITLE
Add blue green upgrade settings.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -79,6 +79,48 @@ func resourceContainerNodePool() *schema.Resource {
 	}
 }
 
+var schemaBlueGreenSettings = &schema.Schema{
+	Type:     schema.TypeList,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"standard_rollout_policy": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Standard rollout policy is the default policy for blue-green.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"batch_percentage": {
+							Type:         schema.TypeFloat,
+							Optional:     true,
+							Description:  `Percentage of the blue pool nodes to drain in a batch.`,
+							ValidateFunc: validation.FloatBetween(0.0, 1.0),
+						},
+						"batch_node_count": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `Number of blue nodes to drain in a batch.`,
+						},
+						"batch_soak_duration": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "0s",
+							Description: `Soak time after each batch gets drained.`,
+						},
+					},
+				},
+			},
+			"node_pool_soak_duration": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "3600s",
+				Description: `Time needed after draining entire blue pool. After this period, blue pool will be cleaned up.`,
+			},
+		},
+	},
+	Description: `Settings for BlueGreen node pool upgrade.`,
+}
+
 var schemaNodePool = map[string]*schema.Schema{
 	"autoscaling": &schema.Schema{
 		Type:        schema.TypeList,
@@ -164,7 +206,6 @@ var schemaNodePool = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		Computed:    true,
-		MaxItems:    1,
 		Description: `Specify node upgrade settings to change how many nodes GKE attempts to upgrade at once. The number of nodes upgraded simultaneously is the sum of max_surge and max_unavailable. The maximum number of nodes upgraded simultaneously is limited to 20.`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -181,6 +222,16 @@ var schemaNodePool = map[string]*schema.Schema{
 					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `The number of nodes that can be simultaneously unavailable during an upgrade. Increasing max_unavailable raises the number of nodes that can be upgraded in parallel. Can be set to 0 or greater.`,
 				},
+
+				"strategy": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "SURGE",
+					ValidateFunc: validation.StringInSlice([]string{"SURGE", "BLUE_GREEN"}, false),
+					Description:  `Update strategy for the given nodepool.`,
+				},
+
+				"blue_green_settings": schemaBlueGreenSettings,
 			},
 		},
 	},
@@ -829,9 +880,85 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 		if v, ok := upgradeSettingsConfig["max_unavailable"]; ok {
 			np.UpgradeSettings.MaxUnavailable = int64(v.(int))
 		}
+
+		if v, ok := upgradeSettingsConfig["strategy"]; ok {
+			np.UpgradeSettings.Strategy = v.(string)
+		}
+
+		if v, ok := upgradeSettingsConfig["blue_green_settings"]; ok && len(v.([]interface{})) > 0 {
+			blueGreenSettingsConfig := v.([]interface{})[0].(map[string]interface{})
+			np.UpgradeSettings.BlueGreenSettings = &container.BlueGreenSettings{}
+
+			if v, ok := blueGreenSettingsConfig["node_pool_soak_duration"]; ok {
+				np.UpgradeSettings.BlueGreenSettings.NodePoolSoakDuration = v.(string)
+			}
+
+			if v, ok := blueGreenSettingsConfig["standard_rollout_policy"]; ok && len(v.([]interface{})) > 0 {
+				standardRolloutPolicyConfig := v.([]interface{})[0].(map[string]interface{})
+				standardRolloutPolicy := &container.StandardRolloutPolicy{}
+
+				if v, ok := standardRolloutPolicyConfig["batch_soak_duration"]; ok {
+					standardRolloutPolicy.BatchSoakDuration = v.(string)
+				}
+				if v, ok := standardRolloutPolicyConfig["batch_node_count"]; ok {
+					standardRolloutPolicy.BatchNodeCount = int64(v.(int))
+				}
+				if v, ok := standardRolloutPolicyConfig["batch_percentage"]; ok {
+					standardRolloutPolicy.BatchPercentage = v.(float64)
+				}
+
+				np.UpgradeSettings.BlueGreenSettings.StandardRolloutPolicy = standardRolloutPolicy
+			}
+		}
 	}
 
 	return np, nil
+}
+
+func flattenStandardRolloutPolicy(rp *container.StandardRolloutPolicy) []map[string]interface{} {
+	if rp == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"batch_node_count":    rp.BatchNodeCount,
+			"batch_percentage":    rp.BatchPercentage,
+			"batch_soak_duration": rp.BatchSoakDuration,
+		},
+	}
+}
+
+func flattenBlueGreenSettings(bg *container.BlueGreenSettings) []map[string]interface{} {
+	if bg == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"node_pool_soak_duration": bg.NodePoolSoakDuration,
+			"standard_rollout_policy": flattenStandardRolloutPolicy(bg.StandardRolloutPolicy),
+		},
+	}
+}
+
+func flattenUpgradeSettings(us *container.UpgradeSettings) []map[string]interface{} {
+	if us == nil {
+		return nil
+	}
+
+	upgradeSettings := make(map[string]interface{})
+
+	if us.Strategy == "BLUE_GREEN" {
+		upgradeSettings["blue_green_settings"] = flattenBlueGreenSettings(us.BlueGreenSettings)
+		upgradeSettings["max_surge"] = 0
+		upgradeSettings["max_unavailable"] = 0
+	} else {
+		upgradeSettings["max_surge"] = us.MaxSurge
+		upgradeSettings["max_unavailable"] = us.MaxUnavailable
+	}
+
+	upgradeSettings["strategy"] = us.Strategy
+	return []map[string]interface{}{upgradeSettings}
 }
 
 func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodePool, prefix string) (map[string]interface{}, error) {
@@ -921,12 +1048,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *container.NodeP
 	}
 
 	if np.UpgradeSettings != nil {
-		nodePool["upgrade_settings"] = []map[string]interface{}{
-			{
-				"max_surge":       np.UpgradeSettings.MaxSurge,
-				"max_unavailable": np.UpgradeSettings.MaxUnavailable,
-			},
-		}
+		nodePool["upgrade_settings"] = flattenUpgradeSettings(np.UpgradeSettings)
 	} else {
 		delete(nodePool, "upgrade_settings")
 	}
@@ -1309,8 +1431,32 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		upgradeSettings := &container.UpgradeSettings{}
 		if v, ok := d.GetOk(prefix + "upgrade_settings"); ok {
 			upgradeSettingsConfig := v.([]interface{})[0].(map[string]interface{})
-			upgradeSettings.MaxSurge = int64(upgradeSettingsConfig["max_surge"].(int))
-			upgradeSettings.MaxUnavailable = int64(upgradeSettingsConfig["max_unavailable"].(int))
+			upgradeSettings.Strategy = upgradeSettingsConfig["strategy"].(string)
+
+			if upgradeSettings.Strategy == "SURGE" {
+				upgradeSettings.MaxSurge = int64(upgradeSettingsConfig["max_surge"].(int))
+				upgradeSettings.MaxUnavailable = int64(upgradeSettingsConfig["max_unavailable"].(int))
+			}
+
+			if v, ok := upgradeSettingsConfig["blue_green_settings"]; ok && len(v.([]interface{})) > 0 {
+				blueGreenSettings := &container.BlueGreenSettings{}
+				blueGreenSettingsConfig := v.([]interface{})[0].(map[string]interface{})
+				blueGreenSettings.NodePoolSoakDuration = blueGreenSettingsConfig["node_pool_soak_duration"].(string)
+
+				if v, ok := blueGreenSettingsConfig["standard_rollout_policy"]; ok && len(v.([]interface{})) > 0 {
+					standardRolloutPolicy := &container.StandardRolloutPolicy{}
+					standardRolloutPolicyConfig := v.([]interface{})[0].(map[string]interface{})
+					standardRolloutPolicy.BatchSoakDuration = standardRolloutPolicyConfig["batch_soak_duration"].(string)
+					if v, ok := standardRolloutPolicyConfig["batch_node_count"]; ok {
+						standardRolloutPolicy.BatchNodeCount = int64(v.(int))
+					}
+					if v, ok := standardRolloutPolicyConfig["batch_percentage"]; ok {
+						standardRolloutPolicy.BatchPercentage = v.(float64)
+					}
+					blueGreenSettings.StandardRolloutPolicy = standardRolloutPolicy
+				}
+				upgradeSettings.BlueGreenSettings = blueGreenSettings
+			}
 		}
 		req := &container.UpdateNodePoolRequest{
 			UpgradeSettings: upgradeSettings,

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -519,7 +519,7 @@ func TestAccContainerNodePool_withUpgradeSettings(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withUpgradeSettings(cluster, np, 2, 3),
+				Config: testAccContainerNodePool_withUpgradeSettings(cluster, np, 2, 3, "SURGE", "", 0, 0.0, ""),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_upgrade_settings",
@@ -527,7 +527,23 @@ func TestAccContainerNodePool_withUpgradeSettings(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerNodePool_withUpgradeSettings(cluster, np, 1, 1),
+				Config: testAccContainerNodePool_withUpgradeSettings(cluster, np, 1, 1, "SURGE", "", 0, 0.0, ""),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_upgrade_settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerNodePool_withUpgradeSettings(cluster, np, 0, 0, "BLUE_GREEN", "100s", 1, 0.0, "0s"),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_upgrade_settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerNodePool_withUpgradeSettings(cluster, np, 0, 0, "BLUE_GREEN", "100s", 0, 0.5, "1s"),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_upgrade_settings",
@@ -2207,7 +2223,34 @@ resource "google_container_node_pool" "with_boot_disk_kms_key" {
 }
 <% end -%>
 
-func testAccContainerNodePool_withUpgradeSettings(clusterName string, nodePoolName string, maxSurge int, maxUnavailable int) string {
+func makeUpgradeSettings(maxSurge int, maxUnavailable int, strategy string, nodePoolSoakDuration string, batchNodeCount int, batchPercentage float64, batchSoakDuration string) string {
+	if strategy == "BLUE_GREEN" {
+		return fmt.Sprintf(`
+upgrade_settings {
+	max_surge = 0
+	max_unavailable = 0
+	strategy = "%s"
+	blue_green_settings {
+		node_pool_soak_duration = "%s"
+		standard_rollout_policy {
+			batch_node_count = %d
+			batch_percentage = %f
+			batch_soak_duration = "%s"
+		}
+	}
+}
+`, strategy, nodePoolSoakDuration, batchNodeCount, batchPercentage, batchSoakDuration)
+	}
+	return fmt.Sprintf(`
+upgrade_settings {
+	max_surge = %d
+	max_unavailable = %d
+	strategy = "%s"
+}
+`, maxSurge, maxUnavailable, strategy)
+}
+
+func testAccContainerNodePool_withUpgradeSettings(clusterName string, nodePoolName string, maxSurge int, maxUnavailable int, strategy string, nodePoolSoakDuration string, batchNodeCount int, batchPercentage float64, batchSoakDuration string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1" {
   location = "us-central1"
@@ -2225,12 +2268,9 @@ resource "google_container_node_pool" "with_upgrade_settings" {
   location = "us-central1"
   cluster = "${google_container_cluster.cluster.name}"
   initial_node_count = 1
-  upgrade_settings {
-    max_surge = %d
-    max_unavailable = %d
-  }
+  %s
 }
-`, clusterName, nodePoolName, maxSurge, maxUnavailable)
+`, clusterName, nodePoolName, makeUpgradeSettings(maxSurge, maxUnavailable, strategy, nodePoolSoakDuration, batchNodeCount, batchPercentage, batchSoakDuration))
 }
 
 func testAccContainerNodePool_withGPU(cluster, np string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Implement GKE blue green node pool upgrade settings.
fixes https://github.com/hashicorp/terraform-provider-google/issues/12045


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added field `strategy` to `google_container_node_pool`
container: Added field `blue_green_settings` to `google_container_node_pool`
```
