### PR TITLE
Add rules field to google_compute_router_nat

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13605,6 +13605,65 @@ objects:
               - :ERRORS_ONLY
               - :TRANSLATIONS_ONLY
               - :ALL
+      - !ruby/object:Api::Type::Array
+        name: rules
+        description: 'A list of rules associated with this NAT.'
+        send_empty_value: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'ruleNumber'
+              description: |
+                An integer uniquely identifying a rule in the list.
+                The rule number must be a positive value between 0 and 65000, and must be unique among rules within a NAT.
+              required: true
+              send_empty_value: true
+            - !ruby/object:Api::Type::String
+              name: 'description'
+              description: 'An optional description of this rule.'
+            - !ruby/object:Api::Type::String
+              name: 'match'
+              description: |
+                CEL expression that specifies the match condition that egress traffic from a VM is evaluated against.
+                If it evaluates to true, the corresponding action is enforced.
+
+                The following examples are valid match expressions for public NAT:
+
+                "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
+
+                "destination.ip == '1.1.0.1' || destination.ip == '8.8.8.8'"
+
+                The following example is a valid match expression for private NAT:
+
+                "nexthop.hub == 'https://networkconnectivity.googleapis.com/v1alpha1/projects/my-project/global/hub/hub-1'"
+              required: true
+            - !ruby/object:Api::Type::NestedObject
+              name: 'action'
+              description: 'The action to be enforced for traffic that matches this rule.'
+              properties:
+                - !ruby/object:Api::Type::Array
+                  name: 'sourceNatActiveIps'
+                  description: |
+                    A list of URLs of the IP resources used for this NAT rule.
+                    These IP addresses must be valid static external IP addresses assigned to the project.
+                    This field is used for public NAT.
+                  item_type: !ruby/object:Api::Type::ResourceRef
+                    name: 'address'
+                    resource: 'Address'
+                    imports: 'selfLink'
+                    description: 'A reference to an address associated with this NAT'
+                - !ruby/object:Api::Type::Array
+                  name: 'sourceNatDrainIps'
+                  description: |
+                    A list of URLs of the IP resources to be drained.
+                    These IPs must be valid static external IPs that have been assigned to the NAT.
+                    These IPs should be used for updating/patching a NAT rule only.
+                    This field is used for public NAT.
+                  item_type: !ruby/object:Api::Type::ResourceRef
+                    name: 'address'
+                    resource: 'Address'
+                    imports: 'selfLink'
+                    description: 'A reference to an address associated with this NAT'
       - !ruby/object:Api::Type::Boolean
         name: enableEndpointIndependentMapping
         description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2560,6 +2560,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "my-network"
           subnet_name: "my-subnetwork"
           address_name: "nat-manual-ip"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "router_nat_rules"
+        primary_resource_id: "nat_rules"
+        skip_test: true
+        vars:
+          router_name: "my-router"
+          nat_name: "my-router-nat"
+          network_name: "my-network"
+          subnet_name: "my-subnetwork"
+          address_name1: "nat-address1"
+          address_name2: "nat-address2"
+          address_name3: "nat-address3"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
@@ -2590,6 +2602,22 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
       enableDynamicPortAllocation: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      rules: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+        set_hash_func: computeRouterNatRulesHash
+      rules.ruleNumber: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: validation.IntBetween(0, 65000)
+      rules.action: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      rules.action.sourceNatActiveIps: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+        set_hash_func: computeRouterNatIPsHash
+        custom_flatten: 'templates/terraform/custom_flatten/nat_rules_ip_set.erb'
+      rules.action.sourceNatDrainIps: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+        set_hash_func: computeRouterNatIPsHash
+        custom_flatten: 'templates/terraform/custom_flatten/nat_rules_ip_set.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: 'templates/terraform/constants/router_nat.go.erb'
       resource_definition: 'templates/terraform/resource_definition/router_nat.go.erb'

--- a/mmv1/templates/terraform/constants/router_nat.go.erb
+++ b/mmv1/templates/terraform/constants/router_nat.go.erb
@@ -97,3 +97,45 @@ func computeRouterNatIPsHash(v interface{}) int {
 	}
 	return schema.HashString(GetResourceNameFromSelfLink(val))
 }
+
+func computeRouterNatRulesHash(v interface{}) int {
+	obj := v.(map[string]interface{})
+	ruleNumber := obj["rule_number"].(int)
+
+	description := obj["description"]
+	descriptionHash := 0
+	if description != nil {
+		descriptionHash = schema.HashString(description.(string))
+	}
+
+	match := obj["match"].(string)
+
+	sourceNatActiveIpHash := 0
+	sourceNatDrainIpHash := 0
+	if obj["action"] != nil {
+		actions := obj["action"].([]interface{})
+		if len(actions) != 0 && actions[0] != nil {
+			action := actions[0].(map[string]interface{})
+
+			sourceNatActiveIps := action["source_nat_active_ips"]
+			if sourceNatActiveIps != nil {
+				sourceNatActiveIpSet := sourceNatActiveIps.(*schema.Set)
+				for _, sourceNatActiveIp := range sourceNatActiveIpSet.List() {
+					sourceNatActiveIpStr := fmt.Sprintf("source_nat_active_ips-%d", computeRouterNatIPsHash(sourceNatActiveIp.(string)))
+					sourceNatActiveIpHash += schema.HashString(sourceNatActiveIpStr)
+				}
+			}
+
+			soureNatDrainIps := action["source_nat_drain_ips"]
+			if soureNatDrainIps != nil {
+				soureNatDrainIpSet := soureNatDrainIps.(*schema.Set)
+				for _, soureNatDrainIp := range soureNatDrainIpSet.List() {
+					sourceNatDrainIpStr := fmt.Sprintf("source_nat_drain_ips-%d", computeRouterNatIPsHash(soureNatDrainIp.(string)))
+					sourceNatDrainIpHash += schema.HashString(sourceNatDrainIpStr)
+				}
+			}
+		}
+	}
+
+	return ruleNumber + descriptionHash + schema.HashString(match) + sourceNatActiveIpHash + sourceNatDrainIpHash
+}

--- a/mmv1/templates/terraform/custom_flatten/nat_rules_ip_set.erb
+++ b/mmv1/templates/terraform/custom_flatten/nat_rules_ip_set.erb
@@ -1,0 +1,6 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return v
+	}
+	return schema.NewSet(computeRouterNatIPsHash, convertStringArrToInterface(convertAndMapStringArr(v.([]interface{}), ConvertSelfLinkToV1)))
+}

--- a/mmv1/templates/terraform/examples/router_nat_rules.tf.erb
+++ b/mmv1/templates/terraform/examples/router_nat_rules.tf.erb
@@ -1,0 +1,58 @@
+resource "google_compute_network" "net" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "<%= ctx[:vars]['subnet_name'] %>"
+  network       = google_compute_network.net.id
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "router" {
+  name    = "<%= ctx[:vars]['router_name'] %>"
+  region  = google_compute_subnetwork.subnet.region
+  network = google_compute_network.net.id
+}
+
+resource "google_compute_address" "addr1" {
+  name   = "<%= ctx[:vars]['address_name1'] %>"
+  region = google_compute_subnetwork.subnet.region
+}
+
+resource "google_compute_address" "addr2" {
+  name   = "<%= ctx[:vars]['address_name2'] %>"
+  region = google_compute_subnetwork.subnet.region
+}
+
+resource "google_compute_address" "addr3" {
+  name   = "<%= ctx[:vars]['address_name3'] %>"
+  region = google_compute_subnetwork.subnet.region
+}
+
+resource "google_compute_router_nat" "<%= ctx[:primary_resource_id] %>" {
+  name   = "<%= ctx[:vars]['nat_name'] %>"
+  router = google_compute_router.router.name
+  region = google_compute_router.router.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.subnet.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = 100
+    description = "nat rules example"
+    match       = "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
+    action {
+      source_nat_active_ips = [google_compute_address.addr2.self_link, google_compute_address.addr3.self_link]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}

--- a/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -277,6 +277,129 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 
 <% end -%>
 
+func TestAccComputeRouterNat_withNatRules(t *testing.T) {
+	t.Parallel()
+
+	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+	ruleDescription := randString(t, 10)
+	ruleDescriptionUpdate := randString(t, 10)
+	match := "inIpRange(destination.ip, '1.1.0.0/16') || inIpRange(destination.ip, '2.2.0.0/16')"
+	matchUpdate := "destination.ip == '1.1.0.1' || destination.ip == '8.8.8.8'"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterNatRulesBasic_omitRules(routerName),
+			},
+			{
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic(routerName, 0, ruleDescription, match),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic(routerName, 65000, ruleDescription, match),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic(routerName, 100, ruleDescription, match),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic(routerName, 100, ruleDescriptionUpdate, match),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic(routerName, 100, ruleDescriptionUpdate, matchUpdate),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesWithSourceActiveAndDrainIps(routerName, 100, ruleDescriptionUpdate, matchUpdate),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesWithDrainIps(routerName, 100, ruleDescriptionUpdate, matchUpdate),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatMultiRules(routerName),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic_omitAction(routerName, 100, ruleDescriptionUpdate, matchUpdate),
+			},
+			{
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic_omitDescription(routerName, 100, matchUpdate),
+			},
+			{
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatMultiRulesWithIpId(routerName),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNatRulesBasic_omitRules(routerName),
+			},
+			{
+				ResourceName: "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -715,7 +838,6 @@ resource "google_compute_router_nat" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName, enableEndpointIndependentMapping, enableDynamicPortAllocation, minPortsPerVm, maxPortsPerVm)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRouterNatBaseResourcesWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -745,14 +867,20 @@ resource "google_compute_address" "addr3" {
   region = google_compute_subnetwork.foobar.region
 }
 
+resource "google_compute_address" "addr4" {
+  name   = "%s-addr4"
+  region = google_compute_subnetwork.foobar.region
+}
+
 resource "google_compute_router" "foobar" {
   name     = "%s"
   region   = google_compute_subnetwork.foobar.region
   network  = google_compute_network.foobar.self_link
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeRouterNatWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 %s
@@ -861,8 +989,293 @@ resource "google_compute_router_nat" "foobar" {
 }
 `, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
-
 <% end -%>
+
+func testAccComputeRouterNatRulesBasic_omitRules(routerName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
+}
+
+func testAccComputeRouterNatRulesBasic_omitAction(routerName string, ruleNumber int, ruleDescription string, ruleMatch string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    description = "%s"
+    match       = "%s"
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName, ruleNumber, ruleDescription, ruleMatch)
+}
+
+func testAccComputeRouterNatRulesBasic_omitDescription(routerName string, ruleNumber int, ruleMatch string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    match       = "%s"
+    action {
+      source_nat_active_ips = [google_compute_address.addr2.self_link, google_compute_address.addr3.self_link]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName, ruleNumber, ruleMatch)
+}
+
+func testAccComputeRouterNatRulesBasic(routerName string, ruleNumber int, ruleDescription string, ruleMatch string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    description = "%s"
+    match       = "%s"
+    action {
+      source_nat_active_ips = [google_compute_address.addr2.self_link, google_compute_address.addr3.self_link]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName, ruleNumber, ruleDescription, ruleMatch)
+}
+
+func testAccComputeRouterNatRulesWithSourceActiveAndDrainIps(routerName string, ruleNumber int, ruleDescription string, ruleMatch string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    description = "%s"
+    match       = "%s"
+    action {
+      source_nat_active_ips = [google_compute_address.addr2.self_link]
+      source_nat_drain_ips = [google_compute_address.addr3.self_link]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName, ruleNumber, ruleDescription, ruleMatch)
+}
+
+func testAccComputeRouterNatRulesWithDrainIps(routerName string, ruleNumber int, ruleDescription string, ruleMatch string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    description = "%s"
+    match       = "%s"
+    action {
+      source_nat_drain_ips = [google_compute_address.addr2.self_link]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName, ruleNumber, ruleDescription, ruleMatch)
+}
+
+func testAccComputeRouterNatMultiRules(routerName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.self_link]
+
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = 100
+    description = "a"
+    match       = "destination.ip == '1.1.1.1' || destination.ip == '2.2.2.2'"
+    action {
+      source_nat_active_ips = [google_compute_address.addr2.self_link]
+    }
+  }
+
+  rules {
+    rule_number = 5000
+    description = "b"
+    match       = "destination.ip == '3.3.3.3' || destination.ip == '4.4.4.4'"
+    action {
+      source_nat_active_ips = [google_compute_address.addr3.self_link]
+    }
+  }
+
+  rules {
+    rule_number = 300
+    description = "c"
+    match       = "destination.ip == '5.5.5.5' || destination.ip == '8.8.8.8'"
+    action {
+      source_nat_active_ips = [google_compute_address.addr4.self_link]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
+}
+
+func testAccComputeRouterNatMultiRulesWithIpId(routerName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name     = "%s"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.addr1.id]
+
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.foobar.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = 100
+    description = "a"
+    match       = "destination.ip == '1.1.1.1' || destination.ip == '2.2.2.2'"
+    action {
+      source_nat_active_ips = [google_compute_address.addr2.id]
+    }
+  }
+
+  rules {
+    rule_number = 5000
+    description = "b"
+    match       = "destination.ip == '3.3.3.3' || destination.ip == '4.4.4.4'"
+    action {
+      source_nat_active_ips = [google_compute_address.addr3.id]
+    }
+  }
+
+  rules {
+    rule_number = 300
+    description = "c"
+    match       = "destination.ip == '5.5.5.5' || destination.ip == '8.8.8.8'"
+    action {
+      source_nat_active_ips = [google_compute_address.addr4.id]
+    }
+  }
+
+  enable_endpoint_independent_mapping = false
+}
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
+}
 
 func testAccComputeRouterNatKeepRouter(routerName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add rules field to google_compute_router_nat

API: https://cloud.google.com/compute/docs/reference/rest/v1/routers
Issue: https://github.com/hashicorp/terraform-provider-google/issues/12179



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added general field `rules` to `google_compute_router_nat`
```
