### PR TITLE
add note regarding workload identity requirements

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
@@ -12,6 +12,8 @@ Get a IAM workload identity pool from Google Cloud by its id.
 ~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
 
+**IAM Requirements Note:** The following resource requires the Beta IAM role "roles/iam.workloadIdentityPoolAdmin" in order to succeed. Owner and Editor roles do not include the necessary permissions.
+
 ## Example Usage
 
 ```tf

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
@@ -12,7 +12,7 @@ Get a IAM workload identity pool from Google Cloud by its id.
 ~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
 
-**IAM Requirements Note:** The following resource requires the Beta IAM role "roles/iam.workloadIdentityPoolAdmin" in order to succeed. Owner and Editor roles do not include the necessary permissions.
+~> **Note:** The following resource requires the Beta IAM role `roles/iam.workloadIdentityPoolAdmin` in order to succeed. `OWNER` and `EDITOR` roles do not include the necessary permissions.
 
 ## Example Usage
 


### PR DESCRIPTION
I'm unsure if this is where to place the note, but I'm hoping this PR helps. It relates to https://github.com/hashicorp/terraform-provider-google/pull/11790 and https://github.com/hashicorp/terraform-provider-google/issues/11789 which identifies a simple documentation note for help with this resource. 


If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.



```release-note:note
workload_identity_pool: added note about IAM permission requirements
```
