### PR TITLE
Bigtable: Remove resources on NOT_FOUND error only

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -256,9 +256,12 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	columnFamily := d.Get("column_family").(string)
 	ti, err := c.TableInfo(ctx, name)
 	if err != nil {
-		log.Printf("[WARN] Removing %s because it's gone", name)
-		d.SetId("")
-		return nil
+		if isNotFoundGrpcError(err) {
+			log.Printf("[WARN] Removing the GC policy because the parent table %s is gone", name)
+			d.SetId("")
+			return nil
+		}
+		return err
 	}
 
 	for _, fi := range ti.FamilyInfos {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
@@ -246,9 +246,12 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 
 	instance, err := c.InstanceInfo(ctx, instanceName)
 	if err != nil {
-		log.Printf("[WARN] Removing %s because it's gone", instanceName)
-		d.SetId("")
-		return nil
+		if isNotFoundGrpcError(err) {
+			log.Printf("[WARN] Removing %s because it's gone", instanceName)
+			d.SetId("")
+			return nil
+		}
+		return err
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_table.go
@@ -173,9 +173,12 @@ func resourceBigtableTableRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	table, err := c.TableInfo(ctx, name)
 	if err != nil {
-		log.Printf("[WARN] Removing %s because it's gone", name)
-		d.SetId("")
-		return nil
+		if isNotFoundGrpcError(err) {
+			log.Printf("[WARN] Removing %s because it's gone", name)
+			d.SetId("")
+			return nil
+		}
+		return err
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type TerraformResourceDataChange interface {
@@ -156,6 +158,15 @@ func isConflictError(err error) bool {
 		if e.Code == 409 || e.Code == 412 {
 			return true
 		}
+	}
+	return false
+}
+
+// gRPC does not return errors of type *googleapi.Error. Instead the errors returned are *status.Error.
+// See the types of codes returned here (https://pkg.go.dev/google.golang.org/grpc/codes#Code).
+func isNotFoundGrpcError(err error) bool {
+	if errorStatus, ok := status.FromError(err); ok && errorStatus.Code() == codes.NotFound {
+		return true
 	}
 	return false
 }

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestConvertStringArr(t *testing.T) {
@@ -692,6 +694,21 @@ func TestConflictError(t *testing.T) {
 		t.Error("did not find that a wrapped 412 was a conflict error.")
 	}
 	// skipping negative tests as other cases may be added later.
+}
+
+func TestIsNotFoundGrpcErrort(t *testing.T) {
+	error_status := status.New(codes.FailedPrecondition, "FailedPrecondition error")
+	if isNotFoundGrpcError(error_status.Err()) {
+		t.Error("found FailedPrecondition as a NotFound error")
+	}
+	error_status = status.New(codes.OK, "OK")
+	if isNotFoundGrpcError(error_status.Err()) {
+		t.Error("found OK as a NotFound error")
+	}
+	error_status = status.New(codes.NotFound, "NotFound error")
+	if !isNotFoundGrpcError(error_status.Err()) {
+		t.Error("expect a NotFound error")
+	}
 }
 
 func TestSnakeToPascalCase(t *testing.T) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Remove Bigtable resources on NOT_FOUND grpc error only. On other errors, we return these errors instead of removing the resource. Note, I am not able to find a way to test the change in acceptance testing (or unit testing). 

fixes https://github.com/hashicorp/terraform-provider-google/issues/10086


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: updated the error handling logic to remove the resource on resource not found error only
```
