### PR TITLE
Fix the test TestAccApigeeInstance_apigeeInstanceServiceAttachmentBas…

### DIFF
--- a/mmv1/products/apigee/terraform.yaml
+++ b/mmv1/products/apigee/terraform.yaml
@@ -145,10 +145,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       consumerAcceptList: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        diff_suppress_func: "projectListDiffSuppress"
       ipRange: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/apigee_instance.go.erb
+      constants: templates/terraform/constants/apigee_instance.go.erb
   Environment: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: true
     import_format: ["{{org_id}}/environments/{{name}}", "{{org_id}}/{{name}}"]

--- a/mmv1/templates/terraform/constants/apigee_instance.go.erb
+++ b/mmv1/templates/terraform/constants/apigee_instance.go.erb
@@ -1,0 +1,24 @@
+// Supress diffs when the lists of project have the same number of entries to handle the case that
+// API does not return what the user originally provided. Instead, API does some transformation.
+// For example, user provides a list of project number, but API returns a list of project Id.
+func projectListDiffSuppress(_, _, _ string, d *schema.ResourceData) bool {
+    return projectListDiffSuppressFunc(d)
+}
+
+func projectListDiffSuppressFunc(d TerraformResourceDataChange) bool {
+	kLength := "consumer_accept_list.#"
+	oldLength, newLength := d.GetChange(kLength)
+
+	oldInt, ok := oldLength.(int)
+	if !ok {
+		return false
+	}
+
+	newInt, ok := newLength.(int)
+	if !ok {
+		return false
+	}
+	log.Printf("[DEBUG] - suppressing diff with oldInt %d, newInt %d", oldInt, newInt)
+
+	return oldInt == newInt
+}

--- a/mmv1/third_party/terraform/tests/resource_apigee_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_apigee_instance_test.go
@@ -1,0 +1,111 @@
+package google
+
+import (
+	"testing"
+)
+
+func TestUnitApigeeInstance_projectListDiffSuppress(t *testing.T) {
+	for _, tc := range apigeeInstanceDiffSuppressTestCases {
+		tc.Test(t)
+	}
+}
+
+type ApigeeInstanceDiffSuppressTestCase struct {
+	Name           string
+	KeysToSuppress []string
+	Before         map[string]interface{}
+	After          map[string]interface{}
+}
+
+var apigeeInstanceDiffSuppressTestCases = []ApigeeInstanceDiffSuppressTestCase{
+	{
+		Name:           "projects with the same length and one project entry is converted to project id",
+		KeysToSuppress: []string{"consumer_accept_list.0"},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "45796856818",
+			"consumer_accept_list.1": "12345",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "12345",
+		},
+	},
+	{
+		Name:           "projects with the same length and no project conversion",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "12345",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "12345",
+		},
+	},
+	{
+		Name:           "projects are empty",
+		KeysToSuppress: []string{},
+		Before:         map[string]interface{}{},
+		After:          map[string]interface{}{},
+	},
+	{
+		Name:           "projects have the different length",
+		KeysToSuppress: []string{},
+		Before:         map[string]interface{}{},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "12345",
+		},
+	},
+}
+
+func (tc *ApigeeInstanceDiffSuppressTestCase) Test(t *testing.T) {
+	mockResourceDiff := &ResourceDiffMock{
+		Before: tc.Before,
+		After:  tc.After,
+	}
+
+	keysHavingDiff := map[string]bool{}
+
+	for key, val1 := range tc.Before {
+		val2, ok := tc.After[key]
+		if !ok {
+			keysHavingDiff[key] = true
+		} else if val1 != val2 {
+			keysHavingDiff[key] = true
+		}
+	}
+
+	for key, val1 := range tc.After {
+		val2, ok := tc.Before[key]
+		if !ok {
+			keysHavingDiff[key] = true
+		} else if val1 != val2 {
+			keysHavingDiff[key] = true
+		}
+	}
+
+	keySuppressionMap := map[string]bool{}
+	for key := range tc.Before {
+		keySuppressionMap[key] = false
+	}
+	for key := range tc.After {
+		keySuppressionMap[key] = false
+	}
+
+	for _, key := range tc.KeysToSuppress {
+		keySuppressionMap[key] = true
+	}
+
+	for key := range keysHavingDiff {
+		actual := projectListDiffSuppressFunc(mockResourceDiff)
+		if actual != keySuppressionMap[key] {
+			t.Errorf("Test %s: expected key `%s` to be suppressed", tc.Name, key)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/12529

The  field consumer_accept_list accepts the list of project id/number. The test fails because when the user enters project numbers for the field, the API returns project ids in the response. 

The workaround is to suppress the diff as long as the number of entries in the list are the same.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
apigee: Fixed permadiff on consumer_accept_list for `google_apigee_instance`
```
