### PR TITLE
Allow custom serviceAccount for GKE Autopilot clusters

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -448,7 +448,6 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: `Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to automatically adjust the size of the cluster and create/delete node pools based on the current needs of the cluster's workload. See the guide to using Node Auto-Provisioning for more details.`,
-				ConflictsWith: []string{"enable_autopilot"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -460,6 +459,7 @@ func resourceContainerCluster() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							Description: `Global constraints for machine resources in the cluster. Configuring the cpu and memory types is required if node auto-provisioning is enabled. These limits will apply to node pool autoscaling in addition to node auto-provisioning.`,
+                            ConflictsWith: []string{"enable_autopilot"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"resource_type": {
@@ -508,6 +508,7 @@ func resourceContainerCluster() *schema.Resource {
 										Default:     100,
 										Description: `Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB.`,
 										ValidateFunc: validation.IntAtLeast(10),
+                                        ConflictsWith: []string{"enable_autopilot"},
 									},
 									"disk_type": {
 										Type:        schema.TypeString,
@@ -515,6 +516,7 @@ func resourceContainerCluster() *schema.Resource {
 										Default:     "pd-standard",
 										Description: `Type of the disk attached to each node.`,
 										ValidateFunc: validation.StringInSlice([]string{"pd-standard", "pd-ssd", "pd-balanced"}, false),
+                                        ConflictsWith: []string{"enable_autopilot"},
 									},
 									"image_type": {
 										Type:        schema.TypeString,
@@ -522,6 +524,7 @@ func resourceContainerCluster() *schema.Resource {
 										Default:     "COS_CONTAINERD",
 										Description: `The default image type used by NAP once a new node pool is being created.`,
 										ValidateFunc: validation.StringInSlice([]string{"COS_CONTAINERD", "COS", "UBUNTU_CONTAINERD", "UBUNTU"}, false),
+                                        ConflictsWith: []string{"enable_autopilot"},
 									},
 									<% unless version == 'ga' -%>
 									"min_cpu_platform": {
@@ -529,6 +532,7 @@ func resourceContainerCluster() *schema.Resource {
 										Optional:         true,
 										DiffSuppressFunc: emptyOrDefaultStringSuppress("automatic"),
 										Description:      `Minimum CPU platform to be used by this instance. The instance may be scheduled on the specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such as Intel Haswell.`,
+                                        ConflictsWith: []string{"enable_autopilot"},
 									},
 									<% end -%>
 									"boot_disk_kms_key": {
@@ -536,6 +540,7 @@ func resourceContainerCluster() *schema.Resource {
 										Optional:    true,
 										ForceNew:    true,
 										Description: `The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool.`,
+                                        ConflictsWith: []string{"enable_autopilot"},
 									},
 								},
 							},
@@ -547,6 +552,7 @@ func resourceContainerCluster() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"BALANCED", "OPTIMIZE_UTILIZATION"}, false),
 							Description:  `Configuration options for the Autoscaling profile feature, which lets you choose whether the cluster autoscaler should optimize for resource utilization or resource availability when deciding to remove nodes from a cluster. Can be BALANCED or OPTIMIZE_UTILIZATION. Defaults to BALANCED.`,
+                            ConflictsWith: []string{"enable_autopilot"},
 						},
 						<% end -%>
 					},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Allows users to set a non-default service account for Autopilot clusters.
From a GKE API perspective, setting the serviceAccount field on [AutoprovisioningNodePoolDefaults](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.AutoprovisioningNodePoolDefaults) is the proper way to do this

Fixes hashicorp/terraform-provider-google#8918, hashicorp/terraform-provider-google#9505



If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
