### PR TITLE
Fix sql_database_instance creation to remove root user earlier

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -992,6 +992,36 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	// If a default root user was created with a wildcard ('%') hostname, delete it. Note it
+	// appears to only be created for certain types of databases, like MySQL.
+	// Users in a replica instance are inherited from the master instance and should be left alone.
+	// This deletion is done immediately after the instance is created, in order to minimize the
+	// risk of it being left on the instance, which would present a security concern.
+	if sqlDatabaseIsMaster(d) {
+		var users *sqladmin.UsersListResponse
+		err = retryTimeDuration(func() error {
+			users, err = config.NewSqlAdminClient(userAgent).Users.List(project, instance.Name).Do()
+			return err
+		}, d.Timeout(schema.TimeoutRead), isSqlOperationInProgressError)
+		if err != nil {
+			return fmt.Errorf("Error, attempting to list users associated with instance %s: %s", instance.Name, err)
+		}
+		for _, u := range users.Items {
+			if u.Name == "root" && u.Host == "%" {
+				err = retry(func() error {
+					op, err = config.NewSqlAdminClient(userAgent).Users.Delete(project, instance.Name).Host(u.Host).Name(u.Name).Do()
+					if err == nil {
+						err = sqlAdminOperationWaitTime(config, op, project, "Delete default root User", userAgent, d.Timeout(schema.TimeoutCreate))
+					}
+					return err
+				})
+				if err != nil {
+					return fmt.Errorf("Error, failed to delete default 'root'@'*' user, but the database was created successfully: %s", err)
+				}
+			}
+		}
+	}
+
 	// patch any fields that need to be sent postcreation
 	if patchData != nil {
 		err = retryTimeDuration(func() (rerr error) {
@@ -1039,33 +1069,6 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		err = resourceSqlDatabaseInstanceRead(d, meta)
 		if err != nil {
 			return err
-		}
-	}
-
-	// If a default root user was created with a wildcard ('%') hostname, delete it.
-	// Users in a replica instance are inherited from the master instance and should be left alone.
-	if sqlDatabaseIsMaster(d) {
-		var users *sqladmin.UsersListResponse
-		err = retryTimeDuration(func() error {
-			users, err = config.NewSqlAdminClient(userAgent).Users.List(project, instance.Name).Do()
-			return err
-		}, d.Timeout(schema.TimeoutRead), isSqlOperationInProgressError)
-		if err != nil {
-			return fmt.Errorf("Error, attempting to list users associated with instance %s: %s", instance.Name, err)
-		}
-		for _, u := range users.Items {
-			if u.Name == "root" && u.Host == "%" {
-				err = retry(func() error {
-					op, err = config.NewSqlAdminClient(userAgent).Users.Delete(project, instance.Name).Host(u.Host).Name(u.Name).Do()
-					if err == nil {
-						err = sqlAdminOperationWaitTime(config, op, project, "Delete default root User", userAgent, d.Timeout(schema.TimeoutCreate))
-					}
-					return err
-				})
-				if err != nil {
-					return fmt.Errorf("Error, failed to delete default 'root'@'*' user, but the database was created successfully: %s", err)
-				}
-			}
 		}
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -319,6 +319,74 @@ func TestAccSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
 	})
 }
 
+// This test requires an arbitrary error to occur during the SQL instance creation. Currently, we
+// are relying on an error that occurs when settings are used on a MySQL clone. Note that this is
+// somewhat brittle, and the test could begin failing if that error no longer behaves the same way.
+// If this test begins failing, we will want to be sure that the root user is removed as early as
+// possible, and we should attempt to find any other scenarios where the root user could otherwise
+// be left on the instance.
+func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *testing.T) {
+	// Service Networking
+	skipIfVcr(t)
+	t.Parallel()
+
+	databaseName := "tf-test-" + randString(t, 10)
+	addressName := "tf-test-" + randString(t, 10)
+	networkName := "tf-bootstrap-net-sql-instance-private-clone"
+	// networkName := BootstrapSharedTestNetwork(t, "sql-instance-private-clone")
+
+	// 1. Create an instance.
+	// 2. Add a root@'%' user.
+	// 3. Create a clone with settings and assert it fails after the instance creation API call.
+	// 4. Check root user was deleted.
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressName),
+			},
+			{
+				PreConfig: func() {
+					// Add a root user
+					config := googleProviderConfig(t)
+					user := sqladmin.User{
+						Name:     "root",
+						Host:     "%",
+						Password: randString(t, 26),
+					}
+					op, err := config.NewSqlAdminClient(config.userAgent).Users.Insert(config.Project, databaseName, &user).Do()
+					if err != nil {
+						t.Errorf("Error while inserting root@%% user: %s", err)
+						return
+					}
+					err = sqlAdminOperationWaitTime(config, op, config.Project, "Waiting for user to insert", config.userAgent, 10 * time.Minute)
+					if err != nil {
+						t.Errorf("Error while waiting for user insert operation to complete: %s", err.Error())
+					}
+				},
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone_withSettings(databaseName, networkName, addressName),
+				ExpectError: regexp.MustCompile("Error, failed to update instance settings"),
+			},
+			{
+				// This PreConfig does a check on the previous step. It is needed because the
+				// previous step expects an error, so it cannot perform a check of its own.
+				PreConfig: func() {
+					var s *terraform.State
+					err := testAccCheckGoogleSqlDatabaseRootUserDoesNotExist(t, databaseName + "-clone1")(s)
+					if err != nil {
+						t.Errorf("Failed to verify that root user was removed: %s", err)
+					}
+				},
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone_withSettings(databaseName, networkName, addressName),
+				PlanOnly: true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_settings_basic(t *testing.T) {
 	t.Parallel()
 
@@ -1881,6 +1949,67 @@ resource "google_sql_database_instance" "clone1" {
     allocated_ip_range   = google_compute_global_address.foobar.name
   }
 
+}
+`, networkName, addressRangeName, databaseName, databaseName)
+}
+
+func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone_withSettings(databaseName, networkName, addressRangeName string) string {
+	return fmt.Sprintf(`
+data "google_compute_network" "servicenet" {
+  name                    = "%s"
+}
+
+resource "google_compute_global_address" "foobar" {
+  name          = "%s"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.servicenet.self_link
+}
+
+resource "google_service_networking_connection" "foobar" {
+  network                 = data.google_compute_network.servicenet.self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.foobar.name]
+}
+
+resource "google_sql_database_instance" "instance" {
+  depends_on = [google_service_networking_connection.foobar]
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled       = "false"
+      private_network    = data.google_compute_network.servicenet.self_link
+    }
+    backup_configuration {
+      enabled            = true
+      start_time         = "00:00"
+      binary_log_enabled = true
+    }
+  }
+}
+
+resource "google_sql_database_instance" "clone1" {
+  name                = "%s-clone1"
+  region              = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+
+  clone {
+    source_instance_name = google_sql_database_instance.instance.name
+    allocated_ip_range   = google_compute_global_address.foobar.name
+  }
+
+  settings {
+	tier = "db-f1-micro"
+	backup_configuration {
+		enabled = false
+	}
+  }
 }
 `, networkName, addressRangeName, databaseName, databaseName)
 }

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -2005,10 +2005,10 @@ resource "google_sql_database_instance" "clone1" {
   }
 
   settings {
-	tier = "db-f1-micro"
-	backup_configuration {
-		enabled = false
-	}
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled = false
+    }
   }
 }
 `, networkName, addressRangeName, databaseName, databaseName)


### PR DESCRIPTION
b/254877908

This fixes a bug where a root user without a password would sometimes remain on an `sql_database_instance` after creation, creating a security risk. The logic in the provider is meant to remove this root user at the end of the creation function, but if there is a failure before then, the instance is still created but the root user remains.

The fix here simply performs the root user removal earlier, so that it is done as soon as it is not longer needed. This eliminates a subset of failure modes that would have left the root user on the instance. I believe this is the best we can do for now, short of more elaborate retry logic.

For testing, it was very difficult to come up with a test that would verify this problem has been resolved, because triggering arbitrary errors is nontrivial, and our test harness does not offer a clean way to check the state of the environment after an error occurs. I've come up with work-arounds to produce a test that I believe is adequate here.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed `sql_database_instance` leaking root users
```
