### PR TITLE
Promote regional target TCP proxy to GA

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -15741,8 +15741,7 @@ objects:
       guides:
         'Official Documentation':
           'https://cloud.google.com/load-balancing/docs/tcp/internal-proxy'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/targetTcpProxies'
-    min_version: beta
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionTargetTcpProxies'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'

--- a/mmv1/templates/terraform/examples/region_target_tcp_proxy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/region_target_tcp_proxy_basic.tf.erb
@@ -1,13 +1,11 @@
 # [START cloudloadbalancing_region_target_tcp_proxy_basic]
 resource "google_compute_region_target_tcp_proxy" "default" {
-  provider        = google-beta
   name            = "<%= ctx[:vars]['region_target_tcp_proxy_name'] %>"
   region          = "europe-west4"
   backend_service = google_compute_region_backend_service.default.id
 }
 
 resource "google_compute_region_backend_service" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['region_backend_service_name'] %>"
   protocol    = "TCP"
   timeout_sec = 10
@@ -18,7 +16,6 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider           = google-beta
   name               = "<%= ctx[:vars]['health_check_name'] %>"
   region             = "europe-west4"
   timeout_sec        = 1

--- a/mmv1/third_party/terraform/tests/resource_compute_region_target_tcp_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_target_tcp_proxy_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -19,7 +18,7 @@ func TestAccComputeRegionTargetTcpProxy_update(t *testing.T) {
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeRegionTargetTcpProxyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -87,7 +86,6 @@ func testAccCheckComputeRegionTargetTcpProxyExists(t *testing.T, n string) resou
 func testAccComputeRegionTargetTcpProxy_basic1(target, backend, hc string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_target_tcp_proxy" "foobar" {
-  provider        = google-beta
   description     = "Resource created for Terraform acceptance testing"
   name            = "%s"
   backend_service = google_compute_region_backend_service.foobar.self_link
@@ -96,7 +94,6 @@ resource "google_compute_region_target_tcp_proxy" "foobar" {
 }
 
 resource "google_compute_region_backend_service" "foobar" {
-  provider      = google-beta
   name          = "%s"
   protocol      = "TCP"
   health_checks = [google_compute_region_health_check.zero.self_link]
@@ -106,7 +103,6 @@ resource "google_compute_region_backend_service" "foobar" {
 }
 
 resource "google_compute_region_health_check" "zero" {
-  provider           = google-beta
   name               = "%s"
   check_interval_sec = 1
   timeout_sec        = 1
@@ -121,7 +117,6 @@ resource "google_compute_region_health_check" "zero" {
 func testAccComputeRegionTargetTcpProxy_update2(target, backend, hc string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_target_tcp_proxy" "foobar" {
-  provider        = google-beta
   description     = "Resource created for Terraform acceptance testing"
   name            = "%s"
   backend_service = google_compute_region_backend_service.foobar2.self_link
@@ -130,7 +125,6 @@ resource "google_compute_region_target_tcp_proxy" "foobar" {
 }
 
 resource "google_compute_region_backend_service" "foobar" { 
-  provider      = google-beta
   name          = "%s"
   protocol      = "TCP"
   health_checks = [google_compute_region_health_check.zero.self_link]
@@ -140,7 +134,6 @@ resource "google_compute_region_backend_service" "foobar" {
 }
 
 resource "google_compute_region_backend_service" "foobar2" { 
-  provider      = google-beta
   name          = "%s-2"
   protocol      = "TCP"
   health_checks = [google_compute_region_health_check.zero.self_link]
@@ -150,7 +143,6 @@ resource "google_compute_region_backend_service" "foobar2" {
 }
 
 resource "google_compute_region_health_check" "zero" {
-  provider           = google-beta
   name               = "%s"
   check_interval_sec = 1
   timeout_sec        = 1
@@ -161,4 +153,3 @@ resource "google_compute_region_health_check" "zero" {
 }
 `, target, backend, backend, hc)
 }
-<% end -%>


### PR DESCRIPTION
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_compute_region_target_tcp_proxy (GA only)
```
