### PR TITLE
Fix sql VCR test failure in replaying

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1283,7 +1283,7 @@ func TestAccSqlDatabaseInstance_mysqlMajorVersionUpgrade(t *testing.T) {
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_basic2,
+				Config: testGoogleSqlDatabaseInstance_basic3,
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1292,7 +1292,7 @@ func TestAccSqlDatabaseInstance_mysqlMajorVersionUpgrade(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_basic2_update,
+				Config: testGoogleSqlDatabaseInstance_basic3_update,
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -1362,10 +1362,11 @@ resource "google_sql_database_instance" "instance" {
 }
 `
 
-var testGoogleSqlDatabaseInstance_basic2_update = `
+var testGoogleSqlDatabaseInstance_basic3 = `
 resource "google_sql_database_instance" "instance" {
+  name                = "%s"
   region              = "us-central1"
-  database_version    = "MYSQL_8_0"
+  database_version    = "MYSQL_5_7"
   deletion_protection = false
   settings {
     tier = "db-f1-micro"
@@ -1373,11 +1374,10 @@ resource "google_sql_database_instance" "instance" {
 }
 `
 
-var testGoogleSqlDatabaseInstance_basic3 = `
+var testGoogleSqlDatabaseInstance_basic3_update = `
 resource "google_sql_database_instance" "instance" {
-  name                = "%s"
   region              = "us-central1"
-  database_version    = "MYSQL_5_7"
+  database_version    = "MYSQL_8_0"
   deletion_protection = false
   settings {
     tier = "db-f1-micro"

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1376,6 +1376,7 @@ resource "google_sql_database_instance" "instance" {
 
 var testGoogleSqlDatabaseInstance_basic3_update = `
 resource "google_sql_database_instance" "instance" {
+  name                = "%s"
   region              = "us-central1"
   database_version    = "MYSQL_8_0"
   deletion_protection = false

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1277,13 +1277,16 @@ func TestAccSqlDatabaseInstance_SqlServerAuditConfig(t *testing.T) {
 func TestAccSqlDatabaseInstance_mysqlMajorVersionUpgrade(t *testing.T) {
 	t.Parallel()
 
+	databaseName := "tf-test-" + randString(t, 10)
+
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_basic3,
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_basic3, databaseName),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1292,7 +1295,8 @@ func TestAccSqlDatabaseInstance_mysqlMajorVersionUpgrade(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_basic3_update,
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_basic3_update, databaseName),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This should prevent `TestAccSqlDatabaseInstance_mysqlMajorVersionUpgrade` from failing in VCR replaying mode. The test takes about 30 mins to run in recording.

Reason that `TestAccSqlDatabaseInstance_mysqlMajorVersionUpgrade` failed in VCR replaying currently:
The test is using a config `testGoogleSqlDatabaseInstance_basic2` which does have the `name` set.
If the name of the sql instance is not explicitly specified, [Terraform will randomly generate one during creation](https://github.com/hashicorp/terraform-provider-google-beta/blob/main/google-beta/resource_sql_database_instance.go#L854), and therefore it creates randomness and makes the test failed in replaying.

The other place `testGoogleSqlDatabaseInstance_basic2` used is in test `TestAccSqlDatabaseInstance_basicInferredName`. The test is intentionally set up to test if the name can be generated when it's not specified by users and it's skipped in VCR. 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```