### PR TITLE
Support BigQuery authorized routines

### DIFF
--- a/mmv1/products/bigquery/api.yaml
+++ b/mmv1/products/bigquery/api.yaml
@@ -138,6 +138,30 @@ objects:
                     but additional target types may be added in the future. Possible values: VIEWS
                   item_type: Api::Type::String
                   required: true
+            - !ruby/object:Api::Type::NestedObject
+              name: 'routine'
+              description: |
+                A routine from a different dataset to grant access to. Queries
+                executed against that routine will have read access to tables in
+                this dataset. The role field is not required when this field is
+                set. If that routine is updated by any user, access to the routine
+                needs to be granted again via an update operation.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'datasetId'
+                  description: The ID of the dataset containing this table.
+                  required: true
+                - !ruby/object:Api::Type::String
+                  name: 'projectId'
+                  description: The ID of the project containing this table.
+                  required: true
+                - !ruby/object:Api::Type::String
+                  name: 'routineId'
+                  description: |
+                    The ID of the routine. The ID must contain only letters (a-z,
+                    A-Z), numbers (0-9), or underscores (_). The maximum length
+                    is 256 characters.
+                  required: true
       - !ruby/object:Api::Type::Integer
         name: 'creationTime'
         output: true
@@ -275,6 +299,7 @@ objects:
       - iamMember
       - view
       - dataset
+      - routine
     description: |
       Gives dataset access for a single entity. This resource is intended to be used in cases where
       it is not possible to compile a full list of access blocks to include in a
@@ -317,6 +342,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
       - !ruby/object:Api::Type::String
         name: 'groupByEmail'
         description: An email address of a Google Group to grant access to.
@@ -328,6 +354,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
       - !ruby/object:Api::Type::String
         name: 'domain'
         description: |
@@ -341,6 +368,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
       - !ruby/object:Api::Type::String
         name: 'specialGroup'
         description: |
@@ -365,6 +393,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
       - !ruby/object:Api::Type::String
         name: 'iamMember'
         description: |
@@ -378,6 +407,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
       - !ruby/object:Api::Type::NestedObject
         name: 'view'
         description: |
@@ -394,6 +424,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
         properties:
           - !ruby/object:Api::Type::String
             name: 'datasetId'
@@ -422,6 +453,7 @@ objects:
           - iam_member
           - view
           - dataset
+          - routine
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: 'dataset'
@@ -443,6 +475,39 @@ objects:
               Which resources in the dataset this entry applies to. Currently, only views are supported,
               but additional target types may be added in the future. Possible values: VIEWS
             item_type: Api::Type::String
+            required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'routine'
+        description: |
+          A routine from a different dataset to grant access to. Queries
+          executed against that routine will have read access to tables in
+          this dataset. The role field is not required when this field is
+          set. If that routine is updated by any user, access to the routine
+          needs to be granted again via an update operation.
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+          - dataset
+          - routine
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'datasetId'
+            description: The ID of the dataset containing this table.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'projectId'
+            description: The ID of the project containing this table.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'routineId'
+            description: |
+              The ID of the routine. The ID must contain only letters (a-z,
+              A-Z), numbers (0-9), or underscores (_). The maximum length
+              is 256 characters.
             required: true
   - !ruby/object:Api::Resource
     name: 'Job'

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -45,9 +45,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "bigquery_dataset_authorized_routine"
         primary_resource_id: "private"
         vars:
-          private_dataset: "private-dataset"
-          public_dataset: "public-dataset"
-          public_routine: "public-routine"
+          private_dataset: "private_dataset"
+          public_dataset: "public_dataset"
+          public_routine: "public_routine"
         test_env_vars:
           service_account: :SERVICE_ACCT
     virtual_fields:
@@ -124,9 +124,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_type: "google_bigquery_dataset_access"
         primary_resource_id: "authorized_routine"
         vars:
-          private_dataset: "private-dataset"
-          public_dataset: "public-dataset"
-          public_routine: "public-routine"
+          private_dataset: "private_dataset"
+          public_dataset: "public_dataset"
+          public_routine: "public_routine"
     properties:
       datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -43,10 +43,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           account_name: "bqowner"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_dataset_authorized_routine"
-        primary_resource_id: "dataset"
+        primary_resource_id: "private"
         vars:
-          private: "private"
-          public: "public"
+          private_dataset: "private-dataset"
+          public_dataset: "public-dataset"
+          public_routine: "public-routine"
         test_env_vars:
           service_account: :SERVICE_ACCT
     virtual_fields:
@@ -120,10 +121,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_dataset_access_authorized_routine"
         skip_test: true  # not importable
-        primary_resource_id: "access"
+        primary_resource_type: "google_bigquery_dataset_access"
+        primary_resource_id: "authorized_routine"
         vars:
-          private: "private"
-          public: "public"
+          private_dataset: "private-dataset"
+          public_dataset: "public-dataset"
+          public_routine: "public-routine"
     properties:
       datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -41,6 +41,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           private: "private"
           public: "public"
           account_name: "bqowner"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_dataset_authorized_routine"
+        primary_resource_id: "dataset"
+        vars:
+          private: "private"
+          public: "public"
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'delete_contents_on_destroy'
@@ -104,6 +110,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           table_id: "example_table"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_dataset_access_authorized_dataset"
+        skip_test: true  # not importable
+        primary_resource_id: "access"
+        vars:
+          private: "private"
+          public: "public"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_dataset_access_authorized_routine"
         skip_test: true  # not importable
         primary_resource_id: "access"
         vars:

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -47,6 +47,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           private: "private"
           public: "public"
+        test_env_vars:
+          service_account: :SERVICE_ACCT
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'delete_contents_on_destroy'

--- a/mmv1/templates/terraform/examples/bigquery_dataset_access_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_access_authorized_routine.tf.erb
@@ -1,11 +1,11 @@
 resource "google_bigquery_dataset" "public" {
-  dataset_id  = "<%= ctx[:vars]['public'] %>"
+  dataset_id  = "<%= ctx[:vars]['public_dataset'] %>"
   description = "This dataset is public"
 }
 
 resource "google_bigquery_routine" "public" {
   dataset_id      = google_bigquery_dataset.public.dataset_id
-  routine_id      = "sample_routine"
+  routine_id      = "<%= ctx[:vars]['public_routine'] %>"
   routine_type    = "TABLE_VALUED_FUNCTION"
   language        = "SQL"
   definition_body = <<-EOS
@@ -22,7 +22,7 @@ resource "google_bigquery_routine" "public" {
 }
 
 resource "google_bigquery_dataset" "private" {
-  dataset_id  = "<%= ctx[:vars]['private'] %>"
+  dataset_id  = "<%= ctx[:vars]['private_dataset'] %>"
   description = "This dataset is private"
 }
 

--- a/mmv1/templates/terraform/examples/bigquery_dataset_access_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_access_authorized_routine.tf.erb
@@ -1,0 +1,36 @@
+resource "google_bigquery_dataset" "public" {
+  dataset_id  = "<%= ctx[:vars]['public'] %>"
+  description = "This dataset is public"
+}
+
+resource "google_bigquery_routine" "public" {
+  dataset_id      = google_bigquery_dataset.public.dataset_id
+  routine_id      = "sample_routine"
+  routine_type    = "TABLE_VALUED_FUNCTION"
+  language        = "SQL"
+  definition_body = <<-EOS
+    SELECT 1 + value AS value
+  EOS
+  arguments {
+    name          = "value"
+    argument_kind = "FIXED_TYPE"
+    data_type     = jsonencode({ "typeKind" = "INT64" })
+  }
+  return_table_type = jsonencode({ "columns" = [
+    { "name" = "value", "type" = { "typeKind" = "INT64" } },
+  ] })
+}
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id  = "<%= ctx[:vars]['private'] %>"
+  description = "This dataset is private"
+}
+
+resource "google_bigquery_dataset_access" "authorized_routine" {
+  dataset_id = google_bigquery_dataset.private.dataset_id
+  routine {
+    project_id = google_bigquery_routine.public.project
+    dataset_id = google_bigquery_routine.public.dataset_id
+    routine_id = google_bigquery_routine.public.routine_id
+  }
+}

--- a/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
@@ -25,20 +25,8 @@ resource "google_bigquery_dataset" "private" {
   dataset_id  = "<%= ctx[:vars]['private'] %>"
   description = "This dataset is private"
   access {
-    role         = "WRITER"
-    specialGroup = "projectWriters"
-  }
-  access {
-    role         = "OWNER"
-    specialGroup = "projectOwners"
-  }
-  access {
     role          = "OWNER"
     user_by_email = "<%= ctx[:test_env_vars]['service_account'] %>"
-  }
-  access {
-    role         = "READER"
-    specialGroup = "projectReaders"
   }
   access {
     routine {

--- a/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
@@ -1,0 +1,35 @@
+resource "google_bigquery_dataset" "public" {
+  dataset_id  = "<%= ctx[:vars]['public'] %>"
+  description = "This dataset is public"
+}
+
+resource "google_bigquery_routine" "public" {
+  dataset_id      = google_bigquery_dataset.public.dataset_id
+  routine_id      = "sample_routine"
+  routine_type    = "TABLE_VALUED_FUNCTION"
+  language        = "SQL"
+  definition_body = <<-EOS
+    SELECT 1 + value AS value
+  EOS
+  arguments {
+    name          = "value"
+    argument_kind = "FIXED_TYPE"
+    data_type     = jsonencode({ "typeKind" = "INT64" })
+  }
+  return_table_type = jsonencode({ "columns" = [
+    { "name" = "value", "type" = { "typeKind" = "INT64" } },
+  ] })
+}
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id  = "<%= ctx[:vars]['private'] %>"
+  description = "This dataset is private"
+
+  access {
+    routine {
+      project_id = google_bigquery_routine.public.project
+      dataset_id = google_bigquery_routine.public.dataset_id
+      routine_id = google_bigquery_routine.public.routine_id
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
@@ -24,7 +24,10 @@ resource "google_bigquery_routine" "public" {
 resource "google_bigquery_dataset" "private" {
   dataset_id  = "<%= ctx[:vars]['private'] %>"
   description = "This dataset is private"
-
+  access {
+    role = "OWNER"
+    user_by_email = "<%= ctx[:test_env_vars]["service_account"] %>"
+  }
   access {
     routine {
       project_id = google_bigquery_routine.public.project

--- a/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
@@ -25,8 +25,20 @@ resource "google_bigquery_dataset" "private" {
   dataset_id  = "<%= ctx[:vars]['private'] %>"
   description = "This dataset is private"
   access {
-    role = "OWNER"
-    user_by_email = "<%= ctx[:test_env_vars]["service_account"] %>"
+    role         = "WRITER"
+    specialGroup = "projectWriters"
+  }
+  access {
+    role         = "OWNER"
+    specialGroup = "projectOwners"
+  }
+  access {
+    role          = "OWNER"
+    user_by_email = "<%= ctx[:test_env_vars]['service_account'] %>"
+  }
+  access {
+    role         = "READER"
+    specialGroup = "projectReaders"
   }
   access {
     routine {

--- a/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_authorized_routine.tf.erb
@@ -1,11 +1,11 @@
 resource "google_bigquery_dataset" "public" {
-  dataset_id  = "<%= ctx[:vars]['public'] %>"
+  dataset_id  = "<%= ctx[:vars]['public_dataset'] %>"
   description = "This dataset is public"
 }
 
 resource "google_bigquery_routine" "public" {
   dataset_id      = google_bigquery_dataset.public.dataset_id
-  routine_id      = "sample_routine"
+  routine_id      = "<%= ctx[:vars]['public_routine'] %>"
   routine_type    = "TABLE_VALUED_FUNCTION"
   language        = "SQL"
   definition_body = <<-EOS
@@ -22,7 +22,7 @@ resource "google_bigquery_routine" "public" {
 }
 
 resource "google_bigquery_dataset" "private" {
-  dataset_id  = "<%= ctx[:vars]['private'] %>"
+  dataset_id  = "<%= ctx[:vars]['private_dataset'] %>"
   description = "This dataset is private"
   access {
     role          = "OWNER"

--- a/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -129,7 +129,7 @@ func TestAccBigQueryDatasetAccess_authorizedRoutine(t *testing.T) {
 			},
 			{
 				// Destroy step instead of CheckDestroy so we can check the access is removed without deleting the dataset
-				Config: testAccBigQueryDatasetAccess_destroy(context["private_dataset"].(string), "private_dataset"),
+				Config: testAccBigQueryDatasetAccess_destroy(context["private_dataset"].(string), "private"),
 				Check:  testAccCheckBigQueryDatasetAccessAbsent(t, "google_bigquery_dataset.private", expected),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -100,6 +100,43 @@ func TestAccBigQueryDatasetAccess_authorizedDataset(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDatasetAccess_authorizedRoutine(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"public_dataset":  fmt.Sprintf("tf_test_public_dataset_%s", randString(t, 10)),
+		"public_routine":  fmt.Sprintf("tf_test_public_routine_%s", randString(t, 10)),
+		"private_dataset": fmt.Sprintf("tf_test_private_dataset_%s", randString(t, 10)),
+	}
+
+	expected := map[string]interface{}{
+		"dataset": map[string]interface{}{
+			"routine": map[string]interface{}{
+				"projectId": getTestProjectFromEnv(),
+				"datasetId": context["public_dataset"],
+				"routineId": context["public_routine"],
+			},
+			"targetTypes": []interface{}{"VIEWS"},
+		},
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryDatasetAccessDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetAccess_authorizedRoutine(context),
+				Check:  testAccCheckBigQueryDatasetAccessPresent(t, "google_bigquery_dataset.private_dataset", expected),
+			},
+			{
+				Config: testAccBigQueryDatasetAccess_destroy(context["private_dataset"], "private_dataset"),
+				Check:  testAccCheckBigQueryDatasetAccessAbsent(t, "google_bigquery_dataset.private_dataset", expected),
+			},
+		},
+	})
+}
+
 func TestAccBigQueryDatasetAccess_multiple(t *testing.T) {
 	// Multiple fine-grained resources
 	skipIfVcr(t)
@@ -356,6 +393,47 @@ resource "google_bigquery_dataset" "public" {
   dataset_id = "%s"
 }
 `, datasetID, datasetID2)
+}
+
+func testAccBigQueryDatasetAccess_authorizedRoutine(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_bigquery_dataset" "public" {
+  dataset_id  = "%{public_dataset}"
+  description = "This dataset is public"
+}
+
+resource "google_bigquery_routine" "public" {
+  dataset_id      = google_bigquery_dataset.public.dataset_id
+  routine_id      = "%{public_routine}"
+  routine_type    = "TABLE_VALUED_FUNCTION"
+  language        = "SQL"
+  definition_body = <<-EOS
+    SELECT 1 + value AS value
+  EOS
+  arguments {
+    name          = "value"
+    argument_kind = "FIXED_TYPE"
+    data_type     = jsonencode({ "typeKind" = "INT64" })
+  }
+  return_table_type = jsonencode({ "columns" = [
+    { "name" = "value", "type" = { "typeKind" = "INT64" } },
+  ] })
+}
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id  = "%{private_dataset}"
+  description = "This dataset is private"
+}
+
+resource "google_bigquery_dataset_access" "authorized_routine" {
+  dataset_id = google_bigquery_dataset.private.dataset_id
+  routine {
+    project_id = google_bigquery_routine.public.project
+    dataset_id = google_bigquery_routine.public.dataset_id
+    routine_id = google_bigquery_routine.public.routine_id
+  }
+}
+`, context)
 }
 
 func testAccBigQueryDatasetAccess_multiple(datasetID string) string {

--- a/mmv1/third_party/terraform/utils/iam_bigquery_dataset.go
+++ b/mmv1/third_party/terraform/utils/iam_bigquery_dataset.go
@@ -242,6 +242,10 @@ func accessToIamMember(access map[string]interface{}) (string, error) {
 		// dataset does not map to an IAM member, use access instead
 		return "", fmt.Errorf("Failed to convert BigQuery Dataset access to IAM member. To use views with a dataset, please use dataset_access")
 	}
+	if _, ok := access["routine"]; ok {
+		// dataset does not map to an IAM member, use access instead
+		return "", fmt.Errorf("Failed to convert BigQuery Dataset access to IAM member. To use views with a dataset, please use dataset_access")
+	}
 	if member, ok := access["userByEmail"]; ok {
 		// service accounts have "gservice" in their email. This is best guess due to lost information
 		if strings.Contains(member.(string), "gserviceaccount") {


### PR DESCRIPTION
Add support for authorized routines on BigQuery.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11501 .

I just tested to assign some routines as an authorized routines to some datasets using local built provider.
But I can not run acceptance tests.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: supported authorized routines on resource `bigquery_dataset` and `bigquery_dataset_access`
```
