### PR TITLE
Bigtable: Check ForceNew for kms_key_name field in the diff function

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
@@ -81,7 +81,6 @@ func resourceBigtableInstance() *schema.Resource {
 						"kms_key_name": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							ForceNew:    true,
 							Computed:    true,
 							Description: `Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the cloudkms.cryptoKeyEncrypterDecrypter role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster. 3) All clusters within an instance must use the same CMEK key. Values are of the form projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}`,
 						},
@@ -554,6 +553,14 @@ func resourceBigtableInstanceClusterReorderTypeList(_ context.Context, diff *sch
 		oST, nST := diff.GetChange(fmt.Sprintf("cluster.%d.storage_type", i))
 		if oST != nST {
 			err := diff.ForceNew(fmt.Sprintf("cluster.%d.storage_type", i))
+			if err != nil {
+				return fmt.Errorf("Error setting cluster diff: %s", err)
+			}
+		}
+
+		oKey, nKey := diff.GetChange(fmt.Sprintf("cluster.%d.kms_key_name", i))
+		if oKey != nKey {
+			err := diff.ForceNew(fmt.Sprintf("cluster.%d.kms_key_name", i))
 			if err != nil {
 				return fmt.Errorf("Error setting cluster diff: %s", err)
 			}

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -131,11 +131,7 @@ for a `DEVELOPMENT` instance.
 
 * `kms_key_name` - (Optional) Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.
 
-!> **Warning**: Modifying this field will cause Terraform to delete/recreate the entire resource. 
-
--> **Note**: To remove this field once it is set, set the value to an empty string. Removing the field entirely from the config will cause the provider to default to the backend value.
-
-!> **Warning:** Modifying the `storage_type` or `zone` of an existing cluster (by
+!> **Warning:** Modifying the `storage_type`, `zone` or kms_key_name` of an existing cluster (by
 `cluster_id`) will cause Terraform to delete/recreate the entire
 `google_bigtable_instance` resource. If these values are changing, use a new
 `cluster_id`.

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -131,6 +131,8 @@ for a `DEVELOPMENT` instance.
 
 * `kms_key_name` - (Optional) Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.
 
+-> **Note**: Removing the field entirely from the config will cause the provider to default to the backend value.
+
 !> **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by
 `cluster_id`) will cause Terraform to delete/recreate the entire
 `google_bigtable_instance` resource. If these values are changing, use a new

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -131,7 +131,7 @@ for a `DEVELOPMENT` instance.
 
 * `kms_key_name` - (Optional) Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.
 
-!> **Warning:** Modifying the `storage_type`, `zone` or kms_key_name` of an existing cluster (by
+!> **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by
 `cluster_id`) will cause Terraform to delete/recreate the entire
 `google_bigtable_instance` resource. If these values are changing, use a new
 `cluster_id`.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

ForceNew property for `kms_key_name` needs to be checked in resourceBigtableInstanceClusterReorderTypeList() similar to `zone` and `storage_type`. Otherwise, we may not be comparing the same cluster based on the index only.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: update checking ForceNew logic for `kms_key_name`
```
