### PR TITLE
make machine_config.cpu_count updatable

### DIFF
--- a/mmv1/products/alloydb/api.yaml
+++ b/mmv1/products/alloydb/api.yaml
@@ -254,9 +254,9 @@ objects:
         base_url: "{{op_id}}"
         wait_ms: 1000
         timeouts: !ruby/object:Api::Timeouts
-          insert_minutes: 10
-          update_minutes: 10
-          delete_minutes: 10
+          insert_minutes: 20
+          update_minutes: 20
+          delete_minutes: 20
       result: !ruby/object:Api::OpAsync::Result
         path: "response"
       status: !ruby/object:Api::OpAsync::Status
@@ -370,5 +370,4 @@ objects:
         properties:
           - !ruby/object:Api::Type::Integer
             name: "cpuCount"
-            input: true
             description: "The number of CPU's in the VM instance."

--- a/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
@@ -4,6 +4,10 @@ resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
   instance_id   = "<%= ctx[:vars]['alloydb_instance_name'] %>"
   instance_type = "PRIMARY"
 
+  machine_config {
+    cpu_count = 2
+  }
+
   depends_on = [google_service_networking_connection.vpc_connection]
 }
 

--- a/mmv1/third_party/terraform/tests/resource_alloydb_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_instance_test.go.erb
@@ -50,6 +50,10 @@ resource "google_alloydb_instance" "default" {
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
 
+  machine_config {
+    cpu_count = 4
+  }
+
   labels = {
 	test = "tf-test-alloydb-instance%{random_suffix}"
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13115


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
alloydb: made `machine_config.cpu_count` updatable on `google_alloydb_instance`
```
