### PR TITLE
fix: attribute names for google_cloud_ids_endpoint

### DIFF
--- a/mmv1/products/cloudids/api.yaml
+++ b/mmv1/products/cloudids/api.yaml
@@ -89,12 +89,12 @@ objects:
         description: |
           An optional description of the endpoint.
       - !ruby/object:Api::Type::String
-        name: 'endpoint_forwarding_rule'
+        name: 'endpointForwardingRule'
         output: true
         description: |
           URL of the endpoint's network address to which traffic is to be sent by Packet Mirroring.
       - !ruby/object:Api::Type::String
-        name: 'endpoint'
+        name: 'endpointIp'
         output: true
         description: |
           Internal IP address of the endpoint's network entry point.


### PR DESCRIPTION
The API uses camel case instead of snake case which is used by terraform.

Without this patch the attributes `endpoint_forwarding_rule` and `endpoint` of `google_cloud_ids_endpoint` are an empty string rendering the resource unusable.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudids: fix `endpoint_forwarding_rule` and `endpoint_ip` attributes for `google_cloud_ids_endpoint`
```
