### PR TITLE
Fix sql_database_instance to include backup_configuration in create request

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -925,12 +925,12 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	var patchData *sqladmin.DatabaseInstance
 
 	// BinaryLogging can be enabled on replica instances but only after creation.
-	if instance.MasterInstanceName != "" && instance.Settings != nil && instance.Settings.BackupConfiguration != nil {
-		bc := instance.Settings.BackupConfiguration
-		instance.Settings.BackupConfiguration = nil
-		if bc.BinaryLogEnabled {
-			patchData = &sqladmin.DatabaseInstance{Settings: &sqladmin.Settings{BackupConfiguration: bc}}
-		}
+	if instance.MasterInstanceName != "" && instance.Settings != nil && instance.Settings.BackupConfiguration != nil && instance.Settings.BackupConfiguration.BinaryLogEnabled {
+		settingsCopy := expandSqlDatabaseInstanceSettings(s.([]interface{}))
+		bc := settingsCopy.BackupConfiguration
+		patchData = &sqladmin.DatabaseInstance{Settings: &sqladmin.Settings{BackupConfiguration: bc}}
+
+		instance.Settings.BackupConfiguration.BinaryLogEnabled = false
 	}
 
 	var op *sqladmin.Operation

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -472,7 +472,12 @@ func TestAccSqlDatabaseInstance_replica(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
-					testGoogleSqlDatabaseInstance_replica, databaseID, databaseID, databaseID),
+					testGoogleSqlDatabaseInstance_replica, databaseID, databaseID, databaseID, "true"),
+				ExpectError: regexp.MustCompile("Error, failed to create instance tf-lw-\\d+-2: googleapi: Error 400: Invalid request: Invalid flag for instance role: Backups cannot be enabled for read replica instance.., invalid"),
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_replica, databaseID, databaseID, databaseID, "false"),
 			},
 			resource.TestStep{
 				ResourceName:      "google_sql_database_instance.instance_master",
@@ -1984,9 +1989,10 @@ resource "google_sql_database_instance" "replica1" {
 
   settings {
     tier = "db-n1-standard-1"
-		backup_configuration {
+    backup_configuration {
+      enabled = false
       binary_log_enabled = true
-		}
+    }
   }
 
   master_instance_name = google_sql_database_instance.instance_master.name
@@ -2009,6 +2015,9 @@ resource "google_sql_database_instance" "replica2" {
 
   settings {
     tier = "db-n1-standard-1"
+    backup_configuration {
+      enabled = %s
+    }
   }
 
   master_instance_name = google_sql_database_instance.instance_master.name


### PR DESCRIPTION
Fixes b/257534640 (TF plan allows google_sql_database_instance.replica to define a backup configuration)

SQL database instances do not allow replicas to enable backups. For example, the following config will fail:

```
resource "google_sql_database_instance" "main" {
  name             = "main-instance"
  ...
}

resource "google_sql_database_instance" "replica" {
  name             = "replica-instance"

  # Defines instance as a replica
  master_instance_name = "${google_sql_database_instance.main.name}"    
  replica_configuration {
    failover_target = false
  }

  settings {
    ...
    # Enables backups
    backup_configuration {
      enabled = true
      point_in_time_recovery_enabled = true
    }
  }
}
```

**Problem**
Previously, config like this would correctly result in an error, but the replica would still be created with the `backup_configuration` omitted. This caused issues with consecutive `terraform apply` calls where the first succeeded, but the second failed with no changes to the config.

**Root cause**
We were using some custom behavior for `backup_configuration.binary_log_enabled` that removed it from the initial create request, and then added it back to the instance with a subsequent patch request. This behavior had a bug that caused the entire `backup_configuration` to be removed and not get patched if `binary_log_enabled` was `false` for a replica.

**Resolution**
This PR proposes fixing the issue by leaving the `backup_configuration` on the create request, so that the server can validate the full configuration before creating any entities. The one exception is `binary_log_enabled`, which cannot be set to `true` until after a replica is created. In that case, we make the initial create request with `binary_log_enabled = false`, and then use the subsequent patch call to set it to `true` like before.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fix `googe_sql_database_instance` to include `backup_configuration` in initial create request
```
