### PR TITLE
Fix compute_service_attachment  consumer_accept diff

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -14750,17 +14750,17 @@ objects:
         send_empty_value: true
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
-          - !ruby/object:Api::Type::String
-            name: 'projectIdOrNum'
-            required: true
-            description: |
-              A project that is allowed to connect to this service attachment.
-          - !ruby/object:Api::Type::Integer
-            name: 'connectionLimit'
-            required: true
-            description: |
-              The number of consumer forwarding rules the consumer project can
-              create.
+            - !ruby/object:Api::Type::String
+              name: 'projectIdOrNum'
+              required: true
+              description: |
+                A project that is allowed to connect to this service attachment.
+            - !ruby/object:Api::Type::Integer
+              name: 'connectionLimit'
+              required: true
+              description: |
+                The number of consumer forwarding rules the consumer project can
+                create.
   - !ruby/object:Api::Resource
     name: 'SslPolicy'
     kind: 'compute#sslPolicy'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2684,6 +2684,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
+      consumerAcceptLists: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       update_encoder: 'templates/terraform/update_encoder/compute_service_attachment.go.erb'
   Snapshot: !ruby/object:Overrides::Terraform::ResourceOverride


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12409


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Fixed permadiff for `consumer_accept_lists` in `google_compute_service_attachment`
```