### PR TITLE
Datastream check private connection state after create and update

### DIFF
--- a/mmv1/products/datastream/api.yaml
+++ b/mmv1/products/datastream/api.yaml
@@ -369,3 +369,14 @@ objects:
             required: true
             description: |
               A free subnet for peering. (CIDR of /29)
+          - !ruby/object:Api::Type::Enum
+            name: 'state'
+            description: |
+              State of the PrivateConnection.
+            values:
+            - :CREATING
+            - :CREATED
+            - :FAILED
+            - :DELETING
+            - :FAILED_TO_DELETE
+            output: true

--- a/mmv1/products/datastream/api.yaml
+++ b/mmv1/products/datastream/api.yaml
@@ -351,6 +351,31 @@ objects:
         name: 'displayName'
         required: true
         description: Display name.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          State of the PrivateConnection.
+        output: true
+        values:
+        - :CREATING
+        - :CREATED
+        - :FAILED
+        - :DELETING
+        - :FAILED_TO_DELETE
+      - !ruby/object:Api::Type::NestedObject
+        name: 'error'
+        output: true
+        description: |
+          The PrivateConnection error in case of failure.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'message'
+            description: |
+              A message containing more information about the error that occurred.
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: 'details'
+            description: |
+              A list of messages that carry the error details.
       - !ruby/object:Api::Type::NestedObject
         name: 'vpcPeeringConfig'
         required: true
@@ -369,14 +394,3 @@ objects:
             required: true
             description: |
               A free subnet for peering. (CIDR of /29)
-          - !ruby/object:Api::Type::Enum
-            name: 'state'
-            description: |
-              State of the PrivateConnection.
-            values:
-            - :CREATING
-            - :CREATED
-            - :FAILED
-            - :DELETING
-            - :FAILED_TO_DELETE
-            output: true

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -89,3 +89,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           private_connection_id: "my-connection"
           network_name: "my-network"
+    virtual_fields:
+      - !ruby/object:Api::Type::Enum
+        name: 'desired_state'
+        description: |
+          Desired state of the PrivateConnection.
+        values:
+        - :CREATED

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -92,6 +92,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/private_connection.go.erb
       post_create: templates/terraform/post_create/private_connection.go.erb
+      post_import: templates/terraform/post_import/private_connection.go.erb
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -92,7 +92,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/private_connection.go.erb
       post_create: templates/terraform/post_create/private_connection.go.erb
-      post_update: templates/terraform/post_update/private_connection.go.erb
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -89,3 +89,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           private_connection_id: "my-connection"
           network_name: "my-network"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/private_connection.go.erb
+      post_create: templates/terraform/post_create/private_connection.go.erb
+      post_update: templates/terraform/post_update/private_connection.go.erb
+
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+  <%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -89,10 +89,3 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           private_connection_id: "my-connection"
           network_name: "my-network"
-    virtual_fields:
-      - !ruby/object:Api::Type::Enum
-        name: 'desired_state'
-        description: |
-          Desired state of the PrivateConnection.
-        values:
-        - :CREATED

--- a/mmv1/templates/terraform/constants/private_connection.go.erb
+++ b/mmv1/templates/terraform/constants/private_connection.go.erb
@@ -1,4 +1,14 @@
 <% unless compiler == "terraformvalidator-codegen" -%>
+
+func extractError(d *schema.ResourceData) error {
+	// Casts are not safe since the logic that populate it is type deterministic.
+	error := d.Get("error").([]interface{})[0].(map[string]interface{})
+	message := error["message"].(string)
+	details := error["details"].(map[string]interface{})
+	detailsJSON, _ := json.Marshal(details)
+	return fmt.Errorf("Failed to create PrivateConnection. %s, details = %s", message, string(detailsJSON))
+}
+
 // waitForPrivateConnectionReady waits for a private connection state to become
 // CREATED, if the state is FAILED propegate the error to the user.
 func waitForPrivateConnectionReady(d *schema.ResourceData, config *Config, timeout time.Duration) error {
@@ -15,9 +25,7 @@ func waitForPrivateConnectionReady(d *schema.ResourceData, config *Config, timeo
 			log.Printf("[DEBUG] PrivateConnection %q has state %q.", name, state)
 			return nil
 		} else if state == "FAILED" {
-      # 		  reason := d.Get("error").Get("reason").(string)
-      # 		  return resource.NonRetryableError(fmt.Errorf("PrivateConnection %q has state %q. reason = %q", name, state, reason))
-      return resource.NonRetryableError(fmt.Errorf("e2 - PrivateConnection %q has state %q.", name, state))
+			return resource.NonRetryableError(extractError(d))
 		} else {
 			return resource.NonRetryableError(fmt.Errorf("PrivateConnection %q has state %q.", name, state))
 		}

--- a/mmv1/templates/terraform/constants/private_connection.go.erb
+++ b/mmv1/templates/terraform/constants/private_connection.go.erb
@@ -6,7 +6,7 @@ func extractError(d *schema.ResourceData) error {
 	message := error["message"].(string)
 	details := error["details"].(map[string]interface{})
 	detailsJSON, _ := json.Marshal(details)
-	return fmt.Errorf("Failed to create PrivateConnection. %s, details = %s", message, string(detailsJSON))
+	return fmt.Errorf("Failed to create PrivateConnection. %s details = %s", message, string(detailsJSON))
 }
 
 // waitForPrivateConnectionReady waits for a private connection state to become

--- a/mmv1/templates/terraform/constants/private_connection.go.erb
+++ b/mmv1/templates/terraform/constants/private_connection.go.erb
@@ -1,0 +1,26 @@
+<% unless compiler == "terraformvalidator-codegen" -%>
+// waitForPrivateConnectionReady waits for a private connection state to become
+// CREATED, if the state is FAILED propegate the error to the user.
+func waitForPrivateConnectionReady(d *schema.ResourceData, config *Config, timeout time.Duration) error {
+	return resource.Retry(timeout, func() *resource.RetryError {
+		if err := resourceDatastreamPrivateConnectionRead(d, config); err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		name := d.Get("name").(string)
+		state := d.Get("state").(string)
+		if state == "CREATING" {
+			return resource.RetryableError(fmt.Errorf("PrivateConnection %q has state %q.", name, state))
+		} else if state == "CREATED" {
+			log.Printf("[DEBUG] PrivateConnection %q has state %q.", name, state)
+			return nil
+		} else if state == "FAILED" {
+      # 		  reason := d.Get("error").Get("reason").(string)
+      # 		  return resource.NonRetryableError(fmt.Errorf("PrivateConnection %q has state %q. reason = %q", name, state, reason))
+      return resource.NonRetryableError(fmt.Errorf("e2 - PrivateConnection %q has state %q.", name, state))
+		} else {
+			return resource.NonRetryableError(fmt.Errorf("PrivateConnection %q has state %q.", name, state))
+		}
+	})
+}
+<% end -%>

--- a/mmv1/templates/terraform/post_create/private_connection.go.erb
+++ b/mmv1/templates/terraform/post_create/private_connection.go.erb
@@ -1,0 +1,3 @@
+if err := waitForPrivateConnectionReady(d, config, d.Timeout(schema.TimeoutCreate) - time.Minute); err != nil {
+  return fmt.Errorf("Error waiting for PrivateConnection %q to be CREATED. %q", d.Get("name").(string), err)
+}

--- a/mmv1/templates/terraform/post_import/private_connection.go.erb
+++ b/mmv1/templates/terraform/post_import/private_connection.go.erb
@@ -1,0 +1,3 @@
+if err := waitForPrivateConnectionReady(d, config, d.Timeout(schema.TimeoutCreate) - time.Minute); err != nil {
+  return nil, fmt.Errorf("Error waiting for PrivateConnection %q to be CREATED during importing: %q", d.Get("name").(string), err)
+}

--- a/mmv1/templates/terraform/post_update/private_connection.go.erb
+++ b/mmv1/templates/terraform/post_update/private_connection.go.erb
@@ -1,0 +1,3 @@
+if err := waitForPrivateConnectionReady(d, config, d.Timeout(schema.TimeoutCreate) - time.Minute); err != nil {
+  return fmt.Errorf("Error waiting for PrivateConnection %q to be CREATED. %q", d.Get("name").(string), err)
+}

--- a/mmv1/templates/terraform/post_update/private_connection.go.erb
+++ b/mmv1/templates/terraform/post_update/private_connection.go.erb
@@ -1,3 +1,0 @@
-if err := waitForPrivateConnectionReady(d, config, d.Timeout(schema.TimeoutCreate) - time.Minute); err != nil {
-  return fmt.Errorf("Error waiting for PrivateConnection %q to be CREATED. %q", d.Get("name").(string), err)
-}


### PR DESCRIPTION
Datastream Private Connection resources create operation can finish successfully when the actual resource fails.

To solve that in TF, we will add a custom post create code (this only happens in create) that will verify the resource state after creation. 

```release-note:bug
datastream: fixed `google_datastream_private_connection` ignoring failures during creation
```