### PR TITLE
add enterprise_config_resource_name to resource google_cloudbuild_trigger (#9956)

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -285,6 +285,11 @@ objects:
           - source_to_build
         properties:
           - !ruby/object:Api::Type::String
+            name: 'enterpriseConfigResourceName'
+            description: |
+                Optional. The resource name of the github enterprise config that should be applied to this installation.
+                For example: "projects/{$projectId}/githubEnterpriseConfigs/{$configId}".
+          - !ruby/object:Api::Type::String
             name: 'owner'
             description: |
                 Owner of the repository. For example: The owner for


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/9956

Cloud Build offers [integration with Private Github Enterprise](https://cloud.google.com/build/docs/automating-builds/github/connect-host-github-enterprise) 

The steps from initial configuration setup to a build trigger are like 
1. create [host connection](https://cloud.google.com/build/docs/automating-builds/github/connect-host-github-enterprise) with private Github Enterprise 
2. [connect to repository](https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github-enterprise) on private Github Enterprise 
3. [create build trigger](https://cloud.google.com/build/docs/automating-builds/github/build-repos-from-github-enterprise) on repository  

As of now, step 1 and 2 could only done manually as described on this ticket https://github.com/integrations/terraform-provider-github/issues/509

Assuming step 1 and 2 have been completed, existing resource google_cloudbuild_trigger ([terraform-google-provider v4.44.1](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger)) does not support  [GitHubEnterpriseConfig](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.githubEnterpriseConfigs) while current [Cloud Build Trigger Rest API ](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.triggers#BuildTrigger) does support [enterpriseConfigResourceName](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.triggers#BuildTrigger.GitHubEventsConfig), so this PR is to address the gap between terraform resource and Cloud Build API.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: added support for `"enterpriseConfigResourceName"` in `google_cloudbuild_trigger`
```
