### PR TITLE
Add github workflow to update status on Label Action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Add comment
+name: Update Breaking Change Status
 on:
   pull_request:
     types:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
       - labeled
 jobs:
   add-comment:
-    if: github.event.label.id == '4598495472' # The unique identifier for the override-breaking change label.. used in place of name so the name can be modified without breaking usage
+    if: github.event.label.id == '4598495472' # The unique identifier for the override-breaking-change label.. used in place of name so the name can be modified without breaking usage
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,10 @@
-name: Update Breaking Change Status
+name: update-breaking-change-status
 on:
   pull_request:
     types:
       - labeled
 jobs:
-  add-comment:
+  update-breaking-change-status:
     if: github.event.label.id == '4598495472' # The unique identifier for the override-breaking-change label.. used in place of name so the name can be modified without breaking usage
     runs-on: ubuntu-latest
     permissions:
@@ -12,12 +12,13 @@ jobs:
       statuses: write
     steps:
     - uses: actions/checkout@v2
-    - name: Allow breaking change to merged
-      uses: Sibz/github-status-action@v1
-      with: 
-        authToken: ${{secrets.GITHUB_TOKEN}}
-        context: 'terraform-provider-breaking-change-test'
-        description: 'terraform-provider-breaking-change-test'
-        state: 'success'
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
+    - run: | 
+        curl -X POST -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/${{github.event.pull_request.head.sha || github.sha}}" \
+        -d '{
+        "context": "terraform-provider-breaking-change-test",
+        "target_url": "https://console.cloud.google.com/cloud-build/builds",
+        "state": "success"
+        }'
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.label.id == '4598495472' # The unique identifier for the override-breaking-change label.. used in place of name so the name can be modified without breaking usage
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: read
       statuses: write
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
       - labeled
 jobs:
   add-comment:
-    if: github.event.label.id == '4598495472'
+    if: github.event.label.id == '4598495472' # The unique identifier for the override-breaking change label.. used in place of name so the name can be modified without breaking usage
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,23 @@
+name: Add comment
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.id == '4598495472'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+    steps:
+    - uses: actions/checkout@v2
+    - name: Allow breaking change to merged
+      uses: Sibz/github-status-action@v1
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        context: 'terraform-provider-breaking-change-test'
+        description: 'terraform-provider-breaking-change-test'
+        state: 'success'
+        sha: ${{github.event.pull_request.head.sha || github.sha}}
+


### PR DESCRIPTION
This change is being made as part of the magician-breaking-change detection work. 

We are planning to block merging on the status check failing but want to allow the developer the ability to override that. This enables that through a switch of a status check after applying a specific label.

companion to:
https://github.com/GoogleCloudPlatform/magic-modules/pull/6642

go/magician-breaking-change

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
