### PR TITLE
[#13139] Add bucket_name argument to logging metric resource

### DIFF
--- a/mmv1/products/logging/api.yaml
+++ b/mmv1/products/logging/api.yaml
@@ -56,6 +56,11 @@ objects:
           description is 8000 characters.
         required: false
       - !ruby/object:Api::Type::String
+        name: bucketName
+        description: |
+          The resource name of the Log Bucket that owns the Log Metric. Only Log Buckets in projects
+          are supported. The bucket has to be in the same project as the metric.
+      - !ruby/object:Api::Type::String
         name: filter
         description: |
           An advanced logs filter (https://cloud.google.com/logging/docs/view/advanced-filters) which

--- a/mmv1/products/logging/terraform.yaml
+++ b/mmv1/products/logging/terraform.yaml
@@ -32,6 +32,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "logging_metric"
         vars:
           logging_metric_name: "my-(custom)/metric"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "logging_metric_logging_bucket"
+        primary_resource_id: "logging_metric"
+        vars:
+          logging_metric_name: "my-(custom)/metric"
+        test_env_vars:
+          project: :PROJECT_NAME
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/templates/terraform/examples/logging_metric_logging_bucket.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_metric_logging_bucket.tf.erb
@@ -1,0 +1,17 @@
+resource "google_logging_project_bucket_config" "<%= ctx[:primary_resource_id] %>" {
+    location  = "global"
+    project   = "<%= ctx[:test_env_vars]['project'] %>"
+    bucket_id = "_Default"
+}
+
+resource "google_logging_metric" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]["logging_metric_name"] %>"
+  filter      = "resource.type=gae_app AND severity>=ERROR"
+  bucket_name = google_logging_project_bucket_config.<%= ctx[:primary_resource_id] %>.id
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
@@ -62,6 +62,46 @@ func TestAccLoggingMetric_explicitBucket(t *testing.T) {
 	})
 }
 
+func TestAccLoggingMetric_loggingBucket(t *testing.T) {
+	t.Parallel()
+
+	filter := "resource.type=gae_app AND severity>=ERROR"
+	project_id := getTestProjectFromEnv()
+	suffix := randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingMetricDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingMetric_loggingBucketBase(suffix, filter),
+			},
+			{
+				ResourceName:      "google_logging_metric.logging_metric",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingMetric_loggingBucket(suffix, filter, project_id),
+			},
+			{
+				ResourceName:      "google_logging_metric.logging_metric",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingMetric_loggingBucketBase(suffix, filter),
+			},
+			{
+				ResourceName:      "google_logging_metric.logging_metric",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingMetric_descriptionUpdated(t *testing.T) {
 	t.Parallel()
 
@@ -128,11 +168,48 @@ resource "google_logging_metric" "logging_metric" {
 `, suffix, filter)
 }
 
+func testAccLoggingMetric_loggingBucketBase(suffix string, filter string) string {
+	return fmt.Sprintf(`
+resource "google_logging_metric" "logging_metric" {
+  name        = "my-custom-metric-%s"
+  filter      = "%s"
+
+  metric_descriptor {
+  	metric_kind = "DELTA"
+    unit        = "1"
+    value_type  = "INT64"
+  }
+}
+`, suffix, filter)
+}
+
+func testAccLoggingMetric_loggingBucket(suffix string, filter string, project_id string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_bucket_config" "logging_bucket" {
+  location  = "global"
+  project   = "%s"
+  bucket_id = "_Default"
+}
+
+resource "google_logging_metric" "logging_metric" {
+  name        = "my-custom-metric-%s"
+  bucket_name = google_logging_project_bucket_config.logging_bucket.id
+  filter      = "%s"
+
+  metric_descriptor {
+  	metric_kind = "DELTA"
+    unit        = "1"
+    value_type  = "INT64"
+  }
+}
+`, project_id, suffix, filter)
+}
+
 func testAccLoggingMetric_descriptionUpdated(suffix, description string) string {
 	return fmt.Sprintf(`
 resource "google_logging_metric" "logging_metric" {
 	name        = "my-custom-metric-%s"
-	description = "Counter for  VM instances that have hostError's"
+	description = "Counter for VM instances that have hostError's"
 	filter      = "resource.type=gce_instance AND protoPayload.methodName=compute.instances.hostError"
 	metric_descriptor {
 	  metric_kind = "DELTA"

--- a/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
@@ -175,7 +175,7 @@ resource "google_logging_metric" "logging_metric" {
   filter      = "%s"
 
   metric_descriptor {
-  	metric_kind = "DELTA"
+    metric_kind = "DELTA"
     unit        = "1"
     value_type  = "INT64"
   }

--- a/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
@@ -197,7 +197,7 @@ resource "google_logging_metric" "logging_metric" {
   filter      = "%s"
 
   metric_descriptor {
-  	metric_kind = "DELTA"
+    metric_kind = "DELTA"
     unit        = "1"
     value_type  = "INT64"
   }


### PR DESCRIPTION
Add bucket_name argument to logging metric resource

This should resolve https://github.com/hashicorp/terraform-provider-google/issues/13139

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
logging: added `bucket_name` argument to `google_logging_metric`
```