### PR TITLE
Fix small issues with breaking change detector

### DIFF
--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -167,7 +167,7 @@ fi
 #;region=global/${BUILD_ID};step=19?project=${PROJECT_ID}"
 BREAKINGSTATE_BODY=$( jq -n \
 	--arg context "terraform-provider-breaking-change-test" \
-	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${BUILD_ID};step=${BUILD_STEP}?project=${PROJECT_ID}"" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${BUILD_ID};step=${BUILD_STEP}?project=${PROJECT_ID}" \
 	--arg breakingstate "${BREAKINGSTATE}" \
 	'{context: $context, target_url: $target_url, state: $breakingstate}')
 

--- a/tools/breaking-change-detector/rules/rules_field.go
+++ b/tools/breaking-change-detector/rules/rules_field.go
@@ -108,7 +108,7 @@ func fieldRule_BecomingComputedOnly_func(old, new *schema.Schema, mc MessageCont
 
 var fieldRule_OptionalComputedToOptional = FieldRule{
 	name:        "Optional and Computed to Optional",
-	definition:  "A field cannot go from Computed + Optional to Optional. On a sequential "apply" the terraform state will have the previously computed value. The value won't be present in the config, thus ultimately causing a diff.",
+	definition:  "A field cannot go from Computed + Optional to Optional. On a sequential `apply` the terraform state will have the previously computed value. The value won't be present in the config, thus ultimately causing a diff.",
 	message:     "Field {{field}} transitioned from optional+computed to optional {{resource}}",
 	identifier:  "field-oc-to-c",
 	isRuleBreak: fieldRule_OptionalComputedToOptional_func,


### PR DESCRIPTION
While I've already pushed the container to fix the bash script this change is for posterity. The breaking change detector unfortunately got some bad code. I'll be pushing a future change to resolve this.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
