### PR TITLE
Support preconfigured_waf_config field on rules for google_compute_security_policy resource

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -454,15 +454,13 @@ func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams
 			Schema: map[string]*schema.Schema{
 				"operator": {
 					Type:         schema.TypeString,
-					Optional:     true,
-					Default:      "EQUALS",
+					Required:     true,
 					ValidateFunc: validation.StringInSlice([]string{"EQUALS", "STARTS_WITH", "ENDS_WITH", "CONTAINS", "EQUALS_ANY"}, false),
 					Description:  `You can specify an exact match or a partial match by using a field operator and a field value. Available options: EQUALS: The operator matches if the field value equals the specified value. STARTS_WITH: The operator matches if the field value starts with the specified value. ENDS_WITH: The operator matches if the field value ends with the specified value. CONTAINS: The operator matches if the field value contains the specified value. EQUALS_ANY: The operator matches if the field value is any value.`,
 				},
 				"value": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Default:     "",
 					Description: `A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation. The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.`,
 				},
 			},

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -150,6 +150,56 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 							Description: `A match condition that incoming traffic is evaluated against. If it evaluates to true, the corresponding action is enforced.`,
 						},
 
+						<% unless version == 'ga' -%>
+						"preconfigured_waf_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"exclusion": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"request_header": resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParamsSchema(
+													`Request header whose value will be excluded from inspection during preconfigured WAF evaluation.`,
+												),
+
+												"request_cookie": resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParamsSchema(
+													`Request cookie whose value will be excluded from inspection during preconfigured WAF evaluation.`,
+												),
+
+												"request_uri": resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParamsSchema(
+													`Request URI from the request line to be excluded from inspection during preconfigured WAF evaluation. When specifying this field, the query or fragment part should be excluded.`,
+												),
+												
+												"request_query_param": resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParamsSchema(
+													`Request query parameter whose value will be excluded from inspection during preconfigured WAF evaluation.  Note that the parameter can be in the query string or in the POST body.`,
+												),
+
+												"target_rule_set": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: `Target WAF rule set to apply the preconfigured WAF exclusion.`,
+												},
+
+												"target_rule_ids": {
+													Type:        schema.TypeSet,
+													Optional:    true,
+													Elem:        &schema.Schema{Type: schema.TypeString},
+													Description: `A list of target rule IDs under the WAF rule set to apply the preconfigured WAF exclusion. If omitted, it refers to all the rule IDs under the WAF rule set.`,
+												},
+											},
+										},
+										Description: `An exclusion to apply during preconfigured WAF evaluation.`,
+									},
+								},
+							},
+							Description: `Preconfigured WAF configuration to be applied for the rule. If the rule does not evaluate preconfigured WAF rules, i.e., if evaluatePreconfiguredWaf() is not used, this field will have no effect.`,
+						},
+						<% end -%>
+
 						"description": {
 							Type:        schema.TypeString,
 							Default:     "",
@@ -394,6 +444,33 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 		UseJSONNumber: true,
 	}
 }
+
+<% unless version == 'ga' -%>
+func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParamsSchema(description string) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"operator": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "EQUALS",
+					ValidateFunc: validation.StringInSlice([]string{"EQUALS", "STARTS_WITH", "ENDS_WITH", "CONTAINS", "EQUALS_ANY"}, false),
+					Description:  `You can specify an exact match or a partial match by using a field operator and a field value. Available options: EQUALS: The operator matches if the field value equals the specified value. STARTS_WITH: The operator matches if the field value starts with the specified value. ENDS_WITH: The operator matches if the field value ends with the specified value. CONTAINS: The operator matches if the field value contains the specified value. EQUALS_ANY: The operator matches if the field value is any value.`,
+				},
+				"value": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: `A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation. The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.`,
+				},
+			},
+		},
+		Description: description,
+	}
+}
+<% end -%>
 
 func rulesCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 	_, n := diff.GetChange("rule")
@@ -697,14 +774,17 @@ func expandSecurityPolicyRules(configured []interface{}) []*compute.SecurityPoli
 func expandSecurityPolicyRule(raw interface{}) *compute.SecurityPolicyRule {
 	data := raw.(map[string]interface{})
 	return &compute.SecurityPolicyRule{
-		Description:     	data["description"].(string),
-		Priority:        	int64(data["priority"].(int)),
-		Action:          	data["action"].(string),
-		Preview:         	data["preview"].(bool),
-		Match:           	expandSecurityPolicyMatch(data["match"].([]interface{})),
-		RateLimitOptions:	expandSecurityPolicyRuleRateLimitOptions(data["rate_limit_options"].([]interface{})),
+		Description:            data["description"].(string),
+		Priority:               int64(data["priority"].(int)),
+		Action:                 data["action"].(string),
+		Preview:                data["preview"].(bool),
+		Match:                  expandSecurityPolicyMatch(data["match"].([]interface{})),
+	<% unless version == 'ga' -%>
+		PreconfiguredWafConfig: expandSecurityPolicyPreconfiguredWafConfig(data["preconfigured_waf_config"].([]interface{})),
+	<% end -%>
+		RateLimitOptions:       expandSecurityPolicyRuleRateLimitOptions(data["rate_limit_options"].([]interface{})),
 		RedirectOptions:        expandSecurityPolicyRuleRedirectOptions(data["redirect_options"].([]interface{})),
-		ForceSendFields: 	[]string{"Description", "Preview"},
+		ForceSendFields:        []string{"Description", "Preview"},
 	}
 }
 
@@ -747,17 +827,69 @@ func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 	}
 }
 
+<% unless version == 'ga' -%>
+func expandSecurityPolicyPreconfiguredWafConfig(configured []interface{}) *compute.SecurityPolicyRulePreconfiguredWafConfig {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	data := configured[0].(map[string]interface{})
+	return &compute.SecurityPolicyRulePreconfiguredWafConfig{
+		Exclusions: expandSecurityPolicyRulePreconfiguredWafConfigExclusions(data["exclusion"].([]interface{})),
+	}
+}
+
+func expandSecurityPolicyRulePreconfiguredWafConfigExclusions(configured []interface{}) []*compute.SecurityPolicyRulePreconfiguredWafConfigExclusion {
+	exclusions := make([]*compute.SecurityPolicyRulePreconfiguredWafConfigExclusion, 0, len(configured))
+	for _, raw := range configured {
+		exclusions = append(exclusions, expandSecurityPolicyRulePreconfiguredWafConfigExclusion(raw))
+	}
+	return exclusions
+}
+
+func expandSecurityPolicyRulePreconfiguredWafConfigExclusion(raw interface{}) *compute.SecurityPolicyRulePreconfiguredWafConfigExclusion {
+	data := raw.(map[string]interface{})
+	return &compute.SecurityPolicyRulePreconfiguredWafConfigExclusion{
+		RequestHeadersToExclude:     expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams(data["request_header"].([]interface{})),
+		RequestCookiesToExclude:     expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams(data["request_cookie"].([]interface{})),
+		RequestUrisToExclude:        expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams(data["request_uri"].([]interface{})),
+		RequestQueryParamsToExclude: expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams(data["request_query_param"].([]interface{})),
+		TargetRuleSet:               data["target_rule_set"].(string),
+		TargetRuleIds:               convertStringArr(data["target_rule_ids"].(*schema.Set).List()),
+	}
+}
+
+func expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams(configured []interface{}) []*compute.SecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams {
+	params := make([]*compute.SecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams, 0, len(configured))
+	for _, raw := range configured {
+		params = append(params, expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParam(raw))
+	}
+	return params
+}
+
+func expandSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParam(raw interface{}) *compute.SecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams {
+	data := raw.(map[string]interface{})
+	return &compute.SecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams{
+		Op:  data["operator"].(string),
+		Val: data["value"].(string),
+	}
+}
+<% end -%>
+
 func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule) []map[string]interface{} {
 	rulesSchema := make([]map[string]interface{}, 0, len(rules))
 	for _, rule := range rules {
 		data := map[string]interface{}{
-			"description": 		rule.Description,
-			"priority":    		rule.Priority,
-			"action":      		rule.Action,
-			"preview":     		rule.Preview,
-			"match":       		flattenMatch(rule.Match),
-			"rate_limit_options":	flattenSecurityPolicyRuleRateLimitOptions(rule.RateLimitOptions),
-			"redirect_options":     flattenSecurityPolicyRedirectOptions(rule.RedirectOptions),
+			"description":              rule.Description,
+			"priority":                 rule.Priority,
+			"action":                   rule.Action,
+			"preview":                  rule.Preview,
+			"match":                    flattenMatch(rule.Match),
+		<% unless version == 'ga' -%>
+			"preconfigured_waf_config": flattenPreconfiguredWafConfig(rule.PreconfiguredWafConfig),
+		<% end -%>
+			"rate_limit_options":	      flattenSecurityPolicyRuleRateLimitOptions(rule.RateLimitOptions),
+			"redirect_options":         flattenSecurityPolicyRedirectOptions(rule.RedirectOptions),
 		}
 
 		rulesSchema = append(rulesSchema, data)
@@ -806,6 +938,49 @@ func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]int
 
 	return []map[string]interface{}{data}
 }
+
+<% unless version == 'ga' -%>
+func flattenPreconfiguredWafConfig(config *compute.SecurityPolicyRulePreconfiguredWafConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"exclusion": flattenPreconfiguredWafConfigExclusions(config.Exclusions),
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func flattenPreconfiguredWafConfigExclusions(exclusions []*compute.SecurityPolicyRulePreconfiguredWafConfigExclusion) []map[string]interface{} {
+	exclusionsSchema := make([]map[string]interface{}, 0, len(exclusions))
+	for _, exclusion := range exclusions {
+		data := map[string]interface{}{
+			"request_header":      flattenPreconfiguredWafConfigExclusionField(exclusion.RequestHeadersToExclude),
+			"request_cookie":      flattenPreconfiguredWafConfigExclusionField(exclusion.RequestCookiesToExclude),
+			"request_uri":         flattenPreconfiguredWafConfigExclusionField(exclusion.RequestUrisToExclude),
+			"request_query_param": flattenPreconfiguredWafConfigExclusionField(exclusion.RequestQueryParamsToExclude),
+			"target_rule_set":     exclusion.TargetRuleSet,
+			"target_rule_ids":     schema.NewSet(schema.HashString, convertStringArrToInterface(exclusion.TargetRuleIds)),
+		}
+
+		exclusionsSchema = append(exclusionsSchema, data)
+	}
+	return exclusionsSchema
+}
+
+func flattenPreconfiguredWafConfigExclusionField(fieldParams []*compute.SecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams) []map[string]interface{} {
+	fieldSchema := make([]map[string]interface{}, 0, len(fieldParams))
+	for _, field := range fieldParams {
+		data := map[string]interface{}{
+			"operator": &field.Op,
+			"value":    &field.Val,
+		}
+		fieldSchema = append(fieldSchema, data)
+	}
+	return fieldSchema
+}
+<% end -%>
 
 func expandSecurityPolicyAdvancedOptionsConfig(configured []interface{}) *compute.SecurityPolicyAdvancedOptionsConfig {
 	if len(configured) == 0 || configured[0] == nil {

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -76,6 +76,46 @@ func TestAccComputeSecurityPolicy_withRuleExpr(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeSecurityPolicy_withPreconfiguredWafConfig(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withPreconfiguredWafConfig(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicy_withPreconfiguredWafConfig_update(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicy_withPreconfiguredWafConfig_clear(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccComputeSecurityPolicy_update(t *testing.T) {
 	t.Parallel()
 
@@ -424,6 +464,164 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeSecurityPolicy_withPreconfiguredWafConfig(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name = "%s"
+
+	rule {
+		action   = "allow"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
+	}
+
+	rule {
+		action   = "deny"
+		priority = "1000"
+		match {
+			expr {
+				expression = "evaluatePreconfiguredWaf('sqli-stable')"
+			}
+		}
+		preconfigured_waf_config {
+			exclusion {
+				request_cookie {
+					operator = "EQUALS_ANY"
+				}
+				request_header {
+					value = "Referer"
+				}
+				request_uri {
+					operator = "STARTS_WITH"
+					value    = "/admin"
+				}
+				request_query_param {
+					value = "password"
+				}
+				request_query_param {
+					operator = "STARTS_WITH"
+					value    = "freeform"
+				}
+				target_rule_set = "sqli-stable"
+			}
+			exclusion {
+				request_query_param {
+					operator = "CONTAINS"
+					value    = "password"
+				}
+				request_query_param {
+					operator = "STARTS_WITH"
+					value    = "freeform"
+				}
+				target_rule_set = "xss-stable"
+			}
+		}
+		preview = false
+	}
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withPreconfiguredWafConfig_update(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name = "%s"
+
+	rule {
+		action   = "allow"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
+	}
+
+	rule {
+		action   = "deny"
+		priority = "1000"
+		match {
+			expr {
+				expression = "evaluatePreconfiguredWaf('rce-stable') || evaluatePreconfiguredWaf('xss-stable')"
+			}
+		}
+		preconfigured_waf_config {
+			exclusion {
+				request_uri {
+					operator = "STARTS_WITH"
+					value    = "/admin"
+				}
+				target_rule_set = "rce-stable"
+			}
+			exclusion {
+				request_query_param {
+					operator = "CONTAINS"
+					value    = "password"
+				}
+				request_query_param {
+					operator = "STARTS_WITH"
+					value    = "freeform"
+				}
+				request_query_param {
+					value = "description"
+				}
+				target_rule_set = "xss-stable"
+				target_rule_ids = [
+					"owasp-crs-v030001-id941330-xss",
+					"owasp-crs-v030001-id941340-xss",
+				]
+			}
+		}
+		preview = false
+	}
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withPreconfiguredWafConfig_clear(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name = "%s"
+
+	rule {
+		action   = "allow"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
+	}
+
+	rule {
+		action   = "deny"
+		priority = "1000"
+		match {
+			expr {
+				expression = "evaluatePreconfiguredWaf('rce-stable') || evaluatePreconfiguredWaf('xss-stable')"
+			}
+		}
+		preconfigured_waf_config {
+			// ensure empty waf config //
+		}
+		preview = false
+	}
+}
+`, spName)
+}
+<% end -%>
 
 func testAccComputeSecurityPolicy_withAdvancedOptionsConfig(spName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -497,14 +497,16 @@ resource "google_compute_security_policy" "policy" {
 					operator = "EQUALS_ANY"
 				}
 				request_header {
-					value = "Referer"
+					operator = "EQUALS"
+					value    = "Referer"
 				}
 				request_uri {
 					operator = "STARTS_WITH"
 					value    = "/admin"
 				}
 				request_query_param {
-					value = "password"
+					operator = "EQUALS"
+					value    = "password"
 				}
 				request_query_param {
 					operator = "STARTS_WITH"
@@ -573,7 +575,8 @@ resource "google_compute_security_policy" "policy" {
 					value    = "freeform"
 				}
 				request_query_param {
-					value = "description"
+					operator = "EQUALS"
+					value    = "description"
 				}
 				target_rule_set = "xss-stable"
 				target_rule_ids = [

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -111,7 +111,7 @@ The following arguments are supported:
 * `match` - (Required) A match condition that incoming traffic is evaluated against.
     If it evaluates to true, the corresponding `action` is enforced. Structure is [documented below](#nested_match).
 
-* `preconfigured_waf_config` - (Optional) Preconfigured WAF configuration to be applied for the rule. If the rule does not evaluate preconfigured WAF rules, i.e., if evaluatePreconfiguredWaf() is not used, this field will have no effect. Structure is [documented below](#nested_preconfigured_waf_config).
+* `preconfigured_waf_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Preconfigured WAF configuration to be applied for the rule. If the rule does not evaluate preconfigured WAF rules, i.e., if evaluatePreconfiguredWaf() is not used, this field will have no effect. Structure is [documented below](#nested_preconfigured_waf_config).
 
 * `description` - (Optional) An optional description of this rule. Max size is 64.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -111,6 +111,8 @@ The following arguments are supported:
 * `match` - (Required) A match condition that incoming traffic is evaluated against.
     If it evaluates to true, the corresponding `action` is enforced. Structure is [documented below](#nested_match).
 
+* `preconfigured_waf_config` - (Optional) Preconfigured WAF configuration to be applied for the rule. If the rule does not evaluate preconfigured WAF rules, i.e., if evaluatePreconfiguredWaf() is not used, this field will have no effect. Structure is [documented below](#nested_preconfigured_waf_config).
+
 * `description` - (Optional) An optional description of this rule. Max size is 64.
 
 * `preview` - (Optional) When set to true, the `action` specified above is not enforced.
@@ -146,6 +148,37 @@ The following arguments are supported:
 
 * `expression` - (Required) Textual representation of an expression in Common Expression Language syntax.
     The application context of the containing message determines which well-known feature set of CEL is supported.
+
+<a name="nested_preconfigured_waf_config"></a>The `preconfigured_waf_config` block supports:
+
+* `exclusion` - (Optional) An exclusion to apply during preconfigured WAF evaluation. Structure is [documented below](#nested_exclusion).
+
+<a name="nested_exclusion"></a>The `exclusion` block supports:
+
+* `request_header` - (Optional) Request header whose value will be excluded from inspection during preconfigured WAF evaluation. Structure is [documented below](#nested_field_params).
+
+* `request_cookie` - (Optional) Request cookie whose value will be excluded from inspection during preconfigured WAF evaluation. Structure is [documented below](#nested_field_params).
+
+* `request_uri` - (Optional) Request query parameter whose value will be excluded from inspection during preconfigured WAF evaluation. Note that the parameter can be in the query string or in the POST body. Structure is [documented below](#nested_field_params).
+
+* `request_query_param` - (Optional) Request URI from the request line to be excluded from inspection during preconfigured WAF evaluation. When specifying this field, the query or fragment part should be excluded. Structure is [documented below](#nested_field_params).
+
+* `target_rule_set` - (Required) Target WAF rule set to apply the preconfigured WAF exclusion.
+
+* `target_rule_ids` - (Optional) A list of target rule IDs under the WAF rule set to apply the preconfigured WAF exclusion. If omitted, it refers to all the rule IDs under the WAF rule set.
+
+<a name="nested_field_params"></a>The `request_header`, `request_cookie`, `request_uri` and `request_query_param` blocks support:
+
+* `operator` - (Optional) You can specify an exact match or a partial match by using a field operator and a field value. If not specified, defaults to "EQUALS"
+
+  * EQUALS: The operator matches if the field value equals the specified value.
+  * STARTS_WITH: The operator matches if the field value starts with the specified value.
+  * ENDS_WITH: The operator matches if the field value ends with the specified value.
+  * CONTAINS: The operator matches if the field value contains the specified value.
+  * EQUALS_ANY: The operator matches if the field value is any value.
+
+* `value` - (Optional) A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
+    The field value must be given if the field `operator` is not "EQUALS_ANY", and cannot be given if the field `operator` is "EQUALS_ANY".
 
 <a name="nested_rate_limit_options"></a>The `rate_limit_options` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 <a name="nested_field_params"></a>The `request_header`, `request_cookie`, `request_uri` and `request_query_param` blocks support:
 
-* `operator` - (Optional) You can specify an exact match or a partial match by using a field operator and a field value. If not specified, defaults to "EQUALS"
+* `operator` - (Required) You can specify an exact match or a partial match by using a field operator and a field value.
 
   * EQUALS: The operator matches if the field value equals the specified value.
   * STARTS_WITH: The operator matches if the field value starts with the specified value.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

* fixes https://github.com/hashicorp/terraform-provider-google/issues/12735


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `preconfigured_waf_config` block to `google_compute_security_policy` resource (beta)
```
