### PR TITLE
Add fields for specifying GKE logging variant at the cluster-wide and node pool level.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -100,7 +100,6 @@ func clusterSchemaNodeConfig() *schema.Schema {
 	return nodeConfigSch
 }
 
-<% unless version == 'ga' -%>
 // Defines default nodel pool settings for the entire cluster. These settings are
 // overridden if specified on the specific NodePool object.
 func clusterSchemaNodePoolDefaults() *schema.Schema {
@@ -118,16 +117,18 @@ func clusterSchemaNodePoolDefaults() *schema.Schema {
 					Description: `Subset of NodeConfig message that has defaults.`,
 					MaxItems:    1,
 					Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-									"gcfs_config": schemaGcfsConfig(false),
-							},
+						Schema: map[string]*schema.Schema{
+<% unless version == 'ga' -%>
+							"gcfs_config": schemaGcfsConfig(false),
+<% end -%>
+							"logging_variant": schemaLoggingVariant(),
+						},
 					},
 				},
 			},
 		},
 	}
 }
-<% end -%>
 
 func rfc5545RecurrenceDiffSuppress(k, o, n string, d *schema.ResourceData) bool {
 	// This diff gets applied in the cloud console if you specify
@@ -1164,9 +1165,9 @@ func resourceContainerCluster() *schema.Resource {
 				ConflictsWith: []string{"enable_autopilot"},
 			},
 
-<% unless version == "ga" -%>
 			"node_pool_defaults": clusterSchemaNodePoolDefaults(),
 
+<% unless version == "ga" -%>
 			"node_pool_auto_config": {
 				Type:             schema.TypeList,
 				Optional:         true,
@@ -1917,11 +1918,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.NodeConfig = expandNodeConfig([]interface{}{})
 	}
 
-<% unless version == 'ga' -%>
         if v, ok := d.GetOk("node_pool_defaults"); ok {
                 cluster.NodePoolDefaults = expandNodePoolDefaults(v)
         }
-<% end -%>
 
 	if v, ok := d.GetOk("node_config"); ok {
 		cluster.NodeConfig = expandNodeConfig(v)
@@ -2356,11 +2355,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 <% end -%>
 
-<% unless version == 'ga' -%>
         if err := d.Set("node_pool_defaults", flattenNodePoolDefaults(cluster.NodePoolDefaults)); err != nil {
                 return err
         }
-<% end -%>
 
 	return nil
 }
@@ -3315,6 +3312,29 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s resource usage export config has been updated", d.Id())
+	}
+
+	if d.HasChange("node_pool_defaults") && d.HasChange("node_pool_defaults.0.node_config_defaults.0.logging_variant") {
+		if v, ok := d.GetOk("node_pool_defaults.0.node_config_defaults.0.logging_variant"); ok {
+			loggingVariant := v.(string)
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
+					DesiredNodePoolLoggingConfig: &container.NodePoolLoggingConfig{
+						VariantConfig: &container.LoggingVariantConfig{
+							Variant: loggingVariant,
+						},
+					},
+				},
+			}
+
+			updateF := updateFunc(req, "updating GKE cluster desired node pool logging configuration defaults.")
+			// Call update serially.
+			if err := lockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] GKE cluster %s node pool logging configuration defaults have been updated", d.Id())
+		}
 	}
 
 <% unless version == 'ga' -%>
@@ -4344,7 +4364,6 @@ func expandContainerClusterAuthenticatorGroupsConfig(configured interface{}) *co
 	}
 }
 
-<% unless version == 'ga' -%>
 func expandNodePoolDefaults(configured interface{}) *container.NodePoolDefaults {
         l, ok := configured.([]interface{})
         if !ok || l == nil || len(l) == 0 || l[0] == nil {
@@ -4364,13 +4383,12 @@ func flattenNodePoolDefaults(c *container.NodePoolDefaults) []map[string]interfa
 	}
 
 	result := make(map[string]interface{})
-	if c.NodeConfigDefaults != nil && c.NodeConfigDefaults.GcfsConfig != nil {
-			result["node_config_defaults"] = flattenNodeConfigDefaults(c.NodeConfigDefaults)
+	if c.NodeConfigDefaults != nil {
+		result["node_config_defaults"] = flattenNodeConfigDefaults(c.NodeConfigDefaults)
 	}
 
 	return []map[string]interface{}{result}
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func expandNodePoolAutoConfig(configured interface{}) *container.NodePoolAutoConfig {

--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -1177,6 +1177,45 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "node_config") {
+
+		if d.HasChange(prefix + "node_config.0.logging_variant") {
+			if v, ok := d.GetOk(prefix + "node_config.0.logging_variant"); ok {
+				loggingVariant := v.(string)
+				req := &container.UpdateNodePoolRequest{
+					Name: name,
+					LoggingConfig: &container.NodePoolLoggingConfig{
+						VariantConfig: &container.LoggingVariantConfig{
+							Variant: loggingVariant,
+						},
+					},
+				}
+
+				updateF := func() error {
+					clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name), req)
+					if config.UserProjectOverride {
+						clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+					}
+					op, err := clusterNodePoolsUpdateCall.Do()
+					if err != nil {
+						return err
+					}
+
+					// Wait until it's updated
+					return containerOperationWait(config, op,
+						nodePoolInfo.project,
+						nodePoolInfo.location,
+						"updating GKE node pool logging_variant", userAgent,
+						timeout)
+				}
+
+				// Call update serially.
+				if err := lockedCall(lockKey, updateF); err != nil {
+					return err
+				}
+
+				log.Printf("[INFO] Updated logging_variant for node pool %s", name)
+			}
+		}
 		
 		if d.HasChange(prefix + "node_config.0.tags") {
 			req := &container.UpdateNodePoolRequest{

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1001,6 +1001,83 @@ func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withLoggingVariantInNodeConfig(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withLoggingVariantInNodeConfig(clusterName, "MAX_THROUGHPUT"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_logging_variant_in_node_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withLoggingVariantInNodePool(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	nodePoolName := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withLoggingVariantInNodePool(clusterName, nodePoolName, "MAX_THROUGHPUT"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_logging_variant_in_node_pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withLoggingVariantUpdates(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withLoggingVariantNodePoolDefault(clusterName, "DEFAULT"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_logging_variant_node_pool_default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerCluster_withLoggingVariantNodePoolDefault(clusterName, "MAX_THROUGHPUT"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_logging_variant_node_pool_default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerCluster_withLoggingVariantNodePoolDefault(clusterName, "DEFAULT"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_logging_variant_node_pool_default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
 <% unless version == 'ga' -%>
 func TestAccContainerCluster_withNodePoolDefaults(t *testing.T) {
         t.Parallel()
@@ -4299,6 +4376,53 @@ resource "google_container_cluster" "with_node_config" {
   }
 }
 `, clusterName)
+}
+
+func testAccContainerCluster_withLoggingVariantInNodeConfig(clusterName, loggingVariant string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_logging_variant_in_node_config" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  node_config {
+    logging_variant = "%s"
+  }
+}
+`, clusterName, loggingVariant)
+}
+
+func testAccContainerCluster_withLoggingVariantInNodePool(clusterName, nodePoolName, loggingVariant string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_logging_variant_in_node_pool" {
+  name               = "%s"
+  location           = "us-central1-f"
+
+  node_pool {
+    name               = "%s"
+    initial_node_count = 1
+    node_config {
+      logging_variant = "%s"
+    }
+  }
+}
+`, clusterName, nodePoolName, loggingVariant)
+}
+
+func testAccContainerCluster_withLoggingVariantNodePoolDefault(clusterName, loggingVariant string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_logging_variant_node_pool_default" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  node_pool_defaults {
+    node_config_defaults {
+      logging_variant = "%s"
+    }
+  }
+}
+`, clusterName, loggingVariant)
 }
 
 <% unless version == 'ga' -%>

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -156,6 +156,45 @@ func TestAccContainerNodePool_noName(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_withLoggingVariantUpdates(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	nodePool := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withLoggingVariant(cluster, nodePool, "DEFAULT"),
+			},
+			{
+				ResourceName:            "google_container_node_pool.with_logging_variant",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerNodePool_withLoggingVariant(cluster, nodePool, "MAX_THROUGHPUT"),
+			},
+			{
+				ResourceName:            "google_container_node_pool.with_logging_variant",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerNodePool_withLoggingVariant(cluster, nodePool, "DEFAULT"),
+			},
+			{
+				ResourceName:            "google_container_node_pool.with_logging_variant",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
 func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 	t.Parallel()
 
@@ -1265,6 +1304,26 @@ resource "google_container_node_pool" "np" {
   initial_node_count = 2
 }
 `, cluster, np)
+}
+
+func testAccContainerNodePool_withLoggingVariant(cluster, np, loggingVariant string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_logging_variant" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+}
+
+resource "google_container_node_pool" "with_logging_variant" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.with_logging_variant.name
+  initial_node_count = 1
+  node_config {
+    logging_variant = "%s"
+  }
+}
+`,	cluster, np, loggingVariant)
 }
 
 func testAccContainerNodePool_basicWithClusterId(cluster, np string) string {

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -25,6 +25,16 @@ var defaultOauthScopes = []string{
 	"https://www.googleapis.com/auth/trace.append",
 }
 
+func schemaLoggingVariant() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeString,
+		Optional: true,
+		Description: `Type of logging agent that is used as the default value for node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT.`,
+		Default: "DEFAULT",
+		ValidateFunc: validation.StringInSlice([]string{"DEFAULT", "MAX_THROUGHPUT"}, false),
+	}
+}
+
 func schemaGcfsConfig(forceNew bool) *schema.Schema {
         return &schema.Schema{
                 Type:     schema.TypeList,
@@ -159,6 +169,8 @@ func schemaNodeConfig() *schema.Schema {
 					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `The number of local SSD disks to be attached to the node.`,
 				},
+
+				"logging_variant": schemaLoggingVariant(),
 
 	<% unless version == 'ga' -%>
 				"ephemeral_storage_config": {
@@ -471,7 +483,6 @@ func schemaNodeConfig() *schema.Schema {
 	}
 }
 
-<% unless version == "ga" -%>
 func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefaults {
         configs := configured.([]interface{})
 	if len(configs) == 0 || configs[0] == nil {
@@ -479,16 +490,24 @@ func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefau
 	}
 	config := configs[0].(map[string]interface{})
 
-        nodeConfigDefaults := &container.NodeConfigDefaults{}
+	nodeConfigDefaults := &container.NodeConfigDefaults{}
+	if variant, ok := config["logging_variant"]; ok {
+		nodeConfigDefaults.LoggingConfig = &container.NodePoolLoggingConfig{
+			VariantConfig: &container.LoggingVariantConfig{
+				Variant: variant.(string),
+			},
+		}
+	}
+<% unless version == "ga" -%>
         if v, ok := config["gcfs_config"]; ok && len(v.([]interface{})) > 0 {
                 gcfsConfig := v.([]interface{})[0].(map[string]interface{})
 		nodeConfigDefaults.GcfsConfig = &container.GcfsConfig{
 			Enabled: gcfsConfig["enabled"].(bool),
 		}
 	}
+<% end -%>
         return nodeConfigDefaults
 }
-<% end -%>
 
 func expandNodeConfig(v interface{}) *container.NodeConfig {
 	nodeConfigs := v.([]interface{})
@@ -543,6 +562,14 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 
 	if v, ok := nodeConfig["local_ssd_count"]; ok {
 		nc.LocalSsdCount = int64(v.(int))
+	}
+
+	if v, ok := nodeConfig["logging_variant"]; ok {
+		nc.LoggingConfig = &container.NodePoolLoggingConfig{
+			VariantConfig: &container.LoggingVariantConfig{
+				Variant: v.(string),
+			},
+		}
 	}
 
 <% unless version == 'ga' -%>
@@ -762,7 +789,6 @@ func expandLinuxNodeConfig(v interface{}) *container.LinuxNodeConfig {
 
 <% end -%>
 
-<% unless version == 'ga' -%>
 func flattenNodeConfigDefaults(c *container.NodeConfigDefaults) []map[string]interface{} {
         result := make([]map[string]interface{}, 0, 1)
         
@@ -770,12 +796,15 @@ func flattenNodeConfigDefaults(c *container.NodeConfigDefaults) []map[string]int
                 return result
         }
 
-        result = append(result, map[string]interface{}{
-                "gcfs_config": flattenGcfsConfig(c.GcfsConfig),
-        })
+	result = append(result, map[string]interface{}{})
+
+	result[0]["logging_variant"] = flattenLoggingVariant(c.LoggingConfig)
+
+<% unless version == 'ga' -%>
+	result[0]["gcfs_config"] = flattenGcfsConfig(c.GcfsConfig)
+<% end -%>
         return result
 }
-<% end -%>
 
 func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 	config := make([]map[string]interface{}, 0, 1)
@@ -790,6 +819,7 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 		"disk_type":                c.DiskType,
 		"guest_accelerator":        flattenContainerGuestAccelerators(c.Accelerators),
 		"local_ssd_count":          c.LocalSsdCount,
+		"logging_variant":          flattenLoggingVariant(c.LoggingConfig),
 <% unless version == 'ga' -%>
 		"ephemeral_storage_config": flattenEphemeralStorageConfig(c.EphemeralStorageConfig),
 <% end -%>
@@ -868,6 +898,14 @@ func flattenEphemeralStorageConfig(c *container.EphemeralStorageConfig) []map[st
 	return result
 }
 <% end -%>
+
+func flattenLoggingVariant(c *container.NodePoolLoggingConfig) string {
+	variant := "DEFAULT"
+	if c != nil && c.VariantConfig != nil && c.VariantConfig.Variant != "" {
+		variant = c.VariantConfig.Variant
+	}
+	return variant
+}
 
 func flattenGcfsConfig(c *container.GcfsConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -269,7 +269,7 @@ region are guaranteed to support the same version.
     [autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison) clusters and
     [node auto-provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)-enabled clusters. Structure is [documented below](#nested_node_pool_auto_config).
 
-* `node_pool_defaults` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Default NodePool settings for the entire cluster. These settings are overridden if specified on the specific NodePool object. Structure is [documented below](#nested_node_pool_defaults).
+* `node_pool_defaults` - (Optional) Default NodePool settings for the entire cluster. These settings are overridden if specified on the specific NodePool object. Structure is [documented below](#nested_node_pool_defaults).
 
 * `node_version` - (Optional) The Kubernetes version on the nodes. Must either be unset
     or set to the same value as `min_master_version` on create. Defaults to the default
@@ -710,6 +710,8 @@ ephemeral_storage_config {
 }
 ```
 
+* `logging_variant` (Optional) Parameter for specifying the type of logging agent used in a node pool. This will override any [cluster-wide default value](#nested_node_pool_defaults). Valid values include DEFAULT and MAX_THROUGHPUT. See [Increasing logging agent throughput](https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#throughput) for more information.
+
 * `gcfs_config` - (Optional) Parameters for the Google Container Filesystem (GCFS).
     If unspecified, GCFS will not be enabled on the node pool. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version` from GKE versions 1.19 or later to use it.
     For GKE versions 1.19, 1.20, and 1.21, the recommended minimum `node_version` would be 1.19.15-gke.1300, 1.20.11-gke.1300, and 1.21.5-gke.1300 respectively.
@@ -901,11 +903,13 @@ node_pool_auto_config {
 ```
 
 <a name="nested_node_pool_defaults"></a>The `node_pool_defaults` block supports:
-* `node_config_defaults` (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) - Subset of NodeConfig message that has defaults.
+* `node_config_defaults` (Optional) - Subset of NodeConfig message that has defaults.
 
 The `node_config_defaults` block supports:
 
-* `gcfs_config` (Optional) The default Google Container Filesystem (GCFS) configuration at the cluster level. e.g. enable [image streaming](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming) across all the node pools within the cluster. Structure is [documented below](#nested_gcfs_config).
+* `logging_variant` (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. See [Increasing logging agent throughput](https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#throughput) for more information.
+
+* `gcfs_config` (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The default Google Container Filesystem (GCFS) configuration at the cluster level. e.g. enable [image streaming](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming) across all the node pools within the cluster. Structure is [documented below](#nested_gcfs_config).
 
 <a name="nested_notification_config"></a>The `notification_config` block supports:
 


### PR DESCRIPTION
  
  <!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/12667

This PR implements the feature request from [Add GKE logging variant field for increasing log agent throughput #12667](https://github.com/hashicorp/terraform-provider-google/issues/12667). By adding a logging_variant field within the node_pool_defaults, GKE users will be able to select a cluster-level default value for the logging agent of the node pools in a cluster. For example, by specifying
```terraform
resource "google_container_cluster" "with_logging_variant_node_pool_default" {
  name               = "example-cluster"
  location           = "us-central1-f"
  initial_node_count = 1

  node_pool_defaults {
    node_config_defaults {
      logging_variant = "MAX_THROUGHPUT"
    }
  }
}
```
every node pool (i.e. the default node pool) in the cluster will have the max throughput logging agent configured by default (see the [GKE docs](https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#high_throughput_for_all_nodes_in_a_cluster) for more information).

GKE users will also be able to select a logging variant at the node pool level. For example, by specifying
```terraform
resource "google_container_cluster" "with_logging_variant_node_pool_default" {
  name               = "example-cluster"
  location           = "us-central1-f"
  initial_node_count = 1

  node_pool_defaults {
    node_config_defaults {
      logging_variant = "DEFAULT"
    }
  }
}
resource "google_container_node_pool" "with_high_throughput_logging_variant" {
  name    = "example-node-pool"
  cluster = google_container_cluster.with_logging_variant_node_pool_default.name
  node_config {
    logging_variant = "MAX_THROUGHPUT"
  }
}
```
node pools in the cluster (e.g. the default node pool) will have the default logging agent configured (see the [GKE docs](https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#high_throughput_for_all_nodes_in_a_cluster) for more information), but the specified node pool will have the max throughput agent.
  
  <!--
  Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
  These steps will speed up the review process, and we appreciate you spending time on them before sending
  your code to be reviewed.
  -->
I acknowledge that I have:
  
  - [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
  
  - [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
  
  The output of `make test` is
  ```
  sh -c "'/usr/local/google/home/giulianosider/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
  ==> Checking that code complies with gofmt requirements...
  go vet
  go generate  ./...
  go test  -timeout=30s $(go list ./... | grep -v github.com/hashicorp/terraform-provider-google/scripts)
  ?   	github.com/hashicorp/terraform-provider-google	[no test files]
  ok  	github.com/hashicorp/terraform-provider-google/google	22.793s
  ?   	github.com/hashicorp/terraform-provider-google/version	[no test files]
  ```
  but only after I run `make fmt`. There were 2 files unrelated to my change that required Go formatting.
  
  - [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
  
  I added the following tests:
- TestAccContainerCluster_withNoSpecifiedLoggingVariant
- TestAccContainerCluster_withDefaultLoggingVariant
- TestAccContainerCluster_withMaxThroughputLoggingVariant
- TestAccContainerCluster_withLoggingVariantUpdates
- TestAccNodePool_withNoSpecifiedLoggingVariant
- TestAccNodePool_withDefaultLoggingVariant
- TestAccNodePool_withMaxThroughputLoggingVariant
- TestAccNodePool_withLoggingVariantUpdates

  - [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
  
I ran the tests that I added myself (see previous items). When I ran `TF_LOG=TRACE make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster' | tee output.log` in the terraform-provider-google repo, I ran into some failures apparently unrelated to my change, but I'm as of yet unable to figure out why. The TRACE level logs suggested by the command in the README generate about 475 MB of log output, and it's difficult to find anything unless you know what to search for (i.e. "Check failed").
  
  - [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
  
  <!-- AUTOCHANGELOG for Downstream PRs.
  
  Please select one of the following "release-note:" headings:
      - release-note:enhancement
      
  Unless you choose release-note:none, please add a release note.
  
  See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.
  
  You can add more release note blocks if you want more than one CHANGELOG
  entry for this PR.
  -->
  **Release Note Template for Downstream PRs (will be copied)**
  
```release-note:enhancement
container: Added `node_pool_defaults.node_config_defaults.logging_variant`, `node_pool.node_config.logging_variant`, and `node_config.logging_variant` to `google_container_cluster`.
```
  
```release-note:enhancement
container: Added `node_config.logging_variant` to `google_container_node_pool`.
```
