### PR TITLE
Make deletion_policy a virtual_field for AndroidApp and AppleApp

### DIFF
--- a/mmv1/products/firebase/api.yaml
+++ b/mmv1/products/firebase/api.yaml
@@ -189,17 +189,6 @@ objects:
       error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
-    parameters:
-      # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
-      - !ruby/object:Api::Type::String
-        name: 'deletion_policy'
-        description: |
-          (Optional) Set to `ABANDON` to allow the AndroidApp to be untracked from terraform state
-          rather than deleted upon `terraform destroy`. This is useful because the AndroidApp may be
-          serving traffic. Set to `DELETE` to delete the AndroidApp. Default to `DELETE`.
-        input: true
-        url_param_only: true
-        default_value: DELETE
     properties:
       - !ruby/object:Api::Type::String
         name: name
@@ -272,17 +261,6 @@ objects:
       error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
-    parameters:
-      # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
-      - !ruby/object:Api::Type::String
-        name: 'deletion_policy'
-        description: |
-          (Optional) Set to `ABANDON` to allow the AppleApp to be untracked from terraform state
-          rather than deleted upon `terraform destroy`. This is useful because the AppleApp may be
-          serving traffic. Set to `DELETE` to delete the AppleApp. Default to `DELETE`.
-        input: true
-        url_param_only: true
-        default_value: DELETE
     properties:
       - !ruby/object:Api::Type::String
         name: name

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -85,6 +85,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           package_name: '"android.package.app" + randString(t, 4)'
         ignore_read_extra:
           - project
+          - deletion_policy
+    virtual_fields:
+      - !ruby/object:Api::Type::String
+        name: 'deletion_policy'
+        description: |
+          (Optional) Set to `ABANDON` to allow the AndroidApp to be untracked from terraform state
+          rather than deleted upon `terraform destroy`. This is useful because the AndroidApp may be
+          serving traffic. Set to `DELETE` to delete the AndroidApp. Defaults to `DELETE`.
+        default_value: DELETE
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
@@ -123,6 +132,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           team_id: "9987654321"
         ignore_read_extra:
           - project
+          - deletion_policy
+    virtual_fields:
+      - !ruby/object:Api::Type::String
+        name: 'deletion_policy'
+        description: |
+          (Optional) Set to `ABANDON` to allow the Apple to be untracked from terraform state
+          rather than deleted upon `terraform destroy`. This is useful because the Apple may be
+          serving traffic. Set to `DELETE` to delete the Apple. Defaults to `DELETE`.
+        default_value: DELETE
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -88,6 +88,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - deletion_policy
     virtual_fields:
       - !ruby/object:Api::Type::String
+        # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
         name: 'deletion_policy'
         description: |
           (Optional) Set to `ABANDON` to allow the AndroidApp to be untracked from terraform state
@@ -101,9 +102,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     import_format: ["projects/{{project}}/iosApps/{{appId}}", "iosApps/{{appId}}", "{{appId}}"]
     autogen_async: true
     skip_sweeper: true # Skip sweeper generation and use hard-delete in hand-written sweeper
-    properties:
-      deletion_policy: !ruby/object:Overrides::Terraform::PropertyOverride
-        diff_suppress_func: 'emptyOrDefaultStringSuppress("DELETE")'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "firebase_apple_app_basic"
@@ -135,6 +133,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - deletion_policy
     virtual_fields:
       - !ruby/object:Api::Type::String
+        # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
         name: 'deletion_policy'
         description: |
           (Optional) Set to `ABANDON` to allow the Apple to be untracked from terraform state


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Similar to #6738, make `deletion_policy` a virtual field to avoid forced replacement on update.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firebase: marked `deletion_policy` as updatable without recreation on `google_firebase_android_app` and `google_firebase_apple_app`
```
