### PR TITLE
Compute `content_base64` for google_storage_bucket_object_content

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_storage_bucket_object_content_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -21,6 +22,8 @@ func TestAccDataSourceStorageBucketObjectContent_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_storage_bucket_object_content.default", "content"),
 					resource.TestCheckResourceAttr("data.google_storage_bucket_object_content.default", "content", content),
+					resource.TestCheckResourceAttrSet("data.google_storage_bucket_object_content.default", "content_base64"),
+					resource.TestCheckResourceAttr("data.google_storage_bucket_object_content.default", "content_base64", base64.StdEncoding.EncodeToString([]byte(content))),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
@@ -42,4 +42,10 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `content` - (Computed) [Content-Language](https://tools.ietf.org/html/rfc7231#section-3.1.3.2) of the object content.
+* `content` - (Computed) Raw content of the object content, assumed by Terraform
+  to be UTF-8 encoded string. Files that do not contain UTF-8 text will have
+  invalid UTF-8 sequences in `content` replaced with the Unicode replacement
+  character.
+
+* `content_base64` - (Computed) Base64 encoded version of the object content.
+  Use this when dealing with binary data.


### PR DESCRIPTION
This returns the same content present in the return object but exposed by using Base64 encoding. This is mostly useful for reading binary content.

Our particular use case is to push the content of a WASM file to a Fastly Compute@Edge service. But this is also useful for other serverless services like AWS Lambda as well.

This alongside including the hash sums for the source object content proposed in
https://github.com/hashicorp/terraform-provider-google/issues/13002, would allow us pushing content directly from Google Storage Object Content data source to Fastly Compute@Edge. AWS Lambda also uses the same version/content discrimination method of sending the content hash sum within the `source_code_hash` parameter.

Sign-off-by: Gorka Lerchundi Osa <glertxundi@gmail.com>

Fixed https://github.com/hashicorp/terraform-provider-google/issues/10835
Fixed https://github.com/hashicorp/terraform-provider-google/issues/13002

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
compute: added `content_base64` computed field to `google_storage_bucket_object_content` data source
```
