### PR TITLE
Add extra BigQuery options to DLP inspect job trigger

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -288,6 +288,27 @@ objects:
                         required: true
                         description: |
                           The name of the table.
+                  - !ruby/object:Api::Type::String
+                    name: 'rowsLimit'
+                    description: |
+                      Max number of rows to scan. If the table has more rows than this value, the rest of the rows are omitted. 
+                      If not set, or if set to 0, all rows will be scanned. Only one of rowsLimit and rowsLimitPercent can be 
+                      specified. Cannot be used in conjunction with TimespanConfig.
+                  - !ruby/object:Api::Type::Integer
+                    name: 'rowsLimitPercent'
+                    description: |
+                      Max percentage of rows to scan. The rest are omitted. The number of rows scanned is rounded down. 
+                      Must be between 0 and 100, inclusively. Both 0 and 100 means no limit. Defaults to 0. Only one of 
+                      rowsLimit and rowsLimitPercent can be specified. Cannot be used in conjunction with TimespanConfig.
+                  - !ruby/object:Api::Type::Enum
+                    name: 'sampleMethod'
+                    description: |
+                      How to sample rows if not all rows are scanned. Meaningful only when used in conjunction with either 
+                      rowsLimit or rowsLimitPercent. If not specified, rows are scanned in the order BigQuery reads them.
+                    values: 
+                      - :TOP
+                      - :RANDOM_START
+                    default_value: :TOP
           - !ruby/object:Api::Type::Array
             name: 'actions'
             required: true

--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -288,7 +288,7 @@ objects:
                         required: true
                         description: |
                           The name of the table.
-                  - !ruby/object:Api::Type::String
+                  - !ruby/object:Api::Type::Integer
                     name: 'rowsLimit'
                     description: |
                       Max number of rows to scan. If the table has more rows than this value, the rest of the rows are omitted. 

--- a/mmv1/products/dlp/terraform.yaml
+++ b/mmv1/products/dlp/terraform.yaml
@@ -49,6 +49,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           trigger: "trigger"
         test_env_vars:
           project: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dlp_job_trigger_bigquery_row_limit"
+        primary_resource_id: "bigquery_row_limit"
+        vars:
+          trigger: "trigger"
+        test_env_vars:
+          project: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dlp_job_trigger_bigquery_row_limit_percentage"
+        primary_resource_id: "bigquery_row_limit_percentage"
+        vars:
+          trigger: "trigger"
+        test_env_vars:
+          project: :PROJECT_NAME
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/wrap_object.go.erb
       custom_import: templates/terraform/custom_import/dlp_import.go.erb

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit.tf.erb
@@ -29,8 +29,8 @@ resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id
 				    table_id = "table_to_scan"
 				}
 
-				rowsLimit = 1000
-				sampleMethod = "RANDOM_START"
+				rows_limit = 1000
+				sample_method = "RANDOM_START"
 			}
 		}
 	}

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit.tf.erb
@@ -22,10 +22,15 @@ resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id
 			}
 		}
 		storage_config {
-			cloud_storage_options {
-				file_set {
-					url = "gs://mybucket/directory/"
+			big_query_options {
+				table_reference {
+				    project_id = "project"
+				    dataset_id = "dataset"
+				    table_id = "table_to_scan"
 				}
+
+				rowsLimit = 1000
+				sampleMethod = "RANDOM_START"
 			}
 		}
 	}

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit_percentage.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit_percentage.tf.erb
@@ -22,10 +22,15 @@ resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id
 			}
 		}
 		storage_config {
-			cloud_storage_options {
-				file_set {
-					url = "gs://mybucket/directory/"
+			big_query_options {
+				table_reference {
+				    project_id = "project"
+				    dataset_id = "dataset"
+				    table_id = "table_to_scan"
 				}
+
+				rowsLimitPercent = 50
+				sampleMethod = "RANDOM_START"
 			}
 		}
 	}

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit_percentage.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_bigquery_row_limit_percentage.tf.erb
@@ -29,8 +29,8 @@ resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id
 				    table_id = "table_to_scan"
 				}
 
-				rowsLimitPercent = 50
-				sampleMethod = "RANDOM_START"
+				rows_limit_percent = 50
+				sample_method = "RANDOM_START"
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds in extra fields for BigQuery which are accessible through the REST API, but not currently through Terraform for creating DLP inspect job triggers. They are particularly useful as they enable limiting the rows scanned in a DLP inspect job which can otherwise be very expensive for large tables.

-rowsLimit
-rowsLimitPercent
-sampleMethod

Part of:
https://github.com/hashicorp/terraform-provider-google/issues/8807


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added fields `rows_limit`, `rows_limit_percent`, and `sample_method` to `big_query_options` in `google_data_loss_prevention_job_trigger` 
```
