### PR TITLE
uniqueWriterIdentity field added to logging_folder_sink

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_logging_folder_sink.go
+++ b/mmv1/third_party/terraform/resources/resource_logging_folder_sink.go
@@ -1,11 +1,15 @@
 package google
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+const nonUniqueWriter = "serviceAccount:cloud-logs@system.gserviceaccount.com"
 
 func resourceLoggingFolderSink() *schema.Resource {
 	schm := &schema.Resource{
@@ -35,6 +39,12 @@ func resourceLoggingFolderSink() *schema.Resource {
 		Default:     false,
 		Description: `Whether or not to include children folders in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided folder are included.`,
 	}
+	schm.Schema["unique_writer_identity"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     true,
+		Description: `Whether or not to create a unique identity associated with this sink. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true. Any requests that don't explicitly set 'uniqueWriterIdentity' to true will be rejected.`,
+	}
 
 	return schm
 }
@@ -49,15 +59,37 @@ func resourceLoggingFolderSinkCreate(d *schema.ResourceData, meta interface{}) e
 	folder := parseFolderId(d.Get("folder"))
 	id, sink := expandResourceLoggingSink(d, "folders", folder)
 	sink.IncludeChildren = d.Get("include_children").(bool)
+	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
-	_, err = config.NewLoggingClient(userAgent).Folders.Sinks.Create(id.parent(), sink).UniqueWriterIdentity(true).Do()
+	_, err = config.NewLoggingClient(userAgent).Folders.Sinks.Create(id.parent(), sink).UniqueWriterIdentity(uniqueWriterIdentity).Do()
 	if err != nil {
 		return err
 	}
 
 	d.SetId(id.canonicalId())
 	return resourceLoggingFolderSinkRead(d, meta)
+}
+
+// if bigquery_options is set unique_writer_identity must be true
+func resourceLoggingFolderSinkCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// separate func to allow unit testing
+	return resourceLoggingFolderSinkCustomizeDiffFunc(d)
+}
+
+func resourceLoggingFolderSinkCustomizeDiffFunc(diff TerraformResourceDiff) error {
+	if !diff.HasChange("bigquery_options.#") {
+		return nil
+	}
+
+	bigqueryOptions := diff.Get("bigquery_options.#").(int)
+	if bigqueryOptions > 0 {
+		uwi := diff.Get("unique_writer_identity")
+		if !uwi.(bool) {
+			return errors.New("unique_writer_identity must be true when bigquery_options is supplied")
+		}
+	}
+	return nil
 }
 
 func resourceLoggingFolderSinkRead(d *schema.ResourceData, meta interface{}) error {
@@ -74,6 +106,16 @@ func resourceLoggingFolderSinkRead(d *schema.ResourceData, meta interface{}) err
 
 	if err := flattenResourceLoggingSink(d, sink); err != nil {
 		return err
+	}
+
+	if sink.WriterIdentity != nonUniqueWriter {
+		if err := d.Set("unique_writer_identity", true); err != nil {
+			return fmt.Errorf("Error setting unique_writer_identity: %s", err)
+		}
+	} else {
+		if err := d.Set("unique_writer_identity", false); err != nil {
+			return fmt.Errorf("Error setting unique_writer_identity: %s", err)
+		}
 	}
 
 	if err := d.Set("include_children", sink.IncludeChildren); err != nil {
@@ -95,10 +137,11 @@ func resourceLoggingFolderSinkUpdate(d *schema.ResourceData, meta interface{}) e
 	// properties though and might break in the future. Always include the value to prevent it changing.
 	sink.IncludeChildren = d.Get("include_children").(bool)
 	sink.ForceSendFields = append(sink.ForceSendFields, "IncludeChildren")
+	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err = config.NewLoggingClient(userAgent).Folders.Sinks.Patch(d.Id(), sink).
-		UpdateMask(updateMask).UniqueWriterIdentity(true).Do()
+		UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -75,6 +75,9 @@ The following arguments are supported:
 
 * `disabled` - (Optional) If set to True, then this sink is disabled and it does not export any log entries.
 
+* `unique_writer_identity` - (Optional) Whether or not to create a unique identity associated with this sink. If `true`,
+    then a unique service account is created and used for this sink. If you wish to publish logs across projects or utilize. Any requests that don't explicitly set 'uniqueWriterIdentity' to true will be rejected.
+
 * `include_children` - (Optional) Whether or not to include children folders in the sink export. If true, logs
     associated with child projects are also exported; otherwise only logs relating to the provided folder are included.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
uniqueWriterIdentity field added to logging_folder_sink along with test
fixes https://github.com/hashicorp/terraform-provider-google/issues/12660


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added `unique_writer_identity` field to `google_logging_folder_sink` resource
```
