### PR TITLE
Added support for persistence_config field to google_redis_instance resource.

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -144,6 +144,57 @@ objects:
         required: true
         input: true
       - !ruby/object:Api::Type::NestedObject
+        name: persistenceConfig
+        description: Maintenance policy for an instance.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'persistenceMode'
+            required: true
+            description: |
+              Optional. Controls whether Persistence features are enabled. If not provided, the existing value will be used.
+
+              - PERSISTENCE_MODE_UNSPECIFIED:	Not set.
+              - DISABLED: 	Persistence is disabled for the instance, and any existing snapshots are deleted.
+              - RDB: RDB based Persistence is enabled.
+            values:
+              - :PERSISTENCE_MODE_UNSPECIFIED
+              - :DISABLED
+              - :RDB
+          - !ruby/object:Api::Type::Enum
+            name: 'rdbSnapshotPeriod'
+            required: true
+            description: |
+              Optional. Available snapshot periods for scheduling.
+
+              - SNAPSHOT_PERIOD_UNSPECIFIED:	Not set.
+              - ONE_HOUR:	Snapshot every 1 hour.
+              - SIX_HOURS:	Snapshot every 6 hours.
+              - TWELVE_HOURS:	Snapshot every 12 hours.
+              - TWENTY_FOUR_HOURS:	Snapshot every 24 horus.
+            values:
+              - :SNAPSHOT_PERIOD_UNSPECIFIED
+              - :ONE_HOUR
+              - :SIX_HOURS
+              - :TWELVE_HOURS
+              - :TWENTY_FOUR_HOURS
+          - !ruby/object:Api::Type::String
+            name: 'rdbNextSnapshotTime'
+            output: true
+            description: |
+              Output only. The next time that a snapshot attempt is scheduled to occur.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up
+              to nine fractional digits.
+              Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+          - !ruby/object:Api::Type::String
+            name: 'rdbSnapshotStartTime'
+            description: |
+              Optional. Date and time that the first snapshot was/will be attempted,
+              and to which future snapshots will be aligned. If not provided,
+              the current time will be used.
+              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution
+              and up to nine fractional digits.
+              Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+      - !ruby/object:Api::Type::NestedObject
         name: maintenancePolicy
         description: Maintenance policy for an instance.
         properties:
@@ -278,7 +329,7 @@ objects:
         name: redisVersion
         description: |
           The version of Redis software. If not provided, latest supported
-          version will be used. Please check the API documentation linked 
+          version will be used. Please check the API documentation linked
           at the top for the latest valid values.
       - !ruby/object:Api::Type::String
         name: reservedIpRange
@@ -347,9 +398,9 @@ objects:
       - !ruby/object:Api::Type::Integer
         name: replicaCount
         description: |
-          Optional. The number of replica nodes. The valid range for the Standard Tier with 
+          Optional. The number of replica nodes. The valid range for the Standard Tier with
           read replicas enabled is [1-5] and defaults to 2. If read replicas are not enabled
-          for a Standard Tier instance, the only valid value is 1 and the default is 1. 
+          for a Standard Tier instance, the only valid value is 1 and the default is 1.
           The valid value for basic tier is 0 and the default is also 0.
       - !ruby/object:Api::Type::Array
         name: nodes
@@ -378,7 +429,7 @@ objects:
       - !ruby/object:Api::Type::Integer
         name: readEndpointPort
         description: |
-          Output only. The port number of the exposed readonly redis endpoint. Standard tier only. 
+          Output only. The port number of the exposed readonly redis endpoint. Standard tier only.
           Write requests should target 'port'.
         output: true
       - !ruby/object:Api::Type::Enum
@@ -386,9 +437,9 @@ objects:
         description: |
           Optional. Read replica mode. Can only be specified when trying to create the instance.
           If not set, Memorystore Redis backend will default to READ_REPLICAS_DISABLED.
-          - READ_REPLICAS_DISABLED: If disabled, read endpoint will not be provided and the 
+          - READ_REPLICAS_DISABLED: If disabled, read endpoint will not be provided and the
           instance cannot scale up or down the number of replicas.
-          - READ_REPLICAS_ENABLED: If enabled, read endpoint will be provided and the instance 
+          - READ_REPLICAS_ENABLED: If enabled, read endpoint will be provided and the instance
           can scale up and down the number of replicas.
         values:
           - :READ_REPLICAS_DISABLED
@@ -398,7 +449,7 @@ objects:
         description: |
           Optional. Additional IP range for node placement. Required when enabling read replicas on
           an existing instance. For DIRECT_PEERING mode value must be a CIDR range of size /28, or
-          "auto". For PRIVATE_SERVICE_ACCESS mode value must be the name of an allocated address 
+          "auto". For PRIVATE_SERVICE_ACCESS mode value must be the name of an allocated address
           range associated with the private service access connection, or "auto".
       - !ruby/object:Api::Type::String
         name: customerManagedKey

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -153,11 +153,9 @@ objects:
             description: |
               Optional. Controls whether Persistence features are enabled. If not provided, the existing value will be used.
 
-              - PERSISTENCE_MODE_UNSPECIFIED:	Not set.
               - DISABLED: 	Persistence is disabled for the instance, and any existing snapshots are deleted.
               - RDB: RDB based Persistence is enabled.
             values:
-              - :PERSISTENCE_MODE_UNSPECIFIED
               - :DISABLED
               - :RDB
           - !ruby/object:Api::Type::Enum
@@ -166,13 +164,11 @@ objects:
             description: |
               Optional. Available snapshot periods for scheduling.
 
-              - SNAPSHOT_PERIOD_UNSPECIFIED:	Not set.
               - ONE_HOUR:	Snapshot every 1 hour.
               - SIX_HOURS:	Snapshot every 6 hours.
               - TWELVE_HOURS:	Snapshot every 12 hours.
               - TWENTY_FOUR_HOURS:	Snapshot every 24 horus.
             values:
-              - :SNAPSHOT_PERIOD_UNSPECIFIED
               - :ONE_HOUR
               - :SIX_HOURS
               - :TWELVE_HOURS

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -160,7 +160,7 @@ objects:
               - :RDB
           - !ruby/object:Api::Type::Enum
             name: 'rdbSnapshotPeriod'
-            required: true
+            required: false
             description: |
               Optional. Available snapshot periods for scheduling.
 

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -83,6 +83,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       persistenceConfig.persistenceMode: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      persistenceConfig.rdb_snapshot_start_time: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       authorizedNetwork: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -47,6 +47,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "cache-persis"
         vars:
           instance_name: "ha-memory-cache-persis"
+          network_name: "redis-test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-mrr")'
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_private_service"
         # Temporary for servicenetworking problems
@@ -76,6 +79,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "redis-cmek")'
     properties:
+      persistenceConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      persistenceConfig.persistenceMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       authorizedNetwork: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -83,7 +83,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       persistenceConfig.persistenceMode: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-      persistenceConfig.rdb_snapshot_start_time: !ruby/object:Overrides::Terraform::PropertyOverride
+      persistenceConfig.rdbSnapshotStartTime: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -43,6 +43,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "redis-full")'
       - !ruby/object:Provider::Terraform::Examples
+        name: "redis_instance_full_with_persistence_config"
+        primary_resource_id: "cache"
+        vars:
+          instance_name: "ha-memory-cache"
+          network_name: "redis-test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-full-with-persistence")'
+      - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_private_service"
         # Temporary for servicenetworking problems
         skip_vcr: true

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -44,12 +44,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: 'BootstrapSharedTestNetwork(t, "redis-full")'
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_full_with_persistence_config"
-        primary_resource_id: "cache"
+        primary_resource_id: "cache-persis"
         vars:
-          instance_name: "ha-memory-cache"
-          network_name: "redis-test-network"
-        test_vars_overrides:
-          network_name: 'BootstrapSharedTestNetwork(t, "redis-full-with-persistence")'
+          instance_name: "ha-memory-cache-persis"
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_private_service"
         # Temporary for servicenetworking problems

--- a/mmv1/templates/terraform/examples/redis_instance_full_with_persistence_config.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_full_with_persistence_config.tf.erb
@@ -3,24 +3,9 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
   tier           = "STANDARD_HA"
   memory_size_gb = 1
 
-  authorized_network = data.google_compute_network.redis-network.id
-
   persistence_config {
-    persistence_mode = "PERSISTENCE_MODE_UNSPECIFIED"
-    rdb_snapshot_period = "SNAPSHOT_PERIOD_UNSPECIFIED"
-    rdb_snapshot_start_time = "2028-10-02T15:01:23Z"
+    persistence_mode = "RDB"
+    rdb_snapshot_period = "SIX_HOURS"
+    rdb_snapshot_start_time = "2023-10-02T15:01:23Z"
   }
 }
-
-// This example assumes this network already exists.
-// The API creates a tenant network per network authorized for a
-// Redis instance and that network is not deleted when the user-created
-// network (authorized_network) is deleted, so this prevents issues
-// with tenant network quota.
-// If this network hasn't been created and you are using this example in your
-// config, add an additional network resource or change
-// this from "data"to "resource"
-data "google_compute_network" "redis-network" {
-  name = "<%= ctx[:vars]['network_name'] %>"
-}
-

--- a/mmv1/templates/terraform/examples/redis_instance_full_with_persistence_config.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_full_with_persistence_config.tf.erb
@@ -1,0 +1,26 @@
+resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
+  name           = "<%= ctx[:vars]['instance_name'] %>"
+  tier           = "STANDARD_HA"
+  memory_size_gb = 1
+
+  authorized_network = data.google_compute_network.redis-network.id
+
+  persistence_config {
+    persistence_mode = "PERSISTENCE_MODE_UNSPECIFIED"
+    rdb_snapshot_period = "SNAPSHOT_PERIOD_UNSPECIFIED"
+    rdb_snapshot_start_time = "2028-10-02T15:01:23Z"
+  }
+}
+
+// This example assumes this network already exists.
+// The API creates a tenant network per network authorized for a
+// Redis instance and that network is not deleted when the user-created
+// network (authorized_network) is deleted, so this prevents issues
+// with tenant network quota.
+// If this network hasn't been created and you are using this example in your
+// config, add an additional network resource or change
+// this from "data"to "resource"
+data "google_compute_network" "redis-network" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}
+

--- a/mmv1/templates/terraform/examples/redis_instance_full_with_persistence_config.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_full_with_persistence_config.tf.erb
@@ -2,10 +2,11 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
   name           = "<%= ctx[:vars]['instance_name'] %>"
   tier           = "STANDARD_HA"
   memory_size_gb = 1
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
 
   persistence_config {
     persistence_mode = "RDB"
-    rdb_snapshot_period = "SIX_HOURS"
-    rdb_snapshot_start_time = "2023-10-02T15:01:23Z"
+    rdb_snapshot_period = "TWELVE_HOURS"
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added support for persistence_config field to google_redis_instance resource.
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: Added  field `persistence_config` to the `google_redis_instance` resource.
```
