### PR TITLE
Promote `public_access_prevention` field on `google_storage_bucket` resource to GA, add to documentation

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_storage_bucket.go.erb
@@ -387,14 +387,12 @@ func resourceStorageBucket() *schema.Resource {
 				},
 				Description: `The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty.`,
 			},
-<% unless version == "ga" -%>
 			"public_access_prevention": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				Description: `Prevents public access to a bucket.`,
 			},
-<% end -%>
 		},
 		UseJSONNumber: true,
 	}
@@ -659,7 +657,7 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if d.HasChange("uniform_bucket_level_access")<% unless version == "ga" -%> || d.HasChange("public_access_prevention")<% end -%> {
+	if d.HasChange("uniform_bucket_level_access") || d.HasChange("public_access_prevention") {
 		sb.IamConfiguration = expandIamConfiguration(d)
 	}
 
@@ -1151,11 +1149,9 @@ func expandIamConfiguration(d *schema.ResourceData) *storage.BucketIamConfigurat
 		},
 	}
 
-<% unless version == "ga" -%>
 	if v, ok := d.GetOk("public_access_prevention"); ok {
 		cfg.PublicAccessPrevention = v.(string)
 	}
-<% end -%>
 
 	return cfg
 }
@@ -1521,13 +1517,11 @@ func setStorageBucket(d *schema.ResourceData, config *Config, res *storage.Bucke
 		}
 	}
 
-<% unless version == "ga" -%>
 	if res.IamConfiguration != nil && res.IamConfiguration.PublicAccessPrevention != "" {
 		if err := d.Set("public_access_prevention", res.IamConfiguration.PublicAccessPrevention); err != nil {
 			return fmt.Errorf("Error setting public_access_prevention: %s", err)
 		}
 	}
-<% end -%>
 
 	if res.Billing == nil {
 		if err := d.Set("requester_pays", nil); err != nil {

--- a/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_storage_bucket_test.go.erb
@@ -867,7 +867,6 @@ func TestAccStorageBucket_encryption(t *testing.T) {
 	})
 }
 
-<% unless version == "ga" -%>
 func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 	t.Parallel()
 
@@ -875,7 +874,7 @@ func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProvidersOiCS,
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStorageBucket_publicAccessPrevention(bucketName, "enforced"),
@@ -889,7 +888,6 @@ func TestAccStorageBucket_publicAccessPrevention(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccStorageBucket_uniformBucketAccessOnly(t *testing.T) {
 	t.Parallel()
@@ -1810,11 +1808,9 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName, enabled)
 }
 
-<% unless version == "ga" -%>
 func testAccStorageBucket_publicAccessPrevention(bucketName string, prevention string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
-  provider                  = google-beta
   name                      = "%s"
   location                  = "US"
   public_access_prevention  = "%s"
@@ -1822,7 +1818,6 @@ resource "google_storage_bucket" "bucket" {
 }
 `, bucketName, prevention)
 }
-<% end -%>
 
 func testAccStorageBucket_encryption(context map[string]interface{}) string {
 	return Nprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -60,6 +60,19 @@ resource "google_storage_bucket" "auto-expire" {
   }
 }
 ```
+
+## Example Usage - Enabling public access prevention
+
+```hcl
+resource "google_storage_bucket" "auto-expire" {
+  name          = "no-public-access-bucket"
+  location      = "US"
+  force_destroy = true
+
+  public_access_prevention = "enforced"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -101,7 +114,7 @@ The following arguments are supported:
 
 * `uniform_bucket_level_access` - (Optional, Default: false) Enables [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) access to a bucket.
 
-* `public_access_prevention` - (Optional, Default: false) Prevents public access to a bucket. See [public access protection](https://cloud.google.com/storage/docs/public-access-prevention).
+* `public_access_prevention` - (Optional) Prevents public access to a bucket. Acceptable values are "inherited" or "enforced". If "inherited", the bucket uses [public access prevention](https://cloud.google.com/storage/docs/public-access-prevention). only if the bucket is subject to the public access prevention organization policy constraint. Defaults to "inherited".
 
 * `custom_placement_config` - (Optional) The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty. Structure is [documented below](#nested_custom_placement_config).
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `uniform_bucket_level_access` - (Optional, Default: false) Enables [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) access to a bucket.
 
+* `public_access_prevention` - (Optional, Default: false) Prevents public access to a bucket. See [public access protection](https://cloud.google.com/storage/docs/public-access-prevention).
+
 * `custom_placement_config` - (Optional) The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty. Structure is [documented below](#nested_custom_placement_config).
 
 <a name="nested_lifecycle_rule"></a>The `lifecycle_rule` block supports:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/11088

This PR promotes the `public_access_prevention` field of `google_storage_bucket` resource from the Beta to the GA provider. It also adds the field to the docs, as it was missing.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: Promoted `public_access_prevention` field on `google_storage_bucket` resource to GA
```
