### PR TITLE
Added custom_placement_config field in google_storage_bucket resource

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -364,6 +364,27 @@ func resourceStorageBucket() *schema.Resource {
 				Computed:    true,
 				Description: `Enables uniform bucket-level access on a bucket.`,
 			},
+			"custom_placement_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"data_locations": {
+							Type:     schema.TypeSet,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 2,
+							MinItems: 2,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Description: `The list of individual regions that comprise a dual-region bucket. See the docs for a list of acceptable regions. Note: If any of the data_locations changes, it will recreate the bucket.`,
+						},
+					},
+				},
+				Description: `The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty.`,
+			},
 <% unless version == "ga" -%>
 			"public_access_prevention": {
 				Type:        schema.TypeString,
@@ -471,6 +492,10 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 		sb.Billing = &storage.BucketBilling{
 			RequesterPays: v.(bool),
 		}
+	}
+
+	if v, ok := d.GetOk("custom_placement_config"); ok {
+		sb.CustomPlacementConfig = expandBucketCustomPlacementConfig(v.([]interface{}))
 	}
 
 	var res *storage.Bucket
@@ -883,6 +908,42 @@ func flattenBucketEncryption(enc *storage.BucketEncryption) []map[string]interfa
 	})
 
 	return encryption
+}
+
+func expandBucketCustomPlacementConfig(configured interface{}) *storage.BucketCustomPlacementConfig {
+	cfcs := configured.([]interface{})
+	if len(cfcs) == 0 || cfcs[0] == nil {
+		return nil
+	}
+	cfc := cfcs[0].(map[string]interface{})
+	bucketcfc := &storage.BucketCustomPlacementConfig{
+		DataLocations: expandBucketDataLocations(cfc["data_locations"]),
+	}
+	return bucketcfc
+}
+
+func flattenBucketCustomPlacementConfig(cfc *storage.BucketCustomPlacementConfig) []map[string]interface{} {
+	customPlacementConfig := make([]map[string]interface{}, 0, 1)
+
+	if cfc == nil {
+		return customPlacementConfig
+	}
+
+	customPlacementConfig = append(customPlacementConfig, map[string]interface{}{
+		"data_locations": cfc.DataLocations,
+	})
+
+	return customPlacementConfig
+}
+
+func expandBucketDataLocations(configured interface{}) []string {
+	l := configured.(*schema.Set).List()
+
+	req := make([]string, 0, len(l))
+	for _, raw := range l {
+		req = append(req, raw.(string))
+	}
+	return req
 }
 
 func expandBucketLogging(configured interface{}) *storage.BucketLogging {
@@ -1426,6 +1487,9 @@ func setStorageBucket(d *schema.ResourceData, config *Config, res *storage.Bucke
 	}
 	if err := d.Set("retention_policy", flattenBucketRetentionPolicy(res.RetentionPolicy)); err != nil {
 		return fmt.Errorf("Error setting retention_policy: %s", err)
+	}
+	if err := d.Set("custom_placement_config", flattenBucketCustomPlacementConfig(res.CustomPlacementConfig)); err != nil {
+		return fmt.Errorf("Error setting custom_placement_config: %s", err)
 	}
 
 	if res.IamConfiguration != nil && res.IamConfiguration.UniformBucketLevelAccess != nil {

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -104,6 +104,29 @@ func TestAccStorageBucket_lowercaseLocation(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_dualLocation(t *testing.T) {
+	t.Parallel()
+
+	bucketName := testBucketName(t)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_dualLocation(bucketName),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccStorageBucket_customAttributes(t *testing.T) {
 	t.Parallel()
 
@@ -1229,6 +1252,19 @@ resource "google_storage_bucket" "bucket" {
   name          = "%s"
   location      = "eu"
   force_destroy = true
+}
+`, bucketName)
+}
+
+func testAccStorageBucket_dualLocation(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "ASIA"
+  force_destroy = true
+  custom_placement_config {
+    data_locations = ["ASIA-EAST1", "ASIA-SOUTHEAST1"]
+  }
 }
 `, bucketName)
 }

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `uniform_bucket_level_access` - (Optional, Default: false) Enables [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) access to a bucket.
 
+* `custom_placement_config` - (Optional) The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty. Structure is [documented below](#nested_custom_placement_config).
+
 <a name="nested_lifecycle_rule"></a>The `lifecycle_rule` block supports:
 
 * `action` - (Required) The Lifecycle Rule's action configuration. A single block of this type is supported. Structure is [documented below](#nested_action).
@@ -188,6 +190,10 @@ The following arguments are supported:
   This data source calls an API which creates the account if required, ensuring your Terraform applies cleanly and repeatedly irrespective of the
   state of the project.
   You should take care for race conditions when the same Terraform manages IAM policy on the Cloud KMS crypto key. See the data source page for more details.
+
+<a name="nested_custom_placement_config"></a>The `custom_placement_config` block supports:
+
+* `data_locations` - (Required) The list of individual regions that comprise a dual-region bucket. See [Cloud Storage bucket locations](https://cloud.google.com/storage/docs/dual-regions#availability) for a list of acceptable regions. **Note**: If any of the data_locations changes, it will [recreate the bucket](https://cloud.google.com/storage/docs/locations#key-concepts).
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added support for custom_placement_config field in google_storage_bucket resource.
fixes https://github.com/hashicorp/terraform-provider-google/issues/12292
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added `custom_placement_config` field to `google_storage_bucket` resource
```