### PR TITLE
Add support for GPU sharing on GKE

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -2274,6 +2274,10 @@ resource "google_container_node_pool" "np_with_gpu" {
       type  = "nvidia-tesla-a100"
       gpu_partition_size = "1g.5gb"
       count = 1
+	  gpu_sharing_config {
+		gpu_sharing_strategy = "TIME_SHARING"
+		max_shared_clients_per_gpu = 2
+	  }
     }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -2274,10 +2274,10 @@ resource "google_container_node_pool" "np_with_gpu" {
       type  = "nvidia-tesla-a100"
       gpu_partition_size = "1g.5gb"
       count = 1
-	  gpu_sharing_config {
-		gpu_sharing_strategy = "TIME_SHARING"
-		max_shared_clients_per_gpu = 2
-	  }
+      gpu_sharing_config {
+        gpu_sharing_strategy = "TIME_SHARING"
+        max_shared_clients_per_gpu = 2
+      }
     }
   }
 }

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -108,20 +108,20 @@ func schemaNodeConfig() *schema.Schema {
 								Optional:     true,
 								ForceNew:     true,
 								ConfigMode: schema.SchemaConfigModeAttr,
-								Description:  `The configuration for GPU sharing options.`,
+								Description:  `Configuration for GPU sharing.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"gpu_sharing_strategy": &schema.Schema{
 											Type:        schema.TypeString,
 											Required:    true,
 											ForceNew:    true,
-											Description: `The type of GPU sharing strategy to enable on the GPU node. Possible value is TIME_SHARING`,
+											Description: `The type of GPU sharing strategy to enable on the GPU node. Possible values are described in the API package (https://pkg.go.dev/google.golang.org/api/container/v1#GPUSharingConfig)`,
 										},
 										"max_shared_clients_per_gpu": &schema.Schema{
 											Type:        schema.TypeInt,
 											Required:    true,
 											ForceNew:    true,
-											Description: `The max number of containers that can share a GPU.`,
+											Description: `The maximum number of containers that can share a GPU.`,
 										},
 									},
 								},
@@ -521,13 +521,11 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 				GpuPartitionSize: data["gpu_partition_size"].(string),
 			}
 
-			if v, ok := data["gpu_sharing_config"]; ok {
-				if len(v.([]interface{})) > 0 {
-					gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
-					guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
-						GpuSharingStrategy: gpuSharingConfig["gpu_sharing_strategy"].(string),
-						MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
-					}
+			if v, ok := data["gpu_sharing_config"]; ok && len(v.([]interface{})) > 0 {
+				gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
+				guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
+					GpuSharingStrategy: gpuSharingConfig["gpu_sharing_strategy"].(string),
+					MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
 				}
 			}
 

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -102,6 +102,30 @@ func schemaNodeConfig() *schema.Schema {
 								ForceNew:         true,
 								Description: `Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig user guide (https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning)`,
 							},
+							"gpu_sharing_config": &schema.Schema{
+								Type:         schema.TypeList,
+								MaxItems:     1,
+								Optional:     true,
+								ForceNew:     true,
+								ConfigMode: schema.SchemaConfigModeAttr,
+								Description:  `The configuration for GPU sharing options.`,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"gpu_sharing_strategy": &schema.Schema{
+											Type:        schema.TypeString,
+											Required:    true,
+											ForceNew:    true,
+											Description: `The type of GPU sharing strategy to enable on the GPU node. Possible value is TIME_SHARING`,
+										},
+										"max_shared_clients_per_gpu": &schema.Schema{
+											Type:        schema.TypeInt,
+											Required:    true,
+											ForceNew:    true,
+											Description: `The max number of containers that can share a GPU.`,
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -491,11 +515,23 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 			if data["count"].(int) == 0 {
 				continue
 			}
-			guestAccelerators = append(guestAccelerators, &container.AcceleratorConfig{
+			guestAcceleratorConfig := &container.AcceleratorConfig{
 				AcceleratorCount: int64(data["count"].(int)),
 				AcceleratorType:  data["type"].(string),
 				GpuPartitionSize: data["gpu_partition_size"].(string),
-			})
+			}
+
+			if v, ok := data["gpu_sharing_config"]; ok {
+				if len(v.([]interface{})) > 0 {
+					gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
+					guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
+						GpuSharingStrategy: gpuSharingConfig["gpu_sharing_strategy"].(string),
+						MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
+					}
+				}
+			}
+
+			guestAccelerators = append(guestAccelerators, guestAcceleratorConfig)
 		}
 		nc.Accelerators = guestAccelerators
 	}
@@ -795,11 +831,20 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 func flattenContainerGuestAccelerators(c []*container.AcceleratorConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	for _, accel := range c {
-		result = append(result, map[string]interface{}{
+		accelerator := map[string]interface{}{
 			"count": accel.AcceleratorCount,
 			"type":  accel.AcceleratorType,
 			"gpu_partition_size": accel.GpuPartitionSize,
-		})
+		}
+		if accel.GpuSharingConfig != nil {
+			accelerator["gpu_sharing_config"] = []map[string]interface{}{
+				{
+					"gpu_sharing_strategy": accel.GpuSharingConfig.GpuSharingStrategy,
+					"max_shared_clients_per_gpu": accel.GpuSharingConfig.MaxSharedClientsPerGpu,
+				},
+			}
+		}
+		result = append(result, accelerator)
 	}
 	return result
 }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -847,7 +847,8 @@ linux_node_config {
 
 <a name="nested_gpu_sharing_config"></a>The `gpu_sharing_config` block supports:
 
-* `gpu_sharing_strategy` (Required) - The type of GPU sharing strategy to enable on the GPU node. Possible value is `TIME_SHARING`.
+* `gpu_sharing_strategy` (Required) - The type of GPU sharing strategy to enable on the GPU node. Accepted values are:
+    * `"TIME_SHARING"`: Allow multiple containers to have [time-shared](https://cloud.google.com/kubernetes-engine/docs/concepts/timesharing-gpus) access to a single GPU device. 
 
 * `max_shared_clients_per_gpu` (Required) - The max number of containers that can share a GPU.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -847,10 +847,11 @@ linux_node_config {
 
 <a name="nested_gpu_sharing_config"></a>The `gpu_sharing_config` block supports:
 
-* `gpu_sharing_strategy` (Required) - The type of GPU sharing strategy to enable on the GPU node. Accepted values are:
+* `gpu_sharing_strategy` (Required) - The type of GPU sharing strategy to enable on the GPU node. 
+    Accepted values are:
     * `"TIME_SHARING"`: Allow multiple containers to have [time-shared](https://cloud.google.com/kubernetes-engine/docs/concepts/timesharing-gpus) access to a single GPU device. 
 
-* `max_shared_clients_per_gpu` (Required) - The max number of containers that can share a GPU.
+* `max_shared_clients_per_gpu` (Required) - The max number of containers that can share a GPU. 
 
 <a name="nested_workload_identity_config"></a> The `workload_identity_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -843,7 +843,7 @@ linux_node_config {
 
 * `gpu_partition_size` (Optional) - Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig [user guide](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning).
 
-* `gpu_sharing_config` (Optional) - The configuration for GPU sharing options. Structure is [documented below](#nested_gpu_sharing_config).
+* `gpu_sharing_config` (Optional) - Configuration for GPU sharing. Structure is [documented below](#nested_gpu_sharing_config).
 
 <a name="nested_gpu_sharing_config"></a>The `gpu_sharing_config` block supports:
 
@@ -851,7 +851,7 @@ linux_node_config {
     Accepted values are:
     * `"TIME_SHARING"`: Allow multiple containers to have [time-shared](https://cloud.google.com/kubernetes-engine/docs/concepts/timesharing-gpus) access to a single GPU device. 
 
-* `max_shared_clients_per_gpu` (Required) - The max number of containers that can share a GPU. 
+* `max_shared_clients_per_gpu` (Required) - The maximum number of containers that can share a GPU. 
 
 <a name="nested_workload_identity_config"></a> The `workload_identity_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -843,6 +843,14 @@ linux_node_config {
 
 * `gpu_partition_size` (Optional) - Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig [user guide](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning).
 
+* `gpu_sharing_config` (Optional) - The configuration for GPU sharing options. Structure is [documented below](#nested_gpu_sharing_config).
+
+<a name="nested_gpu_sharing_config"></a>The `gpu_sharing_config` block supports:
+
+* `gpu_sharing_strategy` (Required) - The type of GPU sharing strategy to enable on the GPU node. Possible value is `TIME_SHARING`.
+
+* `max_shared_clients_per_gpu` (Required) - The max number of containers that can share a GPU.
+
 <a name="nested_workload_identity_config"></a> The `workload_identity_config` block supports:
 
 * `workload_pool` (Optional) - The workload pool to attach all Kubernetes service accounts to.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Implement GKE GPU sharing config settings.
fix: https://github.com/hashicorp/terraform-provider-google/issues/12679

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `node_config.0.guest_accelerator.0.gpu_sharing_config` field to `google_container_node_pool` resource
```