### PR TITLE
[#11206] Add BGP Peer Router Appliance instance argument

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -14401,6 +14401,15 @@ objects:
           If set to true, the peer connection can be established with routing information.
           The default is true.
         default_value: true
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'routerApplianceInstance'
+        resource: 'Instance'
+        imports: 'selfLink'
+        description: |
+          The URI of the VM instance that is used as third-party router appliances
+          such as Next Gen Firewalls, Virtual Routers, or Router Appliances.
+          The VM instance must be located in zones contained in the same region as
+          this Cloud Router. The VM instance is the peer side of the BGP session.
   - !ruby/object:Api::Resource
     name: 'SecurityPolicy'
     kind: 'compute#securityPolicy'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2726,6 +2726,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           router_name: "my-router"
           peer_name: "my-router-peer"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "router_peer_router_appliance"
+        primary_resource_id: "peer"
+        vars:
+          router_name: "my-router"
+          peer_name: "my-router-peer"
     properties:
       advertiseMode: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'

--- a/mmv1/templates/terraform/examples/router_peer_router_appliance.tf.erb
+++ b/mmv1/templates/terraform/examples/router_peer_router_appliance.tf.erb
@@ -1,0 +1,104 @@
+resource "google_compute_network" "network" {
+  name                    = "<%= ctx[:vars]['router_name'] %>-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "<%= ctx[:vars]['router_name'] %>-sub"
+  network       = google_compute_network.network.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "addr_intf" {
+  name         = "<%= ctx[:vars]['router_name'] %>-addr-intf"
+  region       = google_compute_subnetwork.subnetwork.region
+  subnetwork   = google_compute_subnetwork.subnetwork.id
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "addr_intf_redundant" {
+  name         = "<%= ctx[:vars]['router_name'] %>-addr-intf-red"
+  region       = google_compute_subnetwork.subnetwork.region
+  subnetwork   = google_compute_subnetwork.subnetwork.id
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "addr_peer" {
+  name         = "<%= ctx[:vars]['router_name'] %>-addr-peer"
+  region       = google_compute_subnetwork.subnetwork.region
+  subnetwork   = google_compute_subnetwork.subnetwork.id
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_instance" "instance" {
+  name           = "router-appliance"
+  zone           = "us-central1-a"
+  machine_type   = "e2-medium"
+  can_ip_forward = true
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network_ip = google_compute_address.addr_peer.address
+    subnetwork = google_compute_subnetwork.subnetwork.self_link
+  }
+}
+
+resource "google_network_connectivity_hub" "hub" {
+  name = "<%= ctx[:vars]['router_name'] %>-hub"
+}
+
+resource "google_network_connectivity_spoke" "spoke" {
+  name     = "<%= ctx[:vars]['router_name'] %>-spoke"
+  location = google_compute_subnetwork.subnetwork.region
+  hub      = google_network_connectivity_hub.hub.id
+
+  linked_router_appliance_instances {
+    instances {
+      virtual_machine = google_compute_instance.instance.self_link
+      ip_address      = google_compute_address.addr_peer.address
+    }
+    site_to_site_data_transfer = false
+  }
+}
+
+resource "google_compute_router" "router" {
+  name    = "<%= ctx[:vars]['router_name'] %>-router"
+  region  = google_compute_subnetwork.subnetwork.region
+  network = google_compute_network.network.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_interface" "interface_redundant" {
+  name               = "<%= ctx[:vars]['router_name'] %>-intf-red"
+  region             = google_compute_router.router.region
+  router             = google_compute_router.router.name
+  subnetwork         = google_compute_subnetwork.subnetwork.self_link
+  private_ip_address = google_compute_address.addr_intf_redundant.address
+}
+
+resource "google_compute_router_interface" "interface" {
+  name                = "<%= ctx[:vars]['router_name'] %>-intf"
+  region              = google_compute_router.router.region
+  router              = google_compute_router.router.name
+  subnetwork          = google_compute_subnetwork.subnetwork.self_link
+  private_ip_address  = google_compute_address.addr_intf.address
+  redundant_interface = google_compute_router_interface.interface_redundant.name
+}
+
+resource "google_compute_router_peer" "peer" {
+  name                      = "<%= ctx[:vars]['peer_name'] %>"
+  router                    = google_compute_router.router.name
+  region                    = google_compute_router.router.region
+  interface                 = google_compute_router_interface.interface.name
+  router_appliance_instance = google_compute_instance.instance.self_link
+  peer_asn                  = 65513
+  peer_ip_address           = google_compute_address.addr_peer.address
+}

--- a/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
@@ -104,6 +104,7 @@ func resourceComputeRouterInterface() *schema.Resource {
 			"redundant_interface": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: `The name of the interface that is redundant to this interface. Changing this forces a new interface to be created.`,
 			},
@@ -328,6 +329,11 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 			ifaceFound = true
 			continue
 		} else {
+			// If this is a redundant interface,
+			// remove its reference from other interfaces as well
+			if iface.RedundantInterface == ifaceName {
+				iface.RedundantInterface = "";
+			}
 			newIfaces = append(newIfaces, iface)
 		}
 	}


### PR DESCRIPTION
Adds `router_appliance_instance` field to `google_compute_router_bgp_peer`.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
compute: added `router_appliance_instance` field to `google_compute_router_bgp_peer`
```
