### PR TITLE
network-services: Added aws_v4_authentication field to EdgeCacheOrigin

### DIFF
--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -292,6 +292,28 @@ objects:
               - timeout.0.max_attempts_timeout
               - timeout.0.response_timeout
               - timeout.0.read_timeout
+      - !ruby/object:Api::Type::NestedObject
+        name: 'awsV4Authentication'
+        description: |
+          Enable AWS Signature Version 4 origin authentication.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'accessKeyId'
+            required: true
+            description: |
+              The access key ID your origin uses to identify the key.
+          - !ruby/object:Api::Type::String
+            name: 'secretAccessKeyVersion'
+            required: true
+            description: |
+              The Secret Manager secret version of the secret access key used by your origin.
+
+              This is the resource name of the secret version in the format `projects/*/secrets/*/versions/*` where the `*` values are replaced by the project, secret, and version you require.
+          - !ruby/object:Api::Type::String
+            name: 'originRegion'
+            required: true
+            description: |
+              The name of the AWS region that your origin is in.
   - !ruby/object:Api::Resource
     name: 'EdgeCacheService'
     base_url: 'projects/{{project}}/locations/global/edgeCacheServices'

--- a/mmv1/products/networkservices/terraform.yaml
+++ b/mmv1/products/networkservices/terraform.yaml
@@ -50,7 +50,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
         vars:
           resource_name: "my-origin"
-          access_key_id: "ACCESSKEYID"
+          secret_name: "secret-name"
         ignore_read_extra:
          - "timeout"
     properties:

--- a/mmv1/products/networkservices/terraform.yaml
+++ b/mmv1/products/networkservices/terraform.yaml
@@ -80,6 +80,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           bucket_name: "my-bucket"
           origin_name: "my-origin"
           origin_google: "origin-google"
+          origin_v4auth: "origin-v4auth"
+          access_key_id: "ACCESSKEY12345"
           service_name: "my-service"
     properties:
       disableQuic: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/networkservices/terraform.yaml
+++ b/mmv1/products/networkservices/terraform.yaml
@@ -45,6 +45,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           resource_name_2: "my-fallback"
         ignore_read_extra:
          - "timeout"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "network_services_edge_cache_origin_v4auth"
+        primary_resource_id: "default"
+        vars:
+          resource_name: "my-origin"
+          access_key_id: "ACCESSKEYID"
+        ignore_read_extra:
+         - "timeout"
     properties:
       failoverOrigin: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareResourceNames'
@@ -80,8 +88,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           bucket_name: "my-bucket"
           origin_name: "my-origin"
           origin_google: "origin-google"
-          origin_v4auth: "origin-v4auth"
-          access_key_id: "ACCESSKEY12345"
           service_name: "my-service"
     properties:
       disableQuic: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
@@ -1,0 +1,24 @@
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "secret-version"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.id
+
+  secret_data = "secret-data"
+}
+
+resource "google_network_services_edge_cache_origin" "<%= ctx[:primary_resource_id] %>" {
+  name           = "<%= ctx[:vars]['resource_name'] %>"
+  origin_address = "gs://media-edge-default"
+  description    = "The default bucket for V4 authentication"
+  aws_v4_authentication {
+    access_key_id             = "<%= ctx[:vars]['access_key_id'] %>"
+    secret_access_key_version = google_secret_manager_secret_version.secret-version-basic.id
+    origin_region             = "auto"
+  }
+}

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
@@ -1,5 +1,5 @@
 resource "google_secret_manager_secret" "secret-basic" {
-  secret_id = "secret-version"
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
     automatic = true
@@ -17,7 +17,7 @@ resource "google_network_services_edge_cache_origin" "<%= ctx[:primary_resource_
   origin_address = "gs://media-edge-default"
   description    = "The default bucket for V4 authentication"
   aws_v4_authentication {
-    access_key_id             = "<%= ctx[:vars]['access_key_id'] %>"
+    access_key_id             = "ACCESSKEYID"
     secret_access_key_version = google_secret_manager_secret_version.secret-version-basic.id
     origin_region             = "auto"
   }

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_advanced.tf.erb
@@ -4,6 +4,20 @@ resource "google_storage_bucket" "dest" {
   force_destroy = true
 }
 
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "secret-version"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.id
+
+  secret_data = "secret-data"
+}
+
 resource "google_network_services_edge_cache_origin" "google" {
   name                 = "<%= ctx[:vars]['origin_google'] %>"
   origin_address       = "google.com"
@@ -11,6 +25,21 @@ resource "google_network_services_edge_cache_origin" "google" {
   max_attempts         = 2
   timeout {
     connect_timeout = "10s"
+  }
+}
+
+resource "google_network_services_edge_cache_origin" "v4auth" {
+  name                 = "<%= ctx[:vars]['origin_v4auth'] %>"
+  origin_address       = google_storage_bucket.dest.url
+  description          = "The default bucket for V4 authentication"
+  max_attempts         = 2
+  timeout {
+    connect_timeout = "10s"
+  }
+  aws_v4_authentication {
+    access_key_id = "<%= ctx[:vars]['access_key_id'] %>"
+    secret_access_key_version = google_secret_manager_secret_version.secret-version-basic.id
+    origin_region = google_storage_bucket.dest.location
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_advanced.tf.erb
@@ -4,20 +4,6 @@ resource "google_storage_bucket" "dest" {
   force_destroy = true
 }
 
-resource "google_secret_manager_secret" "secret-basic" {
-  secret_id = "secret-version"
-
-  replication {
-    automatic = true
-  }
-}
-
-resource "google_secret_manager_secret_version" "secret-version-basic" {
-  secret = google_secret_manager_secret.secret-basic.id
-
-  secret_data = "secret-data"
-}
-
 resource "google_network_services_edge_cache_origin" "google" {
   name                 = "<%= ctx[:vars]['origin_google'] %>"
   origin_address       = "google.com"
@@ -25,21 +11,6 @@ resource "google_network_services_edge_cache_origin" "google" {
   max_attempts         = 2
   timeout {
     connect_timeout = "10s"
-  }
-}
-
-resource "google_network_services_edge_cache_origin" "v4auth" {
-  name                 = "<%= ctx[:vars]['origin_v4auth'] %>"
-  origin_address       = google_storage_bucket.dest.url
-  description          = "The default bucket for V4 authentication"
-  max_attempts         = 2
-  timeout {
-    connect_timeout = "10s"
-  }
-  aws_v4_authentication {
-    access_key_id = "<%= ctx[:vars]['access_key_id'] %>"
-    secret_access_key_version = google_secret_manager_secret_version.secret-version-basic.id
-    origin_region = google_storage_bucket.dest.location
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds `aws_v4_authentication` field to the `EdgeCacheOrigin` to support [private S3-compatible origins](https://cloud.google.com/media-cdn/docs/connect-to-s3-compatible-buckets).
Resolves hashicorp/terraform-provider-google/issues/12862. 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.
Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
network_services: Added `aws_v4_authentication ` field to `google_network_services_edge_cache_origin ` to support S3-compatible Origins
```
