### PR TITLE
Add GKE support for tier 1 networking in GKE

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -464,6 +464,21 @@ var schemaNodePool = map[string]*schema.Schema{
 						},
 					},
 				},
+				"network_performance_config": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: `Network bandwidth tier configuration.`,
+					Elem:        &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"total_egress_bandwidth_tier": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: `Specifies the total network bandwidth tier for the NodePool.`,
+							},
+						},
+					},
+				},
 			},
 		},
 	},
@@ -1216,10 +1231,21 @@ func flattenNodeNetworkConfig(c *container.NodeNetworkConfig, d *schema.Resource
 			"pod_range":                       c.PodRange,
 			"enable_private_nodes":            c.EnablePrivateNodes,
 			"pod_cidr_overprovision_config":   flattenPodCidrOverprovisionConfig(c.PodCidrOverprovisionConfig),
+			"network_performance_config":      flattenNodeNetworkPerformanceConfig(c.NetworkPerformanceConfig),
 <% unless version == 'ga' -%>
 			"additional_node_network_configs": flattenAdditionalNodeNetworkConfig(c.AdditionalNodeNetworkConfigs),
 			"additional_pod_network_configs":  flattenAdditionalPodNetworkConfig(c.AdditionalPodNetworkConfigs),
 <% end -%>
+		})
+	}
+	return result
+}
+
+func flattenNodeNetworkPerformanceConfig(c *container.NetworkPerformanceConfig) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"total_egress_bandwidth_tier": c.TotalEgressBandwidthTier,
 		})
 	}
 	return result
@@ -1320,6 +1346,14 @@ func expandNodeNetworkConfig(v interface{}) *container.NodeNetworkConfig {
 <% end -%>
 
 	nnc.PodCidrOverprovisionConfig = expandPodCidrOverprovisionConfig(networkNodeConfig["pod_cidr_overprovision_config"])
+
+	if v, ok := networkNodeConfig["network_performance_config"]; ok && len(v.([]interface{})) > 0 {
+		nnc.NetworkPerformanceConfig = &container.NetworkPerformanceConfig{}
+		network_performance_config := v.([]interface{})[0].(map[string]interface{})
+		if total_egress_bandwidth_tier, ok := network_performance_config["total_egress_bandwidth_tier"]; ok {
+			nnc.NetworkPerformanceConfig.TotalEgressBandwidthTier = total_egress_bandwidth_tier.(string)
+		}
+	}
 
 	return nnc
 }
@@ -1978,7 +2012,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	}
 
 	if d.HasChange(prefix + "network_config") {
-		if d.HasChange(prefix + "network_config.0.enable_private_nodes") {
+		if d.HasChange(prefix + "network_config.0.enable_private_nodes") || d.HasChange(prefix + "network_config.0.network_performance_config") {
 			req := &container.UpdateNodePoolRequest{
 				NodePoolId: name,
 				NodeNetworkConfig: expandNodeNetworkConfig(d.Get(prefix + "network_config")),
@@ -1998,7 +2032,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				return ContainerOperationWait(config, op,
 					nodePoolInfo.project,
 					nodePoolInfo.location,
-					"updating GKE node pool workload_metadata_config", userAgent,
+					"updating GKE node pool network_config", userAgent,
 					timeout)
 			}
 
@@ -2006,7 +2040,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					return err
 			}
 
-			log.Printf("[INFO] Updated workload_metadata_config for node pool %s", name)
+			log.Printf("[INFO] Updated network_config for node pool %s", name)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -579,10 +579,12 @@ func TestAccContainerNodePool_withNetworkConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withNetworkConfig(cluster, np, network),
+				Config: testAccContainerNodePool_withNetworkConfig(cluster, np, network, "TIER_1"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_container_node_pool.with_pco_disabled", "network_config.0.pod_cidr_overprovision_config.0.disabled", "true"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_tier1_net", "network_config.0.network_performance_config.#", "1"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_tier1_net", "network_config.0.network_performance_config.0.total_egress_bandwidth_tier", "TIER_1"),
 				),
 			},
 			{
@@ -596,6 +598,14 @@ func TestAccContainerNodePool_withNetworkConfig(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"network_config.0.create_pod_range"},
+			},
+			// edit the updateable network config
+			{
+				Config: testAccContainerNodePool_withNetworkConfig(cluster, np, network, "TIER_UNSPECIFIED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.with_tier1_net", "network_config.0.network_performance_config.#", "1"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_tier1_net", "network_config.0.network_performance_config.0.total_egress_bandwidth_tier", "TIER_UNSPECIFIED"),
+				),
 			},
 		},
 	})
@@ -2998,7 +3008,7 @@ resource "google_container_node_pool" "np" {
 `, cluster, networkName, subnetworkName, np, mode)
 }
 
-func testAccContainerNodePool_withNetworkConfig(cluster, np, network string) string {
+func testAccContainerNodePool_withNetworkConfig(cluster, np, network, netTier string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
   name                    = "%s"
@@ -3075,7 +3085,7 @@ resource "google_container_node_pool" "with_auto_pod_cidr" {
   node_count = 1
   network_config {
 	create_pod_range    = true
-    pod_range           = "auto-pod-range"
+	pod_range           = "auto-pod-range"
 	pod_ipv4_cidr_block = "10.2.0.0/20"
   }
   node_config {
@@ -3091,7 +3101,7 @@ resource "google_container_node_pool" "with_pco_disabled" {
   cluster            = google_container_cluster.cluster.name
   node_count = 1
   network_config {
-        pod_cidr_overprovision_config {
+	pod_cidr_overprovision_config {
 		disabled = true
 	}
   }
@@ -3102,7 +3112,31 @@ resource "google_container_node_pool" "with_pco_disabled" {
   }
 }
 
-`, network, cluster, np, np, np)
+resource "google_container_node_pool" "with_tier1_net" {
+  name               = "%s-tier1"
+  location           = "us-central1"
+  cluster            = google_container_cluster.cluster.name
+  node_count = 1
+  node_locations = [
+	"us-central1-a",
+  ]
+  network_config {
+	network_performance_config {
+		total_egress_bandwidth_tier = "%s"
+	}
+  }
+  node_config {
+	machine_type = "n2-standard-32"
+	gvnic {
+		enabled = true
+	}
+	oauth_scopes = [
+		"https://www.googleapis.com/auth/cloud-platform",
+	]
+  }
+}
+
+`, network, cluster, np, np, np, np, netTier)
 }
 
 <% unless version.nil? || version == 'ga' -%>

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -957,6 +957,12 @@ sole_tenant_config {
 
 * `threads_per_core` - (Required) The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.
 
+* `network_performance_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Network bandwidth tier configuration.
+
+<a name="network_performance_config"></a>The `network_performance_config` block supports:
+
+* `total_egress_bandwidth_tier` (Required) - Specifies the total network bandwidth tier for the NodePool.
+
 <a name="nested_ephemeral_storage_config"></a>The `ephemeral_storage_config` block supports:
 
 * `local_ssd_count` (Required) - Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage.


### PR DESCRIPTION
Add GKE support for tier 1 networking in GKE

Related issue: https://github.com/hashicorp/terraform-provider-google/issues/11588. It covers only thread per core, but I think adding tier1 networking support would be helpful for similar use cases.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Note:** unit tests seem to be broken. I was able to run `make test` for generated code as follows:

```
$ make test
$ make fmt
$ make test
...
google/resource_bigtable_app_profile.go:468:9: undefined: bigtableadmin
google/resource_compute_subnetwork.go:39:22: undefined: cidr
...
$ rm google/resource_bigtable_app_profile.go google/resource_bigtable_app_profile_test.go google/resource_compute_subnetwork.go google/resource_compute_subnetwork_test.go
$ sed -i '/resourceBigtableAppProfile/d' google/provider.go
$ sed -i '/resourceComputeSubnetwork/d' google/provider.go
$ make test
```

Release notes

```release-note:enhancement
container: added support for `network_performance_config.total_egress_bandwidth_tier` to support GKE tier 1 networking
```