### PR TITLE
update BigqueryDatapolicy to ga

### DIFF
--- a/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
+++ b/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
---- !ruby/object:Api::Resource
+---
+!ruby/object:Api::Resource
 name: "DataPolicy"
-min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/dataPolicies
 create_url: projects/{{project}}/locations/{{location}}/dataPolicies
 self_link: projects/{{project}}/locations/{{location}}/dataPolicies/{{data_policy_id}}
@@ -32,7 +32,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   import_format:
     [
       "projects/{{project}}/locations/{{location}}/dataPolicies/{{data_policy_id}}",
-      "{{data_policy_id}}"
+      "{{data_policy_id}}",
     ]
 properties:
   - !ruby/object:Api::Type::String
@@ -84,4 +84,3 @@ properties:
           - :FIRST_FOUR_CHARACTERS
           - :EMAIL_MASK
           - :DATE_YEAR_MASK
-

--- a/mmv1/products/bigquerydatapolicy/product.yaml
+++ b/mmv1/products/bigquerydatapolicy/product.yaml
@@ -21,6 +21,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://bigquerydatapolicy.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://bigquerydatapolicy.googleapis.com/v1/
 apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: BigQuery Data Policy API

--- a/mmv1/products/bigquerydatapolicy/terraform.yaml
+++ b/mmv1/products/bigquerydatapolicy/terraform.yaml
@@ -20,12 +20,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       [
         "projects/{{project}}/locations/{{location}}/dataPolicies/{{data_policy_id}}",
         "{{project}}/{{location}}/{{data_policy_id}}",
-         "{{location}}/{{data_policy_id}}"
+        "{{location}}/{{data_policy_id}}",
       ]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_datapolicy_data_policy_basic"
-        min_version: beta
         primary_resource_id: "data_policy"
         primary_resource_name: 'fmt.Sprintf("tf_test_data_policy%s", context["random_suffix"])'
         vars:

--- a/mmv1/templates/terraform/examples/bigquery_datapolicy_data_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_datapolicy_data_policy_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_bigquery_datapolicy_data_policy" "<%= ctx[:primary_resource_id] %>" {
-    provider = google-beta
     location         = "us-central1"
     data_policy_id   = "<%= ctx[:vars]['data_policy_id'] %>"
     policy_tag       = google_data_catalog_policy_tag.policy_tag.name
@@ -7,14 +6,12 @@ resource "google_bigquery_datapolicy_data_policy" "<%= ctx[:primary_resource_id]
   }
 
   resource "google_data_catalog_policy_tag" "policy_tag" {
-    provider = google-beta
     taxonomy     = google_data_catalog_taxonomy.taxonomy.id
     display_name = "Low security"
     description  = "A policy tag normally associated with low security items"
   }
   
   resource "google_data_catalog_taxonomy" "taxonomy" {
-    provider = google-beta
     region                 = "us-central1"
     display_name           = "<%= ctx[:vars]['taxonomy'] %>"
     description            = "A collection of policy tags"

--- a/mmv1/third_party/terraform/tests/resource_bigquery_datapolicy_data_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_datapolicy_data_policy_test.go
@@ -15,7 +15,7 @@ func TestAccBigqueryDatapolicyDataPolicy_bigqueryDatapolicyDataPolicyUpdate(t *t
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    TestAccProvidersOiCS,
+		Providers:    TestAccProviders,
 		CheckDestroy: testAccCheckBigqueryDatapolicyDataPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/tests/resource_bigquery_datapolicy_data_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_datapolicy_data_policy_test.go
@@ -1,7 +1,4 @@
-<% autogen_exception -%>
 package google
-
-<% unless version == 'ga' -%>
 
 import (
 	"testing"
@@ -40,7 +37,6 @@ func TestAccBigqueryDatapolicyDataPolicy_bigqueryDatapolicyDataPolicyUpdate(t *t
 func testAccBigqueryDatapolicyDataPolicy_bigqueryDatapolicyDataPolicyUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_bigquery_datapolicy_data_policy" "data_policy" {
-    provider = google-beta
     location         = "us-central1"
     data_policy_id   = "tf_test_data_policy%{random_suffix}"
     policy_tag       = google_data_catalog_policy_tag.policy_tag_updated.name
@@ -48,21 +44,18 @@ resource "google_bigquery_datapolicy_data_policy" "data_policy" {
   }
 
   resource "google_data_catalog_policy_tag" "policy_tag" {
-    provider = google-beta
     taxonomy     = google_data_catalog_taxonomy.taxonomy.id
     display_name = "Low security"
     description  = "A policy tag normally associated with low security items"
   }
 
   resource "google_data_catalog_policy_tag" "policy_tag_updated" {
-    provider = google-beta
     taxonomy     = google_data_catalog_taxonomy.taxonomy.id
     display_name = "Low security updated"
     description  = "A policy tag normally associated with low security items"
   }  
 
   resource "google_bigquery_datapolicy_data_policy" "policy_tag_with_data_masking_policy" {
-    provider         = google-beta
     location         = "us-central1"
     data_policy_id   = "masking_policy_test"
     policy_tag       = google_data_catalog_policy_tag.policy_tag_updated.name
@@ -73,7 +66,6 @@ resource "google_bigquery_datapolicy_data_policy" "data_policy" {
   }
 
   resource "google_data_catalog_taxonomy" "taxonomy" {
-    provider = google-beta
     region                 = "us-central1"
     display_name           = "taxonomy%{random_suffix}"
     description            = "A collection of policy tags"
@@ -81,5 +73,3 @@ resource "google_bigquery_datapolicy_data_policy" "data_policy" {
   }
 `, context)
 }
-
-<% end %>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquerydatapolicy: promoted `google_bigquery_datapolicy_data_policy` to GA
```
