### PR TITLE
Added member output only field in service account resource and multiple service account datasources

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_app_engine_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_app_engine_default_service_account.go
@@ -31,6 +31,10 @@ func dataSourceGoogleAppEngineDefaultServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"member": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -74,6 +78,9 @@ func dataSourceGoogleAppEngineDefaultServiceAccountRead(d *schema.ResourceData, 
 	}
 	if err := d.Set("display_name", sa.DisplayName); err != nil {
 		return fmt.Errorf("Error setting display_name: %s", err)
+	}
+	if err := d.Set("member", "serviceAccount:"+sa.Email); err != nil {
+		return fmt.Errorf("Error setting member: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -16,6 +17,10 @@ func dataSourceGoogleBigqueryDefaultServiceAccount() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"member": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -45,6 +50,9 @@ func dataSourceGoogleBigqueryDefaultServiceAccountRead(d *schema.ResourceData, m
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("member", "serviceAccount:"+projectResource.Email); err != nil {
+		return fmt.Errorf("Error setting member: %s", err)
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account.go
@@ -35,6 +35,10 @@ func dataSourceGoogleServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"member": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -74,6 +78,9 @@ func dataSourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}
 	}
 	if err := d.Set("display_name", sa.DisplayName); err != nil {
 		return fmt.Errorf("Error setting display_name: %s", err)
+	}
+	if err := d.Set("member", "serviceAccount:"+sa.Email); err != nil {
+		return fmt.Errorf("Error setting member: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_project_service_account.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -21,6 +22,10 @@ func dataSourceGoogleStorageProjectServiceAccount() *schema.Resource {
 				ForceNew: true,
 			},
 			"email_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"member": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -56,6 +61,9 @@ func dataSourceGoogleStorageProjectServiceAccountRead(d *schema.ResourceData, me
 	}
 	if err := d.Set("email_address", serviceAccount.EmailAddress); err != nil {
 		return fmt.Errorf("Error setting email_address: %s", err)
+	}
+	if err := d.Set("member", "serviceAccount:"+serviceAccount.EmailAddress); err != nil {
+		return fmt.Errorf("Error setting member: %s", err)
 	}
 
 	d.SetId(serviceAccount.EmailAddress)

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
@@ -23,6 +23,10 @@ func dataSourceGoogleStorageTransferProjectServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"member": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -53,6 +57,9 @@ func dataSourceGoogleStorageTransferProjectServiceAccountRead(d *schema.Resource
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("member", "serviceAccount:"+serviceAccount.AccountEmail); err != nil {
+		return fmt.Errorf("Error setting member: %s", err)
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/resources/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/resources/resource_google_service_account.go
@@ -69,6 +69,11 @@ func resourceGoogleServiceAccount() *schema.Resource {
 				ForceNew:    true,
 				Description: `The ID of the project that the service account will be created in. Defaults to the provider project configuration.`,
 			},
+			"member": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Identity of the service account in the form 'serviceAccount:{email}'. This value is often used to refer to the service account in order to grant IAM permissions.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -180,6 +185,9 @@ func resourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}) 
 	}
 	if err := d.Set("disabled", sa.Disabled); err != nil {
 		return fmt.Errorf("Error setting disabled: %s", err)
+	}
+	if err := d.Set("member", "serviceAccount:"+sa.Email); err != nil {
+		return fmt.Errorf("Error setting member: %s", err)
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/tests/data_source_google_app_engine_default_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_app_engine_default_service_account_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceGoogleAppEngineDefaultServiceAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "unique_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "member"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/data_source_google_bigquery_default_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_bigquery_default_service_account_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic(t *testing.T) {
 				Config: testAccCheckGoogleBigqueryDefaultServiceAccount_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "email"),
+					resource.TestCheckResourceAttrSet(resourceName, "member"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/data_source_google_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_service_account_test.go
@@ -26,6 +26,7 @@ func TestAccDatasourceGoogleServiceAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "unique_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "member"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/data_source_google_storage_project_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_storage_project_service_account_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceGoogleStorageProjectServiceAccount_basic(t *testing.T) {
 				Config: testAccCheckGoogleStorageProjectServiceAccount_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "email_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "member"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/data_source_google_storage_transfer_project_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_storage_transfer_project_service_account_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceGoogleStorageTransferProjectServiceAccount_basic(t *testin
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "email"),
 					resource.TestCheckResourceAttrSet(resourceName, "subject_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "member"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/resource_google_service_account_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_service_account_test.go
@@ -30,6 +30,8 @@ func TestAccServiceAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_service_account.acceptance", "project", project),
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "member", "serviceAccount:"+expectedEmail),
 				),
 			},
 			{
@@ -103,6 +105,8 @@ func TestAccServiceAccount_Disabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_service_account.acceptance", "project", project),
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "member", "serviceAccount:"+expectedEmail),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/website/docs/d/app_engine_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/app_engine_default_service_account.html.markdown
@@ -38,3 +38,5 @@ The following attributes are exported:
 * `name` - The fully-qualified name of the service account.
 
 * `display_name` - The display name for the service account.
+
+* `member` - The Identity of the service account in the form `serviceAccount:{email}`. This value is often used to refer to the service account in order to grant IAM permissions.

--- a/mmv1/third_party/terraform/website/docs/d/bigquery_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/bigquery_default_service_account.html.markdown
@@ -42,3 +42,5 @@ The following attributes are exported:
 
 * `email` - The email address of the service account. This value is often used to refer to the service account
 in order to grant IAM permissions.
+
+* `member` - The Identity of the service account in the form `serviceAccount:{email}`. This value is often used to refer to the service account in order to grant IAM permissions.

--- a/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
@@ -69,3 +69,5 @@ exported:
 * `name` - The fully-qualified name of the service account.
 
 * `display_name` - The display name for the service account.
+
+* `member` - The Identity of the service account in the form `serviceAccount:{email}`. This value is often used to refer to the service account in order to grant IAM permissions.

--- a/mmv1/third_party/terraform/website/docs/d/storage_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_project_service_account.html.markdown
@@ -96,3 +96,5 @@ The following attributes are exported:
 
 * `email_address` - The email address of the service account. This value is often used to refer to the service account
 in order to grant IAM permissions.
+
+* `member` - The Identity of the service account in the form `serviceAccount:{email_address}`. This value is often used to refer to the service account in order to grant IAM permissions.

--- a/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
@@ -33,3 +33,4 @@ The following attributes are exported:
 
 * `email` - Email address of the default service account used by Storage Transfer Jobs running in this project.
 * `subject_id` - Unique identifier for the service account.
+* `member` - The Identity of the service account in the form `serviceAccount:{email}`. This value is often used to refer to the service account in order to grant IAM permissions.

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -67,6 +67,8 @@ exported:
 
 * `unique_id` - The unique id of the service account.
 
+* `member` - The Identity of the service account in the form `serviceAccount:{email}`. This value is often used to refer to the service account in order to grant IAM permissions.
+
 ## Timeouts
 
 This resource provides the following


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added member output only field in service account resource and multiple service account datasources.
fixes https://github.com/hashicorp/terraform-provider-google/issues/12193

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
appengine: added `member` field to `google_app_engine_default_service_account` datasource
```
```release-note:enhancement
bigquery: added `member` field to `google_bigquery_default_service_account` datasource
```
```release-note:enhancement
storage: added `member` field to `google_storage_project_service_account` and `google_storage_transfer_project_service_account` datasource
```
```release-note:enhancement
serviceaccount: added `member` field to `google_service_account` resource and datasource
```
