### PR TITLE
tfv: Fix GetOk field name in hand written iam files

### DIFF
--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -133,6 +133,8 @@ module Provider
       )
 
       @non_defined_tests = retrieve_full_manifest_of_non_defined_tests
+      files = retrieve_full_list_of_test_files
+      @tests = files.map { |file| file.split('.')[0] } | []
 
       test_source = retrieve_test_source_code_with_location('[b]').map do |location|
         [location[0].sub('go.erb', 'go'), location[1]]
@@ -149,6 +151,8 @@ module Provider
                            'third_party/terraform/utils/compute_operation.go.erb'],
                           ['converters/google/resources/config.go',
                            'third_party/terraform/utils/config.go.erb'],
+                          ['converters/google/resources/config_test_utils.go',
+                           'third_party/terraform/utils/config_test_utils.go.erb'],
                           ['converters/google/resources/iam.go',
                            'third_party/terraform/utils/iam.go.erb'],
                           ['converters/google/resources/compute_instance_helpers.go',

--- a/mmv1/third_party/terraform/utils/config_test_utils.go.erb
+++ b/mmv1/third_party/terraform/utils/config_test_utils.go.erb
@@ -1,0 +1,39 @@
+<% autogen_exception -%>
+package google
+
+import (
+	"net/http/httptest"
+	"strings"
+)
+
+// NewTestConfig create a config using the http test server.
+func NewTestConfig(server *httptest.Server) *Config {
+	cfg := &Config{}
+	cfg.client = server.Client()
+	configureTestBasePaths(cfg, server.URL)
+	return cfg
+}
+
+func configureTestBasePaths(c *Config, url string) {
+  if !strings.HasSuffix(url, "/") {
+		url = url + "/"
+	}
+	// Generated Products
+	<% products.map.each do |product| -%>
+	c.<%= product[:definitions].name -%>BasePath = url
+	<% end -%>
+
+	// Handwritten Products / Versioned / Atypical Entries
+	c.CloudBillingBasePath = url
+	c.ComposerBasePath = url
+	c.ContainerBasePath = url
+	c.DataprocBasePath = url
+	c.DataflowBasePath = url
+	c.IamCredentialsBasePath = url
+	c.ResourceManagerV3BasePath = url
+	c.IAMBasePath = url
+	c.ServiceNetworkingBasePath = url
+	c.BigQueryBasePath = url
+	c.StorageTransferBasePath = url
+	c.BigtableAdminBasePath = url
+}

--- a/mmv1/third_party/validator/bigquery_dataset_iam.go
+++ b/mmv1/third_party/validator/bigquery_dataset_iam.go
@@ -89,7 +89,7 @@ func newBigqueryDatasetIamAsset(
 
 func FetchBigqueryDatasetIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	// Check if the identity field returns a value
-	if _, ok := d.GetOk("{{dataset_id}}"); !ok {
+	if _, ok := d.GetOk("dataset_id"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 

--- a/mmv1/third_party/validator/kms_crypto_key_iam.go
+++ b/mmv1/third_party/validator/kms_crypto_key_iam.go
@@ -93,7 +93,7 @@ func newKmsCryptoKeyIamAsset(
 
 func FetchKmsCryptoKeyIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	// Check if the identity field returns a value
-	if _, ok := d.GetOk("{{crypto_key_id}}"); !ok {
+	if _, ok := d.GetOk("crypto_key_id"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 

--- a/mmv1/third_party/validator/pubsub_subscription_iam.go
+++ b/mmv1/third_party/validator/pubsub_subscription_iam.go
@@ -89,7 +89,7 @@ func newPubsubSubscriptionIamAsset(
 
 func FetchPubsubSubscriptionIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	// Check if the identity field returns a value
-	if _, ok := d.GetOk("{{subscription}}"); !ok {
+	if _, ok := d.GetOk("subscription"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 

--- a/mmv1/third_party/validator/spanner_database_iam.go
+++ b/mmv1/third_party/validator/spanner_database_iam.go
@@ -89,11 +89,11 @@ func newSpannerDatabaseIamAsset(
 
 func FetchSpannerDatabaseIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	// Check if the identity field returns a value
-	if _, ok := d.GetOk("{{instance}}"); !ok {
+	if _, ok := d.GetOk("instance"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 
-	if _, ok := d.GetOk("{{database}}"); !ok {
+	if _, ok := d.GetOk("database"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 

--- a/mmv1/third_party/validator/spanner_instance_iam.go
+++ b/mmv1/third_party/validator/spanner_instance_iam.go
@@ -89,7 +89,7 @@ func newSpannerInstanceIamAsset(
 
 func FetchSpannerInstanceIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	// Check if the identity field returns a value
-	if _, ok := d.GetOk("{{instance}}"); !ok {
+	if _, ok := d.GetOk("instance"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 

--- a/mmv1/third_party/validator/storage_bucket_iam.go
+++ b/mmv1/third_party/validator/storage_bucket_iam.go
@@ -92,7 +92,7 @@ func newStorageBucketIamAsset(
 
 func FetchStorageBucketIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
 	// Check if the identity field returns a value
-	if _, ok := d.GetOk("{{bucket}}"); !ok {
+	if _, ok := d.GetOk("bucket"); !ok {
 		return Asset{}, ErrEmptyIdentityField
 	}
 

--- a/mmv1/third_party/validator/tests/source/iam_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/iam_test.go.erb
@@ -1,0 +1,104 @@
+<% autogen_exception -%>
+package test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	crmv1 "google.golang.org/api/cloudresourcemanager/v1"
+
+	resources "github.com/GoogleCloudPlatform/terraform-validator/converters/google/resources"
+	"github.com/GoogleCloudPlatform/terraform-validator/tfdata"
+	"github.com/GoogleCloudPlatform/terraform-validator/tfplan"
+	provider "github.com/hashicorp/terraform-provider-google/google"
+)
+
+func TestIAMFetchFullResource(t *testing.T) {
+	cases := []struct {
+		name string
+	}{
+	<% @tests.each do |test| -%>
+  <% if test.end_with?("iam_binding") || test.end_with?("iam_member") -%>
+		  {name: "<%= test -%>"},
+  <% end -%>
+	<% end -%>
+	}
+
+	converters := resources.ResourceConverters()
+	schema := provider.Provider()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload []byte
+		var err error
+		if strings.Contains(r.URL.String(), "dataset") {
+			obj := map[string][]interface{}{
+				"access": {&crmv1.Policy{}},
+			}
+			payload, err = json.Marshal(obj)
+		} else {
+			payload, err = (&crmv1.Policy{}).MarshalJSON()
+		}
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("failed to MarshalJSON: %s", err)))
+			return
+		}
+		w.Write(payload)
+	}))
+
+	// Using Cleanup instead of defer because t.Parallel() does not block t.Run.
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	cfg := resources.NewTestConfig(server)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a temporary directory for generating tfplan.json from template.
+			dir, err := ioutil.TempDir(tmpDir, "terraform")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+
+			generateTestFiles(t, "../testdata/templates", dir, c.name+".tfplan.json")
+			path := filepath.Join(dir, c.name+".tfplan.json")
+
+			data, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("opening JSON plan file: %s", err)
+			}
+			changes, err := tfplan.ReadResourceChanges(data)
+			if err != nil {
+				t.Fatalf("ReadResourceChanges failed: %s", err)
+			}
+
+			for _, rc := range changes {
+				resource := schema.ResourcesMap[rc.Type]
+				rd := tfdata.NewFakeResourceData(
+					rc.Type,
+					resource.Schema,
+					rc.Change.After.(map[string]interface{}),
+				)
+				for _, converter := range converters[rd.Kind()] {
+					if converter.FetchFullResource == nil {
+						continue
+					}
+					_, err := converter.FetchFullResource(rd, cfg)
+					if err != nil {
+						t.Errorf("FetchFullResource() = %s, want = nil", err)
+					}
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

b/255831148
terraform validator: GetOk() function should not have {{}} within the parameter. 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
