### PR TITLE
Add fields to compute instance template, image

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -5733,11 +5733,10 @@ objects:
                       name: 'sourceImage'
                       description: |
                         The source image to create this disk. When creating a
-                        new instance, one of initializeParams.sourceImage,
-                        initializeParams.sourceSnapshot, or disks.source is
-                        required.  To create a disk with one of the public
-                        operating system images, specify the image by its
-                        family name.
+                        new instance, one of initializeParams.sourceImage or
+                        disks.source is required.  To create a disk with one of
+                        the public operating system images, specify the image
+                        by its family name.
                     - !ruby/object:Api::Type::NestedObject
                       name: 'sourceImageEncryptionKey'
                       description: |
@@ -5751,104 +5750,18 @@ objects:
                         images are encrypted with your own keys.
                       properties:
                         - !ruby/object:Api::Type::String
-                          name: 'sha256'
-                          description: |
-                            The RFC 4648 base64 encoded SHA-256 hash of the
-                            customer-supplied encryption key that protects this
-                            resource.
-                          output: true
-                        - !ruby/object:Api::Type::String
-                          name: 'kmsKeyServiceAccount'
-                          description: |
-                            The service account being used for the encryption
-                            request for the given KMS key. If absent, the
-                            Compute Engine default service account is used.
-                        - !ruby/object:Api::Type::String
                           name: 'rawKey'
                           description: |
                             Specifies a 256-bit customer-supplied encryption
                             key, encoded in RFC 4648 base64 to either encrypt
                             or decrypt this resource.
                         - !ruby/object:Api::Type::String
-                          name: 'rsaEncryptedKey'
-                          description: |
-                            Specifies an RFC 4648 base64 encoded, RSA-wrapped
-                            2048-bit customer-supplied encryption key to either
-                            encrypt or decrypt this resource. You can provide
-                            either the rawKey or the rsaEncryptedKey.
-
-                            The key must meet the following requirements before
-                            you can provide it to Compute Engine:
-
-                            1. The key is wrapped using a RSA public key
-                            certificate provided by Google.
-
-                            2. After being wrapped, the key must be encoded in
-                            RFC 4648 base64 encoding.
-
-                            Get the RSA public key certificate provided by Google at:
-                            https://cloud-certs.storage.googleapis.com/google-cloud-csek-ingress.pem
-                        - !ruby/object:Api::Type::String
-                          name: 'kmsKeyName'
-                          description: |
-                            The name of the encryption key that is stored in
-                            Google Cloud KMS.
-                    - !ruby/object:Api::Type::String
-                      name: 'sourceSnapshot'
-                      description: |
-                        The source snapshot to create this disk. When creating
-                        a new instance, one of initializeParams.sourceSnapshot,
-                        initializeParams.sourceImage, or disks.source is
-                        required except for local SSD.
-                    - !ruby/object:Api::Type::NestedObject
-                      name: 'sourceSnapshotEncryptionKey'
-                      description: |
-                        The customer-supplied encryption key of the source snapshot.
-                      properties:
-                        - !ruby/object:Api::Type::String
                           name: 'sha256'
                           description: |
                             The RFC 4648 base64 encoded SHA-256 hash of the
                             customer-supplied encryption key that protects this
                             resource.
                           output: true
-                        - !ruby/object:Api::Type::String
-                          name: 'kmsKeyServiceAccount'
-                          description: |
-                            The service account being used for the encryption
-                            request for the given KMS key. If absent, the
-                            Compute Engine default service account is used.
-                        - !ruby/object:Api::Type::String
-                          name: 'rawKey'
-                          description: |
-                            Specifies a 256-bit customer-supplied encryption
-                            key, encoded in RFC 4648 base64 to either encrypt or
-                            decrypt this resource. You can provide either the
-                            rawKey or the rsaEncryptedKey.
-                        - !ruby/object:Api::Type::String
-                          name: 'rsaEncryptedKey'
-                          description: |
-                            Specifies an RFC 4648 base64 encoded, RSA-wrapped
-                            2048-bit customer-supplied encryption key to either
-                            encrypt or decrypt this resource. You can provide
-                            either the rawKey or the rsaEncryptedKey.
-
-                            The key must meet the following requirements before
-                            you can provide it to Compute Engine:
-
-                            1. The key is wrapped using a RSA public key
-                            certificate provided by Google.
-
-                            2. After being wrapped, the key must be encoded in
-                            RFC 4648 base64 encoding.
-
-                            Get the RSA public key certificate provided by Google at:
-                            https://cloud-certs.storage.googleapis.com/google-cloud-csek-ingress.pem
-                        - !ruby/object:Api::Type::String
-                          name: 'kmsKeyName'
-                          description: |
-                            The name of the encryption key that is stored in
-                            Google Cloud KMS.
                 - !ruby/object:Api::Type::Enum
                   name: 'interface'
                   description: |
@@ -5879,9 +5792,7 @@ objects:
                   imports: 'name'
                   description: |
                     Reference to a disk. When creating a new instance,
-                    one of initializeParams.sourceImage,
-                    initializeParams.sourceSnapshot, or disks.source is
-                    required.
+                    one of initializeParams.sourceImage or disks.source is required.
 
                     If desired, you can also attach existing non-root
                     persistent disks using this property. This field is only

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -5733,10 +5733,11 @@ objects:
                       name: 'sourceImage'
                       description: |
                         The source image to create this disk. When creating a
-                        new instance, one of initializeParams.sourceImage or
-                        disks.source is required.  To create a disk with one of
-                        the public operating system images, specify the image
-                        by its family name.
+                        new instance, one of initializeParams.sourceImage,
+                        initializeParams.sourceSnapshot, or disks.source is
+                        required.  To create a disk with one of the public
+                        operating system images, specify the image by its
+                        family name.
                     - !ruby/object:Api::Type::NestedObject
                       name: 'sourceImageEncryptionKey'
                       description: |
@@ -5750,11 +5751,60 @@ objects:
                         images are encrypted with your own keys.
                       properties:
                         - !ruby/object:Api::Type::String
+                          name: 'sha256'
+                          description: |
+                            The RFC 4648 base64 encoded SHA-256 hash of the
+                            customer-supplied encryption key that protects this
+                            resource.
+                          output: true
+                        - !ruby/object:Api::Type::String
+                          name: 'kmsKeyServiceAccount'
+                          description: |
+                            The service account being used for the encryption
+                            request for the given KMS key. If absent, the
+                            Compute Engine default service account is used.
+                        - !ruby/object:Api::Type::String
                           name: 'rawKey'
                           description: |
                             Specifies a 256-bit customer-supplied encryption
                             key, encoded in RFC 4648 base64 to either encrypt
                             or decrypt this resource.
+                        - !ruby/object:Api::Type::String
+                          name: 'rsaEncryptedKey'
+                          description: |
+                            Specifies an RFC 4648 base64 encoded, RSA-wrapped
+                            2048-bit customer-supplied encryption key to either
+                            encrypt or decrypt this resource. You can provide
+                            either the rawKey or the rsaEncryptedKey.
+
+                            The key must meet the following requirements before
+                            you can provide it to Compute Engine:
+
+                            1. The key is wrapped using a RSA public key
+                            certificate provided by Google.
+
+                            2. After being wrapped, the key must be encoded in
+                            RFC 4648 base64 encoding.
+
+                            Get the RSA public key certificate provided by Google at:
+                            https://cloud-certs.storage.googleapis.com/google-cloud-csek-ingress.pem
+                        - !ruby/object:Api::Type::String
+                          name: 'kmsKeyName'
+                          description: |
+                            The name of the encryption key that is stored in
+                            Google Cloud KMS.
+                    - !ruby/object:Api::Type::String
+                      name: 'sourceSnapshot'
+                      description: |
+                        The source snapshot to create this disk. When creating
+                        a new instance, one of initializeParams.sourceSnapshot,
+                        initializeParams.sourceImage, or disks.source is
+                        required except for local SSD.
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'sourceSnapshotEncryptionKey'
+                      description: |
+                        The customer-supplied encryption key of the source snapshot.
+                      properties:
                         - !ruby/object:Api::Type::String
                           name: 'sha256'
                           description: |
@@ -5762,6 +5812,43 @@ objects:
                             customer-supplied encryption key that protects this
                             resource.
                           output: true
+                        - !ruby/object:Api::Type::String
+                          name: 'kmsKeyServiceAccount'
+                          description: |
+                            The service account being used for the encryption
+                            request for the given KMS key. If absent, the
+                            Compute Engine default service account is used.
+                        - !ruby/object:Api::Type::String
+                          name: 'rawKey'
+                          description: |
+                            Specifies a 256-bit customer-supplied encryption
+                            key, encoded in RFC 4648 base64 to either encrypt or
+                            decrypt this resource. You can provide either the
+                            rawKey or the rsaEncryptedKey.
+                        - !ruby/object:Api::Type::String
+                          name: 'rsaEncryptedKey'
+                          description: |
+                            Specifies an RFC 4648 base64 encoded, RSA-wrapped
+                            2048-bit customer-supplied encryption key to either
+                            encrypt or decrypt this resource. You can provide
+                            either the rawKey or the rsaEncryptedKey.
+
+                            The key must meet the following requirements before
+                            you can provide it to Compute Engine:
+
+                            1. The key is wrapped using a RSA public key
+                            certificate provided by Google.
+
+                            2. After being wrapped, the key must be encoded in
+                            RFC 4648 base64 encoding.
+
+                            Get the RSA public key certificate provided by Google at:
+                            https://cloud-certs.storage.googleapis.com/google-cloud-csek-ingress.pem
+                        - !ruby/object:Api::Type::String
+                          name: 'kmsKeyName'
+                          description: |
+                            The name of the encryption key that is stored in
+                            Google Cloud KMS.
                 - !ruby/object:Api::Type::Enum
                   name: 'interface'
                   description: |
@@ -5792,7 +5879,9 @@ objects:
                   imports: 'name'
                   description: |
                     Reference to a disk. When creating a new instance,
-                    one of initializeParams.sourceImage or disks.source is required.
+                    one of initializeParams.sourceImage,
+                    initializeParams.sourceSnapshot, or disks.source is
+                    required.
 
                     If desired, you can also attach existing non-root
                     persistent disks using this property. This field is only
@@ -6264,9 +6353,14 @@ objects:
           - !ruby/object:Api::Type::String
             # TODO(chrisst) Change to ResourceRef once KMS is in Magic Modules
             name: 'kmsKeyName'
-            min_version: beta
             description: |
               The name of the encryption key that is stored in Google Cloud KMS.
+          - !ruby/object:Api::Type::String
+            name: 'kmsKeyServiceAccount'
+            description: |
+              The service account being used for the encryption request for the
+              given KMS key. If absent, the Compute Engine default service
+              account is used.
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: Labels to apply to this Image.
@@ -14569,8 +14663,19 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'snapshotEncryptionKey'
         description: |
-          The customer-supplied encryption key of the snapshot. Required if the
-          source snapshot is protected by a customer-supplied encryption key.
+          Encrypts the snapshot using a customer-supplied encryption key.
+
+          After you encrypt a snapshot using a customer-supplied key, you must
+          provide the same key if you use the snapshot later. For example, you
+          must provide the encryption key when you create a disk from the
+          encrypted snapshot in a future request.
+
+          Customer-supplied encryption keys do not protect access to metadata of
+          the snapshot.
+
+          If you do not provide an encryption key when creating the snapshot,
+          then the snapshot will be encrypted using an automatically generated
+          key and you do not need to provide a key to use the snapshot later.
         properties:
           - !ruby/object:Api::Type::String
             name: 'rawKey'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1371,8 +1371,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       guestOsFeatures: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         is_set: true
-      imageEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
+      imageEncryptionKey.rawKey: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      imageEncryptionKey.sha256: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
+      imageEncryptionKey.kmsKeyName: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/image_kms_key_name.go.erb'
+        diff_suppress_func: 'compareSelfLinkRelativePaths'
+        name: 'kmsKeySelfLink'
+        description: |
+          The self link of the encryption key that is stored in Google Cloud
+          KMS.
       licenses: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       rawDisk.sha1Checksum: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/custom_flatten/image_kms_key_name.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/image_kms_key_name.go.erb
@@ -1,0 +1,21 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2022 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return v
+	}
+	vStr := v.(string)
+	return strings.Split(vStr, "/cryptoKeyVersions/")[0]
+}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -191,7 +191,7 @@ Engine default service account is used.`,
 									},
 									"kms_key_self_link": {
 										Type:     schema.TypeString,
-										Optional: true,
+										Required: true,
 										ForceNew: true,
 										Description: `The self link of the encryption key that is stored in
 Google Cloud KMS.`,
@@ -226,7 +226,7 @@ Engine default service account is used.`,
 									},
 									"kms_key_self_link": {
 										Type:     schema.TypeString,
-										Optional: true,
+										Required: true,
 										ForceNew: true,
 										Description: `The self link of the encryption key that is stored in
 Google Cloud KMS.`,

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -30,7 +30,7 @@ var (
 		"scheduling.0.node_affinities",
 		"scheduling.0.min_node_cpus",
 		"scheduling.0.provisioning_model",
-                "scheduling.0.instance_termination_action",
+		"scheduling.0.instance_termination_action",
 	}
 
 	shieldedInstanceTemplateConfigKeys = []string{
@@ -165,6 +165,74 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Computed:    true,
 							ForceNew:    true,
 							Description: `The image from which to initialize this disk. This can be one of: the image's self_link, projects/{project}/global/images/{image}, projects/{project}/global/images/family/{family}, global/images/{image}, global/images/family/{family}, family/{family}, {project}/{family}, {project}/{image}, {family}, or {image}. ~> Note: Either source or source_image is required when creating a new instance except for when creating a local SSD.`,
+						},
+						"source_image_encryption_key": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Description: `The customer-supplied encryption key of the source
+image. Required if the source image is protected by a
+customer-supplied encryption key.
+
+Instance templates do not store customer-supplied
+encryption keys, so you cannot create disks for
+instances in a managed instance group if the source
+images are encrypted with your own keys.`,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_service_account": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Description: `The service account being used for the encryption
+request for the given KMS key. If absent, the Compute
+Engine default service account is used.`,
+									},
+									"kms_key_self_link": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Description: `The self link of the encryption key that is stored in
+Google Cloud KMS.`,
+									},
+								},
+							},
+						},
+						"source_snapshot": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Description: `The source snapshot to create this disk. When creating
+a new instance, one of initializeParams.sourceSnapshot,
+initializeParams.sourceImage, or disks.source is
+required except for local SSD.`,
+						},
+						"source_snapshot_encryption_key": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The customer-supplied encryption key of the source snapshot.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_service_account": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Description: `The service account being used for the encryption
+request for the given KMS key. If absent, the Compute
+Engine default service account is used.`,
+									},
+									"kms_key_self_link": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Description: `The self link of the encryption key that is stored in
+Google Cloud KMS.`,
+									},
+								},
+							},
 						},
 
 						"interface": {
@@ -921,7 +989,7 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*compute.AttachedDisk
 
 		if v, ok := d.GetOk(prefix + ".source"); ok {
 			disk.Source = v.(string)
-			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "source_image", "labels"}
+			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "source_image", "source_snapshot", "labels"}
 			for _, conflict := range conflicts {
 				if _, ok := d.GetOk(prefix + "." + conflict); ok {
 					return nil, fmt.Errorf("Cannot use `source` with any of the fields in %s", conflicts)
@@ -941,6 +1009,8 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*compute.AttachedDisk
 				disk.InitializeParams.DiskType = v.(string)
 			}
 
+			disk.InitializeParams.Labels = expandStringMap(d, prefix+".labels")
+
 			if v, ok := d.GetOk(prefix + ".source_image"); ok {
 				imageName := v.(string)
 				imageUrl, err := resolveImage(config, project, imageName, userAgent)
@@ -952,7 +1022,30 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*compute.AttachedDisk
 				disk.InitializeParams.SourceImage = imageUrl
 			}
 
-			disk.InitializeParams.Labels = expandStringMap(d, prefix+".labels")
+			if _, ok := d.GetOk(prefix + ".source_image_encryption_key"); ok {
+				disk.InitializeParams.SourceImageEncryptionKey = &compute.CustomerEncryptionKey{}
+				if v, ok := d.GetOk(prefix + ".source_image_encryption_key.0.kms_key_self_link"); ok {
+					disk.InitializeParams.SourceImageEncryptionKey.KmsKeyName = v.(string)
+				}
+				if v, ok := d.GetOk(prefix + ".source_image_encryption_key.0.kms_key_service_account"); ok {
+					disk.InitializeParams.SourceImageEncryptionKey.KmsKeyServiceAccount = v.(string)
+				}
+			}
+
+
+			if v, ok := d.GetOk(prefix + ".source_snapshot"); ok {
+				disk.InitializeParams.SourceSnapshot = v.(string)
+			}
+
+			if _, ok := d.GetOk(prefix + ".source_snapshot_encryption_key"); ok {
+				disk.InitializeParams.SourceSnapshotEncryptionKey = &compute.CustomerEncryptionKey{}
+				if v, ok := d.GetOk(prefix + ".source_snapshot_encryption_key.0.kms_key_self_link"); ok {
+					disk.InitializeParams.SourceSnapshotEncryptionKey.KmsKeyName = v.(string)
+				}
+				if v, ok := d.GetOk(prefix + ".source_snapshot_encryption_key.0.kms_key_service_account"); ok {
+					disk.InitializeParams.SourceSnapshotEncryptionKey.KmsKeyServiceAccount = v.(string)
+				}
+			}
 
 			if _, ok := d.GetOk(prefix + ".resource_policies"); ok {
 				// instance template only supports a resource name here (not uri)
@@ -1147,8 +1240,15 @@ func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
 	return dc
 }
 
-func flattenDisk(disk *compute.AttachedDisk, defaultProject string) (map[string]interface{}, error) {
+func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultProject string) (map[string]interface{}, error) {
 	diskMap := make(map[string]interface{})
+
+
+	// These values are not returned by the API, so we copy them from the config.
+	diskMap["source_image_encryption_key"] = configDisk["source_image_encryption_key"]
+	diskMap["source_snapshot"] = configDisk["source_snapshot"]
+	diskMap["source_snapshot_encryption_key"] = configDisk["source_snapshot_encryption_key"]
+
 	if disk.InitializeParams != nil {
 		if disk.InitializeParams.SourceImage != "" {
 			path, err := resolveImageRefToRelativeURI(defaultProject, disk.InitializeParams.SourceImage)
@@ -1313,11 +1413,12 @@ func flattenDisks(disks []*compute.AttachedDisk, d *schema.ResourceData, default
 	apiDisks := make([]map[string]interface{}, len(disks))
 
 	for i, disk := range disks {
-		d, err := flattenDisk(disk, defaultProject)
+		configDisk := d.Get(fmt.Sprintf("disk.%d", i)).(map[string]any)
+		apiDisk, err := flattenDisk(disk, configDisk, defaultProject)
 		if err != nil {
 			return nil, err
 		}
-		apiDisks[i] = d
+		apiDisks[i] = apiDisk
 	}
 
 	return reorderDisks(d.Get("disk").([]interface{}), apiDisks), nil

--- a/mmv1/third_party/terraform/tests/resource_compute_image_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_image_test.go.erb
@@ -216,6 +216,30 @@ func TestAccComputeImage_resolveImage(t *testing.T) {
 	})
 }
 
+func TestAccComputeImage_imageEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	kmsKey := BootstrapKMSKeyInLocation(t, "us-central1")
+	kmsKeyName := GetResourceNameFromSelfLink(kmsKey.CryptoKey.Name)
+	kmsRingName := GetResourceNameFromSelfLink(kmsKey.KeyRing.Name)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeImage_imageEncryptionKey(kmsRingName, kmsKeyName, randString(t, 10)),
+			},
+			{
+				ResourceName:            "google_compute_image.image",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeImageResolution(t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -454,4 +478,43 @@ resource "google_compute_image" "foobar" {
   source_snapshot = google_compute_snapshot.foobar.self_link
 }
 `, diskName, snapshotName, imageName)
+}
+
+func testAccComputeImage_imageEncryptionKey(kmsRingName, kmsKeyName, suffix string) string {
+	return fmt.Sprintf(`
+data "google_kms_key_ring" "ring" {
+  name     = "%s"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "key" {
+  name     = "%s"
+  key_ring = data.google_kms_key_ring.ring.id
+}
+
+resource "google_service_account" "test" {
+  account_id   = "tf-test-sa-%s"
+  display_name = "KMS Ops Account"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = data.google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.test.email}"
+}
+
+data "google_compute_image" "debian" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_image" "image" {
+  name         = "tf-test-image-%s"
+  source_image = data.google_compute_image.debian.self_link
+  image_encryption_key {
+    kms_key_self_link       = data.google_kms_crypto_key.key.id
+    kms_key_service_account = google_service_account.test.email
+  }
+}
+`, kmsRingName, kmsKeyName, suffix, suffix)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -3025,7 +3025,7 @@ data "google_kms_crypto_key" "key" {
 }
 
 resource "google_service_account" "test" {
-  account_id   = "test-sa-%s"
+  account_id   = "tf-test-sa-%s"
   display_name = "KMS Ops Account"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1136,6 +1136,66 @@ func TestAccComputeInstanceTemplate_spot(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_sourceSnapshotEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	kmsKey := BootstrapKMSKeyInLocation(t, "us-central1")
+	kmsKeyName := GetResourceNameFromSelfLink(kmsKey.CryptoKey.Name)
+	kmsRingName := GetResourceNameFromSelfLink(kmsKey.KeyRing.Name)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_sourceSnapshotEncryptionKey(kmsRingName, kmsKeyName, randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.template", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:            "google_compute_instance_template.template",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk.0.source_snapshot", "disk.0.source_snapshot_encryption_key"},
+			},
+		},
+	})
+}
+
+func TestAccComputeInstanceTemplate_sourceImageEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	kmsKey := BootstrapKMSKeyInLocation(t, "us-central1")
+	kmsKeyName := GetResourceNameFromSelfLink(kmsKey.CryptoKey.Name)
+	kmsRingName := GetResourceNameFromSelfLink(kmsKey.KeyRing.Name)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_sourceImageEncryptionKey(kmsRingName, kmsKeyName, randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.template", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:            "google_compute_instance_template.template",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk.0.source_image_encryption_key"},
+			},
+		},
+	})
+}
+
 func testAccCheckComputeInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -2885,3 +2945,128 @@ resource "google_compute_instance_template" "foobar" {
 `, suffix)
 }
 
+func testAccComputeInstanceTemplate_sourceSnapshotEncryptionKey(kmsRingName, kmsKeyName, suffix string) string {
+	return fmt.Sprintf(`
+data "google_kms_key_ring" "ring" {
+  name     = "%s"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "key" {
+  name     = "%s"
+  key_ring = data.google_kms_key_ring.ring.id
+}
+
+resource "google_service_account" "test" {
+  account_id   = "test-sa-%s"
+  display_name = "KMS Ops Account"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = data.google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.test.email}"
+}
+
+data "google_compute_image" "debian" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "persistent" {
+  name  = "debian-disk"
+  image = data.google_compute_image.debian.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapshot" {
+  name        = "my-snapshot"
+  source_disk = google_compute_disk.persistent.id
+  zone        = "us-central1-a"
+  snapshot_encryption_key {
+    kms_key_self_link       = data.google_kms_crypto_key.key.id
+    kms_key_service_account = google_service_account.test.email
+  }
+}
+
+resource "google_compute_instance_template" "template" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+
+  disk {
+    source_snapshot = google_compute_snapshot.snapshot.self_link
+    source_snapshot_encryption_key {
+      kms_key_self_link       = data.google_kms_crypto_key.key.id
+      kms_key_service_account = google_service_account.test.email
+    }
+    auto_delete = true
+    boot        = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, kmsRingName, kmsKeyName, suffix, suffix)
+}
+
+func testAccComputeInstanceTemplate_sourceImageEncryptionKey(kmsRingName, kmsKeyName, suffix string) string {
+	return fmt.Sprintf(`
+data "google_kms_key_ring" "ring" {
+  name     = "%s"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "key" {
+  name     = "%s"
+  key_ring = data.google_kms_key_ring.ring.id
+}
+
+resource "google_service_account" "test" {
+  account_id   = "test-sa-%s"
+  display_name = "KMS Ops Account"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = data.google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.test.email}"
+}
+
+data "google_compute_image" "debian" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_image" "image" {
+  name         = "debian-image"
+  source_image = data.google_compute_image.debian.self_link
+  image_encryption_key {
+    kms_key_self_link       = data.google_kms_crypto_key.key.id
+    kms_key_service_account = google_service_account.test.email
+  }
+}
+
+
+resource "google_compute_instance_template" "template" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+
+  disk {
+    source_image = google_compute_image.image.self_link
+    source_image_encryption_key {
+      kms_key_self_link       = data.google_kms_crypto_key.key.id
+      kms_key_service_account = google_service_account.test.email
+    }
+    auto_delete = true
+    boot        = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, kmsRingName, kmsKeyName, suffix, suffix)
+}

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -382,7 +382,23 @@ The following arguments are supported:
     `projects/{project}/global/images/family/{family}`, `global/images/{image}`,
     `global/images/family/{family}`, `family/{family}`, `{project}/{family}`,
     `{project}/{image}`, `{family}`, or `{image}`.
-~> **Note:** Either `source` or `source_image` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+~> **Note:** Either `source`, `source_image`, or `source_snapshot` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `source_image_encryption_key` - (Optional) The customer-supplied encryption
+    key of the source image. Required if the source image is protected by a
+    customer-supplied encryption key.
+
+    Instance templates do not store customer-supplied encryption keys, so you
+    cannot create disks for instances in a managed instance group if the source
+    images are encrypted with your own keys. Structure
+    [documented below](#nested_source_image_encryption_key).
+
+* `source_snapshot` - (Optional) The source snapshot to create this disk.
+~> **Note:** Either `source`, `source_image`, or `source_snapshot` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `source_snapshot_encryption_key` - (Optional) The customer-supplied encryption
+    key of the source snapshot. Structure
+    [documented below](#nested_source_snapshot_encryption_key).
 
 * `interface` - (Optional) Specifies the disk interface to use for attaching this disk,
     which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI
@@ -395,7 +411,7 @@ The following arguments are supported:
 
 * `source` - (Optional) The name (**not self_link**)
     of the disk (such as those managed by `google_compute_disk`) to attach.
-~> **Note:** Either `source` or `source_image` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+~> **Note:** Either `source`, `source_image`, or `source_snapshot` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
 
 * `disk_type` - (Optional) The GCE disk type. Such as `"pd-ssd"`, `"local-ssd"`,
     `"pd-balanced"` or `"pd-standard"`.
@@ -418,11 +434,29 @@ The following arguments are supported:
 
     If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
 
-    Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
+    Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group. Structure [documented below](#nested_access_config).
 
 * `resource_policies` (Optional) -- A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
 
-The `disk_encryption_key` block supports:
+<a name="nested_source_image_encryption_key"></a>The `source_image_encryption_key` block supports:
+
+* `kms_key_service_account` - (Optional) The service account being used for the
+    encryption request for the given KMS key. If absent, the Compute Engine
+    default service account is used.
+
+* `kms_key_self_link` - (Optional) The self link of the encryption key that is
+    stored in Google Cloud KMS.
+
+<a name="nested_source_snapshot_encryption_key"></a>The `source_snapshot_encryption_key` block supports:
+
+* `kms_key_service_account` - (Optional) The service account being used for the
+    encryption request for the given KMS key. If absent, the Compute Engine
+    default service account is used.
+
+* `kms_key_self_link` - (Optional) The self link of the encryption key that is
+    stored in Google Cloud KMS.
+
+<a name="nested_disk_encryption_key"></a>The `disk_encryption_key` block supports:
 
 * `kms_key_self_link` - (Required) The self link of the encryption key that is stored in Google Cloud KMS
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -444,7 +444,7 @@ The following arguments are supported:
     encryption request for the given KMS key. If absent, the Compute Engine
     default service account is used.
 
-* `kms_key_self_link` - (Optional) The self link of the encryption key that is
+* `kms_key_self_link` - (Required) The self link of the encryption key that is
     stored in Google Cloud KMS.
 
 <a name="nested_source_snapshot_encryption_key"></a>The `source_snapshot_encryption_key` block supports:
@@ -453,7 +453,7 @@ The following arguments are supported:
     encryption request for the given KMS key. If absent, the Compute Engine
     default service account is used.
 
-* `kms_key_self_link` - (Optional) The self link of the encryption key that is
+* `kms_key_self_link` - (Required) The self link of the encryption key that is
     stored in Google Cloud KMS.
 
 <a name="nested_disk_encryption_key"></a>The `disk_encryption_key` block supports:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add the source_snapshot, source_snapshot_encyption_key, and source_image_encryption_key fields to compute instance template

fixes b/247829126

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `image_encryption_key` to `google_compute_image`
```

```release-note:enhancement
compute: added support for `source_snapshot`, `source_snapshot_encyption_key`, and `source_image_encryption_key` to `google_compute_instance_template`
```
