### PR TITLE
Added handling of amd64 images on compute disk

### DIFF
--- a/mmv1/templates/terraform/constants/disk.erb
+++ b/mmv1/templates/terraform/constants/disk.erb
@@ -122,6 +122,19 @@ func diskImageEquals(oldImageName, newImageName string) bool {
 func diskImageFamilyEquals(imageName, familyName string) bool {
 	// Handles the case when the image name includes the family name
 	// e.g. image name: debian-11-bullseye-v20220719, family name: debian-11
+
+	// First condition is to check if image contains arm64 because of case like:
+	// image name: opensuse-leap-15-4-v20220713-arm64, family name: opensuse-leap (should not be evaluated during handling of amd64 cases)
+	// In second condition, we have to check for amd64 because of cases like:
+	// image name: ubuntu-2210-kinetic-amd64-v20221022, family name: ubuntu-2210 (should not suppress)
+	if !strings.Contains(imageName, "-arm64") && strings.Contains(imageName, strings.TrimSuffix(familyName, "-amd64")) {
+		if strings.Contains(imageName, "-amd64") {
+			return strings.HasSuffix(familyName, "-amd64")
+		} else {
+			return !strings.HasSuffix(familyName, "-amd64")
+		}
+	}
+
 	// We have to check for arm64 because of cases like:
 	// image name: opensuse-leap-15-4-v20220713-arm64, family name: opensuse-leap (should not suppress)
 	if strings.Contains(imageName, strings.TrimSuffix(familyName, "-arm64")) {
@@ -129,16 +142,6 @@ func diskImageFamilyEquals(imageName, familyName string) bool {
 			return strings.HasSuffix(familyName, "-arm64")
 		} else {
 			return !strings.HasSuffix(familyName, "-arm64")
-		}
-	}
-
-	// We have to check for amd64 because of cases like:
-	// image name: ubuntu-2210-kinetic-amd64-v20221022, family name: ubuntu-2210 (should not suppress)
-	if strings.Contains(imageName, strings.TrimSuffix(familyName, "-amd64")) {
-		if strings.Contains(imageName, "-amd64") {
-			return strings.HasSuffix(familyName, "-amd64")
-		} else {
-			return !strings.HasSuffix(familyName, "-amd64")
 		}
 	}
 

--- a/mmv1/templates/terraform/constants/disk.erb
+++ b/mmv1/templates/terraform/constants/disk.erb
@@ -132,6 +132,16 @@ func diskImageFamilyEquals(imageName, familyName string) bool {
 		}
 	}
 
+	// We have to check for amd64 because of cases like:
+	// image name: ubuntu-2210-kinetic-amd64-v20221022, family name: ubuntu-2210 (should not suppress)
+	if strings.Contains(imageName, strings.TrimSuffix(familyName, "-amd64")) {
+		if strings.Contains(imageName, "-amd64") {
+			return strings.HasSuffix(familyName, "-amd64")
+		} else {
+			return !strings.HasSuffix(familyName, "-amd64")
+		}
+	}
+
 	if suppressCanonicalFamilyDiff(imageName, familyName) {
 		return true
 	}

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -252,6 +252,37 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			New:                "debian-11-arm64",
 			ExpectDiffSuppress: false,
 		},
+		// amd images
+		"matching image ubuntu amd64 self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-amd64-v20221022",
+			New:                "ubuntu-2210-amd64",
+			ExpectDiffSuppress: true,
+		},
+		"matching image ubuntu-minimal amd64 self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2210-kinetic-amd64-v20221022",
+			New:                "ubuntu-minimal-2210-amd64",
+			ExpectDiffSuppress: true,
+		},
+		"different architecture image ubuntu amd64 self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-amd64-v20221022",
+			New:                "ubuntu-2210",
+			ExpectDiffSuppress: false,
+		},
+		"different architecture image ubuntu-minimal amd64 self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2210-kinetic-amd64-v20221022",
+			New:                "ubuntu-minimal-2210",
+			ExpectDiffSuppress: false,
+		},
+		"different architecture image ubuntu amd64 family": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-v20221022",
+			New:                "ubuntu-2210-amd64",
+			ExpectDiffSuppress: false,
+		},
+		"different architecture image ubuntu-minimal amd64 family": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2210-kinetic-v20221022",
+			New:                "ubuntu-minimal-2210-amd64",
+			ExpectDiffSuppress: false,
+		},
 	}
 
 	for tn, tc := range cases {

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -252,37 +252,6 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			New:                "debian-11-arm64",
 			ExpectDiffSuppress: false,
 		},
-		// amd images
-		"matching image ubuntu amd64 self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-amd64-v20221022",
-			New:                "ubuntu-2210-amd64",
-			ExpectDiffSuppress: true,
-		},
-		"matching image ubuntu-minimal amd64 self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2210-kinetic-amd64-v20221022",
-			New:                "ubuntu-minimal-2210-amd64",
-			ExpectDiffSuppress: true,
-		},
-		"different architecture image ubuntu amd64 self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-amd64-v20221022",
-			New:                "ubuntu-2210",
-			ExpectDiffSuppress: false,
-		},
-		"different architecture image ubuntu-minimal amd64 self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2210-kinetic-amd64-v20221022",
-			New:                "ubuntu-minimal-2210",
-			ExpectDiffSuppress: false,
-		},
-		"different architecture image ubuntu amd64 family": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-v20221022",
-			New:                "ubuntu-2210-amd64",
-			ExpectDiffSuppress: false,
-		},
-		"different architecture image ubuntu-minimal amd64 family": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2210-kinetic-v20221022",
-			New:                "ubuntu-minimal-2210-amd64",
-			ExpectDiffSuppress: false,
-		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added handling of amd64 images on the compute disk.
fixes https://github.com/hashicorp/terraform-provider-google/issues/12907

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed perma-diff on `google_compute_disk` for new amd64 images
```
