### PR TITLE
Add custom GKE On-Prem error and operation

### DIFF
--- a/mmv1/overrides/terraform/resource_override.rb
+++ b/mmv1/overrides/terraform/resource_override.rb
@@ -61,6 +61,7 @@ module Overrides
           :virtual_fields,
 
           # TODO(alexstephen): Deprecate once all resources using autogen async.
+          # If true, generates product operation handling logic.
           :autogen_async,
 
           # If true, resource is not importable

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -168,9 +168,7 @@ module Provider
                           ['converters/google/resources/metadata.go',
                            'third_party/terraform/utils/metadata.go.erb'],
                           ['converters/google/resources/compute_instance.go',
-                           'third_party/validator/compute_instance.go.erb'],
-                          ['converters/google/resources/gkeonprem_operation.go',
-                           'third_party/terraform/utils/gkeonprem_operation.go.erb']
+                           'third_party/validator/compute_instance.go.erb']
                         ],
                         file_template)
     end

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -168,7 +168,9 @@ module Provider
                           ['converters/google/resources/metadata.go',
                            'third_party/terraform/utils/metadata.go.erb'],
                           ['converters/google/resources/compute_instance.go',
-                           'third_party/validator/compute_instance.go.erb']
+                           'third_party/validator/compute_instance.go.erb'],
+                          ['converters/google/resources/gkeonprem_operation.go',
+                           'third_party/terraform/utils/gkeonprem_operation.go.erb']
                         ],
                         file_template)
     end

--- a/mmv1/third_party/terraform/utils/gkeonprem_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/gkeonprem_operation.go.erb
@@ -1,0 +1,138 @@
+<% autogen_exception -%>
+package google
+<% if version == 'private' -%>
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+)
+
+type gkeonpremOpError struct {
+	*cloudresourcemanager.Status
+}
+
+func (e gkeonpremOpError) Error() string {
+	var validationCheck map[string]interface{}
+
+	for _, msg := range e.Details {
+		detail := make(map[string]interface{})
+		if err := json.Unmarshal(msg, &detail); err != nil {
+			continue
+		}
+
+		if _, ok := detail["validationCheck"]; ok {
+			delete(detail, "@type")
+			validationCheck = detail
+		}
+	}
+
+	if validationCheck != nil {
+		bytes, err := json.MarshalIndent(validationCheck, "", "  ")
+		if err != nil {
+			return fmt.Sprintf("Error code %v message: %s validation check: %s", e.Code, e.Message, validationCheck)
+		}
+
+		return fmt.Sprintf("Error code %v message: %s\n %s", e.Code, e.Message, bytes)
+	}
+
+	return fmt.Sprintf("Error code %v, message: %s", e.Code, e.Message)
+}
+
+type gkeonpremOperationWaiter struct {
+	Config    *Config
+	UserAgent string
+	Project   string
+	Op        CommonOperation
+}
+
+func (w *gkeonpremOperationWaiter) State() string {
+	if w == nil {
+		return fmt.Sprintf("Operation is nil!")
+	}
+
+	return fmt.Sprintf("done: %v", w.Op.Done)
+}
+
+func (w *gkeonpremOperationWaiter) Error() error {
+	if w != nil && w.Op.Error != nil {
+		return &gkeonpremOpError{w.Op.Error}
+	}
+	return nil
+}
+
+func (w *gkeonpremOperationWaiter) IsRetryable(error) bool {
+	return false
+}
+
+func (w *gkeonpremOperationWaiter) SetOp(op interface{}) error {
+	if err := Convert(op, &w.Op); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *gkeonpremOperationWaiter) OpName() string {
+	if w == nil {
+		return "<nil>"
+	}
+
+	return w.Op.Name
+}
+
+func (w *gkeonpremOperationWaiter) PendingStates() []string {
+	return []string{"done: false"}
+}
+
+func (w *gkeonpremOperationWaiter) TargetStates() []string {
+	return []string{"done: true"}
+}
+
+func (w *gkeonpremOperationWaiter) QueryOp() (interface{}, error) {
+	if w == nil {
+		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
+	}
+	// Returns the proper get.
+	url := fmt.Sprintf("%s%s", w.Config.gkeonpremBasePath, w.Op.Name)
+
+	return sendRequest(w.Config, "GET", w.Project, url, w.UserAgent, nil)
+}
+
+func creategkeonpremWaiter(config *Config, op map[string]interface{}, project, activity, userAgent string) (*gkeonpremOperationWaiter, error) {
+	w := &gkeonpremOperationWaiter{
+		Config:    config,
+		UserAgent: userAgent,
+		Project:   project,
+	}
+	if err := w.SetOp(op); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+// nolint: deadcode,unused
+func gkeonpremOperationWaitTimeWithResponse(config *Config, op map[string]interface{}, response *map[string]interface{}, project, activity, userAgent string, timeout time.Duration) error {
+	w, err := creategkeonpremWaiter(config, op, project, activity, userAgent)
+	if err != nil {
+		return err
+	}
+	if err := OperationWait(w, activity, timeout, config.PollInterval); err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(w.Op.Response), response)
+}
+
+func gkeonpremOperationWaitTime(config *Config, op map[string]interface{}, project, activity, userAgent string, timeout time.Duration) error {
+	if val, ok := op["name"]; !ok || val == "" {
+		// This was a synchronous call - there is no operation to wait for.
+		return nil
+	}
+	w, err := creategkeonpremWaiter(config, op, project, activity, userAgent)
+	if err != nil {
+		// If w is nil, the op was synchronous.
+		return err
+	}
+	return OperationWait(w, activity, timeout, config.PollInterval)
+}
+<% end -%>


### PR DESCRIPTION
The GKE OnPrem API outputs JSON error details in our long-running operations error_details. This isn't supported by mmv1.

This adds a custom implementation of the operation/error type by disabling the async file generation and using our own hand written one.

Our resources are only in the EAP provider today. If there's a way to include this there, let me know. Our API itself is public, so theres no concerns on our end with this being released.


See example: https://screenshot.googleplex.com/4GtiKbrTAQBMF2t
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
