### PR TITLE
project_id validated in datasource

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_project.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project.go
@@ -12,6 +12,7 @@ func dataSourceGoogleProject() *schema.Resource {
 
 	addOptionalFieldsToSchema(dsSchema, "project_id")
 
+	dsSchema["project_id"].ValidateFunc = validateDSProjectID()
 	return &schema.Resource{
 		Read:   datasourceGoogleProjectRead,
 		Schema: dsSchema,

--- a/mmv1/third_party/terraform/utils/validation.go
+++ b/mmv1/third_party/terraform/utils/validation.go
@@ -212,6 +212,20 @@ func validateProjectID() schema.SchemaValidateFunc {
 	}
 }
 
+func validateDSProjectID() schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (ws []string, errors []error) {
+		value := v.(string)
+		ids := strings.Split(value, "/")
+		value = ids[len(ids)-1]
+
+		if !regexp.MustCompile("^" + ProjectRegex + "$").MatchString(value) {
+			errors = append(errors, fmt.Errorf(
+				"%q project_id must be 6 to 30 with lowercase letters, digits, hyphens and start with a letter. Trailing hyphens are prohibited.", value))
+		}
+		return
+	}
+}
+
 func validateProjectName() schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
 		value := v.(string)

--- a/mmv1/third_party/terraform/utils/validation_test.go
+++ b/mmv1/third_party/terraform/utils/validation_test.go
@@ -271,6 +271,29 @@ func TestValidateProjectID(t *testing.T) {
 	}
 }
 
+func TestValidateDSProjectID(t *testing.T) {
+	x := []StringValidationTestCase{
+		// No errors
+		{TestName: "basic", Value: "foobar"},
+		{TestName: "with numbers", Value: "foobar123"},
+		{TestName: "short", Value: "foofoo"},
+		{TestName: "long", Value: "foobarfoobarfoobarfoobarfoobar"},
+		{TestName: "has projects", Value: "projects/foo-bar"},
+		{TestName: "has multiple projects", Value: "projects/projects/foobar"},
+		{TestName: "has a hyphen", Value: "foo-bar"},
+
+		// With errors
+		{TestName: "empty", Value: "", ExpectError: true},
+		{TestName: "has an uppercase letter", Value: "foo-Bar", ExpectError: true},
+		{TestName: "has a final hyphen", Value: "foo-bar-", ExpectError: true},
+	}
+
+	es := testStringValidationCases(x, validateDSProjectID())
+	if len(es) > 0 {
+		t.Errorf("Failed to validate project ID's: %v", es)
+	}
+}
+
 func TestValidateProjectName(t *testing.T) {
 	x := []StringValidationTestCase{
 		// No errors


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
project_id validated for datasource and required test added
fixes https://github.com/hashicorp/terraform-provider-google/issues/5687


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudplatform: Validated `project_id` for `google_project` data-source
```
