### PR TITLE
Promoted `managed_prometheus` field in google_container_cluster` to GA

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -951,7 +951,6 @@ func resourceContainerCluster() *schema.Resource {
 <% end -%>
 							},
 						},
-<% unless version == "ga" -%>
 						"managed_prometheus": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -968,7 +967,6 @@ func resourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-<% end -%>
 					},
 				},
 			},
@@ -4326,14 +4324,12 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 			EnableComponents: convertStringArr(enable_components),
 		}
 	}
-<% unless version == 'ga' -%>
 	if v, ok := config["managed_prometheus"]; ok && len(v.([]interface{})) > 0 {
 		managed_prometheus := v.([]interface{})[0].(map[string]interface{})
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
 	}
-<% end -%>
 	return mc
 }
 
@@ -5038,15 +5034,12 @@ func flattenMonitoringConfig(c *container.MonitoringConfig) []map[string]interfa
 	if c.ComponentConfig != nil {
 		result["enable_components"] = c.ComponentConfig.EnableComponents
 	}
-<% unless version == 'ga' -%>
 	if c.ManagedPrometheusConfig != nil {
 		result["managed_prometheus"] = flattenManagedPrometheusConfig(c.ManagedPrometheusConfig)
 	}
-<% end -%>
 	return []map[string]interface{}{result}
 }
 
-<% unless version == 'ga' -%>
 func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
@@ -5054,7 +5047,6 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
 		},
 	}
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2474,7 +2474,7 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
-			<% unless version == "ga" -%>
+			<% if version == "beta" -%>
 			{
 				Config: testAccContainerCluster_withMonitoringConfigUpdated(clusterName),
 			},
@@ -6695,7 +6695,7 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
-<% unless version == "ga" -%>
+<% if version == "beta" -%>
 func testAccContainerCluster_withMonitoringConfigUpdated(name string) string {
        return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -6736,8 +6736,8 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
 	min_master_version = "1.23.8-gke.1900"
   monitoring_config {
+	     enable_components = []
          managed_prometheus {
-				enable_components = []
                 enabled = true
          }
   }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2474,7 +2474,6 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
-<% if version == 'beta' -%>
 			{
 				Config: testAccContainerCluster_withMonitoringConfigUpdated(clusterName),
 			},
@@ -2512,7 +2511,6 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
-<% end -%>
 			{
 				Config: testAccContainerCluster_basic_1_23_8(clusterName),
 			},
@@ -6695,7 +6693,6 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
-<% if version == 'beta' -%>
 func testAccContainerCluster_withMonitoringConfigUpdated(name string) string {
        return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -6742,7 +6739,7 @@ resource "google_container_cluster" "primary" {
 }
 `, name)
 }
-<% end -%>
+
 
 func testAccContainerCluster_withSoleTenantGroup(name string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2474,6 +2474,7 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
+			<% unless version == "ga" -%>
 			{
 				Config: testAccContainerCluster_withMonitoringConfigUpdated(clusterName),
 			},
@@ -2483,6 +2484,7 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
+			<% end -%>
 			{
 				Config: testAccContainerCluster_withMonitoringConfigPrometheusUpdated(clusterName),
 			},
@@ -6693,6 +6695,7 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
+<% unless version == "ga" -%>
 func testAccContainerCluster_withMonitoringConfigUpdated(name string) string {
        return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -6706,6 +6709,7 @@ resource "google_container_cluster" "primary" {
 }
 `, name)
 }
+<% end -%>
 
 func testAccContainerCluster_withMonitoringConfigPrometheusUpdated(name string) string {
        return fmt.Sprintf(`
@@ -6713,9 +6717,17 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
+private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = "172.16.0.32/28"
+  }
+  ip_allocation_policy {
+
+  }
 	min_master_version = "1.23.8-gke.1900"
   monitoring_config {
-         enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER", "WORKLOADS" ]
+         enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER" ]
          managed_prometheus {
                  enabled = true
          }
@@ -6730,10 +6742,19 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
+private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = "172.16.0.32/28"
+  }
+  ip_allocation_policy {
+
+  }
 	min_master_version = "1.23.8-gke.1900"
   monitoring_config {
          managed_prometheus {
-                 enabled = true
+				enable_components = []
+                enabled = true
          }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -6646,7 +6646,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   logging_config {
-	  enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER", "WORKLOADS" ]
+	  enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER"]
   }
   monitoring_config {
 	  enable_components = [ "SYSTEM_COMPONENTS" ]

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -6717,14 +6717,6 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-private_cluster_config {
-    enable_private_nodes    = true
-    enable_private_endpoint = false
-    master_ipv4_cidr_block  = "172.16.0.32/28"
-  }
-  ip_allocation_policy {
-
-  }
 	min_master_version = "1.23.8-gke.1900"
   monitoring_config {
          enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER" ]
@@ -6742,14 +6734,6 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-private_cluster_config {
-    enable_private_nodes    = true
-    enable_private_endpoint = false
-    master_ipv4_cidr_block  = "172.16.0.32/28"
-  }
-  ip_allocation_policy {
-
-  }
 	min_master_version = "1.23.8-gke.1900"
   monitoring_config {
          managed_prometheus {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -543,7 +543,7 @@ This block also contains several computed attributes, documented below.
 
 *  `enable_components` - (Optional) The GKE components exposing metrics. Supported values include: `SYSTEM_COMPONENTS`, `APISERVER`, `CONTROLLER_MANAGER`, and `SCHEDULER`. In beta provider, `WORKLOADS` is supported on top of those 4 values. (`WORKLOADS` is deprecated and removed in GKE 1.24.)
 
-*  `managed_prometheus` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for Managed Service for Prometheus. Structure is [documented below](#nested_managed_prometheus).
+*  `managed_prometheus` - (Optional) Configuration for Managed Service for Prometheus. Structure is [documented below](#nested_managed_prometheus).
 
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: promoted `managed_prometheus` field in google_container_cluster` to GA
```
