### PR TITLE
Corrected links in detailed contributing guide

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -329,12 +329,12 @@ any affected tools, the primary reviewer will merge your changes.
 
 Task          | Section
 --------------|--------------
-Resource      | [handwritten](./handwritten/#resource) / [mmv1](./mmv1/#resource)
-Datasource    | [handwritten](./handwritten/#datasource) / (only handwritten datasources are supported)
-IAM resource  | [handwritten](./handwritten/#iam-resource) / [mmv1](./mmv1/#iam-resource)
-Testing       | [handwritten](./handwritten/#testing) / [mmv1](./mmv1/#testing)
-Documentation | [handwritten](./handwritten/#documentation) / [mmv1](./mmv1/#documentation)
-Beta feature  | [handwritten](./handwritten/#beta-feature) / [mmv1](./mmv1/#beta-feature)
+Resource      | [handwritten](./docs/handwritten/#resource) / [mmv1](./docs/mmv1/#resource)
+Datasource    | [handwritten](./docs/handwritten/#datasource) / (only handwritten datasources are supported)
+IAM resource  | [handwritten](./docs/handwritten/#iam-resource) / [mmv1](./docs/mmv1/#iam-resource)
+Testing       | [handwritten](./docs/handwritten/#testing) / [mmv1](./docs/mmv1/#testing)
+Documentation | [handwritten](./docs/handwritten/#documentation) / [mmv1](./docs/mmv1/#documentation)
+Beta feature  | [handwritten](./docs/handwritten/#beta-feature) / [mmv1](./docs/mmv1/#beta-feature)
 
 ---
 


### PR DESCRIPTION
These were left over from the jekyll-based implementation.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
