### PR TITLE
Revert "Added upgrade_settings attribute to the google_container_clus…

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -563,44 +563,44 @@ func resourceContainerCluster() *schema.Resource {
 											},
 										},
 									},
-								},
-							},
-						},
-						"management": {
-							Type:        schema.TypeList,
-							Optional:    true,
-							Computed:    true,
-							MaxItems:    1,
-							Description: `NodeManagement configuration for this NodePool.`,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"auto_upgrade": {
-										Type:        schema.TypeBool,
-										Optional:    true,
-										Computed:    true,
-										Description: `Specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes.`,
-									},
-									"auto_repair": {
-										Type:        schema.TypeBool,
-										Optional:    true,
-										Computed:    true,
-										Description: `Specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered.`,
-									},
-									"upgrade_options": {
+									"management": {
 										Type:        schema.TypeList,
+										Optional:    true,
 										Computed:    true,
-										Description: `Specifies the Auto Upgrade knobs for the node pool.`,
+										MaxItems:    1,
+										Description: `NodeManagement configuration for this NodePool.`,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"auto_upgrade_start_time": {
-													Type:        schema.TypeString,
+												"auto_upgrade": {
+													Type:        schema.TypeBool,
+													Optional:    true,
 													Computed:    true,
-													Description: `This field is set when upgrades are about to commence with the approximate start time for the upgrades, in RFC3339 text format.`,
+													Description: `Specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes.`,
 												},
-												"description": {
-													Type:        schema.TypeString,
+												"auto_repair": {
+													Type:        schema.TypeBool,
+													Optional:    true,
 													Computed:    true,
-													Description: `This field is set when upgrades are about to commence with the description of the upgrade.`,
+													Description: `Specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered.`,
+												},
+												"upgrade_options": {
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: `Specifies the Auto Upgrade knobs for the node pool.`,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"auto_upgrade_start_time": {
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: `This field is set when upgrades are about to commence with the approximate start time for the upgrades, in RFC3339 text format.`,
+															},
+															"description": {
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: `This field is set when upgrades are about to commence with the description of the upgrade.`,
+															},
+														},
+													},
 												},
 											},
 										},

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -566,6 +566,48 @@ func resourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						"management": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `NodeManagement configuration for this NodePool.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"auto_upgrade": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    true,
+										Description: `Specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes.`,
+									},
+									"auto_repair": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    true,
+										Description: `Specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered.`,
+									},
+									"upgrade_options": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `Specifies the Auto Upgrade knobs for the node pool.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"auto_upgrade_start_time": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `This field is set when upgrades are about to commence with the approximate start time for the upgrades, in RFC3339 text format.`,
+												},
+												"description": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `This field is set when upgrades are about to commence with the description of the upgrade.`,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						<% unless version == 'ga' -%>
 						"autoscaling_profile": {
 							Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"strconv"
 	"regexp"
 	"strings"
 	"time"
@@ -520,12 +519,14 @@ func resourceContainerCluster() *schema.Resource {
 										Description: `The default image type used by NAP once a new node pool is being created.`,
 										ValidateFunc: validation.StringInSlice([]string{"COS_CONTAINERD", "COS", "UBUNTU_CONTAINERD", "UBUNTU"}, false),
 									},
+									<% unless version == 'ga' -%>
 									"min_cpu_platform": {
 										Type:             schema.TypeString,
 										Optional:         true,
 										DiffSuppressFunc: emptyOrDefaultStringSuppress("automatic"),
 										Description:      `Minimum CPU platform to be used by this instance. The instance may be scheduled on the specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such as Intel Haswell.`,
 									},
+									<% end -%>
 									"boot_disk_kms_key": {
 										Type:        schema.TypeString,
 										Optional:    true,
@@ -557,133 +558,6 @@ func resourceContainerCluster() *schema.Resource {
 													AtLeastOneOf: []string{
 														"cluster_autoscaling.0.auto_provisioning_defaults.0.shielded_instance_config.0.enable_secure_boot",
 														"cluster_autoscaling.0.auto_provisioning_defaults.0.shielded_instance_config.0.enable_integrity_monitoring",
-													},
-												},
-											},
-										},
-									},
-									"upgrade_settings": {
-										Type:             schema.TypeList,
-										Optional:         true,
-										Description:      `Specifies the upgrade settings for NAP created node pools`,
-										Computed:         true,
-										DiffSuppressFunc: UpgradeSettingsDiffSuppress,
-										MaxItems:         1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"max_surge": {
-													Type:        schema.TypeInt,
-													Optional:    true,
-													Computed:    true,
-													Description: `The maximum number of nodes that can be created beyond the current size of the node pool during the upgrade process.`,
-												},
-												"max_unavailable": {
-													Type:        schema.TypeInt,
-													Optional:    true,
-													Computed:    true,
-													Description: `The maximum number of nodes that can be simultaneously unavailable during the upgrade process.`,
-												},
-												"strategy": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													Computed:     true,
-													Description:  `Update strategy of the node pool.`,
-													ValidateFunc: validation.StringInSlice([]string{"NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED", "BLUE_GREEN", "SURGE"}, false),
-												},
-												"blue_green_settings": {
-													Type:        schema.TypeList,
-													Optional:    true,
-													MaxItems:    1,
-													Description: `Settings for blue-green upgrade strategy.`,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"node_pool_soak_duration": {
-																Type:     schema.TypeString,
-																Optional: true,
-																Description: `Time needed after draining entire blue pool. After this period, blue pool will be cleaned up.
-
-																A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".`,
-															},
-															"standard_rollout_policy": {
-																Type:        schema.TypeList,
-																Optional:    true,
-																MaxItems:    1,
-																Description: `Standard policy for the blue-green upgrade.`,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"batch_percentage": {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: validation.FloatBetween(0.0, 1.0),
-																			ExactlyOneOf: []string{
-																				"cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.blue_green_settings.0.standard_rollout_policy.0.batch_percentage",
-																				"cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.blue_green_settings.0.standard_rollout_policy.0.batch_node_count",
-																			},
-																			Description: `Percentage of the bool pool nodes to drain in a batch. The range of this field should be (0.0, 1.0].`,
-																		},
-																		"batch_node_count": {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																			ExactlyOneOf: []string{
-																				"cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.blue_green_settings.0.standard_rollout_policy.0.batch_percentage",
-																				"cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.blue_green_settings.0.standard_rollout_policy.0.batch_node_count",
-																			},
-																			Description: `Number of blue nodes to drain in a batch.`,
-																		},
-																		"batch_soak_duration": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			Default:  "0s",
-																			Description: `Soak time after each batch gets drained.
-
-																			A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".`,
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"management": {
-										Type:        schema.TypeList,
-										Optional:    true,
-										Computed:    true,
-										MaxItems:    1,
-										Description: `NodeManagement configuration for this NodePool.`,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"auto_upgrade": {
-													Type:        schema.TypeBool,
-													Optional:    true,
-													Computed:    true,
-													Description: `Specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes.`,
-												},
-												"auto_repair": {
-													Type:        schema.TypeBool,
-													Optional:    true,
-													Computed:    true,
-													Description: `Specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered.`,
-												},
-												"upgrade_options": {
-													Type:        schema.TypeList,
-													Computed:    true,
-													Description: `Specifies the Auto Upgrade knobs for the node pool.`,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auto_upgrade_start_time": {
-																Type:        schema.TypeString,
-																Computed:    true,
-																Description: `This field is set when upgrades are about to commence with the approximate start time for the upgrades, in RFC3339 text format.`,
-															},
-															"description": {
-																Type:        schema.TypeString,
-																Computed:    true,
-																Description: `This field is set when upgrades are about to commence with the description of the upgrade.`,
-															},
-														},
 													},
 												},
 											},
@@ -3913,13 +3787,12 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 	config := l[0].(map[string]interface{})
 
 	npd := &container.AutoprovisioningNodePoolDefaults{
-		OauthScopes:    	convertStringArr(config["oauth_scopes"].([]interface{})),
-		ServiceAccount: 	config["service_account"].(string),
-		DiskSizeGb:     	int64(config["disk_size"].(int)),
-		DiskType:       	config["disk_type"].(string),
-		ImageType:      	config["image_type"].(string),
-		BootDiskKmsKey: 	config["boot_disk_kms_key"].(string),
-		UpgradeSettings:	expandUpgradeSettings(config["upgrade_settings"]),
+		OauthScopes:    convertStringArr(config["oauth_scopes"].([]interface{})),
+		ServiceAccount: config["service_account"].(string),
+		DiskSizeGb:     int64(config["disk_size"].(int)),
+		DiskType:       config["disk_type"].(string),
+		ImageType:      config["image_type"].(string),
+		BootDiskKmsKey: config["boot_disk_kms_key"].(string),
 		Management:		expandManagement(config["management"]),
 	}
 
@@ -3931,13 +3804,14 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 		}
 	}
 
+<% unless version == 'ga' -%>
 	cpu := config["min_cpu_platform"].(string)
 	// the only way to unset the field is to pass "automatic" as its value
 	if cpu == "" {
 		cpu = "automatic"
 	}
 	npd.MinCpuPlatform = cpu
-
+<% end -%>
 	return npd
 }
 
@@ -3970,54 +3844,6 @@ func expandUpgradeOptions(configured interface{}) *container.AutoUpgradeOptions 
 	}
 
 	return upgradeOptions
-}
-
-func expandUpgradeSettings(configured interface{}) *container.UpgradeSettings {
-	l, ok := configured.([]interface{})
-	if !ok || l == nil || len(l) == 0 || l[0] == nil {
-		return &container.UpgradeSettings{}
-	}
-	config := l[0].(map[string]interface{})
-
-	upgradeSettings := &container.UpgradeSettings{
-		MaxSurge:          int64(config["max_surge"].(int)),
-		MaxUnavailable:    int64(config["max_unavailable"].(int)),
-		Strategy:          config["strategy"].(string),
-		BlueGreenSettings: expandBlueGreenSettings(config["blue_green_settings"]),
-	}
-
-	return upgradeSettings
-}
-
-func expandBlueGreenSettings(configured interface{}) *container.BlueGreenSettings {
-	l, ok := configured.([]interface{})
-	if !ok || l == nil || len(l) == 0 || l[0] == nil {
-		return &container.BlueGreenSettings{}
-	}
-	config := l[0].(map[string]interface{})
-
-	blueGreenSettings := &container.BlueGreenSettings{
-		NodePoolSoakDuration:  config["node_pool_soak_duration"].(string),
-		StandardRolloutPolicy: expandStandardRolloutPolicy(config["standard_rollout_policy"]),
-	}
-
-	return blueGreenSettings
-}
-
-func expandStandardRolloutPolicy(configured interface{}) *container.StandardRolloutPolicy {
-	l, ok := configured.([]interface{})
-	if !ok || l == nil || len(l) == 0 || l[0] == nil {
-		return &container.StandardRolloutPolicy{}
-	}
-
-	config := l[0].(map[string]interface{})
-	standardRolloutPolicy := &container.StandardRolloutPolicy{
-		BatchPercentage:   config["batch_percentage"].(float64),
-		BatchNodeCount:    int64(config["batch_node_count"].(int)),
-		BatchSoakDuration: config["batch_soak_duration"].(string),
-	}
-
-	return standardRolloutPolicy
 }
 
 func expandAuthenticatorGroupsConfig(configured interface{}) *container.AuthenticatorGroupsConfig {
@@ -4964,10 +4790,11 @@ func flattenAutoProvisioningDefaults(a *container.AutoprovisioningNodePoolDefaul
 	r["disk_size"] = a.DiskSizeGb
 	r["disk_type"] = a.DiskType
 	r["image_type"] = a.ImageType
+	<% unless version == 'ga' -%>
 	r["min_cpu_platform"] = a.MinCpuPlatform
+	<% end -%>
 	r["boot_disk_kms_key"] = a.BootDiskKmsKey
 	r["shielded_instance_config"] = flattenShieldedInstanceConfig(a.ShieldedInstanceConfig)
-	r["upgrade_settings"] = flattenUpgradeSettings(a.UpgradeSettings)
 	r["management"] = flattenManagement(a.Management)
 
 	return []map[string]interface{}{r}
@@ -4993,44 +4820,6 @@ func flattenUpgradeOptions(a *container.AutoUpgradeOptions) []map[string]interfa
 	r := make(map[string]interface{})
 	r["auto_upgrade_start_time"] = a.AutoUpgradeStartTime
 	r["description"] = a.Description
-
-	return []map[string]interface{}{r}
-}
-
-func flattenUpgradeSettings(a *container.UpgradeSettings) []map[string]interface{} {
-	if a == nil {
-		return nil
-	}
-	r := make(map[string]interface{})
-	r["max_surge"] = a.MaxSurge
-	r["max_unavailable"] = a.MaxUnavailable
-	r["strategy"] = a.Strategy
-	r["blue_green_settings"] = flattenBlueGreenSettings(a.BlueGreenSettings)
-
-	return []map[string]interface{}{r}
-}
-
-func flattenBlueGreenSettings(a *container.BlueGreenSettings) []map[string]interface{} {
-	if a == nil {
-		return nil
-	}
-
-	r := make(map[string]interface{})
-	r["node_pool_soak_duration"] = a.NodePoolSoakDuration
-	r["standard_rollout_policy"] = flattenStandardRolloutPolicy(a.StandardRolloutPolicy)
-
-	return []map[string]interface{}{r}
-}
-
-func flattenStandardRolloutPolicy(a *container.StandardRolloutPolicy) []map[string]interface{} {
-	if a == nil {
-		return nil
-	}
-
-	r := make(map[string]interface{})
-	r["batch_percentage"] = a.BatchPercentage
-	r["batch_node_count"] = a.BatchNodeCount
-	r["batch_soak_duration"] = a.BatchSoakDuration
 
 	return []map[string]interface{}{r}
 }
@@ -5445,31 +5234,3 @@ func validateNodePoolAutoConfig(cluster *container.Cluster) error {
 	return nil
 }
 <% end -%>
-
-func UpgradeSettingsDiffSuppress(k, old, new string, r *schema.ResourceData) bool {
-	// the number of digits after decimal point may differ for soak_duration in config. ("3.5s" - "3.500s")
-	// suppress the difference if both floats are equal.
-	// max_surge and max_unavailable should not be _ideally_ specified with the strategy set to BLUE_GREEN,
-	// but in case it is specified, suppress it.
-
-	nodePoolSoakDuration := "cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.blue_green_settings.0.node_pool_soak_duration"
-
-	o, n := r.GetChange("cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.strategy")
-
-	if o == "BLUE_GREEN" && n == "BLUE_GREEN" {
-		if k == nodePoolSoakDuration {
-			fs1, fs2 := r.GetChange(nodePoolSoakDuration)
-
-			f1, _ := strconv.ParseFloat(strings.Trim(fs1.(string), "s"), 32)
-			f2, _ := strconv.ParseFloat(strings.Trim(fs2.(string), "s"), 32)
-
-			return f1 == f2
-		}
-
-		return k == "cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.max_surge" ||
-			k == "cluster_autoscaling.0.auto_provisioning_defaults.0.upgrade_settings.0.max_unavailable"
-
-	}
-
-	return false
-}

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2025,7 +2025,6 @@ func TestAccContainerCluster_nodeAutoprovisioningDefaults(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
-	includeMinCpuPlatform := true
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:	  func() { testAccPreCheck(t) },
@@ -2049,24 +2048,6 @@ func TestAccContainerCluster_nodeAutoprovisioningDefaults(t *testing.T) {
 				Config: testAccContainerCluster_autoprovisioningDefaults(clusterName, true),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
-			},
-			{
-				Config: testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(clusterName, includeMinCpuPlatform),
-			},
-			{
-				ResourceName:		 "google_container_cluster.with_autoprovisioning",
-				ImportState:		 true,
-				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"min_master_version"},
-			},
-			{
-				Config: testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(clusterName, !includeMinCpuPlatform),
-			},
-			{
-				ResourceName:		 "google_container_cluster.with_autoprovisioning",
-				ImportState:		 true,
-				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 		},
 	})
@@ -2454,6 +2435,38 @@ func TestAccContainerCluster_withSoleTenantGroup(t *testing.T) {
 <% unless version == 'ga' -%>
 // consider merging this test with TestAccContainerCluster_nodeAutoprovisioningDefaults
 // once the feature is GA
+func TestAccContainerCluster_nodeAutoprovisioningDefaultsMinCpuPlatform(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	includeMinCpuPlatform := true
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(clusterName, includeMinCpuPlatform),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_autoprovisioning",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(clusterName, !includeMinCpuPlatform),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_autoprovisioning",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
 
 func TestAccContainerCluster_withAutoscalingProfile(t *testing.T) {
 	t.Parallel()
@@ -2852,36 +2865,6 @@ func TestAccContainerCluster_autoprovisioningDefaultsManagement(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
-			},
-		},
-	})
-}
-
-func TestAccContainerCluster_autoprovisioningDefaultsUpgradeSettings(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_autoprovisioningDefaultsUpgradeSettings(clusterName, 2, 1, "SURGE"),
-			},
-			{
-				ResourceName:      "google_container_cluster.with_autoprovisioning_upgrade_settings",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccContainerCluster_autoprovisioningDefaultsUpgradeSettings(clusterName, 2, 1, "BLUE_GREEN"),
-			},
-			{
-				ResourceName:      "google_container_cluster.with_autoprovisioning_upgrade_settings",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -4954,6 +4937,7 @@ if monitoringWrite {
 	return config
 }
 
+<% unless version == 'ga' -%>
 func testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(cluster string, includeMinCpuPlatform bool) string {
 	minCpuPlatformCfg := ""
 	if includeMinCpuPlatform {
@@ -4990,52 +4974,7 @@ resource "google_container_cluster" "with_autoprovisioning" {
   }
 }`, cluster, minCpuPlatformCfg)
 }
-
-func testAccContainerCluster_autoprovisioningDefaultsUpgradeSettings(clusterName string, maxSurge, maxUnavailable int, strategy string) string {
-	blueGreenSettings := ""
-	if strategy == "BLUE_GREEN" {
-		blueGreenSettings = `
-		blue_green_settings {
-			node_pool_soak_duration = "3.500s"
-			standard_rollout_policy {
-			  batch_percentage    = 0.5
-			  batch_soak_duration = "3.500s"
-			}
-		  }
-		`
-	}
-
-	return fmt.Sprintf(`
-resource "google_container_cluster" "with_autoprovisioning_upgrade_settings" {
-  name               = "%s"
-  location           = "us-central1-f"
-  initial_node_count = 1
-
-  cluster_autoscaling {
-    enabled = true
-
-	resource_limits {
-	  resource_type = "cpu"
-	  maximum       = 2
-	}
-
-	resource_limits {
-	  resource_type = "memory"
-	  maximum       = 2048
-	}
-
-    auto_provisioning_defaults {
-      upgrade_settings {
-        max_surge       = %d
-        max_unavailable = %d
-        strategy        = "%s"
-		%s
-      }
-    }
-  }
-}
-`, clusterName, maxSurge, maxUnavailable, strategy, blueGreenSettings)
-}
+<% end -%>
 
 func testAccContainerCluster_autoprovisioningDefaultsDiskSizeGb(cluster string, includeDiskSizeGb bool) string {
 	DiskSizeGbCfg := ""

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -529,32 +529,6 @@ as "Intel Haswell" or "Intel Sandy Bridge".
 
 This block also contains several computed attributes, documented below.
 
-* `upgrade_settings` - (Optional) Specifies the upgrade settings for NAP created node pools. Structure is [documented below](#nested_upgrade_settings).
-
-<a name="nested_upgrade_settings"></a>The `upgrade_settings` block supports:
-
-* `strategy` - (Optional) Strategy used for node pool update. Strategy can only be one of BLUE_GREEN or SURGE. The default is value is SURGE.
-
-* `max_surge` - (Optional) The maximum number of nodes that can be created beyond the current size of the node pool during the upgrade process. To be used when strategy is set to SURGE. Default is 0.
-
-* `max_unavailable` - (Optional) The maximum number of nodes that can be simultaneously unavailable during the upgrade process. To be used when strategy is set to SURGE. Default is 0.
-
-* `blue_green_settings` - (Optional) Settings for blue-green upgrade strategy. To be specified when strategy is set to BLUE_GREEN. Structure is [documented below](#nested_blue_green_settings).
-
-<a name="nested_blue_green_settings"></a>The `blue_green_settings` block supports:
-
-* `node_pool_soak_duration` - (Optional) Time needed after draining entire blue pool. After this period, blue pool will be cleaned up. A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
-
-* `standard_rollout_policy`: (Optional) Standard policy for the blue-green upgrade. To be specified when strategy is set to BLUE_GREEN. Structure is [documented below](#nested_standard_rollout_policy).
-
-<a name="nested_standard_rollout_policy"></a>The `standard_rollout_policy` block supports:
-
-* `batch_percentage`: (Optional) Percentage of the bool pool nodes to drain in a batch. The range of this field should be (0.0, 1.0). Only one of the batch_percentage or batch_node_count can be specified.
-
-* `batch_node_count` - (Optional) Number of blue nodes to drain in a batch. Only one of the batch_percentage or batch_node_count can be specified.
-
-* `batch_soak_duration` - (Optional) Soak time after each batch gets drained. A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".`.
-
 <a name="nested_authenticator_groups_config"></a>The `authenticator_groups_config` block supports:
 
 * `security_group` - (Required) The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format `gke-security-groups@yourdomain.com`.


### PR DESCRIPTION
…ter resource and promoted min_cpu_platform to GA (#6771)"

This reverts commit f8db021005ef5a9fd5d0ededd959773e58240402.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Reverts #6771 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
