### PR TITLE
Add SOA to root-level record deletion exception

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/resources/resource_dns_record_set.go
@@ -350,7 +350,7 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 		domain := mz.DnsName
 
 		if domain == d.Get("name").(string) {
-			log.Printf("[DEBUG] root-level %s records can't be deleted due to API restrictions, so they're being left in place. See https://www.terraform.io/docs/providers/google/r/dns_record_set.html for more information.", d.Get("type").(string))
+			log.Printf("[DEBUG] root-level %s records can't be deleted due to API restrictions, so they're being left in place. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set for more information.", d.Get("type").(string))
 			return nil
 		}
 	}


### PR DESCRIPTION
Added SOA to the google_dns_record_set types that are faux-deleted.

When trying to delete record-sets that are managed by terraform, some types can't actually be deleted by DNS and API restrictions. The code previously only pretended deletes for root-level NS records. This change adds SOA to that behavior so that terraform delete/destroy can function properly when SOA is explicitly managed. 

(It doesn't make sense to delete the Start Of Authority (SOA) or root-level NS records by themselves as they're fundamental to the zone construct – their value can be changed, but they must exist for the zone itself to exist.)

This problem would only manifest when managing SOA as a google_dns_record_set resource in terraform with custom values. If left unspecified/implied (default) as part of the zone resource, the zone resource already correctly bypasses deletion of the SOA record on deletion.

See issue https://github.com/hashicorp/terraform-provider-google/issues/12827

This PR is for Terraform, and I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests. **See below**
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). 
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). **Tests not run successfully. I'm not sure if there is a better branch to choose from that would have succeeded. 
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

I did build the terraform-provider-google successfully, but `make test` and `lint` in the resultant provider failed due to `google/resource_compute_subnetwork.go:39:22: undefined: cidr` issues (not any code I touched). `main` (without my change) `make test` fails for me (possibly, my dev environment is not correct). I reached a limit with how much I was willing to pursue tests on my own given the 2 line of code proposed change. 

I have not run acceptance tests as earlier tests failed. I'm willing to give it another go. 
 
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dns: Fixed deletion of managed SOA `google_dns_record_set` resources to match the short-circuited delete behavior of root-level NS records. 
```
