### PR TITLE
Made cloud identity groups updatable and updated documentation

### DIFF
--- a/mmv1/products/cloudidentity/api.yaml
+++ b/mmv1/products/cloudidentity/api.yaml
@@ -42,6 +42,27 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/identity/docs/how-to/setup'
       api: 'https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 5
+          update_minutes: 5
+          delete_minutes: 5
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: true
+        allowed:
+          - true
+          - false
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
     parameters:
       - !ruby/object:Api::Type::Enum
         name: 'initialGroupConfig'
@@ -129,13 +150,16 @@ objects:
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         required: true
-        input: true
         description: |
-          The labels that apply to the Group.
+          One or more label entries that apply to the Group. Currently supported labels contain a key with an empty value.
 
-          Must not contain more than one entry. Must contain the entry
-          'cloudidentity.googleapis.com/groups.discussion_forum': '' if the Group is a Google Group or
-          'system/groups/external': '' if the Group is an external-identity-mapped group.
+          Google Groups are the default type of group and have a label with a key of cloudidentity.googleapis.com/groups.discussion_forum and an empty value.
+
+          Existing Google Groups can have an additional label with a key of cloudidentity.googleapis.com/groups.security and an empty value added to them. This is an immutable change and the security label cannot be removed once added.
+          
+          Dynamic groups have a label with a key of cloudidentity.googleapis.com/groups.dynamic.
+          
+          Identity-mapped groups for Cloud Search have a label with a key of system/groups/external and an empty value.
   - !ruby/object:Api::Resource
     name: 'GroupMembership'
     base_url: '{{group}}/memberships'

--- a/mmv1/products/cloudidentity/terraform.yaml
+++ b/mmv1/products/cloudidentity/terraform.yaml
@@ -16,8 +16,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Group: !ruby/object:Overrides::Terraform::ResourceOverride
     async: !ruby/object:Provider::Terraform::PollAsync
       check_response_func_existence: PollCheckForExistenceWith403
+      check_response_func_absence: PollCheckForAbsenceWith403
       target_occurrences: 10
-      actions: ['create']
+      actions: ['create', 'update', 'delete']
     docs: !ruby/object:Provider::Terraform::Docs
       warning: |
         If you are using User ADCs (Application Default Credentials) with this resource,

--- a/mmv1/third_party/terraform/tests/resource_cloud_identity_group_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_identity_group_test.go
@@ -44,6 +44,7 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
 
   labels = {
     "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+	"cloudidentity.googleapis.com/groups.security" = ""
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/utils/common_polling.go
+++ b/mmv1/third_party/terraform/utils/common_polling.go
@@ -129,6 +129,18 @@ func PollCheckForExistenceWith403(_ map[string]interface{}, respErr error) PollR
 	return SuccessPollResult()
 }
 
+// PollCheckForAbsence waits for a 404/403 response, continues polling on a successful
+// response, and returns any other error.
+func PollCheckForAbsenceWith403(_ map[string]interface{}, respErr error) PollResult {
+	if respErr != nil {
+		if isGoogleApiErrorWithCode(respErr, 404) || isGoogleApiErrorWithCode(respErr, 403) {
+			return SuccessPollResult()
+		}
+		return ErrorPollResult(respErr)
+	}
+	return PendingStatusPollResult("found")
+}
+
 // PollCheckForAbsence waits for a 404 response, continues polling on a successful
 // response, and returns any other error.
 func PollCheckForAbsence(_ map[string]interface{}, respErr error) PollResult {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Continuing forward from @melinath PR https://github.com/GoogleCloudPlatform/magic-modules/pull/5460

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement 
cloudidentity: for group resource, made security label settable by making labels updatable
```
