### PR TITLE
Add nonexistant fields to vertex endpoint to test missing test detect…

### DIFF
--- a/mmv1/products/vertexai/Endpoint.yaml
+++ b/mmv1/products/vertexai/Endpoint.yaml
@@ -59,6 +59,12 @@ properties:
     required: true
     immutable: true
   - !ruby/object:Api::Type::String
+    name: coveredField
+    description: A non-existant field that has test coverage
+  - !ruby/object:Api::Type::String
+    name: uncoveredField
+    description: A non-existant field that has no test coverage
+  - !ruby/object:Api::Type::String
     name: displayName
     description: Required. The display name of the Endpoint. The name can be up to 128 characters long and can consist of any UTF-8 characters.
     required: true

--- a/mmv1/third_party/terraform/tests/resource_vertex_ai_endpoint_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vertex_ai_endpoint_test.go
@@ -64,6 +64,7 @@ func testAccVertexAIEndpoint_vertexAiEndpointNetwork(context map[string]interfac
 	return Nprintf(`
 resource "google_vertex_ai_endpoint" "endpoint" {
   name         = "%{endpoint_name}"
+  covered_field = "some-value"
   display_name = "sample-endpoint"
   description  = "A sample vertex endpoint"
   location     = "us-central1"


### PR DESCRIPTION
…ion.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Nonexistant fields added, do not release.
```
