### PR TITLE
Bq capacity commitment

### DIFF
--- a/mmv1/products/bigqueryreservation/api.yaml
+++ b/mmv1/products/bigqueryreservation/api.yaml
@@ -81,7 +81,7 @@ objects:
           Applicable only for reservations located within one of the BigQuery multi-regions (US or EU).
           If set to true, this reservation is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this reservation is placed in the organization's default region.
   - !ruby/object:Api::Resource
-    name: 'CapacityCommitment'
+    name: 'ReservationCapacityCommitment'
     base_url: projects/{{project}}/locations/{{location}}/capacityCommitments
     create_url: projects/{{project}}/locations/{{location}}/capacityCommitments?capacityCommitmentId={{capacityCommitmentId}}
     update_verb: :PATCH
@@ -121,6 +121,7 @@ objects:
           Number of slots in this commitment.
       - !ruby/object:Api::Type::String
         name: 'plan'
+        required: true
         description: |
           Capacity commitment commitment plan.
       - !ruby/object:Api::Type::String

--- a/mmv1/products/bigqueryreservation/api.yaml
+++ b/mmv1/products/bigqueryreservation/api.yaml
@@ -80,3 +80,55 @@ objects:
         description: |
           Applicable only for reservations located within one of the BigQuery multi-regions (US or EU).
           If set to true, this reservation is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this reservation is placed in the organization's default region.
+  - !ruby/object:Api::Resource
+    name: 'CapacityCommitment'
+    base_url: projects/{{project}}/locations/{{location}}/capacityCommitments
+    create_url: projects/{{project}}/locations/{{location}}/capacityCommitments?capacityCommitmentId={{capacityCommitmentId}}
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      Capacity commitment is a way to purchase compute capacity for BigQuery jobs (in the form of slots) with some committed period of usage.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        "Capacity commitment plans": "https://cloud.google.com/bigquery/docs/reservations-details"
+      api: "https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1/projects.locations.capacityCommitments/create"
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        url_param_only: true
+        input: true
+        description: |
+          The geographic location where the capacity commitment should reside.
+          Examples: US, EU, asia-northeast1.
+      - !ruby/object:Api::Type::String
+        name: 'capacityCommitmentId'
+        url_param_only: true
+        input: true
+        required: true
+        description: |
+          The name of the capacity commitment. This field must only contain alphanumeric characters or dash.
+      - !ruby/object:Api::Type::Boolean
+        name: 'enforceSingleAdminProjectPerOrg'
+        url_param_only: true
+        input: true
+        description: |
+          If true, fail the request if another project in the organization has a capacity commitment.
+    properties:
+      - !ruby/object:Api::Type::Integer
+        name: 'slotCount'
+        required: true
+        description: |
+          Number of slots in this commitment.
+      - !ruby/object:Api::Type::String
+        name: 'plan'
+        description: |
+          Capacity commitment commitment plan.
+      - !ruby/object:Api::Type::String
+        name: 'renewalPlan'
+        description: |
+          The plan this capacity commitment is converted to after commitmentEndTime passes. Once the plan is changed, committed period is extended according to commitment plan. Only applicable for ANNUAL and TRIAL commitments.
+      - !ruby/object:Api::Type::Boolean
+        name: 'multiRegionAuxiliary'
+        description: |
+          Applicable only for commitments located within one of the BigQuery multi-regions (US or EU).
+          If set to true, this commitment is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this commitment is placed in the organization's default region.

--- a/mmv1/products/bigqueryreservation/terraform.yaml
+++ b/mmv1/products/bigqueryreservation/terraform.yaml
@@ -23,6 +23,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "reservation"
         vars:
           name: 'my-reservation'
+  CapacityCommitment: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_reservation_capacity_commitment_basic"
+        primary_resource_id: "commitment"
+        vars:
+          name: 'my-commitment'          
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/products/bigqueryreservation/terraform.yaml
+++ b/mmv1/products/bigqueryreservation/terraform.yaml
@@ -23,7 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "reservation"
         vars:
           name: 'my-reservation'
-  CapacityCommitment: !ruby/object:Overrides::Terraform::ResourceOverride
+  ReservationCapacityCommitment: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_reservation_capacity_commitment_basic"

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -1,0 +1,8 @@
+resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
+	capacity_commitment_id = "<%= ctx[:vars]['name'] %>"
+	location               = "asia-northeast1"
+	// Set to 0 for testing purposes
+	// In reality this would be larger than zero
+	slot_count = 0
+	plan       = "FLEX"
+}

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -1,4 +1,4 @@
-resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
+resource "google_bigquery_reservation_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
 	capacity_commitment_id = "<%= ctx[:vars]['name'] %>"
 	location               = "asia-northeast1"
 	// Set to 0 for testing purposes

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -1,8 +1,6 @@
 resource "google_bigquery_reservation_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
 	capacity_commitment_id = "<%= ctx[:vars]['name'] %>"
 	location               = "asia-northeast1"
-	// Set to 0 for testing purposes
-	// In reality this would be larger than zero
-	slot_count = 0
-	plan       = "FLEX"
+	slot_count             = 100
+	plan                   = "FLEX"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Closes https://github.com/hashicorp/terraform-provider-google/issues/6694

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_bigquery_reservation_capacity_commitment
```
