### PR TITLE
feat: feat: release_channel_latest_version in google_container_engine_versions in google_container_engine_versions

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go
@@ -51,6 +51,11 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"release_channel_latest_version": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -117,12 +122,23 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 		return fmt.Errorf("Error setting default_cluster_version: %s", err)
 	}
 
-	channels := map[string]string{}
-	for _, v := range resp.Channels {
-		channels[v.Channel] = v.DefaultVersion
+	releaseChannelDefaultVersion := map[string]string{}
+	releaseChannelLatestVersion := map[string]string{}
+	for _, channelResp := range resp.Channels {
+		releaseChannelDefaultVersion[channelResp.Channel] = channelResp.DefaultVersion
+		for _, v := range channelResp.ValidVersions {
+			if strings.HasPrefix(v, d.Get("version_prefix").(string)) {
+				releaseChannelLatestVersion[channelResp.Channel] = v
+				break
+			}
+		}
 	}
-	if err := d.Set("release_channel_default_version", channels); err != nil {
+
+	if err := d.Set("release_channel_default_version", releaseChannelDefaultVersion); err != nil {
 		return fmt.Errorf("Error setting release_channel_default_version: %s", err)
+	}
+	if err := d.Set("release_channel_latest_version", releaseChannelLatestVersion); err != nil {
+		return fmt.Errorf("Error setting release_channel_latest_version: %s", err)
 	}
 
 	d.SetId(time.Now().UTC().String())

--- a/mmv1/third_party/terraform/tests/data_source_google_container_engine_versions_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_container_engine_versions_test.go
@@ -111,6 +111,16 @@ func testAccCheckGoogleContainerEngineVersionsMeta(n string) resource.TestCheckF
 			return errors.New("Didn't get a default cluster version.")
 		}
 
+		_, ok = rs.Primary.Attributes["release_channel_default_version.STABLE"]
+		if !ok {
+			return errors.New("failed to read default STABLE version")
+		}
+
+		_, ok = rs.Primary.Attributes["release_channel_latest_version.STABLE"]
+		if !ok {
+			return errors.New("failed to read latest STABLE version")
+		}
+
 		return nil
 	}
 }

--- a/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
@@ -31,8 +31,12 @@ resource "google_container_cluster" "foo" {
   initial_node_count = 1
 }
 
-output "stable_channel_version" {
+output "stable_channel_default_version" {
   value = data.google_container_engine_versions.central1b.release_channel_default_version["STABLE"]
+}
+
+output "stable_channel_latest_version" {
+  value = data.google_container_engine_versions.central1b.release_channel_latest_version["STABLE"]
 }
 ```
 
@@ -65,3 +69,4 @@ The following attributes are exported:
 * `latest_node_version` - The latest version available in the given zone for use with node instances.
 * `default_cluster_version` - Version of Kubernetes the service deploys by default.
 * `release_channel_default_version` - A map from a release channel name to the channel's default version.
+* `release_channel_latest_version` - A map from a release channel name to the channel's latest versions.

--- a/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
@@ -69,4 +69,4 @@ The following attributes are exported:
 * `latest_node_version` - The latest version available in the given zone for use with node instances.
 * `default_cluster_version` - Version of Kubernetes the service deploys by default.
 * `release_channel_default_version` - A map from a release channel name to the channel's default version.
-* `release_channel_latest_version` - A map from a release channel name to the channel's latest versions.
+* `release_channel_latest_version` - A map from a release channel name to the channel's latest version.


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/7462



If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added `release_channel_latest_version` in `google_container_engine_versions` datasource
```
