### PR TITLE
Add cloud_asset_resources_search_all data source.

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloud_asset_resources_search_all.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloud_asset_resources_search_all.go.erb
@@ -1,0 +1,214 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleCloudAssetResourcesSearchAll() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceGoogleCloudAssetResourcesSearchAllRead,
+		Schema: map[string]*schema.Schema{
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"query": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"asset_types": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"asset_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"additional_attributes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"network_tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceGoogleCloudAssetResourcesSearchAllRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return err
+	}
+
+	params := make(map[string]string)
+	results := make([]map[string]interface{}, 0)
+
+	scope := d.Get("scope").(string)
+	query := d.Get("query").(string)
+	assetTypes := d.Get("asset_types").([]interface{})
+
+	url := fmt.Sprintf("https://cloudasset.googleapis.com/v1p1beta1/%s/resources:searchAll", scope)
+	params["query"] = query
+
+	url, err = addArrayQueryParam(url, "asset_types", assetTypes)
+	if err != nil {
+		return fmt.Errorf("Error setting asset_types: %s", err)
+	}
+
+	for {
+		url, err := addQueryParams(url, params)
+		if err != nil {
+			return err
+		}
+
+		res, err := sendRequest(config, "GET", "", url, userAgent, nil)
+		if err != nil {
+			return fmt.Errorf("Error searching resources: %s", err)
+		}
+
+		pageResults := flattenDatasourceGoogleCloudAssetResourcesList(res["results"])
+		results = append(results, pageResults...)
+
+		pToken, ok := res["nextPageToken"]
+		if ok && pToken != nil && pToken.(string) != "" {
+			params["pageToken"] = pToken.(string)
+		} else {
+			break
+		}
+	}
+
+	if err := d.Set("results", results); err != nil {
+		return fmt.Errorf("Error searching resources: %s", err)
+	}
+
+	if err := d.Set("query", query); err != nil {
+		return fmt.Errorf("Error setting query: %s", err)
+	}
+
+	if err := d.Set("asset_types", assetTypes); err != nil {
+		return fmt.Errorf("Error setting asset_types: %s", err)
+	}
+
+	d.SetId(scope)
+
+	return nil
+}
+
+func flattenDatasourceGoogleCloudAssetResourcesList(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return make([]map[string]interface{}, 0)
+	}
+
+	ls := v.([]interface{})
+	results := make([]map[string]interface{}, 0, len(ls))
+	for _, raw := range ls {
+		p := raw.(map[string]interface{})
+
+		var mName, mAssetType, mProject, mDisplayName, mDescription, mAdditionalAttributes, mLocation, mLabels, mNetworkTags interface{}
+		if pName, ok := p["name"]; ok {
+			mName = pName
+		}
+		if pAssetType, ok := p["assetType"]; ok {
+			mAssetType = pAssetType
+		}
+		if pProject, ok := p["project"]; ok {
+			mProject = pProject
+		}
+		if pDisplayName, ok := p["displayName"]; ok {
+			mDisplayName = pDisplayName
+		}
+		if pDescription, ok := p["description"]; ok {
+			mDescription = pDescription
+		}
+		if pAdditionalAttributes, ok := p["additionalAttributes"]; ok {
+			mAdditionalAttributes = pAdditionalAttributes
+		}
+		if pLocation, ok := p["location"]; ok {
+			mLocation = pLocation
+		}
+		if pLabels, ok := p["labels"]; ok {
+			mLabels = pLabels
+		}
+		if pNetworkTags, ok := p["networkTags"]; ok {
+			mNetworkTags = pNetworkTags
+		}
+		results = append(results, map[string]interface{}{
+			"name":                  mName,
+			"asset_type":            mAssetType,
+			"project":               mProject,
+			"display_name":          mDisplayName,
+			"description":           mDescription,
+			"additional_attributes": mAdditionalAttributes,
+			"location":              mLocation,
+			"labels":                mLabels,
+			"network_tags":          mNetworkTags,
+		})
+	}
+
+	return results
+}
+
+func addArrayQueryParam(rawurl string, param string, values []interface{}) (string, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	for _, v := range values {
+		q.Add(param, v.(string))
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_cloud_asset_resources_search_all_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_cloud_asset_resources_search_all_test.go.erb
@@ -20,7 +20,7 @@ func TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckGoogleCloudAssetProjectResorces(project),
+				Config: testAccCheckGoogleCloudAssetProjectResources(project),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
 						"results.0.asset_type", regexp.MustCompile("cloudresourcemanager.googleapis.com/Project")),
@@ -38,7 +38,7 @@ func TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckGoogleCloudAssetProjectResorces(project string) string {
+func testAccCheckGoogleCloudAssetProjectResources(project string) string {
 	return fmt.Sprintf(`
 data google_cloud_asset_resources_search_all resources {
 	scope = "projects/%s"

--- a/mmv1/third_party/terraform/tests/data_source_google_cloud_asset_resources_search_all_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_cloud_asset_resources_search_all_test.go.erb
@@ -1,0 +1,52 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic(t *testing.T) {
+	t.Parallel()
+
+	project := getTestProjectFromEnv()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleCloudAssetProjectResorces(project),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
+						"results.0.asset_type", regexp.MustCompile("cloudresourcemanager.googleapis.com/Project")),
+					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
+						"results.0.display_name", regexp.MustCompile(project)),
+					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
+						"results.0.name", regexp.MustCompile(fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project))),
+					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
+						"results.0.additional_attributes.0", regexp.MustCompile(project)),
+					resource.TestCheckResourceAttrSet("data.google_cloud_asset_resources_search_all.resources", "results.0.location"),
+					resource.TestCheckResourceAttrSet("data.google_cloud_asset_resources_search_all.resources", "results.0.project"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleCloudAssetProjectResorces(project string) string {
+	return fmt.Sprintf(`
+data google_cloud_asset_resources_search_all resources {
+	scope = "projects/%s"
+	asset_types = [
+		"cloudresourcemanager.googleapis.com/Project"
+	]
+}
+`, project)
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -202,6 +202,9 @@ func Provider() *schema.Provider {
 			"google_client_openid_userinfo":                    dataSourceGoogleClientOpenIDUserinfo(),
 			"google_cloudfunctions_function":                   dataSourceGoogleCloudFunctionsFunction(),
 			"google_cloudfunctions2_function":                  dataSourceGoogleCloudFunctions2Function(),
+			<% unless version == 'ga' -%>
+			"google_cloud_asset_resources_search_all":          dataSourceGoogleCloudAssetResourcesSearchAll(),
+			<% end -%>
 			"google_cloud_identity_groups":                     dataSourceGoogleCloudIdentityGroups(),
 			"google_cloud_identity_group_memberships":          dataSourceGoogleCloudIdentityGroupMemberships(),
 			"google_cloud_run_locations":                       dataSourceGoogleCloudRunLocations(),

--- a/mmv1/third_party/terraform/website/docs/d/cloud_asset_resources_search_all.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_asset_resources_search_all.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Cloud Asset Inventory"
+page_title: "Google: google_cloud_asset_resources_search_all"
+description: |-
+  Retrieve all the resources within a given accessible CRM scope (project/folder/organization).
+---
+
+# google\_cloud\_asset\_resources\_search\_all
+
+Retrieve all the resources within a given accessible CRM scope (project/folder/organization). See the
+[REST API](https://cloud.google.com/asset-inventory/docs/reference/rest/v1p1beta1/resources/searchAll)
+for more details.
+
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+
+## Example Usage - searching for all projects in an org
+
+```hcl
+data google_cloud_asset_resources_search_all projects {
+  provider = google-beta
+  scope = "organizations/0123456789"
+  asset_types = [
+    "cloudresourcemanager.googleapis.com/Project"
+  ]
+}
+```
+
+## Example Usage - searching for all projects with CloudBuild API enabled
+
+```hcl
+data google_cloud_asset_resources_search_all cloud_build_projects {
+  provider = google-beta
+  scope = "organizations/0123456789"
+  asset_types = [
+    "serviceusage.googleapis.com/Service"
+  ]
+  query = "displayName:cloudbuild.googleapis.com AND state:ENABLED"
+}
+```
+
+## Example Usage - searching for all Service Accounts in a project
+
+```hcl
+data google_cloud_asset_resources_search_all project_service_accounts {
+  provider = google-beta
+  scope = "projects/my-project-id"
+  asset_types = [
+    "iam.googleapis.com/ServiceAccount"
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `scope` - (Required) A scope can be a project, a folder, or an organization. The allowed value must be: organization number (such as "organizations/123"), folder number (such as "folders/1234"), project number (such as "projects/12345") or project id (such as "projects/abc")
+* `asset_types` - (Optional) A list of asset types that this request searches for. If empty, it will search all the [supported asset types](https://cloud.google.com/asset-inventory/docs/supported-asset-types). 
+* `query` - (Optional) The query statement. See [how to construct a query](https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query) for more information. If not specified or empty, it will search all the resources within the specified `scope` and `asset_types`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `results` - A list of search results based on provided inputs. Structure is [defined below](#nested_results).
+
+<a name="nested_results"></a>The `results` block supports:
+
+* `name` - The full resource name. See [Resource Names](https://cloud.google.com/apis/design/resource_names#full_resource_name) for more information.
+* `asset_type` - The type of this resource. 
+* `project` - The project that this resource belongs to, in the form of `projects/{project_number}`.
+* `display_name` - The display name of this resource.
+* `description` - One or more paragraphs of text description of this resource. Maximum length could be up to 1M bytes.
+* `additional_attributes` - Additional searchable attributes of this resource. Informational only. The exact set of attributes is subject to change. For example: project id, DNS name etc.
+* `location` - Location can be `global`, regional like `us-east1`, or zonal like `us-west1-b`.
+* `labels` - Labels associated with this resource.
+* `network_tags` - Network tags associated with this resource.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
A new beta datasource `cloud_asset_resources_search_all` is introduced, it allows retrieving multiple types of resources within one API call. A good use case is when a user wants to include all new projects into a VPCSC perimeter, that datasource allow getting all projects under a specific parent. (Current `projects` data source does not retrieve projects from nested folders).  There are many more use cases like retrieving all Agent Service Accounts etc.

[v1p1beta1](https://cloud.google.com/asset-inventory/docs/reference/rest/v1p1beta1/resources/searchAll) api is used (only added to the beta provider) because [v1](https://cloud.google.com/asset-inventory/docs/reference/rest/v1/TopLevel/searchAllResources#resourcesearchresult) returns much more complex output with multiple optional substructures.
 
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_cloud_asset_resources_search_all` (beta)
```
