### PR TITLE
Add fields related to health checked targets to dns_record_set resource

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
@@ -264,6 +264,9 @@ func TestAccDNSRecordSet_uppercaseMX(t *testing.T) {
 func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 	t.Parallel()
 
+	networkName := fmt.Sprintf("tf-test-network-%s", randString(t, 10))
+	backendName := fmt.Sprintf("tf-test-backend-%s", randString(t, 10))
+	forwardingRuleName := fmt.Sprintf("tf-test-forwarding-rule-%s", randString(t, 10))
 	zoneName := fmt.Sprintf("dnszone-test-%s", randString(t, 10))
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -271,7 +274,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordSetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDnsRecordSet_routingPolicyWRR(zoneName, "127.0.0.10", 300, 0.1),
+				Config: testAccDnsRecordSet_routingPolicyWRR(networkName, backendName, forwardingRuleName, zoneName, 300),
 			},
 			{
 				ResourceName:      "google_dns_record_set.foobar",
@@ -280,7 +283,16 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDnsRecordSet_routingPolicyGEO(zoneName, "127.0.0.10", 300, "us-central1"),
+				Config: testAccDnsRecordSet_routingPolicyGEO(networkName, backendName, forwardingRuleName, zoneName, 300),
+			},
+			{
+				ResourceName:  "google_dns_record_set.foobar",
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", getTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:   true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsRecordSet_routingPolicyPrimaryBackup(networkName, backendName, forwardingRuleName, zoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.foobar",
@@ -295,6 +307,9 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 func TestAccDNSRecordSet_changeRouting(t *testing.T) {
 	t.Parallel()
 
+	networkName := fmt.Sprintf("tf-test-network-%s", randString(t, 10))
+	backendName := fmt.Sprintf("tf-test-backend-%s", randString(t, 10))
+	forwardingRuleName := fmt.Sprintf("tf-test-forwarding-rule-%s", randString(t, 10))
 	zoneName := fmt.Sprintf("dnszone-test-%s", randString(t, 10))
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -311,7 +326,7 @@ func TestAccDNSRecordSet_changeRouting(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDnsRecordSet_routingPolicyGEO(zoneName, "127.0.0.10", 300, "us-central1"),
+				Config: testAccDnsRecordSet_routingPolicyGEO(networkName, backendName, forwardingRuleName, zoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.foobar",
@@ -477,8 +492,27 @@ resource "google_dns_record_set" "foobar" {
 `, name, name, name, ttl)
 }
 
-func testAccDnsRecordSet_routingPolicyWRR(zoneName, addr2 string, ttl int, weight float64) string {
+func testAccDnsRecordSet_routingPolicyWRR(networkName, backendName, forwardingRuleName, zoneName string, ttl int) string {
 	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name = "%s"
+}
+
+resource "google_compute_region_backend_service" "backend" {
+  name   = "%s"
+  region = "us-central1"
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name   = "%s"
+  region = "us-central1"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.backend.id
+  all_ports             = true
+  network               = google_compute_network.default.name
+}
+
 resource "google_dns_managed_zone" "parent-zone" {
   name        = "%s"
   dns_name    = "%s.hashicorptest.com."
@@ -493,20 +527,56 @@ resource "google_dns_record_set" "foobar" {
 
   routing_policy {
     wrr {
-      weight       = 0.9
-      rrdatas      = ["127.0.0.1"]
+      weight  = 0
+      rrdatas = ["1.2.3.4", "4.3.2.1"]
     }
+
     wrr {
-      weight       = %g
-      rrdatas      = ["%s"]
+      weight  = 0
+      rrdatas = ["2.3.4.5", "5.4.3.2"]
+    }
+
+    wrr {
+      weight = 1.0
+
+      health_checked_targets {
+        internal_load_balancers {
+          load_balancer_type = "regionalL4ilb"
+          ip_address         = google_compute_forwarding_rule.default.ip_address
+          port               = "80"
+          ip_protocol        = "tcp"
+          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.default.id}"
+          project            = google_compute_forwarding_rule.default.project
+          region             = google_compute_forwarding_rule.default.region
+        }
+      }
     }
   }
 }
-`, zoneName, zoneName, zoneName, ttl, weight, addr2)
+`, networkName, backendName, forwardingRuleName, zoneName, zoneName, zoneName, ttl)
 }
 
-func testAccDnsRecordSet_routingPolicyGEO(zoneName, addr2  string, ttl int, location string) string {
+func testAccDnsRecordSet_routingPolicyGEO(networkName, backendName, forwardingRuleName, zoneName string, ttl int) string {
 	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name = "%s"
+}
+
+resource "google_compute_region_backend_service" "backend" {
+  name   = "%s"
+  region = "us-central1"
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name   = "%s"
+  region = "us-central1"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.backend.id
+  all_ports             = true
+  network               = google_compute_network.default.name
+}
+
 resource "google_dns_managed_zone" "parent-zone" {
   name        = "%s"
   dns_name    = "%s.hashicorptest.com."
@@ -520,17 +590,101 @@ resource "google_dns_record_set" "foobar" {
   ttl          = %d
 
   routing_policy {
+    enable_geo_fencing = true
+
+    geo {
+      location = "us-east4"
+      rrdatas  = ["1.2.3.4", "4.3.2.1"]
+    }
+
     geo {
       location = "asia-east1"
-      rrdatas  = ["127.0.0.1"]
+      rrdatas  = ["2.3.4.5", "5.4.3.2"]
     }
+
     geo {
-      location = "%s"
-      rrdatas  = ["%s"]
+      location = "us-central1"
+
+      health_checked_targets {
+        internal_load_balancers {
+          load_balancer_type = "regionalL4ilb"
+          ip_address         = google_compute_forwarding_rule.default.ip_address
+          port               = "80"
+          ip_protocol        = "tcp"
+          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.default.id}"
+          project            = google_compute_forwarding_rule.default.project
+          region             = google_compute_forwarding_rule.default.region
+        }
+      }
     }
   }
 }
-`, zoneName, zoneName, zoneName, ttl, location, addr2)
+`, networkName, backendName, forwardingRuleName, zoneName, zoneName, zoneName, ttl)
+}
+
+func testAccDnsRecordSet_routingPolicyPrimaryBackup(networkName, backendName, forwardingRuleName, zoneName string, ttl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name = "%s"
+}
+
+resource "google_compute_region_backend_service" "backend" {
+  name   = "%s"
+  region = "us-central1"
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name   = "%s"
+  region = "us-central1"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.backend.id
+  all_ports             = true
+  network               = google_compute_network.default.name
+}
+
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest.com."
+  description = "Test Description"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = "test-record.%s.hashicorptest.com."
+  type         = "A"
+  ttl          = %d
+
+  routing_policy {
+    primary_backup {
+      trickle_ratio                  = 0.1
+      enable_geo_fencing_for_backups = true
+
+      primary {
+        internal_load_balancers {
+          load_balancer_type = "regionalL4ilb"
+          ip_address         = google_compute_forwarding_rule.default.ip_address
+          port               = "80"
+          ip_protocol        = "tcp"
+          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.default.id}"
+          project            = google_compute_forwarding_rule.default.project
+          region             = google_compute_forwarding_rule.default.region
+        }
+      }
+
+      backup_geo {
+        location = "us-west1"
+        rrdatas  = ["1.2.3.4"]
+      }
+
+      backup_geo {
+        location = "asia-east1"
+        rrdatas  = ["5.6.7.8"]
+      }
+    }
+  }
+}
+`, networkName, backendName, forwardingRuleName, zoneName, zoneName, zoneName, ttl)
 }
 
 func testAccDnsRecordSet_interpolated(zoneName string) string {

--- a/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_record_set_test.go.erb
@@ -545,7 +545,7 @@ resource "google_dns_record_set" "foobar" {
           ip_address         = google_compute_forwarding_rule.default.ip_address
           port               = "80"
           ip_protocol        = "tcp"
-          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.default.id}"
+          network_url        = google_compute_network.default.id
           project            = google_compute_forwarding_rule.default.project
           region             = google_compute_forwarding_rule.default.region
         }
@@ -611,7 +611,7 @@ resource "google_dns_record_set" "foobar" {
           ip_address         = google_compute_forwarding_rule.default.ip_address
           port               = "80"
           ip_protocol        = "tcp"
-          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.default.id}"
+          network_url        = google_compute_network.default.id
           project            = google_compute_forwarding_rule.default.project
           region             = google_compute_forwarding_rule.default.region
         }
@@ -666,7 +666,7 @@ resource "google_dns_record_set" "foobar" {
           ip_address         = google_compute_forwarding_rule.default.ip_address
           port               = "80"
           ip_protocol        = "tcp"
-          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.default.id}"
+          network_url        = google_compute_network.default.id
           project            = google_compute_forwarding_rule.default.project
           region             = google_compute_forwarding_rule.default.region
         }

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -178,6 +178,69 @@ resource "google_dns_record_set" "geo" {
 }
 ```
 
+#### Primary-Backup
+
+```hcl
+resource "google_dns_record_set" "a" {
+  name         = "backend.${google_dns_managed_zone.prod.dns_name}"
+  managed_zone = google_dns_managed_zone.prod.name
+  type         = "A"
+  ttl          = 300
+
+  routing_policy {
+    primary_backup {
+      trickle_ratio = 0.1
+
+      primary {
+        internal_load_balancers {
+          load_balancer_type = "regionalL4ilb"
+          ip_address         = google_compute_forwarding_rule.prod.ip_address
+          port               = "80"
+          ip_protocol        = "tcp"
+          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.prod.id}"
+          project            = google_compute_forwarding_rule.prod.project
+          region             = google_compute_forwarding_rule.prod.region
+        }
+      }
+
+      backup_geo {
+        location = "asia-east1"
+        rrdatas  = ["10.128.1.1"]
+      }
+
+      backup_geo {
+        location = "us-west1"
+        rrdatas  = ["10.130.1.1"]
+      }
+    }
+  }
+}
+
+resource "google_dns_managed_zone" "prod" {
+  name     = "prod-zone"
+  dns_name = "prod.mydomain.com."
+}
+
+resource "google_compute_forwarding_rule" "prod" {
+  name   = "prod-ilb"
+  region = "us-central1"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.prod.id
+  all_ports             = true
+  network               = google_compute_network.prod.name
+}
+
+resource "google_compute_region_backend_service" "prod" {
+  name   = "prod-backend"
+  region = "us-central1"
+}
+
+resource "google_compute_network" "prod" {
+  name = "prod-network"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -211,17 +274,61 @@ The following arguments are supported:
 * `geo` - (Optional) The configuration for Geolocation based routing policy.
     Structure is [document below](#nested_geo).
 
+* `enable_geo_fencing` - (Optional) Specifies whether to enable fencing for geo queries.
+
+* `primary_backup` - (Optional) The configuration for a primary-backup policy with global to regional failover. Queries are responded to with the global primary targets, but if none of the primary targets are healthy, then we fallback to a regional failover policy.
+    Structure is [document below](#nested_primary_backup).
+
 <a name="nested_wrr"></a>The `wrr` block supports:
 
 * `weight`  - (Required) The ratio of traffic routed to the target.
 
-* `rrdatas` - (Required) Same as `rrdatas` above.
+* `rrdatas` - (Optional) Same as `rrdatas` above.
+
+* `health_checked_targets` - (Optional) The list of targets to be health checked. Note that if DNSSEC is enabled for this zone, only one of `rrdatas` or `health_checked_targets` can be set.
+    Structure is [document below](#nested_health_checked_targets).
 
 <a name="nested_geo"></a>The `geo` block supports:
 
 * `location` - (Required) The location name defined in Google Cloud.
 
-* `rrdatas` - (Required) Same as `rrdatas` above.
+* `rrdatas` - (Optional) Same as `rrdatas` above.
+
+* `health_checked_targets` - (Optional) For A and AAAA types only. The list of targets to be health checked. These can be specified along with `rrdatas` within this item.
+    Structure is [document below](#nested_health_checked_targets).
+
+<a name="nested_primary_backup"></a>The `primary_backup` block supports:
+
+* `primary` - (Required) The list of global primary targets to be health checked.
+    Structure is [document below](#nested_health_checked_targets).
+
+* `backup_geo` - (Required) The backup geo targets, which provide a regional failover policy for the otherwise global primary targets.
+    Structure is [document above](#nested_geo).
+
+* `enable_geo_fencing_for_backups` - (Optional) Specifies whether to enable fencing for backup geo queries.
+
+* `trickle_ratio` - (Optional) Specifies the percentage of traffic to send to the backup targets even when the primary targets are healthy.
+
+<a name="nested_health_checked_targets"></a>The `health_checked_targets` block supports:
+
+* `internal_load_balancers` - (Required) The list of internal load balancers to health check.
+    Structure is [document below](#nested_internal_load_balancers).
+
+<a name="nested_internal_load_balancers"></a>The `internal_load_balancers` block supports:
+
+* `load_balancer_type` - (Required) The type of load balancer. This value is case-sensitive. Possible values: ["regionalL4ilb"]
+
+* `ip_address` - (Required) The frontend IP address of the load balancer.
+
+* `port` - (Required) The configured port of the load balancer.
+
+* `ip_protocol` - (Required) The configured IP protocol of the load balancer. This value is case-sensitive. Possible values: ["tcp", "udp"]
+
+* `network_url` - (Required) The fully qualified url of the network in which the load balancer belongs. This should be formatted like `https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}`.
+
+* `project` - (Required) The ID of the project in which the load balancer belongs.
+
+* `region` - (Optional) The region of the load balancer. Only needed for regional load balancers.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -197,7 +197,7 @@ resource "google_dns_record_set" "a" {
           ip_address         = google_compute_forwarding_rule.prod.ip_address
           port               = "80"
           ip_protocol        = "tcp"
-          network_url        = "https://www.googleapis.com/compute/v1/${google_compute_network.prod.id}"
+          network_url        = google_compute_network.prod.id
           project            = google_compute_forwarding_rule.prod.project
           region             = google_compute_forwarding_rule.prod.region
         }
@@ -324,7 +324,7 @@ The following arguments are supported:
 
 * `ip_protocol` - (Required) The configured IP protocol of the load balancer. This value is case-sensitive. Possible values: ["tcp", "udp"]
 
-* `network_url` - (Required) The fully qualified url of the network in which the load balancer belongs. This should be formatted like `https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}`.
+* `network_url` - (Required) The fully qualified url of the network in which the load balancer belongs. This should be formatted like `projects/{project}/global/networks/{network}` or `https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}`.
 
 * `project` - (Required) The ID of the project in which the load balancer belongs.
 


### PR DESCRIPTION
This resource used to support two types of routing policies: weighted round robin (wrr) and geo location (geo). Now we will be supporting a third option: primary-backup.

In addition, the existing routing types are being updated in two ways:
- `enabled_geo_fencing` is being added to support fencing behavior of all `geo` items
- `health_checked_targets` is being added to both `wrr` and `geo`, which provides another option for configuring the routing behavior

All together, this work aims to support health checking capabilities for internal load balancers.

b/239887327

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: added `primary_backup` to `routing_policy` block of `google_dns_record_set` resource
```
```release-note:enhancement
dns: added `enable_geo_fencing` to `routing_policy` block of `google_dns_record_set` resource
```
```release-note:enhancement
dns: added `health_checked_targets` to `wrr` and `geo` blocks of `google_dns_record_set` resource
```
