### PR TITLE
google_vpc_access_connector missing GA args

### DIFF
--- a/mmv1/products/vpcaccess/api.yaml
+++ b/mmv1/products/vpcaccess/api.yaml
@@ -99,7 +99,6 @@ objects:
         description: |
           Machine type of VM Instance underlying connector. Default is e2-micro
         default_value: e2-micro
-        min_version: beta
       - !ruby/object:Api::Type::Integer
         name: minThroughput
         description: |
@@ -109,12 +108,10 @@ objects:
         name: minInstances
         description: |
           Minimum value of instances in autoscaling group underlying the connector.
-        min_version: beta
       - !ruby/object:Api::Type::Integer
         name: maxInstances
         description: |
           Maximum value of instances in autoscaling group underlying the connector.
-        min_version: beta
       - !ruby/object:Api::Type::Integer
         name: maxThroughput
         # The API documentation says this will default to 200, but when I tried that I got an error that the minimum
@@ -131,7 +128,6 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'subnet'
         input: true
-        min_version: beta
         description: |
           The subnet in which to house the connector
         properties:
@@ -144,10 +140,8 @@ objects:
               - network
               - subnet.0.name
             input: true
-            min_version: beta
           - !ruby/object:Api::Type::String
             name: 'projectId'
             description: |
               Project in which the subnet exists. If not set, this project is assumed to be the project for which the connector create request was issued.
             input: true
-            min_version: beta

--- a/mmv1/products/vpcaccess/terraform.yaml
+++ b/mmv1/products/vpcaccess/terraform.yaml
@@ -24,7 +24,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "vpc_access_connector_shared_vpc"
         primary_resource_id: "connector"
-        min_version: beta
         vars:
           name: "vpc-con"
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/templates/terraform/examples/vpc_access_connector_shared_vpc.tf.erb
+++ b/mmv1/templates/terraform/examples/vpc_access_connector_shared_vpc.tf.erb
@@ -1,5 +1,4 @@
 resource "google_vpc_access_connector" "connector" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['name'] %>"
   subnet {
     name = google_compute_subnetwork.custom_test.name
@@ -8,7 +7,6 @@ resource "google_vpc_access_connector" "connector" {
 }
 
 resource "google_compute_subnetwork" "custom_test" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['name'] %>"
   ip_cidr_range = "10.2.0.0/28"
   region        = "us-central1"
@@ -16,7 +14,6 @@ resource "google_compute_subnetwork" "custom_test" {
 }
 
 resource "google_compute_network" "custom_test" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['name'] %>"
   auto_create_subnetworks = false
 }

--- a/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"testing"
@@ -17,16 +15,16 @@ func TestAccVPCAccessConnector_vpcAccessConnectorThroughput(t *testing.T) {
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVPCAccessConnectorDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVPCAccessConnector_vpcAccessConnectorThroughput(context),
 			},
 			{
-				ResourceName:            "google_vpc_access_connector.connector",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "google_vpc_access_connector.connector",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -35,7 +33,6 @@ func TestAccVPCAccessConnector_vpcAccessConnectorThroughput(t *testing.T) {
 func testAccVPCAccessConnector_vpcAccessConnectorThroughput(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_vpc_access_connector" "connector" {
-  provider      = google-beta
   name          = "tf-test-vpc-con%{random_suffix}"
   subnet {
     name = google_compute_subnetwork.custom_test.name
@@ -47,7 +44,6 @@ resource "google_vpc_access_connector" "connector" {
 }
 
 resource "google_compute_subnetwork" "custom_test" {
-  provider      = google-beta
   name          = "tf-test-vpc-con%{random_suffix}"
   ip_cidr_range = "10.2.0.0/28"
   region        = "us-central1"
@@ -55,11 +51,8 @@ resource "google_compute_subnetwork" "custom_test" {
 }
 
 resource "google_compute_network" "custom_test" {
-  provider                = google-beta
   name                    = "tf-test-vpc-con%{random_suffix}"
   auto_create_subnetworks = false
 }
 `, context)
 }
-
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/11934


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vpcaccess - promoted `machine_type`, `min_instances`, `max_instances`, and `subnet` in `google_vpc_access_connector` to GA
```
