### PR TITLE
Changes to add MCP support in service mesh gke hub feature

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -5,7 +5,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/bigtable v1.17.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.26.4
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.27.1
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/client9/misspell v0.3.4
 	github.com/davecgh/go-spew v1.1.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -55,8 +55,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.26.4 h1:nP8L2TqVbGehmlt6sfYiu4BKE0lJrGW1RrtP9/+FwfY=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.26.4/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.27.1 h1:cjRzz6gP7oxlYq+GEEhOU5HCNlG4Wc+jKxllKFayJBA=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.27.1/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
@@ -590,7 +590,7 @@ func TestAccGkeHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 		CheckDestroy: testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGkeHubFeatureMembership_gkehubFeatureMeshStart(context),
+				Config: testAccGkeHubFeatureMembership_meshStart(context),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGkeHubFeatureMembershipPresent(t, fmt.Sprintf("tf-test-gkehub%s", context["random_suffix"]), "global", "servicemesh", fmt.Sprintf("tf-test1%s", context["random_suffix"])),
 				),
@@ -601,7 +601,18 @@ func TestAccGkeHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGkeHubFeatureMembership_gkehubFeatureMeshUpdate(context),
+				Config: testAccGkeHubFeatureMembership_meshUpdateManagement(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGkeHubFeatureMembershipPresent(t, fmt.Sprintf("tf-test-gkehub%s", context["random_suffix"]), "global", "servicemesh", fmt.Sprintf("tf-test1%s", context["random_suffix"])),
+				),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature_membership.feature_member",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+      {
+				Config: testAccGkeHubFeatureMembership_meshUpdateControlPlane(context),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGkeHubFeatureMembershipPresent(t, fmt.Sprintf("tf-test-gkehub%s", context["random_suffix"]), "global", "servicemesh", fmt.Sprintf("tf-test1%s", context["random_suffix"])),
 				),
@@ -615,7 +626,7 @@ func TestAccGkeHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 	})
 }
 
-func testAccGkeHubFeatureMembership_gkehubFeatureMeshStart(context map[string]interface{}) string {
+func testAccGkeHubFeatureMembership_meshStart(context map[string]interface{}) string {
 	return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "google_container_cluster" "primary" {
   project = google_project.project.project_id
@@ -623,7 +634,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   provider = google-beta
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
+  depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -647,7 +658,7 @@ resource "google_gke_hub_feature" "feature" {
     foo = "bar"
   }
   provider = google-beta
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -663,13 +674,14 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   membership = google_gke_hub_membership.membership.membership_id
   mesh {
     management = "MANAGEMENT_AUTOMATIC"
+    control_plane = "AUTOMATIC"
   }
   provider = google-beta
 }
 `, context)
 }
 
-func testAccGkeHubFeatureMembership_gkehubFeatureMeshUpdate(context map[string]interface{}) string {
+func testAccGkeHubFeatureMembership_meshUpdateManagement(context map[string]interface{}) string {
 	return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "google_container_cluster" "primary" {
   project = google_project.project.project_id
@@ -677,7 +689,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   provider = google-beta
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container]
+  depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -701,7 +713,7 @@ resource "google_gke_hub_feature" "feature" {
     foo = "bar"
   }
   provider = google-beta
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -717,6 +729,60 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   membership = google_gke_hub_membership.membership.membership_id
   mesh {
     management = "MANAGEMENT_MANUAL"
+  }
+  provider = google-beta
+}
+`, context)
+}
+
+func testAccGkeHubFeatureMembership_meshUpdateControlPlane(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetup(context) + Nprintf(`
+resource "google_container_cluster" "primary" {
+  project = google_project.project.project_id
+  name               = "tf-test-cl%{random_suffix}"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  provider = google-beta
+  depends_on = [google_project_service.container, google_project_service.gkehub]
+}
+
+resource "google_gke_hub_membership" "membership" {
+  project = google_project.project.project_id
+  membership_id = "tf-test1%{random_suffix}"
+  endpoint {
+    gke_cluster {
+      resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
+    }
+  }
+  description = "test resource."
+  provider = google-beta
+}
+
+resource "google_gke_hub_feature" "feature" {
+  project = google_project.project.project_id
+  name = "servicemesh"
+  location = "global"
+
+  labels = {
+    foo = "bar"
+  }
+  provider = google-beta
+  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
+}
+
+resource "google_service_account" "feature_sa" {
+  project = google_project.project.project_id
+  account_id = "feature-sa"
+  provider = google-beta
+}
+
+resource "google_gke_hub_feature_membership" "feature_member" {
+  project = google_project.project.project_id
+  location = "global"
+  feature = google_gke_hub_feature.feature.name
+  membership = google_gke_hub_membership.membership.membership_id
+  mesh {
+    control_plane = "MANUAL"
   }
   provider = google-beta
 }

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -105,6 +105,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   membership = google_gke_hub_membership.membership.membership_id
   mesh {
     management = "MANAGEMENT_AUTOMATIC"
+    control_plane = "AUTOMATIC"
   }
   provider = google-beta
 }
@@ -270,6 +271,10 @@ The following arguments are supported:
 * `management` -
   (Optional)
   Whether to automatically manage Service Mesh. Can either be `MANAGEMENT_AUTOMATIC` or `MANAGEMENT_MANUAL`.
+
+* `control_plane` -
+  (Optional)
+  Whether to automatically manage Service Mesh Control Plane. Can either be `AUTOMATIC` or `MANUAL`.
 
 ## Attributes Reference
 

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.26.4
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.27.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/hcl v1.0.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -37,6 +37,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.26.4 h1:nP8L2TqVbGehmlt6sfYiu4BKE0lJrGW1RrtP9/+FwfY=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.26.4/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.27.1 h1:cjRzz6gP7oxlYq+GEEhOU5HCNlG4Wc+jKxllKFayJBA=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.27.1/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
- Updated DCL version to 1.27.1 to support Managed Control Plane in `google_gke_hub_feature_membership` .
- Added support for Managed Control Plane in `google_gke_hub_feature_membership::mesh`

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
anthos-fleet-management: added option `mesh: control_plane` to resource `google_gke_hub_feature_membership`.
```
