### PR TITLE
Add GKE support for threads_per_core option

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -844,7 +844,7 @@ func TestAccContainerNodePool_regionalAutoscaling(t *testing.T) {
 	})
 }
 
-//This test exists to validate a node pool with total size *and* and update to it.
+// This test exists to validate a node pool with total size *and* and update to it.
 func TestAccContainerNodePool_totalSize(t *testing.T) {
 	t.Parallel()
 
@@ -1440,6 +1440,60 @@ resource "google_container_node_pool" "np" {
   }
 }
 `, cluster, np, placementType)
+}
+
+func TestAccContainerNodePool_threadsPerCore(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", RandString(t, 10))
+	np := fmt.Sprintf("tf-test-nodepool-%s", RandString(t, 10))
+
+        VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_threadsPerCore(cluster, np, 1),
+			},
+			{
+				ResourceName:      "google_container_cluster.cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_threadsPerCore(cluster, np string, threadsPerCore int) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "c2-standard-4"
+	advanced_machine_features {
+		threads_per_core = "%v"
+	}
+  }
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 2
+
+  node_config {
+    machine_type = "c2-standard-4"
+	advanced_machine_features {
+		threads_per_core = "%v"
+	}
+  }
+}
+`, cluster, threadsPerCore, np, threadsPerCore)
 }
 
 func testAccCheckContainerNodePoolDestroyProducer(t *testing.T) func(s *terraform.State) error {

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -506,6 +506,24 @@ func schemaNodeConfig() *schema.Schema {
 					ForceNew: true,
 					Description: `Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on sole tenant nodes.`,
 				},
+
+				"advanced_machine_features": &schema.Schema{
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: `Specifies options for controlling advanced machine features.`,
+					ForceNew:    true,
+					Elem:        &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"threads_per_core": {
+								Type:        schema.TypeInt,
+                                                                Required:    true,
+                                                                ForceNew:    true,
+								Description: `The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.`,
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -759,6 +777,13 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		nc.NodeGroup = v.(string)
 	}
 
+	if v, ok := nodeConfig["advanced_machine_features"]; ok && len(v.([]interface{})) > 0 {
+		advanced_machine_features := v.([]interface{})[0].(map[string]interface{})
+		nc.AdvancedMachineFeatures = &container.AdvancedMachineFeatures{
+			ThreadsPerCore: int64(advanced_machine_features["threads_per_core"].(int)),
+		}
+	}
+
 	return nc
 }
 
@@ -861,7 +886,7 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 		"local_ssd_count":          c.LocalSsdCount,
 		"logging_variant":          flattenLoggingVariant(c.LoggingConfig),
 <% unless version == 'ga' -%>
-		"ephemeral_storage_config": flattenEphemeralStorageConfig(c.EphemeralStorageConfig),
+		"ephemeral_storage_config":  flattenEphemeralStorageConfig(c.EphemeralStorageConfig),
 <% end -%>
 		"local_nvme_ssd_block_config": flattenLocalNvmeSsdBlockConfig(c.LocalNvmeSsdBlockConfig),
 		"gcfs_config":              flattenGcfsConfig(c.GcfsConfig),
@@ -880,12 +905,13 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 		"taint":                    flattenTaints(c.Taints),
 		"workload_metadata_config": flattenWorkloadMetadataConfig(c.WorkloadMetadataConfig),
 <% unless version == 'ga' -%>
-		"sandbox_config": 			flattenSandboxConfig(c.SandboxConfig),
+		"sandbox_config": 			 flattenSandboxConfig(c.SandboxConfig),
 <% end -%>
 		"boot_disk_kms_key": 		c.BootDiskKmsKey,
-		"kubelet_config":           flattenKubeletConfig(c.KubeletConfig),
-		"linux_node_config":        flattenLinuxNodeConfig(c.LinuxNodeConfig),
-		"node_group":               c.NodeGroup,
+		"kubelet_config":            flattenKubeletConfig(c.KubeletConfig),
+		"linux_node_config":         flattenLinuxNodeConfig(c.LinuxNodeConfig),
+                "node_group":                c.NodeGroup,
+		"advanced_machine_features": flattenAdvancedMachineFeaturesConfig(c.AdvancedMachineFeatures),
 	})
 
 	if len(c.OauthScopes) > 0 {
@@ -893,6 +919,16 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 	}
 
 	return config
+}
+
+func flattenAdvancedMachineFeaturesConfig(c *container.AdvancedMachineFeatures) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"threads_per_core": c.ThreadsPerCore,
+		})
+	}
+	return result
 }
 
 func flattenContainerGuestAccelerators(c []*container.AcceleratorConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -880,6 +880,13 @@ linux_node_config {
 
 * `node_group` - (Optional) Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on [sole tenant nodes](https://cloud.google.com/compute/docs/nodes/sole-tenant-nodes).
 
+* `advanced_machine_features` - (Optional) Specifies options for controlling
+  advanced machine features.
+
+<a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
+
+* `threads_per_core` - (Required) The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.
+
 <a name="nested_ephemeral_storage_config"></a>The `ephemeral_storage_config` block supports:
 
 * `local_ssd_count` (Required) - Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -881,7 +881,7 @@ linux_node_config {
 * `node_group` - (Optional) Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on [sole tenant nodes](https://cloud.google.com/compute/docs/nodes/sole-tenant-nodes).
 
 * `advanced_machine_features` - (Optional) Specifies options for controlling
-  advanced machine features.
+  advanced machine features. Structure is documented below.
 
 <a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
 


### PR DESCRIPTION
Add GKE support for threads_per_core option

Related issue: https://github.com/hashicorp/terraform-provider-google/issues/11588

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Note:** unit tests seem to be broken. I was able to run `make test` for generated code as follows:

```
$ make test
$ make fmt
$ make test
...
google/resource_bigtable_app_profile.go:468:9: undefined: bigtableadmin
google/resource_compute_subnetwork.go:39:22: undefined: cidr
...
$ rm google/resource_bigtable_app_profile.go google/resource_bigtable_app_profile_test.go google/resource_compute_subnetwork.go google/resource_compute_subnetwork_test.go
$ sed -i '/resourceBigtableAppProfile/d' google/provider.go
$ sed -i '/resourceComputeSubnetwork/d' google/provider.go
$ make test
```

Release notes

```release-note:enhancement
container: added support for `advanced_machine_features.threads_per_core`
```
