### PR TITLE
Fixed the test TestAccCloudBuildTrigger_migration

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_upgrade_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_upgrade_test.go
@@ -34,10 +34,10 @@ func TestAccCloudBuildTrigger_migration(t *testing.T) {
 				ExternalProviders: oldVersion,
 			},
 			{
-				ResourceName:      "google_cloudbuild_trigger.simple-trigger",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ExternalProviders: oldVersion,
+				ResourceName:            "google_cloudbuild_trigger.simple-trigger",
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"location"},
+				ExternalProviders:       oldVersion,
 			},
 			{
 				Config:            newConfigWithFilename(name),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixed https://github.com/hashicorp/terraform-provider-google/issues/12909

We do not need to check the import state for a previous provider release.

Actually, there is a bug in sdk. They made [the bug fix]( https://github.com/hashicorp/terraform-plugin-sdk/pull/1057) in [2.23.0](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/CHANGELOG.md). The test passed after upgrading sdk to 2.24.0. But sdk 2.24.0 introduced another bug, which caused more tests failing. Please check the PR https://github.com/GoogleCloudPlatform/magic-modules/pull/6818. 

For now we remove ImportStateVerify to fix the test from our side. 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
