### PR TITLE
Add new Enhanced Origin API fields.

### DIFF
--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -411,19 +411,12 @@ objects:
           - !ruby/object:Api::Type::Array
             name: 'redirectConditions'
             description: |
-              The set of redirect response codes that the CDN follows.
+              The set of redirect response codes that the CDN
+              follows. Values of
+              [RedirectConditions](https://cloud.google.com/media-cdn/docs/reference/rest/v1/projects.locations.edgeCacheOrigins#redirectconditions)
+              are accepted.
             max_size: 5
-            item_type: !ruby/object:Api::Type::Enum
-              name: 'undefined'
-              description: |
-                This field only has a name and description because of MM
-                limitations. It should not appear in downstreams.
-              values:
-                - :MOVED_PERMANENTLY
-                - :FOUND
-                - :SEE_OTHER
-                - :TEMPORARY_REDIRECT
-                - :PERMANENT_REDIRECT
+            item_type: Api::Type::String
   - !ruby/object:Api::Resource
     name: 'EdgeCacheService'
     base_url: 'projects/{{project}}/locations/global/edgeCacheServices'

--- a/mmv1/products/networkservices/api.yaml
+++ b/mmv1/products/networkservices/api.yaml
@@ -346,6 +346,84 @@ objects:
             required: true
             description: |
               The name of the AWS region that your origin is in.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'originOverrideAction'
+        description: |
+          The override actions, including url rewrites and header
+          additions, for requests that use this origin.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'urlRewrite'
+            description: |
+              The URL rewrite configuration for request that are
+              handled by this origin.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'hostRewrite'
+                description: |
+                  Prior to forwarding the request to the selected
+                  origin, the request's host header is replaced with
+                  contents of the hostRewrite.
+
+                  This value must be between 1 and 255 characters.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'headerAction'
+            description: |
+              The header actions, including adding and removing
+              headers, for request handled by this origin.
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: requestHeadersToAdd
+                description: |
+                  Describes a header to add.
+
+                  You may add a maximum of 5 request headers.
+                min_size: 1
+                max_size: 5
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'headerName'
+                      required: true
+                      description: |
+                        The name of the header to add.
+                    - !ruby/object:Api::Type::String
+                      name: 'headerValue'
+                      required: true
+                      description: |
+                        The value of the header to add.
+                    - !ruby/object:Api::Type::Boolean
+                      name: 'replace'
+                      description: |
+                        Whether to replace all existing headers with the same name.
+
+                        By default, added header values are appended
+                        to the response or request headers with the
+                        same field names. The added values are
+                        separated by commas.
+
+                        To overwrite existing values, set `replace` to `true`.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'originRedirect'
+        description: |
+          Follow redirects from this origin.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'redirectConditions'
+            description: |
+              The set of redirect response codes that the CDN follows.
+            max_size: 5
+            item_type: !ruby/object:Api::Type::Enum
+              name: 'undefined'
+              description: |
+                This field only has a name and description because of MM
+                limitations. It should not appear in downstreams.
+              values:
+                - :MOVED_PERMANENTLY
+                - :FOUND
+                - :SEE_OTHER
+                - :TEMPORARY_REDIRECT
+                - :PERMANENT_REDIRECT
   - !ruby/object:Api::Resource
     name: 'EdgeCacheService'
     base_url: 'projects/{{project}}/locations/global/edgeCacheServices'

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_advanced.tf.erb
@@ -1,7 +1,6 @@
-
 resource "google_network_services_edge_cache_origin" "fallback" {
   name                 = "<%= ctx[:vars]['resource_name_2'] %>"
-  origin_address       = "gs://media-edge-fallback"
+  origin_address       = "fallback.example.com"
   description          = "The default bucket for media edge test"
   max_attempts         = 3
   protocol = "HTTP"
@@ -18,6 +17,27 @@ resource "google_network_services_edge_cache_origin" "fallback" {
     max_attempts_timeout = "20s"
     response_timeout = "60s"
     read_timeout = "5s"
+  }
+  origin_override_action {
+    url_rewrite {
+      host_rewrite = "example.com"
+    }
+    header_action {
+      request_headers_to_add {
+        header_name = "x-header"
+	header_value = "value"
+	replace = true
+      }
+    }
+  }
+  origin_redirect {
+    redirect_conditions = [
+      "MOVED_PERMANENTLY",
+      "FOUND",
+      "SEE_OTHER",
+      "TEMPORARY_REDIRECT",
+      "PERMANENT_REDIRECT",
+    ]
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolves https://github.com/hashicorp/terraform-provider-google/issues/13073. Add support for [Media CDN Redirect Following](https://cloud.google.com/media-cdn/docs/origins#failover-with-redirect-following) as well as [Per-Origin Override Actions](https://cloud.google.com/media-cdn/docs/origins#failover-example).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`network_services`: added `origin_override_action` and `origin_redirect` to `google_network_services_edge_cache_origin` 
```
