### PR TITLE
update repoType to accept bitbucket_server

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -134,12 +134,12 @@ objects:
             required: true
             description: |
               The type of the repo, since it may not be explicit from the repo field (e.g from a URL). 
-              Values can be UNKNOWN, CLOUD_SOURCE_REPOSITORIES, GITHUB, BITBUCKET
+              Values can be UNKNOWN, CLOUD_SOURCE_REPOSITORIES, GITHUB, BITBUCKET_SERVER
             values:
                   - :UNKNOWN
                   - :CLOUD_SOURCE_REPOSITORIES
                   - :GITHUB
-                  - :BITBUCKET
+                  - :BITBUCKET_SERVER
           - !ruby/object:Api::Type::String
             name: 'revision'
             description: |
@@ -175,12 +175,12 @@ objects:
             required: true
             description: |
               The type of the repo, since it may not be explicit from the repo field (e.g from a URL).
-              Values can be UNKNOWN, CLOUD_SOURCE_REPOSITORIES, GITHUB, BITBUCKET
+              Values can be UNKNOWN, CLOUD_SOURCE_REPOSITORIES, GITHUB, BITBUCKET_SERVER
             values:
                   - :UNKNOWN
                   - :CLOUD_SOURCE_REPOSITORIES
                   - :GITHUB
-                  - :BITBUCKET
+                  - :BITBUCKET_SERVER
       - !ruby/object:Api::Type::Array
         name: 'ignoredFiles'
         item_type: Api::Type::String

--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -209,6 +209,27 @@ func TestAccCloudBuildTrigger_fullStep(t *testing.T) {
 	})
 }
 
+func TestAccCloudBuildTrigger_basic_bitbucket(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("tf-test-%d", randInt(t))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudBuildTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudBuildTrigger_basic_bitbucket(name),
+			},
+			{
+				ResourceName:      "google_cloudbuild_trigger.build_trigger",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCloudBuildTrigger_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_cloudbuild_trigger" "build_trigger" {
@@ -261,6 +282,25 @@ resource "google_cloudbuild_trigger" "build_trigger" {
         path = "v1"
       }
     }
+  }
+}
+`, name)
+}
+
+func testAccCloudBuildTrigger_basic_bitbucket(name string) string {
+	return fmt.Sprintf(`
+resource "google_cloudbuild_trigger" "build_trigger" {
+  name        = "%s"
+  description = "acceptance test build trigger on bitbucket"
+  trigger_template {
+    branch_name = "main"
+    repo_name   = "some-repo"
+  }
+  git_file_source {
+    path      = "cloudbuild.yaml"
+    uri       = "https://bitbucket.org/myorg/myrepo"
+    revision  = "refs/heads/develop"
+    repo_type = "BITBUCKET_SERVER"
   }
 }
 `, name)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/13003


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudbuild: fixed the failure when BITBUCKET is provided for `repo_type` on `google_cloudbuild_trigger`
```
