### PR TITLE
switch deletion_policy to virtual field for google_firebase_web_app

### DIFF
--- a/mmv1/products/firebase/api.yaml
+++ b/mmv1/products/firebase/api.yaml
@@ -134,16 +134,6 @@ objects:
       error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
-    parameters:
-      - !ruby/object:Api::Type::String
-        name: 'deletion_policy'
-        description: |
-          (Optional) Set to `ABANDON` to allow the WebApp to be untracked from terraform state
-          rather than deleted upon `terraform destroy`. This is useful becaue the WebApp may be 
-          serving traffic. Set to `DELETE` to delete the WebApp. Default to `ABANDON`
-        input: true
-        url_param_only: true
-        default_value: ABANDON
     properties:
       - !ruby/object:Api::Type::String
         name: name

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -58,7 +58,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Api::Type::String
         name: 'deletion_policy'
         description: |
-          (Optional) Set to `ABANDON` to allow the WebApp to be untracked from terraform state
+          Set to `ABANDON` to allow the WebApp to be untracked from terraform state
           rather than deleted upon `terraform destroy`. This is useful becaue the WebApp may be
           serving traffic. Set to `DELETE` to delete the WebApp. Default to `ABANDON`
         default_value: ABANDON

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -54,6 +54,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
         ignore_read_extra:
           - project
+          - deletion_policy
     virtual_fields:
       - !ruby/object:Api::Type::String
         name: 'deletion_policy'

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -54,6 +54,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
         ignore_read_extra:
           - project
+    virtual_fields:
+      - !ruby/object:Api::Type::String
+        name: 'deletion_policy'
+        description: |
+          (Optional) Set to `ABANDON` to allow the WebApp to be untracked from terraform state
+          rather than deleted upon `terraform destroy`. This is useful becaue the WebApp may be
+          serving traffic. Set to `DELETE` to delete the WebApp. Default to `ABANDON`
+        default_value: ABANDON
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -119,7 +119,7 @@ func resource<%= resource_name -%>() *schema.Resource {
             "<%= field.name -%>": {
               Type: <%= tf_type(field) -%>,
               Optional: true,
-              <% unless field.default_value.nil? -%>
+            <% unless field.default_value.nil? -%>
               Default:  <%= go_literal(field.default_value) -%>,
             <% end -%>
               Description: `<%= field.description.strip.gsub("`", "'") -%>`,

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -119,10 +119,11 @@ func resource<%= resource_name -%>() *schema.Resource {
             "<%= field.name -%>": {
               Type: <%= tf_type(field) -%>,
               Optional: true,
-            <% unless field.default_value.nil? -%>
+              <% unless field.default_value.nil? -%>
               Default:  <%= go_literal(field.default_value) -%>,
             <% end -%>
-            },
+              Description: `<%= field.description.strip.gsub("`", "'") -%>`,
+          },
 <%        end -%>
 <%      end -%>
 <%=     lines(compile(pwd + '/' + object.custom_code.extra_schema_entry)) if object.custom_code.extra_schema_entry -%>
@@ -287,7 +288,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <% unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
-<%  end -%>         
+<%  end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 


### PR DESCRIPTION
Fix for issues caused by https://github.com/GoogleCloudPlatform/magic-modules/pull/6652

This new field was forcing recreation due to not being set on READ. 

abandon default forcing recreation.
```
  # google_firebase_web_app.skip_delete must be replaced
-/+ resource "google_firebase_web_app" "skip_delete" {
      ~ app_id          = "1:82023037933:web:5ec7d3d6a16d2b322945e4" -> (known after apply)
      + deletion_policy = "ABANDON" # forces replacement
      ~ id              = "projects/scottsuarez-graphite/webApps/1:82023037933:web:5ec7d3d6a16d2b322945e4" -> (known after apply)
      ~ name            = "projects/scottsuarez-graphite/webApps/1:82023037933:web:5ec7d3d6a16d2b322945e4" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

Although, even adding a value with a default will break configurations since we don't read this value anywhere. This leads me to believe adding any value that has a default will encounter this unless it's set on read if the api doesn't return it.  It looks like the normal generator save `url-param-only` already accounts for this.
```
Terraform will perform the following actions:

  # google_firebase_web_app.skip_delete will be updated in-place
  ~ resource "google_firebase_web_app" "skip_delete" {
      + deletion_policy = "ABANDON"
        id              = "projects/scottsuarez-graphite/webApps/1:82023037933:web:5ec7d3d6a16d2b322945e4"
        name            = "projects/scottsuarez-graphite/webApps/1:82023037933:web:5ec7d3d6a16d2b322945e4"
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Switching to a virtual field resolved this.
```
No changes. Your infrastructure matches the configuration.
```
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
