### PR TITLE
`network_services`: Dual-Token Authentication Support

### DIFF
--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -76,13 +76,14 @@ objects:
         description: 'Set of label tags associated with the EdgeCache resource.'
       - !ruby/object:Api::Type::Array
         name: publicKeys
-        required: true
         description: |
           An ordered list of Ed25519 public keys to use for validating signed requests.
-          You must specify at least one (1) key, and may have up to three (3) keys.
+          You must specify `public_keys` or `validation_shared_keys` (or both). The keys in `public_keys` are checked first.
+          You may specify no more than one Google-managed public key.
+          If you specify `public_keys`, you must specify at least one (1) key and may specify up to three (3) keys.
 
           Ed25519 public keys are not secret, and only allow Google to validate a request was signed by your corresponding private key.
-          You should ensure that the private key is kept secret, and that only authorized users can add public keys to a keyset.
+          Ensure that the private key is kept secret, and that only authorized users can add public keys to a keyset.
         min_size: 1
         max_size: 3
         item_type: !ruby/object:Api::Type::NestedObject
@@ -96,10 +97,41 @@ objects:
                 which means the first character must be a letter, and all following characters must be a dash, underscore, letter or digit.
             - !ruby/object:Api::Type::String
               name: 'value'
-              required: true
               description: |
                 The base64-encoded value of the Ed25519 public key. The base64 encoding can be padded (44 bytes) or unpadded (43 bytes).
                 Representations or encodings of the public key other than this will be rejected with an error.
+            - !ruby/object:Api::Type::Boolean
+              name: 'managed'
+              description: |
+                Set to true to have the CDN automatically manage this public key value.
+        at_least_one_of:
+          - public_key
+          - validation_shared_keys
+      - !ruby/object:Api::Type::Array
+        name: 'validationSharedKeys'
+        description: |
+          An ordered list of shared keys to use for validating signed requests.
+          Shared keys are secret.  Ensure that only authorized users can add `validation_shared_keys` to a keyset.
+          You can rotate keys by appending (pushing) a new key to the list of `validation_shared_keys` and removing any superseded keys.
+          You must specify `public_keys` or `validation_shared_keys` (or both). The keys in `public_keys` are checked first.
+        min_size: 1
+        max_size: 3
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'secretVersion'
+              required: true
+              description: |
+                The name of the secret version in Secret Manager.
+                
+                The resource name of the secret version must be in the format `projects/*/secrets/*/versions/*` where the `*` values are replaced by the secrets themselves.
+                The secrets must be at least 16 bytes large.  The recommended secret size depends on the signature algorithm you are using.
+                * If you are using HMAC-SHA1, we suggest 20-byte secrets.
+                * If you are using HMAC-SHA256, we suggest 32-byte secrets.
+                See RFC 2104, Section 3 for more details on these recommendations.
+        at_least_one_of:
+          - public_key
+          - validation_shared_keys
   - !ruby/object:Api::Resource
     name: 'EdgeCacheOrigin'
     base_url: 'projects/{{project}}/locations/global/edgeCacheOrigins'
@@ -814,10 +846,131 @@ objects:
                                 values:
                                   - :DISABLED
                                   - :REQUIRE_SIGNATURES
+                                  - :REQUIRE_TOKENS
                               - !ruby/object:Api::Type::String
                                 name: 'signedRequestKeyset' # resource ref, EdgeCacheKeyset?
                                 description: |
                                   The EdgeCacheKeyset containing the set of public keys used to validate signed requests at the edge.
+                              - !ruby/object:Api::Type::NestedObject
+                                name: 'signedTokenOptions'
+                                description: |
+                                  Additional options for signed tokens.
+
+                                  signedTokenOptions may only be specified when signedRequestMode is REQUIRE_TOKENS.
+                                properties:
+                                  - !ruby/object:Api::Type::String
+                                    name: 'tokenQueryParameter'
+                                    description: |
+                                      The query parameter in which to find the token.
+
+                                      The name must be 1-64 characters long and match the regular expression `[a-zA-Z]([a-zA-Z0-9_-])*` which means the first character must be a letter, and all following characters must be a dash, underscore, letter or digit.
+
+                                      Defaults to `edge-cache-token`.
+                                  - !ruby/object:Api::Type::Array
+                                    name: 'allowedSignatureAlgorithms'
+                                    description: |
+                                      The allowed signature algorithms to use.
+
+                                      Defaults to using only ED25519.
+
+                                      You may specify up to 3 signature algorithms to use.
+                                    max_size: 3
+                                    item_type: !ruby/object:Api::Type::Enum
+                                      name: 'allowedSignatureAlgorithm'
+                                      description: |
+                                        The signed request signature algorithm to use.
+                                      values:
+                                        - :ED25519
+                                        - :HMAC_SHA_256
+                                        - :HMAC_SHA1
+                              - !ruby/object:Api::Type::NestedObject
+                                name: 'addSignatures'
+                                description: |
+                                  Enable signature generation or propagation on this route.
+
+                                  This field may only be specified when signedRequestMode is set to REQUIRE_TOKENS.
+                                properties:
+                                  - !ruby/object:Api::Type::Array
+                                    name: actions
+                                    description: |
+                                      The actions to take to add signatures to responses.
+                                    required: true
+                                    max_size: 1
+                                    item_type: !ruby/object:Api::Type::Enum
+                                      name: action
+                                      description: |
+                                        The ways a signature can be manipulated in a response.
+                                      values:
+                                        - :GENERATE_COOKIE
+                                        - :GENERATE_TOKEN_HLS_COOKIELESS
+                                        - :PROPAGATE_TOKEN_HLS_COOKIELESS
+                                  - !ruby/object:Api::Type::String
+                                    name: 'keyset'
+                                    description: |
+                                      The keyset to use for signature generation.
+
+                                      The following are both valid paths to an EdgeCacheKeyset resource:
+
+                                        * `projects/project/locations/global/edgeCacheKeysets/yourKeyset`
+                                        * `yourKeyset`
+
+                                      This must be specified when the GENERATE_COOKIE or GENERATE_TOKEN_HLS_COOKIELESS actions are specified.  This field may not be specified otherwise.
+                                  - !ruby/object:Api::Type::String
+                                    name: tokenTtl
+                                    description: |
+                                      The duration the token is valid starting from the moment the token is first generated.
+                                      
+                                      Defaults to `86400s` (1 day).
+
+                                      The TTL must be >= 0 and <= 604,800 seconds (1 week).
+                                      
+                                      This field may only be specified when the GENERATE_COOKIE or GENERATE_TOKEN_HLS_COOKIELESS actions are specified.
+
+                                      A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+                                  - !ruby/object:Api::Type::String
+                                    name: 'tokenQueryParameter'
+                                    description: |
+                                      The query parameter in which to put the generated token.
+                                      
+                                      If not specified, defaults to `edge-cache-token`.
+
+                                      If specified, the name must be 1-64 characters long and match the regular expression `[a-zA-Z]([a-zA-Z0-9_-])*` which means the first character must be a letter, and all following characters must be a dash, underscore, letter or digit.
+
+                                      This field may only be set when the GENERATE_TOKEN_HLS_COOKIELESS or PROPAGATE_TOKEN_HLS_COOKIELESS actions are specified.
+                                  - !ruby/object:Api::Type::Array
+                                    name: 'copiedParameters'
+                                    description: |
+                                      The parameters to copy from the verified token to the generated token.
+
+                                      Only the following parameters may be copied:
+
+                                        * `PathGlobs`
+                                        * `paths`
+                                        * `acl`
+                                        * `URLPrefix`
+                                        * `IPRanges`
+                                        * `SessionID`
+                                        * `id`
+                                        * `Data`
+                                        * `data`
+                                        * `payload`
+                                        * `Headers`
+
+                                      You may specify up to 6 parameters to copy.  A given parameter is be copied only if the parameter exists in the verified token.  Parameter names are matched exactly as specified.  The order of the parameters does not matter.  Duplicates are not allowed.
+
+                                      This field may only be specified when the GENERATE_COOKIE or GENERATE_TOKEN_HLS_COOKIELESS actions are specified.
+                                    item_type: Api::Type::String
+                              - !ruby/object:Api::Type::String
+                                name: 'signedRequestMaximumExpirationTtl'
+                                description: |
+                                  Limit how far into the future the expiration time of a signed request may be.
+
+                                  When set, a signed request is rejected if its expiration time is later than now + signedRequestMaximumExpirationTtl, where now is the time at which the signed request is first handled by the CDN.
+
+                                  - The TTL must be > 0.
+                                  - Fractions of a second are not allowed.
+
+                                  By default, signedRequestMaximumExpirationTtl is not set and the expiration time of a signed request may be arbitrarily far into future.
                           - !ruby/object:Api::Type::NestedObject
                             name: urlRewrite
                             description: |

--- a/mmv1/products/networkservices/terraform.yaml
+++ b/mmv1/products/networkservices/terraform.yaml
@@ -21,6 +21,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
         vars:
           resource_name: "default"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "network_services_edge_cache_keyset_dual_token"
+        primary_resource_id: "default"
+        vars:
+          resource_name: "default"
+          secret_name: "secret-name"
     properties:
       publicKeys: !ruby/object:Overrides::Terraform::PropertyOverride
         name: "public_key"
@@ -80,6 +86,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           bucket_name: "my-bucket"
           origin_name: "my-origin"
           origin_google: "origin-google"
+          service_name: "my-service"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "network_services_edge_cache_service_dual_token"
+        primary_resource_id: "instance"
+        vars:
+          secret_name: "secret-name"
+          keyset_name: "keyset-name"
+          origin_name: "my-origin"
           service_name: "my-service"
     properties:
       disableQuic: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
@@ -1,0 +1,25 @@
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.id
+
+  secret_data = "secret-data"
+}
+
+resource "google_network_services_edge_cache_keyset" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['resource_name'] %>"
+  description = "The default keyset"
+  public_key {
+    id      = "my-public-key"
+    managed = true
+  }
+  validation_shared_keys {
+    secret_version = google_secret_manager_secret_version.secret-version-basic.id
+  }
+}

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
@@ -1,0 +1,115 @@
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.id
+
+  secret_data = "secret-data"
+}
+
+resource "google_network_services_edge_cache_keyset" "keyset" {
+  name        = "<%= ctx[:vars]['keyset_name'] %>"
+  description = "The default keyset"
+  public_key {
+    id      = "my-public-key"
+    managed = true
+  }
+  validation_shared_keys {
+    secret_version = google_secret_manager_secret_version.secret-version-basic.id
+  }
+}
+
+resource "google_network_services_edge_cache_origin" "instance" {
+  name                 = "<%= ctx[:vars]['origin_name'] %>"
+  origin_address       = "gs://media-edge-default"
+  description          = "The default bucket for media edge test"
+}
+
+resource "google_network_services_edge_cache_service" "<%= ctx[:primary_resource_id] %>" {
+  name                 = "<%= ctx[:vars]['service_name'] %>"
+  description          = "some description"
+  routing {
+    host_rule {
+      description = "host rule description"
+      hosts = ["sslcert.tf-test.club"]
+      path_matcher = "routes"
+    }
+    path_matcher {
+      name = "routes"
+      route_rule {
+        description = "a route rule to match against master playlist"
+        priority = 1
+        match_rule {
+          path_template_match = "/master.m3u8"
+	}	
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+	    signed_request_mode = "REQUIRE_TOKENS"
+	    signed_request_keyset = google_network_services_edge_cache_keyset.keyset.id
+	    signed_token_options {
+	      token_query_parameter = "edge-cache-token"
+	    }
+	    signed_request_maximum_expiration_ttl = "600s"
+	    add_signatures {
+	      actions = ["GENERATE_COOKIE"]
+	      keyset = google_network_services_edge_cache_keyset.keyset.id
+	      copied_parameters = ["PathGlobs", "SessionID"]
+	    }
+          }
+        }
+      }
+      route_rule {
+        description = "a route rule to match against all playlists"
+        priority = 2
+        match_rule {
+          path_template_match = "/*.m3u8"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+	    signed_request_mode = "REQUIRE_TOKENS"
+	    signed_request_keyset = google_network_services_edge_cache_keyset.keyset.id
+	    signed_token_options {
+	      token_query_parameter = "hdnts"
+	      allowed_signature_algorithms = ["ED25519", "HMAC_SHA_256", "HMAC_SHA1"]
+	    }
+	    add_signatures {
+	      actions = ["GENERATE_TOKEN_HLS_COOKIELESS"]
+	      keyset = google_network_services_edge_cache_keyset.keyset.id
+	      token_ttl = "1200s"
+	      token_query_parameter = "hdntl"
+	      copied_parameters = ["URLPrefix"]
+	    }
+          }
+        }
+      }
+      route_rule {
+        description = "a route rule to match against"
+        priority = 3
+        match_rule {
+          path_template_match = "/**.m3u8"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+	    signed_request_mode = "REQUIRE_TOKENS"
+	    signed_request_keyset = google_network_services_edge_cache_keyset.keyset.id
+	    signed_token_options {
+	      token_query_parameter = "hdntl"
+	    }
+	    add_signatures {
+	      actions = ["PROPAGATE_TOKEN_HLS_COOKIELESS"]
+	      token_query_parameter = "hdntl"
+	    }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds `signed_token_options` and `add_signatures` field to `google_network_services_edge_cache_service` and `validation_shared_keys` to `google_network_services_edge_cache_keyset` to support [dual-token authentication](https://cloud.google.com/media-cdn/docs/use-dual-token-authentication).
Resolves https://github.com/hashicorp/terraform-provider-google/issues/12775.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
network_services: added `signed_token_options` and `add_signatures` field to `google_network_services_edge_cache_service` and `validation_shared_keys` to `google_network_services_edge_cache_keyset` to support dual-token authentication
```
