### PR TITLE
Add PubSub action to DLP Job Trigger

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -297,7 +297,9 @@ objects:
               properties:
                 - !ruby/object:Api::Type::NestedObject
                   name: 'saveFindings'
-                  required: true
+                  exactly_one_of:
+                    - save_findings
+                    - pub_sub
                   description: |
                     Schedule for triggered jobs
                   properties:
@@ -345,6 +347,19 @@ objects:
                             - :DATASTORE_COLUMNS
                             - :BIG_QUERY_COLUMNS
                             - :ALL_COLUMNS
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'pubSub'
+                  exactly_one_of:
+                    - save_findings
+                    - pub_sub
+                  description: |
+                    Publish a message into a given Pub/Sub topic when the job completes.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'topic'
+                      required: true
+                      description: |
+                        Cloud Pub/Sub topic to send notifications to.
   - !ruby/object:Api::Resource
     name: 'InspectTemplate'
     create_url:  "{{parent}}/inspectTemplates"

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -41,6 +41,31 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerUpdateExample(t *testing.T
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerPubsub(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project": getTestProjectFromEnv(),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_publishToPubSub(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.pubsub",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -101,6 +126,38 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 						dataset_id = "asdf"
 					}
 				}
+			}
+		}
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_publishToPubSub(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "pubsub" {
+	parent = "projects/%{project}"
+	description = "Starting description"
+	display_name = "display"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			pub_sub {
+				topic = "projects/%{project}/topics/bar"
 			}
 		}
 		storage_config {


### PR DESCRIPTION
Adds support for an additional type of action, "Publish to PubSub", to the Data Loss Prevention Job Trigger schema.

This allows terraform users to configure their DLP triggers to publish to a PubSub topic upon completion.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] ~Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it~ (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), ~and ran `make test` and `make lint` to ensure it passes unit and linter tests.~ **both of those failed with `make: *** No rule to make target 'test' (or 'lint').  Stop.`**
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] ~[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests~ (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). **I could not find the section "tests" in the linked document.**
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added pubsub action to `google_data_loss_prevention_job_trigger`
```
