### PR TITLE
Patch up VPN tests due to Classic VPN deprecation

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
@@ -296,41 +296,25 @@ resource "google_compute_address" "foobar" {
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-frfr1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -339,11 +323,13 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "%s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
 }
 
 resource "google_compute_router_interface" "foobar" {
@@ -364,7 +350,7 @@ resource "google_compute_router_peer" "foobar" {
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {
@@ -386,41 +372,25 @@ resource "google_compute_address" "foobar" {
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-fr1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -429,11 +399,13 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "%s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
 }
 
 resource "google_compute_router_interface" "foobar" {
@@ -443,7 +415,7 @@ resource "google_compute_router_interface" "foobar" {
   ip_range   = "169.254.3.1/30"
   vpn_tunnel = google_compute_vpn_tunnel.foobar.name
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerAdvertiseMode(routerName string) string {
@@ -465,41 +437,25 @@ resource "google_compute_address" "foobar" {
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-fr1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -508,11 +464,13 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "%s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0  
 }
 
 resource "google_compute_router_interface" "foobar" {
@@ -532,7 +490,7 @@ resource "google_compute_router_peer" "foobar" {
   advertise_mode            = "DEFAULT"
   interface = google_compute_router_interface.foobar.name
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerAdvertiseModeUpdate(routerName string) string {
@@ -554,41 +512,25 @@ resource "google_compute_address" "foobar" {
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-fr1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -597,12 +539,15 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "%s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0  
 }
+
 
 resource "google_compute_router_interface" "foobar" {
   name       = "%s"
@@ -626,7 +571,7 @@ resource "google_compute_router_peer" "foobar" {
   }
   interface = google_compute_router_interface.foobar.name
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerEnable(routerName string, enable bool) string {
@@ -644,45 +589,29 @@ resource "google_compute_subnetwork" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  name   = "%s"
+  name   = "%s-addr"
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-frfr1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -691,11 +620,13 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "%s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0  
 }
 
 resource "google_compute_router_interface" "foobar" {
@@ -707,16 +638,16 @@ resource "google_compute_router_interface" "foobar" {
 }
 
 resource "google_compute_router_peer" "foobar" {
-  name                   = "%s"
+  name                      = "%s"
   router                    = google_compute_router.foobar.name
   region                    = google_compute_router.foobar.region
   peer_ip_address           = "169.254.3.2"
   peer_asn                  = 65515
-  advertised_route_priority = 100
-  interface                 = google_compute_router_interface.foobar.name
-  enable                    = %v
+  advertised_route_priority = 100  
+  interface = google_compute_router_interface.foobar.name
+  enable                    = %v  
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enable)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enable)
 }
 
 func testAccComputeRouterPeerBfd(routerName, bfdMode string) string {
@@ -738,41 +669,25 @@ resource "google_compute_address" "foobar" {
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-frfr1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -781,11 +696,13 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "%s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.self_link
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0    
 }
 
 resource "google_compute_router_interface" "foobar" {
@@ -813,5 +730,5 @@ resource "google_compute_router_peer" "foobar" {
     session_initialization_mode = "%s"
   }
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, bfdMode)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, bfdMode)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_vpn_tunnel_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_vpn_tunnel_test.go
@@ -162,41 +162,25 @@ resource "google_compute_address" "foobar" {
   region = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_vpn_gateway" "foobar" {
+resource "google_compute_ha_vpn_gateway" "foobar" {
   name    = "tf-test-%[1]s"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
-resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "tf-test-%[1]s-1"
-  region      = google_compute_vpn_gateway.foobar.region
-  ip_protocol = "ESP"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "tf-test-%[1]s-2"
-  region      = google_compute_forwarding_rule.foobar_esp.region
-  ip_protocol = "UDP"
-  port_range  = "500-500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
-}
-
-resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "tf-test-%[1]s-3"
-  region      = google_compute_forwarding_rule.foobar_udp500.region
-  ip_protocol = "UDP"
-  port_range  = "4500-4500"
-  ip_address  = google_compute_address.foobar.address
-  target      = google_compute_vpn_gateway.foobar.self_link
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "external-gateway-%[1]s"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
 }
 
 resource "google_compute_router" "foobar" {
   name    = "%[2]s"
-  region  = google_compute_forwarding_rule.foobar_udp500.region
+  region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
     asn = 64514
@@ -205,11 +189,13 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_vpn_tunnel" "foobar" {
   name               = "tf-test-%[1]s"
-  region             = google_compute_forwarding_rule.foobar_udp4500.region
-  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
   shared_secret      = "unguessable"
-  peer_ip            = "8.8.8.8"
   router             = google_compute_router.foobar.self_link
+  vpn_gateway_interface           = 0  
 }
 `, suffix, router)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Noticed that a bunch of VPN+Router tests are failing due to the [Classic VPN deprecation](https://cloud.google.com/network-connectivity/docs/vpn/deprecations/classic-vpn-deprecation)

Since these tests are either for Router or VPNTunnel, I've upgraded all failing tests to HA VPN tunnels which allow the pattern being tested without changing the resource type under test.

Hoping that this saves us from a few failed tests going forward.
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
