### PR TITLE
Bigtable: Add support for abandoning GC policy

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -45,6 +45,7 @@ resource "google_bigtable_gc_policy" "policy" {
   instance_name = google_bigtable_instance.instance.name
   table         = google_bigtable_table.table.name
   column_family = "name"
+  deletion_policy = "ABANDON"
 
   max_age {
     duration = "168h"
@@ -59,6 +60,7 @@ resource "google_bigtable_gc_policy" "policy" {
   instance_name = google_bigtable_instance.instance.name
   table         = google_bigtable_table.table.name
   column_family = "name"
+  deletion_policy = "ABANDON"
 
   mode = "UNION"
 
@@ -101,6 +103,7 @@ resource "google_bigtable_gc_policy" "policy" {
   instance_name = google_bigtable_instance.instance.id
   table         = google_bigtable_table.table.name
   column_family = "cf1"
+  deletion_policy = "ABANDON"
 
   gc_rules = <<EOF
 {
@@ -150,6 +153,11 @@ The following arguments are supported:
 * `max_version` - (Optional) GC policy that applies to all versions of a cell except for the most recent.
 
 * `gc_rules` - (Optional) Serialized JSON object to represent a more complex GC policy. Conflicts with `mode`, `max_age` and `max_version`. Conflicts with `mode`, `max_age` and `max_version`.
+
+* `deletion_policy` - (Optional) The deletion policy for the GC policy.
+    Setting ABANDON allows the resource to be abandoned rather than deleted. This is useful for GC policy as it cannot be deleted in a replicated instance.
+
+    Possible values are: `ABANDON`.
 
 -----
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Deleting a GC policy is not allowed in a replicated instance (an instance has more than one cluster).

Users who are running into this problem have to add an extra step to un-replicate the instance first before destroying all the resources.

With abandoning GC policy support, users can mark the GCP policy to be `ABANDON`. That way, the GC policy won't be deleted first, but will be deleted when the parent resource (table) is deleted.

fixes b/257991134

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added support for abandoning GC policy
```
