### PR TITLE
Add GKE OnPrem update tests

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_cluster_test.go.erb
@@ -1,0 +1,133 @@
+<% autogen_exception -%>
+package google
+<% if version == 'private' -%>
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccgkeonpremBareMetalCluster_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersOiCS,
+		CheckDestroy: testAccCheckgkeonpremBareMetalClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccgkeonpremBareMetalCluster_gkeonpremBareMetalClusterExample(context),
+			},
+			{
+				ResourceName:            "google_gkeonprem_bare_metal_cluster.cluster1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location"},
+			},
+			{
+				Config: testAccgkeonpremBareMetalCluster_update(context),
+			},
+			{
+				ResourceName:            "google_gkeonprem_bare_metal_cluster.cluster1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location"},
+			},
+		},
+	})
+}
+
+func testAccgkeonpremBareMetalCluster_update(context map[string]interface{}) string {
+	return Nprintf(`
+
+resource "google_gkeonprem_bare_metal_cluster" "cluster1" {
+	name = "basic%{random_suffix}"
+	location = "us-west1"
+	admin_cluster_membership = "projects/624768296925/locations/global/memberships/td7bb198b0744eeb-cluster"
+	bare_metal_version = "1.12.3"
+	network_config {
+		island_mode_cidr {
+			service_address_cidr_blocks = ["172.26.0.0/16"]
+			pod_address_cidr_blocks = ["10.240.0.0/13"]
+		}
+	}
+	control_plane {
+		node_pool_config {
+			node_pool_config {
+				labels = {}
+				operating_system = "LINUX"
+				node_configs {
+					labels = {}
+					node_ip = "10.200.0.9"
+				}
+			}
+		}
+	}
+	load_balancer {
+		port_config {
+			control_plane_load_balancer_port = 443
+		}
+		vip_config {
+			control_plane_vip = "10.200.0.13"
+			ingress_vip = "10.200.0.14"
+		}
+		metallb_lb_config {
+			address_pools {
+				pool = "pool1"
+				addresses = [
+					"10.200.0.14/32",
+					"10.200.0.15/32",
+					"10.200.0.16/32",
+					"10.200.0.17/32",
+					"10.200.0.18/32",
+					"fd00:1::f/128",
+					"fd00:1::10/128",
+					"fd00:1::11/128",
+					"fd00:1::12/128"
+				]
+			}
+		}
+	}
+	storage {
+		lvp_share_config {
+			lvp_config {
+				path = "/mnt/localpv-share"
+				storage_class = "local-shared"
+			}
+			shared_path_pv_count = 5
+		}
+		lvp_node_mounts_config {
+			path = "/mnt/localpv-disk"
+			storage_class = "local-disks"
+		}
+	}
+	
+	security_config {
+		authorization {
+			admin_users {
+				username = "aliberat@google.com"
+			}
+		}
+	}
+	
+	provider = google-beta
+	
+	lifecycle {
+		ignore_changes = [
+			annotations["onprem.cluster.gke.io/user-cluster-resource-link"],
+			annotations["alpha.baremetal.cluster.gke.io/cluster-metrics-webhook"],
+			annotations["baremetal.cluster.gke.io/operation"],
+			annotations["baremetal.cluster.gke.io/operation-id"],
+			annotations["baremetal.cluster.gke.io/start-time"],
+			annotations["baremetal.cluster.gke.io/upgrade-from-version"]
+		]
+	}
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_node_pool_test.go.erb
@@ -1,0 +1,159 @@
+<% autogen_exception -%>
+package google
+<% if version == 'private' -%>
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccgkeonpremBareMetalNodePool_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersOiCS,
+		CheckDestroy: testAccCheckgkeonpremBareMetalNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccgkeonpremBareMetalNodePool_gkeonpremBareMetalNodePoolExample(context),
+			},
+			{
+				ResourceName:            "google_gkeonprem_bare_metal_node_pool.np1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "bare_metal_cluster", "location"},
+			},
+			{
+				Config: testAccgkeonpremBareMetalNodePool_update(context),
+			},
+			{
+				ResourceName:            "google_gkeonprem_bare_metal_node_pool.np1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "bare_metal_cluster", "location"},
+			},
+		},
+	})
+}
+
+func testAccgkeonpremBareMetalNodePool_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_gkeonprem_bare_metal_cluster" "cluster1" {
+	name = "basiccluster%{random_suffix}"
+	location = "us-west1"
+	admin_cluster_membership = "projects/624768296925/locations/global/memberships/td7bb198b0744eeb-cluster"
+	bare_metal_version = "1.12.3"
+	network_config {
+		island_mode_cidr {
+			service_address_cidr_blocks = ["172.26.0.0/16"]
+			pod_address_cidr_blocks = ["10.240.0.0/13"]
+		}
+	}
+	control_plane {
+		node_pool_config {
+			node_pool_config {
+				labels = {}
+				operating_system = "LINUX"
+				node_configs {
+					labels = {}
+					node_ip = "10.200.0.9"
+				}
+			}
+		}
+	}
+	load_balancer {
+		port_config {
+			control_plane_load_balancer_port = 443
+		}
+		vip_config {
+			control_plane_vip = "10.200.0.13"
+			ingress_vip = "10.200.0.14"
+		}
+		metal_lb_config {
+			address_pools {
+				pool = "pool1"
+				addresses = [
+					"10.200.0.14/32",
+					"10.200.0.15/32",
+					"10.200.0.16/32",
+					"10.200.0.17/32",
+					"10.200.0.18/32",
+					"fd00:1::f/128",
+					"fd00:1::10/128",
+					"fd00:1::11/128",
+					"fd00:1::12/128"
+				]
+			}
+		}
+	}
+	storage {
+		lvp_share_config {
+			lvp_config {
+				path = "/mnt/localpv-share"
+				storage_class = "local-shared"
+			}
+			shared_path_pv_count = 5
+		}
+		lvp_node_mounts_config {
+			path = "/mnt/localpv-disk"
+			storage_class = "local-disks"
+		}
+	}
+
+	security_config {
+		authorization {
+			admin_users {
+				username = "aliberat@google.com"
+			}
+		}
+	}
+
+	provider = google-beta
+
+	lifecycle {
+		ignore_changes = [
+			annotations["onprem.cluster.gke.io/user-cluster-resource-link"],
+			annotations["alpha.baremetal.cluster.gke.io/cluster-metrics-webhook"],
+			annotations["baremetal.cluster.gke.io/operation"],
+			annotations["baremetal.cluster.gke.io/operation-id"],
+			annotations["baremetal.cluster.gke.io/start-time"],
+			annotations["baremetal.cluster.gke.io/upgrade-from-version"]
+		]
+	}
+}
+
+resource "google_gkeonprem_bare_metal_node_pool" "np1" {
+	name =  "basic%{random_suffix}"
+	bare_metal_cluster = google_gkeonprem_bare_metal_cluster.cluster1.name
+	location = "us-west1"
+	node_pool_config {
+		operating_system = "LINUX"
+		labels = {}
+		node_configs {
+			labels = {}
+			node_ip = "10.200.0.11"
+		}
+		node_configs {
+			labels = {}
+			node_ip = "10.200.0.12"
+		}
+	}
+	
+	provider = google-beta
+
+	lifecycle {
+		ignore_changes = [
+			annotations["baremetal.cluster.gke.io/gke-version"],
+			annotations["baremetal.cluster.gke.io/version"]
+		]
+	}
+} 
+`, context)
+}
+<% end -%>


### PR DESCRIPTION
Adds update tests for the GKE OnPrem Bare Metal APIs. The resources are currently in the private mmv1 repository.

```release-note:none
Release note
```