### PR TITLE
Add support for Beyondcorp AppConnection resource

### DIFF
--- a/mmv1/products/beyondcorp/api.yaml
+++ b/mmv1/products/beyondcorp/api.yaml
@@ -41,10 +41,6 @@ objects:
     create_url: projects/{{project}}/locations/{{region}}/appConnectors?app_connector_id={{name}}
     update_verb: :PATCH
     update_mask: true
-    iam_policy: !ruby/object:Api::Resource::IamPolicy
-      parent_resource_attribute: name
-      method_name_separator: ':'
-      fetch_iam_policy_verb: :GET
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
@@ -128,10 +124,6 @@ objects:
     create_url: projects/{{project}}/locations/{{region}}/appGateways?app_gateway_id={{name}}
     # This resources is not updatable
     input: true
-    iam_policy: !ruby/object:Api::Resource::IamPolicy
-      parent_resource_attribute: name
-      method_name_separator: ':'
-      fetch_iam_policy_verb: :GET
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
@@ -236,10 +228,6 @@ objects:
     create_url: projects/{{project}}/locations/{{region}}/appConnections?app_connection_id={{name}}
     update_verb: :PATCH
     update_mask: true
-    iam_policy: !ruby/object:Api::Resource::IamPolicy
-      parent_resource_attribute: name
-      method_name_separator: ':'
-      fetch_iam_policy_verb: :GET
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'

--- a/mmv1/products/beyondcorp/api.yaml
+++ b/mmv1/products/beyondcorp/api.yaml
@@ -41,6 +41,10 @@ objects:
     create_url: projects/{{project}}/locations/{{region}}/appConnectors?app_connector_id={{name}}
     update_verb: :PATCH
     update_mask: true
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      parent_resource_attribute: name
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :GET
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
@@ -124,6 +128,10 @@ objects:
     create_url: projects/{{project}}/locations/{{region}}/appGateways?app_gateway_id={{name}}
     # This resources is not updatable
     input: true
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      parent_resource_attribute: name
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :GET
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
@@ -228,6 +236,10 @@ objects:
     create_url: projects/{{project}}/locations/{{region}}/appConnections?app_connection_id={{name}}
     update_verb: :PATCH
     update_mask: true
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      parent_resource_attribute: name
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :GET
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'

--- a/mmv1/products/beyondcorp/api.yaml
+++ b/mmv1/products/beyondcorp/api.yaml
@@ -271,26 +271,13 @@ objects:
         name: 'labels'
         description: |
           Resource labels to represent user provided metadata.
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'type'
         description: |
-          The type of network connectivity used by the AppConnection.
-        values:
-          - :TYPE_UNSPECIFIED
-          - :TCP_PROXY
-        default_value: :TYPE_UNSPECIFIED
-      - !ruby/object:Api::Type::Enum
-        name: 'state'
-        output: true
-        description: |
-           Represents the different states of a AppConnection.
-        values:
-          - :STATE_UNSPECIFIED
-          - :CREATING
-          - :CREATED
-          - :UPDATING
-          - :DELETING
-          - :DOWN
+          The type of network connectivity used by the AppConnection. Refer to
+          https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appConnections#type
+          for a list of possible values.
+        input: true
       - !ruby/object:Api::Type::NestedObject
         name: 'applicationEndpoint'
         description: |
@@ -322,13 +309,12 @@ objects:
             description: |
               AppGateway name in following format: projects/{project_id}/locations/{locationId}/appgateways/{gateway_id}.
             required: true
-          - !ruby/object:Api::Type::Enum
+          - !ruby/object:Api::Type::String
             name: 'type'
             description: |
-              The type of hosting used by the gateway.
-            values:
-              - :TYPE_UNSPECIFIED
-              - :GCP_REGIONAL_MIG
+              The type of hosting used by the gateway. Refer to
+              https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appConnections#Type_1
+              for a list of possible values.
           - !ruby/object:Api::Type::String
             name: 'uri'
             description: |

--- a/mmv1/products/beyondcorp/api.yaml
+++ b/mmv1/products/beyondcorp/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Beyondcorp
-display_name: Google BeyondCorp
+display_name: BeyondCorp
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/mmv1/products/beyondcorp/api.yaml
+++ b/mmv1/products/beyondcorp/api.yaml
@@ -213,3 +213,129 @@ objects:
             name: 'ingressPort'
             description: |
               The ingress port of an allocated connection.
+  - !ruby/object:Api::Resource
+    name: 'AppConnection'
+    description: |
+      A BeyondCorp AppConnection resource represents a BeyondCorp protected AppConnection to a remote application.
+      It creates all the necessary GCP components needed for creating a BeyondCorp protected AppConnection. 
+      Multiple connectors can be authorised for a single AppConnection.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/beyondcorp-enterprise/docs/enable-app-connector'
+      api: 'https://cloud.google.com/beyondcorp/docs/reference/rest#rest-resource:-v1.projects.locations.appconnections'
+    base_url: projects/{{project}}/locations/{{region}}/appConnections
+    self_link: projects/{{project}}/locations/{{region}}/appConnections/{{name}}
+    create_url: projects/{{project}}/locations/{{region}}/appConnections?app_connection_id={{name}}
+    update_verb: :PATCH
+    update_mask: true
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 30
+          update_minutes: 30
+          delete_minutes: 30
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: true
+        allowed:
+          - true
+          - false
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        required: true
+        input: true
+        description: |
+          ID of the AppConnection.
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'region'
+        description: |
+          The region of the AppConnection.
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          An arbitrary user-provided name for the AppConnection.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Resource labels to represent user provided metadata.
+      - !ruby/object:Api::Type::Enum
+        name: 'type'
+        description: |
+          The type of network connectivity used by the AppConnection.
+        values:
+          - :TYPE_UNSPECIFIED
+          - :TCP_PROXY
+        default_value: :TYPE_UNSPECIFIED
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        output: true
+        description: |
+           Represents the different states of a AppConnection.
+        values:
+          - :STATE_UNSPECIFIED
+          - :CREATING
+          - :CREATED
+          - :UPDATING
+          - :DELETING
+          - :DOWN
+      - !ruby/object:Api::Type::NestedObject
+        name: 'applicationEndpoint'
+        description: |
+          Address of the remote application endpoint for the BeyondCorp AppConnection.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'host'
+            description: |
+              Hostname or IP address of the remote application endpoint.
+            required: true
+          - !ruby/object:Api::Type::Integer
+            name: 'port'
+            description: |
+              Port of the remote application endpoint.
+            required: true
+      - !ruby/object:Api::Type::Array
+        name: connectors
+        item_type: Api::Type::String
+        description: |
+          List of AppConnectors that are authorised to be associated with this AppConnection
+      - !ruby/object:Api::Type::NestedObject
+        name: gateway
+        description: |
+          Gateway used by the AppConnection.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'appGateway'
+            description: |
+              AppGateway name in following format: projects/{project_id}/locations/{locationId}/appgateways/{gateway_id}.
+            required: true
+          - !ruby/object:Api::Type::Enum
+            name: 'type'
+            description: |
+              The type of hosting used by the gateway.
+            values:
+              - :TYPE_UNSPECIFIED
+              - :GCP_REGIONAL_MIG
+          - !ruby/object:Api::Type::String
+            name: 'uri'
+            description: |
+              Server-defined URI for this resource.
+            output: true
+          - !ruby/object:Api::Type::Integer
+            name: 'ingressPort'
+            description: |
+              Ingress port reserved on the gateways for this AppConnection, if not specified or zero, the default port is 19443.
+            output: true

--- a/mmv1/products/beyondcorp/terraform.yaml
+++ b/mmv1/products/beyondcorp/terraform.yaml
@@ -47,6 +47,31 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           app_gateway_name: "my-app-gateway"
           display_name: "some display name"
+  AppConnection: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    properties:
+      gateway: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "beyondcorp_app_connection_basic"
+        primary_resource_id: "app_connection"
+        primary_resource_name: "fmt.Sprintf(\"tf_test_my_app_connection%s\", context[\"random_suffix\"])"
+        vars:
+          account_id: "my-account"
+          app_connector_name: "my-app-connector"
+          app_connection_name: "my-app-connection"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "beyondcorp_app_connection_full"
+        # skip the test until gateway delete issue is resolved
+        skip_test: true
+        primary_resource_id: "app_connection"
+        primary_resource_name: "fmt.Sprintf(\"tf_test_my_app_connection%s\", context[\"random_suffix\"])"
+        vars:
+          account_id: "my-account"
+          app_connector_name: "my-app-connector"
+          app_connection_name: "my-app-connection"
+          display_name: "some display name"
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/products/beyondcorp/terraform.yaml
+++ b/mmv1/products/beyondcorp/terraform.yaml
@@ -63,8 +63,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           app_connection_name: "my-app-connection"
       - !ruby/object:Provider::Terraform::Examples
         name: "beyondcorp_app_connection_full"
-        # skip the test until gateway delete issue is resolved
-        skip_test: true
         primary_resource_id: "app_connection"
         primary_resource_name: "fmt.Sprintf(\"tf_test_my_app_connection%s\", context[\"random_suffix\"])"
         vars:

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.erb
@@ -1,0 +1,24 @@
+resource "google_service_account" "service_account" {
+  account_id   = "<%= ctx[:vars]['account_id'] %>"
+  display_name = "Test Service Account"
+}
+
+resource "google_beyondcorp_app_connector" "app_connector" {
+  name = "<%= ctx[:vars]['app_connector_name'] %>"
+  principal_info {
+    service_account {
+     email = google_service_account.service_account.email
+    }
+  }
+}
+
+resource "google_beyondcorp_app_connection" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['app_connection_name'] %>"
+  type = "TCP_PROXY"
+  region = "us-central1"
+  application_endpoint {
+    host = "foo-host"
+    port = 8080
+  }
+  connectors = [google_beyondcorp_app_connector.app_connector.id]
+}

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.erb
@@ -5,6 +5,7 @@ resource "google_service_account" "service_account" {
 
 resource "google_beyondcorp_app_connector" "app_connector" {
   name = "<%= ctx[:vars]['app_connector_name'] %>"
+  region = "us-east1"
   principal_info {
     service_account {
      email = google_service_account.service_account.email
@@ -15,7 +16,7 @@ resource "google_beyondcorp_app_connector" "app_connector" {
 resource "google_beyondcorp_app_connection" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['app_connection_name'] %>"
   type = "TCP_PROXY"
-  region = "us-central1"
+  region = "us-east1"
   application_endpoint {
     host = "foo-host"
     port = 8080

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.erb
@@ -5,7 +5,6 @@ resource "google_service_account" "service_account" {
 
 resource "google_beyondcorp_app_connector" "app_connector" {
   name = "<%= ctx[:vars]['app_connector_name'] %>"
-  region = "us-east1"
   principal_info {
     service_account {
      email = google_service_account.service_account.email
@@ -16,7 +15,6 @@ resource "google_beyondcorp_app_connector" "app_connector" {
 resource "google_beyondcorp_app_connection" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['app_connection_name'] %>"
   type = "TCP_PROXY"
-  region = "us-east1"
   application_endpoint {
     host = "foo-host"
     port = 8080

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
@@ -5,14 +5,12 @@ resource "google_service_account" "service_account" {
 
 resource "google_beyondcorp_app_gateway" "app_gateway" {
   name = "tf-test-my-app-gateway%{random_suffix}"
-  region = "us-east1"
   type = "TCP_PROXY"
   host_type = "GCP_REGIONAL_MIG"
 }
 
 resource "google_beyondcorp_app_connector" "app_connector" {
   name = "<%= ctx[:vars]['app_connector_name'] %>"
-  region = "us-east1"
   principal_info {
     service_account {
      email = google_service_account.service_account.email
@@ -23,7 +21,6 @@ resource "google_beyondcorp_app_connector" "app_connector" {
 resource "google_beyondcorp_app_connection" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['app_connection_name'] %>"
   type = "TCP_PROXY"
-  region = "us-east1"
   display_name = "<%= ctx[:vars]['display_name'] %>"
   application_endpoint {
     host = "foo-host"

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
@@ -4,10 +4,10 @@ resource "google_service_account" "service_account" {
 }
 
 resource "google_beyondcorp_app_gateway" "app_gateway" {
-	name = "tf-test-my-app-gateway%{random_suffix}"
+  name = "tf-test-my-app-gateway%{random_suffix}"
   region = "us-east1"
-	type = "TCP_PROXY"
-	host_type = "GCP_REGIONAL_MIG"
+  type = "TCP_PROXY"
+  host_type = "GCP_REGIONAL_MIG"
 }
 
 resource "google_beyondcorp_app_connector" "app_connector" {

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
@@ -1,0 +1,38 @@
+resource "google_service_account" "service_account" {
+  account_id   = "<%= ctx[:vars]['account_id'] %>"
+  display_name = "Test Service Account"
+}
+
+resource "google_beyondcorp_app_gateway" "app_gateway" {
+	name = "tf-test-my-app-gateway%{random_suffix}"
+	type = "TCP_PROXY"
+	host_type = "GCP_REGIONAL_MIG"
+}
+
+resource "google_beyondcorp_app_connector" "app_connector" {
+  name = "<%= ctx[:vars]['app_connector_name'] %>"
+  principal_info {
+    service_account {
+     email = google_service_account.service_account.email
+    }
+  }
+}
+
+resource "google_beyondcorp_app_connection" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['app_connection_name'] %>"
+  type = "TCP_PROXY"
+  region = "us-central1"
+  display_name = "<%= ctx[:vars]['display_name'] %>"
+  application_endpoint {
+    host = "foo-host"
+    port = 8080
+  }
+  connectors = [google_beyondcorp_app_connector.app_connector.id]
+  gateway {
+    app_gateway = google_beyondcorp_app_gateway.app_gateway.id
+  }
+  labels = {
+    foo = "bar"
+    bar = "baz"
+  }
+}

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.erb
@@ -5,12 +5,14 @@ resource "google_service_account" "service_account" {
 
 resource "google_beyondcorp_app_gateway" "app_gateway" {
 	name = "tf-test-my-app-gateway%{random_suffix}"
+  region = "us-east1"
 	type = "TCP_PROXY"
 	host_type = "GCP_REGIONAL_MIG"
 }
 
 resource "google_beyondcorp_app_connector" "app_connector" {
   name = "<%= ctx[:vars]['app_connector_name'] %>"
+  region = "us-east1"
   principal_info {
     service_account {
      email = google_service_account.service_account.email
@@ -21,7 +23,7 @@ resource "google_beyondcorp_app_connector" "app_connector" {
 resource "google_beyondcorp_app_connection" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['app_connection_name'] %>"
   type = "TCP_PROXY"
-  region = "us-central1"
+  region = "us-east1"
   display_name = "<%= ctx[:vars]['display_name'] %>"
   application_endpoint {
     host = "foo-host"

--- a/mmv1/third_party/terraform/tests/resource_beyondcorp_app_connection_test.go
+++ b/mmv1/third_party/terraform/tests/resource_beyondcorp_app_connection_test.go
@@ -1,0 +1,74 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccBeyondcorpAppConnection_beyondcorpAppConnectionUpdateExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBeyondcorpAppConnection_beyondcorpAppConnectionBasicExample(context),
+			},
+			{
+				ResourceName:            "google_beyondcorp_app_connection.app_connection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "region", "gateway"},
+			},
+			{
+				Config: testAccBeyondcorpAppConnection_beyondcorpAppConnectionUpdateExample(context),
+			},
+			{
+				ResourceName:            "google_beyondcorp_app_connection.app_connection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "region", "gateway"},
+			},
+			{
+				Config: testAccBeyondcorpAppConnection_beyondcorpAppConnectionBasicExample(context),
+			},
+		},
+	})
+}
+
+func testAccBeyondcorpAppConnection_beyondcorpAppConnectionUpdateExample(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_account" "service_account" {
+  account_id   = "tf-test-my-account%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
+resource "google_beyondcorp_app_connector" "app_connector" {
+  name = "tf-test-my-app-connector%{random_suffix}"
+  principal_info {
+    service_account {
+     email = google_service_account.service_account.email
+    }
+  }
+}
+
+resource "google_beyondcorp_app_connection" "app_connection" {
+  name = "tf-test-my-app-connection%{random_suffix}"
+  type = "TCP_PROXY"
+  region = "us-central1"
+  application_endpoint {
+    host = "foo-host"
+    port = 8080
+  }
+  connectors = [google_beyondcorp_app_connector.app_connector.id]
+  display_name = "Some display name"
+}
+`, context)
+}


### PR DESCRIPTION
Add terraform support for BeyondCorp AppConnection resource (https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appConnections). Adding API and Terraforms yamls and couple of examples.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_beyondcorp_app_connection`
```
