### PR TITLE
[#11206] Add redundant_interface argument to cloud router interface

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
@@ -146,18 +146,6 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	iface := &compute.RouterInterface{Name: ifaceName}
 
 	if riVal, ok := d.GetOk("redundant_interface"); ok {
-		ifaceFound := false	
-		for _, iface := range ifaces {
-			if iface.Name == riVal {
-				ifaceFound = true
-				break	
-			}
-		}
-		if !ifaceFound {
-			d.SetId("")
-			return fmt.Errorf("Router %s does not have interface named %s", routerName, riVal)
-		}
-
 		iface.RedundantInterface = riVal.(string)
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
@@ -85,6 +85,13 @@ func resourceComputeRouterInterface() *schema.Resource {
 				ForceNew:    true,
 				Description: `The region this interface's router sits in. If not specified, the project region will be used. Changing this forces a new interface to be created.`,
 			},
+
+			"redundant_interface": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The name of the interface that is redundant to this interface.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -128,6 +135,7 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	}
 
 	ifaces := router.Interfaces
+
 	for _, iface := range ifaces {
 		if iface.Name == ifaceName {
 			d.SetId("")
@@ -136,6 +144,22 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	}
 
 	iface := &compute.RouterInterface{Name: ifaceName}
+
+	if riVal, ok := d.GetOk("redundant_interface"); ok {
+		ifaceFound := false	
+		for _, iface := range ifaces {
+			if iface.Name == riVal {
+				ifaceFound = true
+				break	
+			}
+		}
+		if !ifaceFound {
+			d.SetId("")
+			return fmt.Errorf("Router %s does not have interface named %s", routerName, riVal)
+		}
+
+		iface.RedundantInterface = riVal.(string)
+	}
 
 	if ipVal, ok := d.GetOk("ip_range"); ok {
 		iface.IpRange = ipVal.(string)
@@ -229,6 +253,9 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 			}
 			if err := d.Set("project", project); err != nil {
 				return fmt.Errorf("Error setting project: %s", err)
+			}
+			if err := d.Set("redundant_interface", iface.RedundantInterface); err != nil {
+				return fmt.Errorf("Error setting redundant interface: %s", err)
 			}
 			return nil
 		}

--- a/mmv1/third_party/terraform/tests/resource_compute_router_interface_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_interface_test.go
@@ -305,7 +305,7 @@ resource "google_compute_router_interface" "foobar_int2" {
   name                = "%s-int2"
   router              = google_compute_router.foobar.name
   region              = google_compute_router.foobar.region
-  ip_range 					  = "169.254.4.1/30"
+  ip_range            = "169.254.4.1/30"
   redundant_interface = google_compute_router_interface.foobar_int1.name
 }
 `, routerName, routerName, routerName, routerName, routerName)

--- a/mmv1/third_party/terraform/tests/resource_compute_router_interface_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_interface_test.go
@@ -36,6 +36,29 @@ func TestAccComputeRouterInterface_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouterInterface_redundant(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterInterfaceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterInterfaceRedundant(routerName),
+				Check: testAccCheckComputeRouterInterfaceExists(
+					t, "google_compute_router_interface.foobar_int2"),
+			},
+			{
+				ResourceName:      "google_compute_router_interface.foobar_int2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeRouterInterface_withTunnel(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +270,45 @@ resource "google_compute_router_interface" "foobar" {
   ip_range = "169.254.3.1/30"
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterInterfaceRedundant(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_interface" "foobar_int1" {
+  name     = "%s-int1"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+  ip_range = "169.254.3.1/30"
+}
+
+resource "google_compute_router_interface" "foobar_int2" {
+  name                = "%s-int2"
+  router              = google_compute_router.foobar.name
+  region              = google_compute_router.foobar.region
+  ip_range 					  = "169.254.4.1/30"
+  redundant_interface = google_compute_router_interface.foobar_int1.name
+}
+`, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterInterfaceKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -52,6 +52,10 @@ or both.
   be created. Only one of `vpn_tunnel` and `interconnect_attachment` can be
   specified.
 
+* `redundant_interface` - (Optional) The name of the interface that is redundant to
+  this interface. Changing this forces a new interface to
+  be created.
+
 * `project` - (Optional) The ID of the project in which this interface's router belongs. If it
     is not provided, the provider project is used. Changing this forces a new interface to be created.
 


### PR DESCRIPTION
Add optional redundant_interface argument to google_compute_router_interface resource.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
compute: Added optional `redundant_interface` argument to `google_compute_router_interface` resource
```
