### PR TITLE
tfv: Fix empty folder ID causing error for folder_iam

### DIFF
--- a/mmv1/third_party/validator/folder_iam.go
+++ b/mmv1/third_party/validator/folder_iam.go
@@ -89,6 +89,10 @@ func newFolderIamAsset(
 }
 
 func FetchFolderIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
+	if _, ok := d.GetOk("folder"); !ok {
+		return Asset{}, ErrEmptyIdentityField
+	}
+
 	return fetchIamPolicy(
 		NewFolderIamUpdater,
 		d,

--- a/mmv1/third_party/validator/tests/data/example_folder_iam_member_empty_folder.json
+++ b/mmv1/third_party/validator/tests/data/example_folder_iam_member_empty_folder.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "//cloudresourcemanager.googleapis.com/placeholder-c2WD8F2q",
+    "asset_type": "cloudresourcemanager.googleapis.com/Folder",
+    "ancestry_path": "organization/unknown",
+    "iam_policy": {
+      "bindings": [
+        {
+          "role": "roles/editor",
+          "members": [
+            "user:jane@example.com"
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/mmv1/third_party/validator/tests/data/example_folder_iam_member_empty_folder.tf
+++ b/mmv1/third_party/validator/tests/data/example_folder_iam_member_empty_folder.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+resource "google_folder_iam_member" "editor" {
+  folder  = "${random_string.suffix.result}"
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
+}

--- a/mmv1/third_party/validator/tests/data/example_folder_iam_member_empty_folder.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/example_folder_iam_member_empty_folder.tfplan.json
@@ -1,0 +1,157 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.10",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_folder_iam_member.editor",
+          "mode": "managed",
+          "type": "google_folder_iam_member",
+          "name": "editor",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "condition": [],
+            "member": "user:jane@example.com",
+            "role": "roles/editor"
+          },
+          "sensitive_values": {
+            "condition": []
+          }
+        },
+        {
+          "address": "random_string.suffix",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "suffix",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 1,
+          "values": {
+            "keepers": null,
+            "length": 4,
+            "lower": true,
+            "min_lower": 0,
+            "min_numeric": 0,
+            "min_special": 0,
+            "min_upper": 0,
+            "number": true,
+            "override_special": null,
+            "special": false,
+            "upper": false
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_folder_iam_member.editor",
+      "mode": "managed",
+      "type": "google_folder_iam_member",
+      "name": "editor",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "condition": [],
+          "member": "user:jane@example.com",
+          "role": "roles/editor"
+        },
+        "after_unknown": {
+          "condition": [],
+          "etag": true,
+          "folder": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "condition": []
+        }
+      }
+    },
+    {
+      "address": "random_string.suffix",
+      "mode": "managed",
+      "type": "random_string",
+      "name": "suffix",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": null,
+          "length": 4,
+          "lower": true,
+          "min_lower": 0,
+          "min_numeric": 0,
+          "min_special": 0,
+          "min_upper": 0,
+          "number": true,
+          "override_special": null,
+          "special": false,
+          "upper": false
+        },
+        "after_unknown": {
+          "id": true,
+          "result": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_folder_iam_member.editor",
+          "mode": "managed",
+          "type": "google_folder_iam_member",
+          "name": "editor",
+          "provider_config_key": "google",
+          "expressions": {
+            "folder": {
+              "references": [
+                "random_string.suffix.result",
+                "random_string.suffix"
+              ]
+            },
+            "member": {
+              "constant_value": "user:jane@example.com"
+            },
+            "role": {
+              "constant_value": "roles/editor"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "random_string.suffix",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "suffix",
+          "provider_config_key": "random",
+          "expressions": {
+            "length": {
+              "constant_value": 4
+            },
+            "special": {
+              "constant_value": false
+            },
+            "upper": {
+              "constant_value": false
+            }
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fix empty folder ID causing error for folder_iam resource
Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/999


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
