### PR TITLE
Add script field in cloud build trigger

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -716,6 +716,11 @@ objects:
                     have completed successfully. If `wait_for` is empty, this build step
                     will start when all previous build steps in the `Build.Steps` list
                     have completed successfully.
+                - !ruby/object:Api::Type::String
+                  name: 'script'
+                  description: | 
+                    A shell script to be executed in the step. 
+                    When script is provided, the user cannot specify the entrypoint or args.
           - !ruby/object:Api::Type::NestedObject
             name: 'artifacts'
             description: |

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
@@ -16,7 +16,7 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
 
     step {
       name   = "ubuntu"
-      script = "echo hello" # using `script` field
+      script = "echo hello" # using script field
     }
     
     source {

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
@@ -14,6 +14,11 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
       secret_env = ["MY_SECRET"]
     }
 
+    step {
+      name   = "ubuntu"
+      script = "echo hello" # using `script` field
+    }
+    
     source {
       storage_source {
         bucket = "mybucket"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes the issue :[ Cloud Build Trigger with script field](https://github.com/hashicorp/terraform-provider-google/issues/12702) 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: added `script` field to `google_cloudbuild_trigger` resource
```
