### PR TITLE
Extend service networking connection example

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -15,10 +15,12 @@ and
 ## Example usage
 
 ```hcl
+# Create a VPC network
 resource "google_compute_network" "peering_network" {
   name = "peering-network"
 }
 
+# Create an IP address
 resource "google_compute_global_address" "private_ip_alloc" {
   name          = "private-ip-alloc"
   purpose       = "VPC_PEERING"
@@ -27,13 +29,14 @@ resource "google_compute_global_address" "private_ip_alloc" {
   network       = google_compute_network.peering_network.id
 }
 
+# Create a private connection
 resource "google_service_networking_connection" "default" {
   network                 = google_compute_network.peering_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 
-# Import or export custom routes
+# (Optional) Import or export custom routes
 resource "google_compute_network_peering_routes_config" "peering_routes" {
   peering = google_service_networking_connection.default.peering
   network = google_compute_network.peering_network.name

--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -27,10 +27,19 @@ resource "google_compute_global_address" "private_ip_alloc" {
   network       = google_compute_network.peering_network.id
 }
 
-resource "google_service_networking_connection" "foobar" {
+resource "google_service_networking_connection" "default" {
   network                 = google_compute_network.peering_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}
+
+# Import or export custom routes
+resource "google_compute_network_peering_routes_config" "peering_routes" {
+  peering = google_service_networking_connection.default.peering
+  network = google_compute_network.peering_network.name
+
+  import_custom_routes = true
+  export_custom_routes = true
 }
 ```
 


### PR DESCRIPTION
enocom@ said:

When configuring a service networking connections, customers often want to advertise routes. It's a little tricky figuring this out without an example.


```release-note:none
```
