### PR TITLE
Adds `grpc` field to `startup_probe` and `liveness_probe` in `google_cloud_run_service` beta resource

### DIFF
--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -659,6 +659,7 @@ objects:
                   exactly_one_of:
                     - template.0.spec.0.containers.0.startup_probe.0.tcp_socket
                     - template.0.spec.0.containers.0.startup_probe.0.http_get
+                    - template.0.spec.0.containers.0.startup_probe.0.grpc
                   send_empty_value: true
                   allow_empty_object: true
                   properties:
@@ -673,6 +674,7 @@ objects:
                   exactly_one_of:
                     - template.0.spec.0.containers.0.startup_probe.0.tcp_socket
                     - template.0.spec.0.containers.0.startup_probe.0.http_get
+                    - template.0.spec.0.containers.0.startup_probe.0.grpc
                   send_empty_value: true
                   allow_empty_object: true
                   properties:
@@ -698,6 +700,27 @@ objects:
                               The header field value.
                             default_value: ""
                             send_empty_value: true
+                - !ruby/object:Api::Type::NestedObject
+                  name: grpc
+                  description: |-
+                    GRPC specifies an action involving a GRPC port.
+                  exactly_one_of:
+                    - template.0.spec.0.containers.0.startup_probe.0.tcp_socket
+                    - template.0.spec.0.containers.0.startup_probe.0.http_get
+                    - template.0.spec.0.containers.0.startup_probe.0.grpc
+                  send_empty_value: true
+                  allow_empty_object: true
+                  properties:
+                    - !ruby/object:Api::Type::Integer
+                      name: port
+                      description: |-
+                        Port number to access on the container. Number must be in the range 1 to 65535.
+                    - !ruby/object:Api::Type::String
+                      name: service
+                      description: |-
+                        The name of the service to place in the gRPC HealthCheckRequest
+                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                        If this is not specified, the default behavior is defined by gRPC.
             - !ruby/object:Api::Type::NestedObject
               name: livenessProbe
               min_version: beta
@@ -760,6 +783,26 @@ objects:
                               The header field value.
                             default_value: ""
                             send_empty_value: true
+                - !ruby/object:Api::Type::NestedObject
+                  name: grpc
+                  description: |-
+                    GRPC specifies an action involving a GRPC port.
+                  exactly_one_of:
+                    - template.0.spec.0.containers.0.liveness_probe.0.http_get
+                    - template.0.spec.0.containers.0.liveness_probe.0.grpc
+                  send_empty_value: true
+                  allow_empty_object: true
+                  properties:
+                    - !ruby/object:Api::Type::Integer
+                      name: port
+                      description: |-
+                        Port number to access on the container. Number must be in the range 1 to 65535.
+                    - !ruby/object:Api::Type::String
+                      name: service
+                      description: |-
+                        The name of the service to place in the gRPC HealthCheckRequest
+                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                        If this is not specified, the default behavior is defined by gRPC.
 
         - !ruby/object:Api::Type::Integer
           name: containerConcurrency

--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -758,6 +758,9 @@ objects:
                   name: httpGet
                   description: |-
                     HttpGet specifies the http request to perform.
+                  exactly_one_of:
+                    - template.0.spec.0.containers.0.liveness_probe.0.http_get
+                    - template.0.spec.0.containers.0.liveness_probe.0.grpc
                   send_empty_value: true
                   allow_empty_object: true
                   properties:

--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -205,6 +205,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       spec.template.spec.containers.startupProbe.tcpSocket.port: !ruby/object:Overrides::Terraform::PropertyOverride
         # when port is not specified, container.ports[0].port is a possible default value 
         default_from_api: true
+      spec.template.spec.containers.startupProbe.grpc.port: !ruby/object:Overrides::Terraform::PropertyOverride
+        # when port is not specified, container.ports[0].port is a possible default value 
+        default_from_api: true
+      spec.template.spec.containers.livenessProbe.grpc.port: !ruby/object:Overrides::Terraform::PropertyOverride
+        # when port is not specified, container.ports[0].port is a possible default value 
+        default_from_api: true
       # Terraform autofills the only required field in metadata
       metadata: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -408,6 +408,24 @@ func TestAccCloudRunService_probes(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
 			},
+      {
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithEmptyGRPCLivenessProbe(name, project),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+      {
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithGRPCLivenessProbe(name, project),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
 		},
 	})
 }
@@ -573,6 +591,77 @@ resource "google_cloud_run_service" "default" {
             http_headers {
               name = "Some-Name"
             }
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+}
+`, name, project)
+}
+
+func testAccCloudRunService_cloudRunServiceUpdateWithEmptyGRPCLivenessProbe(name, project string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_run_service" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%s"
+    annotations = {
+      generated-by = "magic-modules"
+      "run.googleapis.com/launch-stage" = "BETA"
+    }
+  }
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        liveness_probe {
+          grpc {}
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+}
+`, name, project)
+}
+
+func testAccCloudRunService_cloudRunServiceUpdateWithGRPCLivenessProbe(name, project string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_run_service" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%s"
+    annotations = {
+      generated-by = "magic-modules"
+      "run.googleapis.com/launch-stage" = "BETA"
+    }
+  }
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        liveness_probe {
+          grpc {
+            port = 8080
+            service = "health"
           }
         }
       }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/12532.

Adds `grpc` field to `startup_probe` and `liveness_probe` in `google_cloud_run_service` beta resource. This allows user to use gRPC probe in liveness and startup probes.

This one is a followup of https://github.com/GoogleCloudPlatform/magic-modules/pull/6677.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: added field `liveness_probe.grpc` and `startup_probe.grpc` to resource `google_cloud_run_service` (beta)
```
