### PR TITLE
compute: Add support for IGM/RIGM list_managed_instances_results field.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -170,6 +170,14 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Description: `The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. Defaults to 0.`,
 			},
 
+			"list_managed_instances_results": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "PAGELESS",
+				ValidateFunc: validation.StringInSlice([]string{"PAGELESS", "PAGINATED"}, false),
+				Description:  `Pagination behavior of the listManagedInstances API method for this managed instance group. Valid values are: "PAGELESS", "PAGINATED". If PAGELESS (default), Pagination is disabled for the group's listManagedInstances API method. maxResults and pageToken query parameters are ignored and all instances are returned in a single response. If PAGINATED, pagination is enabled, maxResults and pageToken query parameters are respected.`,
+			},
+
 			"auto_healing_policies": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -466,19 +474,20 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 	// Build the parameter
 	manager := &compute.InstanceGroupManager{
-		Name:                d.Get("name").(string),
-		Description:         d.Get("description").(string),
-		BaseInstanceName:    d.Get("base_instance_name").(string),
-		TargetSize:          int64(d.Get("target_size").(int)),
-		NamedPorts:          getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
-		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
-		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
-		Versions:            expandVersions(d.Get("version").([]interface{})),
-		UpdatePolicy:        expandUpdatePolicy(d.Get("update_policy").([]interface{})),
+		Name:                        d.Get("name").(string),
+		Description:                 d.Get("description").(string),
+		BaseInstanceName:            d.Get("base_instance_name").(string),
+		TargetSize:                  int64(d.Get("target_size").(int)),
+		ListManagedInstancesResults: d.Get("list_managed_instances_results").(string),
+		NamedPorts:                  getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
+		TargetPools:                 convertStringSet(d.Get("target_pools").(*schema.Set)),
+		AutoHealingPolicies:         expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
+		Versions:                    expandVersions(d.Get("version").([]interface{})),
+		UpdatePolicy:                expandUpdatePolicy(d.Get("update_policy").([]interface{})),
     <% unless version == "ga" -%>
-		AllInstancesConfig:  expandAllInstancesConfig(nil, d.Get("all_instances_config").([]interface{})),
+		AllInstancesConfig:          expandAllInstancesConfig(nil, d.Get("all_instances_config").([]interface{})),
 		<% end -%>
-		StatefulPolicy:      expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
+		StatefulPolicy:              expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
 		// Force send TargetSize to allow a value of 0.
 		ForceSendFields: []string{"TargetSize"},
 	}
@@ -657,6 +666,9 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err := d.Set("target_size", manager.TargetSize); err != nil {
 		return fmt.Errorf("Error setting target_size: %s", err)
 	}
+	if err := d.Set("list_managed_instances_results", manager.ListManagedInstancesResults); err != nil {
+		return fmt.Errorf("Error setting list_managed_instances_results: %s", err)
+	}
 	if err = d.Set("target_pools", mapStringArr(manager.TargetPools, ConvertSelfLinkToV1)); err != nil {
 		return fmt.Errorf("Error setting target_pools in state: %s", err.Error())
 	}
@@ -771,6 +783,11 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 	if d.HasChange("stateful_disk") {
 		updatedManager.StatefulPolicy = expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List())
+		change = true
+	}
+
+	if d.HasChange("list_managed_instances_results") {
+		updatedManager.ListManagedInstancesResults = d.Get("list_managed_instances_results").(string)
 		change = true
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -171,6 +171,14 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 				Description: `The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. Defaults to 0.`,
 			},
 
+			"list_managed_instances_results": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "PAGELESS",
+				ValidateFunc: validation.StringInSlice([]string{"PAGELESS", "PAGINATED"}, false),
+				Description:  `Pagination behavior of the listManagedInstances API method for this managed instance group. Valid values are: "PAGELESS", "PAGINATED". If PAGELESS (default), Pagination is disabled for the group's listManagedInstances API method. maxResults and pageToken query parameters are ignored and all instances are returned in a single response. If PAGINATED, pagination is enabled, maxResults and pageToken query parameters are respected.`,
+			},
+
 			// If true, the resource will report ready only after no instances are being created.
 			// This will not block future reads if instances are being recreated, and it respects
 			// the "createNoRetry" parameter that's available for this resource.
@@ -468,20 +476,21 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 	}
 
 	manager := &compute.InstanceGroupManager{
-		Name:                d.Get("name").(string),
-		Description:         d.Get("description").(string),
-		BaseInstanceName:    d.Get("base_instance_name").(string),
-		TargetSize:          int64(d.Get("target_size").(int)),
-		NamedPorts:          getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
-		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
-		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
-		Versions:            expandVersions(d.Get("version").([]interface{})),
-		UpdatePolicy:        expandRegionUpdatePolicy(d.Get("update_policy").([]interface{})),
+		Name:                        d.Get("name").(string),
+		Description:                 d.Get("description").(string),
+		BaseInstanceName:            d.Get("base_instance_name").(string),
+		TargetSize:                  int64(d.Get("target_size").(int)),
+		ListManagedInstancesResults: d.Get("list_managed_instances_results").(string),
+		NamedPorts:                  getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
+		TargetPools:                 convertStringSet(d.Get("target_pools").(*schema.Set)),
+		AutoHealingPolicies:         expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
+		Versions:                    expandVersions(d.Get("version").([]interface{})),
+		UpdatePolicy:                expandRegionUpdatePolicy(d.Get("update_policy").([]interface{})),
 		<% unless version == "ga" -%>
-		AllInstancesConfig:  expandAllInstancesConfig(nil, d.Get("all_instances_config").([]interface{})),
+		AllInstancesConfig:          expandAllInstancesConfig(nil, d.Get("all_instances_config").([]interface{})),
 		<% end -%>
-		DistributionPolicy:  expandDistributionPolicy(d),
-		StatefulPolicy:      expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
+		DistributionPolicy:          expandDistributionPolicy(d),
+		StatefulPolicy:              expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
 		// Force send TargetSize to allow size of 0.
 		ForceSendFields: []string{"TargetSize"},
 	}
@@ -632,6 +641,9 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	if err := d.Set("target_size", manager.TargetSize); err != nil {
 		return fmt.Errorf("Error setting target_size: %s", err)
 	}
+	if err := d.Set("list_managed_instances_results", manager.ListManagedInstancesResults); err != nil {
+		return fmt.Errorf("Error setting list_managed_instances_results: %s", err)
+	}
 	if err := d.Set("target_pools", mapStringArr(manager.TargetPools, ConvertSelfLinkToV1)); err != nil {
 		return fmt.Errorf("Error setting target_pools in state: %s", err.Error())
 	}
@@ -746,6 +758,11 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 
 	if d.HasChange("stateful_disk") {
 		updatedManager.StatefulPolicy = expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List())
+		change = true
+	}
+
+	if d.HasChange("list_managed_instances_results") {
+		updatedManager.ListManagedInstancesResults = d.Get("list_managed_instances_results").(string)
 		change = true
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -493,10 +493,11 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "tf-test-igm-basic"
-  zone               = "us-central1-c"
-  target_size        = 2
+  target_pools                   = [google_compute_target_pool.igm-basic.self_link]
+  base_instance_name             = "tf-test-igm-basic"
+  zone                           = "us-central1-c"
+  target_size                    = 2
+  list_managed_instances_results = "PAGINATED"
 }
 
 resource "google_compute_instance_group_manager" "igm-no-tp" {
@@ -698,9 +699,10 @@ resource "google_compute_instance_group_manager" "igm-update" {
     google_compute_target_pool.igm-update.self_link,
     google_compute_target_pool.igm-update2.self_link,
   ]
-  base_instance_name = "tf-test-igm-update"
-  zone               = "us-central1-c"
-  target_size        = 3
+  base_instance_name             = "tf-test-igm-update"
+  zone                           = "us-central1-c"
+  target_size                    = 3
+  list_managed_instances_results = "PAGINATED"
   named_port {
     name = "customhttp"
     port = 8080
@@ -795,9 +797,10 @@ resource "google_compute_instance_group_manager" "igm-update" {
     instance_template = google_compute_instance_template.igm-update2.self_link
   }
 
-  base_instance_name = "tf-test-igm-update"
-  zone               = "us-central1-c"
-  target_size        = 3
+  base_instance_name             = "tf-test-igm-update"
+  zone                           = "us-central1-c"
+  target_size                    = 3
+  list_managed_instances_results = "PAGINATED"
   named_port {
     name = "customhttp"
     port = 8080

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -463,9 +463,10 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  target_pools       = [google_compute_target_pool.igm-basic.self_link]
-  base_instance_name = "tf-test-igm-basic"
-  target_size        = 2
+  target_pools                   = [google_compute_target_pool.igm-basic.self_link]
+  base_instance_name             = "tf-test-igm-basic"
+  target_size                    = 2
+  list_managed_instances_results = "PAGINATED"
 }
 
 resource "google_compute_region_instance_group_manager" "igm-no-tp" {
@@ -477,9 +478,9 @@ resource "google_compute_region_instance_group_manager" "igm-no-tp" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "tf-test-igm-no-tp"
-  region             = "us-central1"
-  target_size        = 2
+  base_instance_name             = "tf-test-igm-no-tp"
+  region                         = "us-central1"
+  target_size                    = 2
 }
 `, template, target, igm1, igm2)
 }
@@ -668,9 +669,10 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
     google_compute_target_pool.igm-update.self_link,
     google_compute_target_pool.igm-update2.self_link,
   ]
-  base_instance_name = "tf-test-igm-update"
-  region             = "us-central1"
-  target_size        = 3
+  base_instance_name             = "tf-test-igm-update"
+  region                         = "us-central1"
+  target_size                    = 3
+  list_managed_instances_results = "PAGINATED"
   named_port {
     name = "customhttp"
     port = 8080
@@ -765,9 +767,10 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
     name              = "primary"
   }
 
-  base_instance_name = "tf-test-igm-update"
-  region             = "us-central1"
-  target_size        = 3
+  base_instance_name             = "tf-test-igm-update"
+  region                         = "us-central1"
+  target_size                    = 3
+  list_managed_instances_results = "PAGINATED"
   named_port {
     name = "customhttp"
     port = 8080

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -39,7 +39,7 @@ resource "google_compute_instance_group_manager" "appserver" {
   version {
     instance_template  = google_compute_instance_template.appserver.id
   }
-  
+
   all_instances_config {
     metadata = {
       metadata_key = "metadata_value"
@@ -127,6 +127,13 @@ The following arguments are supported:
 * `target_size` - (Optional) The target number of running instances for this managed
     instance group. This value should always be explicitly set unless this resource is attached to
      an autoscaler, in which case it should never be set. Defaults to `0`.
+
+* `list_managed_instances_results` - (Optional) Pagination behavior of the `listManagedInstances` API
+    method for this managed instance group. Valid values are: `PAGELESS`, `PAGINATED`.
+    If `PAGELESS` (default), Pagination is disabled for the group's `listManagedInstances` API method.
+    `maxResults` and `pageToken` query parameters are ignored and all instances are returned in a single
+    response. If `PAGINATED`, pagination is enabled, `maxResults` and `pageToken` query parameters are
+    respected.
 
 * `target_pools` - (Optional) The full URL of all target pools to which new
     instances in the group are added. Updating the target pools attribute does

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -45,7 +45,7 @@ resource "google_compute_region_instance_group_manager" "appserver" {
   version {
     instance_template = google_compute_instance_template.appserver.id
   }
-  
+
   all_instances_config {
     metadata = {
       metadata_key = "metadata_value"
@@ -129,6 +129,13 @@ The following arguments are supported:
 * `target_size` - (Optional) The target number of running instances for this managed
     instance group. This value should always be explicitly set unless this resource is attached to
      an autoscaler, in which case it should never be set. Defaults to `0`.
+
+* `list_managed_instances_results` - (Optional) Pagination behavior of the `listManagedInstances` API
+    method for this managed instance group. Valid values are: `PAGELESS`, `PAGINATED`.
+    If `PAGELESS` (default), Pagination is disabled for the group's `listManagedInstances` API method.
+    `maxResults` and `pageToken` query parameters are ignored and all instances are returned in a single
+    response. If `PAGINATED`, pagination is enabled, `maxResults` and `pageToken` query parameters are
+    respected.
 
 * `target_pools` - (Optional) The full URL of all target pools to which new
     instances in the group are added. Updating the target pools attribute does


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds a support for recently added `list_managed_instances_results` field to `compute_instance_group_manager` and `compute_region_instance_group_manager` resources.

Upgrade of `google.golang.org/api` to version `v0.102.0` was required for the GA availability.

**Testing disclaimer:** I had some trouble with acceptance tests, which were all failing with error:

```
provider_test.go:307: Failed state verification, resource with ID projects/debian-cloud/global/images/debian-11-bullseye-v20221102 not found
```

All the tests are passing with `ImportStateVerify` set to `false`, but I wasn't able to get the state verification to work.

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `list_managed_instances_results` to `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```
