### PR TITLE
rename to mostDisruptiveAllowedAction

### DIFF
--- a/mmv1/templates/terraform/post_update/compute_per_instance_config.go.erb
+++ b/mmv1/templates/terraform/post_update/compute_per_instance_config.go.erb
@@ -17,7 +17,7 @@ mostDisruptiveAction := d.Get("most_disruptive_allowed_action")
 if isEmptyValue(reflect.ValueOf(mostDisruptiveAction)) {
 	mostDisruptiveAction = "REPLACE"
 }
-obj["mostDisruptiveActionAllowed"] = mostDisruptiveAction
+obj["mostDisruptiveAllowedAction"] = mostDisruptiveAction
 
 url, err = replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/applyUpdatesToInstances")
 if err != nil {

--- a/mmv1/templates/terraform/post_update/compute_region_per_instance_config.go.erb
+++ b/mmv1/templates/terraform/post_update/compute_region_per_instance_config.go.erb
@@ -17,7 +17,7 @@ mostDisruptiveAction := d.Get("most_disruptive_allowed_action")
 if isEmptyValue(reflect.ValueOf(mostDisruptiveAction)) {
 	mostDisruptiveAction = "REPLACE"
 }
-obj["mostDisruptiveActionAllowed"] = mostDisruptiveAction
+obj["mostDisruptiveAllowedAction"] = mostDisruptiveAction
 
 url, err = replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/applyUpdatesToInstances")
 if err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13062


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a failure in updating `most_disruptive_allowed_action` on `google_compute_per_instance_config` and `google_compute_region_per_instance_config`
```
