### PR TITLE
Add resource override to tainted on create failures

### DIFF
--- a/mmv1/overrides/terraform/resource_override.rb
+++ b/mmv1/overrides/terraform/resource_override.rb
@@ -94,7 +94,12 @@ module Overrides
           :read_error_transform,
 
           # If true, only generate tests and cgc samples
-          :cgc_only
+          :cgc_only,
+
+          # If true, resources that failed creation will be marked as tainted. As a consequence
+          # these resources will be deleted and recreated on the next apply call. This pattern
+          # is preferred over deleting the resource directly in post_create_failure hooks.
+          :taint_resource_on_failed_create
         ]
       end
 
@@ -130,6 +135,7 @@ module Overrides
         check :supports_indirect_user_project_override, type: :boolean, default: false
         check :read_error_transform, type: String
         check :cgc_only, type: :boolean, default: false
+        check :taint_resource_on_failed_create, type: :boolean, default: false
       end
 
       def apply(resource)

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -284,8 +284,10 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%        if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
 <%        end -%>
+<% unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
+<%  end -%>         
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 
@@ -335,8 +337,10 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%      if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
 <%      end -%>
+<% unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
+<%      end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 


### PR DESCRIPTION
Adds the `taint_resource_on_failed_create` resource override for code generation which adds a taint on the resource when its creation fails rather than deleting it from the .tfstate.

Many APIs keep remote resources when LROs fail, so as to allow the user to debug what can be a long, error prone provisioning process. In the current system, the .tfstate and remote are out of sync and users need to manually reconcile changes. Marking the resource as tainted will force the resource's recreation on the next `terraform apply`. This has the benefit over deletion in post_create_failure hooks as it allows users the chance to review errors and other status information then fix and untaint the resource.

Context: https://yaqs.corp.google.com/eng/q/8870145130338713600

Tested manually in cloud-graphite-eng/magic-modules-private-overrides/+/40611.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
