### PR TITLE
fix RFC3399 to RFC3339

### DIFF
--- a/mmv1/third_party/terraform/utils/validation.go
+++ b/mmv1/third_party/terraform/utils/validation.go
@@ -143,7 +143,7 @@ func validateRFC1918Network(min, max int) schema.SchemaValidateFunc {
 func validateRFC3339Time(v interface{}, k string) (warnings []string, errors []error) {
 	time := v.(string)
 	if len(time) != 5 || time[2] != ':' {
-		errors = append(errors, fmt.Errorf("%q (%q) must be in the format HH:mm (RFC3399)", k, time))
+		errors = append(errors, fmt.Errorf("%q (%q) must be in the format HH:mm (RFC3339)", k, time))
 		return
 	}
 	if hour, err := strconv.ParseUint(time[:2], 10, 0); err != nil || hour > 23 {

--- a/tpgtools/ignored_handwritten/validation.go
+++ b/tpgtools/ignored_handwritten/validation.go
@@ -133,7 +133,7 @@ func validateRFC1918Network(min, max int) schema.SchemaValidateFunc {
 func validateRFC3339Time(v interface{}, k string) (warnings []string, errors []error) {
 	time := v.(string)
 	if len(time) != 5 || time[2] != ':' {
-		errors = append(errors, fmt.Errorf("%q (%q) must be in the format HH:mm (RFC3399)", k, time))
+		errors = append(errors, fmt.Errorf("%q (%q) must be in the format HH:mm (RFC3339)", k, time))
 		return
 	}
 	if hour, err := strconv.ParseUint(time[:2], 10, 0); err != nil || hour > 23 {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/12794


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
validation: updated error message from `RFC3399` to `RFC3339`
```
