### PR TITLE
Bigtable: Retry GC policy operations with a longer poll interval

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -202,10 +202,14 @@ func resourceBigtableGCPolicyUpsert(d *schema.ResourceData, meta interface{}) er
 	tableName := d.Get("table").(string)
 	columnFamily := d.Get("column_family").(string)
 
-	err = retryTimeDuration(func() error {
+	retryFunc := func() (interface{}, error) {
 		reqErr := c.SetGCPolicy(ctx, tableName, columnFamily, gcPolicy)
-		return reqErr
-	}, d.Timeout(schema.TimeoutCreate), isBigTableRetryableError)
+		return "", reqErr
+	}
+	// The default create timeout is 20 minutes.
+	timeout := d.Timeout(schema.TimeoutCreate)
+	pollInterval := time.Duration(30) * time.Second
+	_, err = retryWithPolling(retryFunc, timeout, pollInterval, isBigTableRetryableError)
 	if err != nil {
 		return err
 	}
@@ -376,10 +380,14 @@ func resourceBigtableGCPolicyDestroy(d *schema.ResourceData, meta interface{}) e
 
 	defer c.Close()
 
-	err = retryTimeDuration(func() error {
+	retryFunc := func() (interface{}, error) {
 		reqErr := c.SetGCPolicy(ctx, d.Get("table").(string), d.Get("column_family").(string), bigtable.NoGcPolicy())
-		return reqErr
-	}, d.Timeout(schema.TimeoutDelete), isBigTableRetryableError)
+		return "", reqErr
+	}
+	// The default delete timeout is 20 minutes.
+	timeout := d.Timeout(schema.TimeoutDelete)
+	pollInterval := time.Duration(30) * time.Second
+	_, err = retryWithPolling(retryFunc, timeout, pollInterval, isBigTableRetryableError)
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -209,6 +209,9 @@ func resourceBigtableGCPolicyUpsert(d *schema.ResourceData, meta interface{}) er
 	// The default create timeout is 20 minutes.
 	timeout := d.Timeout(schema.TimeoutCreate)
 	pollInterval := time.Duration(30) * time.Second
+	// Mutations to gc policies can only happen one-at-a-time and take some amount of time.
+	// Use a fixed polling rate of 30s based on the RetryInfo returned by the server rather than
+	// the standard up-to-10s exponential backoff for those operations.
 	_, err = retryWithPolling(retryFunc, timeout, pollInterval, isBigTableRetryableError)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

A followup of PR/6581, use the utility function to retry GC policy operations with a longer poll interval.
With this, we hope our users will have less chance of running out of the API quota.

See the internal bug for details: b/247584824.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: retry GC policy operations with a longer poll interval
```
