### PR TITLE
Enable CMEK for Datafusion instance 

### DIFF
--- a/mmv1/products/datafusion/api.yaml
+++ b/mmv1/products/datafusion/api.yaml
@@ -206,3 +206,15 @@ objects:
               project the network should specified in the form of projects/{host-project-id}/global/networks/{network}
             required: true
             input: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'cryptoKeyConfig'
+        description: |
+          The crypto key configuration. This field is used by the Customer-Managed Encryption Keys (CMEK) feature.
+        input: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'keyReference'
+            description: |
+              The name of the key which is used to encrypt/decrypt customer data. For key in Cloud KMS, the key should be in the format of projects/*/locations/*/keyRings/*/cryptoKeys/*.
+            required: true
+            input: true

--- a/mmv1/products/datafusion/terraform.yaml
+++ b/mmv1/products/datafusion/terraform.yaml
@@ -30,6 +30,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "extended_instance"
         vars:
           instance_name: "my-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "data_fusion_instance_cmek"
+        primary_resource_id: "basic_cmek"
+        vars:
+          instance_name: "my-instance"
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/templates/terraform/examples/data_fusion_instance_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_cmek.tf.erb
@@ -1,0 +1,32 @@
+resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
+  name   = "<%= ctx[:vars]["instance_name"] %>"
+  region = "us-central1"
+  type   = "BASIC"
+
+  crypto_key_config {
+    key_reference = google_kms_crypto_key.crypto_key.id
+  }
+
+  depends_on = [google_kms_crypto_key_iam_binding.crypto_key_binding]
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "<%= ctx[:vars]['instance_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "<%= ctx[:vars]['instance_name'] %>"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-datafusion.iam.gserviceaccount.com"
+  ]
+}
+
+data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
@@ -13,7 +13,6 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
     network = "default"
     ip_allocation = "10.89.48.0/22"
   }
-  version = "6.3.0"
   dataproc_service_account = data.google_app_engine_default_service_account.default.email
   # Mark for testing to avoid service networking connection usage that is not cleaned up
   options = {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added support for CMEK for Data fusion instances
fixes https://github.com/hashicorp/terraform-provider-google/issues/10536


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```
datafusion: added `crypto_key_config` field to `google_data_fusion_instance` resource
```
