### PR TITLE
Cloud SQL - Change bucket field to optional in sql_server_audit_config

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -154,7 +154,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"domain": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
 										Description: `Domain name of the Active Directory for SQL Server (e.g., mydomain.com).`,
 									},
 								},
@@ -193,7 +193,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"bucket": {
 										Type:         schema.TypeString,
-										Required:     true,
+										Optional:     true,
 										Description:  `The name of the destination bucket (e.g., gs://mybucket).`,
 									},
 									"retention_interval": {

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -84,6 +84,12 @@ var (
 		"settings.0.insights_config.0.record_client_address",
 		"settings.0.insights_config.0.query_plans_per_minute",
   }
+
+	sqlServerAuditConfigurationKeys = []string{
+		"settings.0.sql_server_audit_config.0.bucket",
+		"settings.0.sql_server_audit_config.0.retention_interval",
+		"settings.0.sql_server_audit_config.0.upload_interval",
+  }
 )
 
 func resourceSqlDatabaseInstance() *schema.Resource {
@@ -194,16 +200,19 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 									"bucket": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										AtLeastOneOf: sqlServerAuditConfigurationKeys,
 										Description:  `The name of the destination bucket (e.g., gs://mybucket).`,
 									},
 									"retention_interval": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										AtLeastOneOf: sqlServerAuditConfigurationKeys,
 										Description:  `How long to keep generated audit files. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s"..`,
 									},
 									"upload_interval": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										AtLeastOneOf: sqlServerAuditConfigurationKeys,
 										Description:  `How often to upload generated audit files. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".`,
 		 							},
 								},
@@ -1269,10 +1278,9 @@ func expandBackupRetentionSettings(configured interface{}) *sqladmin.BackupReten
 
 func expandActiveDirectoryConfig(configured interface{}) *sqladmin.SqlActiveDirectoryConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-
 	config := l[0].(map[string]interface{})
 	return &sqladmin.SqlActiveDirectoryConfig{
 		Domain: config["domain"].(string),

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -160,7 +160,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"domain": {
 										Type:        schema.TypeString,
-										Optional:    true,
+										Required:    true,
 										Description: `Domain name of the Active Directory for SQL Server (e.g., mydomain.com).`,
 									},
 								},
@@ -1278,9 +1278,10 @@ func expandBackupRetentionSettings(configured interface{}) *sqladmin.BackupReten
 
 func expandActiveDirectoryConfig(configured interface{}) *sqladmin.SqlActiveDirectoryConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 || l[0] == nil {
+	if len(l) == 0 {
 		return nil
 	}
+
 	config := l[0].(map[string]interface{})
 	return &sqladmin.SqlActiveDirectoryConfig{
 		Domain: config["domain"].(string),

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1154,6 +1154,42 @@ func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_ActiveDirectoryEmptyConfig(t *testing.T) {
+	t.Parallel()
+	sqlServerDatabaseName := "tf-test-" + randString(t, 10)
+	mySqlDatabaseName := "tf-test-" + randString(t, 10)
+	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private-test-ad")
+	addressName := "tf-test-" + randString(t, 10)
+	rootPassword := randString(t, 15)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(sqlServerDatabaseName, networkName, addressName, rootPassword),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.sqlserver-empty-ad",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
+			},
+			{
+				Config: testGoogleMySqlDatabaseInstance_ActiveDirectoryEmptyConfig(mySqlDatabaseName),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.mysql-empty-ad",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
+			},
+		},
+	})
+}
+
+
 func TestAccSQLDatabaseInstance_DenyMaintenancePeriod(t* testing.T){
 	t.Parallel()
 	databaseName := "tf-test-" + randString(t,10)
@@ -1201,7 +1237,7 @@ func TestAccSqlDatabaseInstance_SqlServerAuditConfig(t *testing.T) {
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval),
+				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval, false /*omitBucketField*/),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1210,7 +1246,17 @@ func TestAccSqlDatabaseInstance_SqlServerAuditConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketNameUpdate, uploadIntervalUpdate, retentionIntervalUpdate),
+				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketNameUpdate, uploadIntervalUpdate, retentionIntervalUpdate, false /*omitBucketField*/),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
+			},
+			{
+			  // No bucket field in sql_server_audit_config.
+				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval, true /*omitBucketField*/),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1436,6 +1482,62 @@ resource "google_sql_database_instance" "instance-with-ad" {
 }`, networkName, addressRangeName, databaseName, rootPassword, adDomainName)
 }
 
+func testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName, networkName, addressRangeName, rootPassword string) string {
+	return fmt.Sprintf(`
+data "google_compute_network" "servicenet" {
+  name                    = "%s"
+}
+
+resource "google_compute_global_address" "foobar" {
+  name          = "%s"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.servicenet.self_link
+}
+
+resource "google_service_networking_connection" "foobar" {
+  network                 = data.google_compute_network.servicenet.self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.foobar.name]
+}
+
+resource "google_sql_database_instance" "sqlserver-empty-ad" {
+  depends_on = [google_service_networking_connection.foobar]
+  name             = "%s"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password    = "%s"
+  deletion_protection = false
+  settings {
+    tier = "db-custom-2-7680"
+    ip_configuration {
+      ipv4_enabled       = "false"
+      private_network    = data.google_compute_network.servicenet.self_link
+    }
+
+    active_directory_config {}
+  }
+}`, networkName, addressRangeName, databaseName, rootPassword)
+}
+
+func testGoogleMySqlDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName string) string {
+	return fmt.Sprintf(`
+	resource "google_sql_database_instance" "mysql-empty-ad" {
+  name                = "%s"
+  database_version    = "MYSQL_5_7"
+  region              = "us-central1"
+  deletion_protection = false
+  encryption_key_name = google_kms_crypto_key.key.id
+
+  settings {
+    tier = "db-n1-standard-1"
+		active_directory_config {}
+  }
+}
+}`, databaseName)
+}
+
 func testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig(databaseName, endDate, startDate, time string) string {
 	return fmt.Sprintf(`
 
@@ -1455,7 +1557,13 @@ resource "google_sql_database_instance" "instance" {
 }`, databaseName, endDate, startDate, time)
 }
 
-func testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval string) string {
+func testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval string, omitBucketField bool) string {
+	auditConfig := fmt.Sprintf(`retention_interval = "%s"
+                upload_interval = "%s"
+               `, retentionInterval, uploadInterval)
+	if !omitBucketField {
+		auditConfig += fmt.Sprintf(`bucket = "gs://%s"`, bucketName)
+	}
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "gs-bucket" {
   name                      	= "%s"
@@ -1495,13 +1603,11 @@ resource "google_sql_database_instance" "instance" {
       private_network    = data.google_compute_network.servicenet.self_link
     }
     sql_server_audit_config {
-      bucket = "gs://%s"
-      retention_interval = "%s"
-      upload_interval = "%s"
+      %s
     }
   }
 }
-`, bucketName, networkName, addressName, databaseName, rootPassword, bucketName, retentionInterval, uploadInterval)
+`, bucketName, networkName, addressName, databaseName, rootPassword, auditConfig)
 }
 
 func testGoogleSqlDatabaseInstance_Timezone(networkName, addressName, databaseName, rootPassword, timezone string) string {

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1156,11 +1156,8 @@ func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 
 func TestAccSqlDatabaseInstance_ActiveDirectoryEmptyConfig(t *testing.T) {
 	t.Parallel()
-	sqlServerDatabaseName := "tf-test-" + randString(t, 10)
-	mySqlDatabaseName := "tf-test-" + randString(t, 10)
-	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private-test-ad")
-	addressName := "tf-test-" + randString(t, 10)
 	rootPassword := randString(t, 15)
+	sqlServerDatabaseName := "tf-test-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1168,22 +1165,13 @@ func TestAccSqlDatabaseInstance_ActiveDirectoryEmptyConfig(t *testing.T) {
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(sqlServerDatabaseName, networkName, addressName, rootPassword),
+				Config: testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(sqlServerDatabaseName, rootPassword),
 			},
 			{
-				ResourceName:      "google_sql_database_instance.sqlserver-empty-ad",
+				ResourceName:      "google_sql_database_instance.instance",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
-			},
-			{
-				Config: testGoogleMySqlDatabaseInstance_ActiveDirectoryEmptyConfig(mySqlDatabaseName),
-			},
-			{
-				ResourceName:      "google_sql_database_instance.mysql-empty-ad",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection", "active_directory_config"},
 			},
 		},
 	})
@@ -1482,60 +1470,35 @@ resource "google_sql_database_instance" "instance-with-ad" {
 }`, networkName, addressRangeName, databaseName, rootPassword, adDomainName)
 }
 
-func testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName, networkName, addressRangeName, rootPassword string) string {
+func testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName, rootPassword string) string {
 	return fmt.Sprintf(`
-data "google_compute_network" "servicenet" {
-  name                    = "%s"
-}
-
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
-resource "google_sql_database_instance" "sqlserver-empty-ad" {
-  depends_on = [google_service_networking_connection.foobar]
-  name             = "%s"
-  region           = "us-central1"
-  database_version = "SQLSERVER_2017_STANDARD"
-  root_password    = "%s"
-  deletion_protection = false
-  settings {
-    tier = "db-custom-2-7680"
-    ip_configuration {
-      ipv4_enabled       = "false"
-      private_network    = data.google_compute_network.servicenet.self_link
-    }
-
-    active_directory_config {}
-  }
-}`, networkName, addressRangeName, databaseName, rootPassword)
+	resource "google_sql_database_instance" "instance" {
+		name                = "%s"
+		database_version    = "SQLSERVER_2019_STANDARD"
+		root_password       = "%s"
+		deletion_protection = false
+		settings {
+			tier = "db-custom-1-3840"
+			active_directory_config {}
+		}
+	}`, databaseName, rootPassword)
 }
 
 func testGoogleMySqlDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName string) string {
 	return fmt.Sprintf(`
-	resource "google_sql_database_instance" "mysql-empty-ad" {
-  name                = "%s"
-  database_version    = "MYSQL_5_7"
-  region              = "us-central1"
-  deletion_protection = false
-  encryption_key_name = google_kms_crypto_key.key.id
+		resource "google_sql_database_instance" "instance" {
+		name                = "%s"
+		database_version    = "MYSQL_5_7"
+		region              = "us-central1"
+		deletion_protection = false
 
-  settings {
-    tier = "db-n1-standard-1"
-		active_directory_config {}
-  }
-}
-}`, databaseName)
+		settings {
+			tier = "db-f1-micro"
+			active_directory_config {
+				domain = "testdomain.com"
+			}
+		}
+	}`, databaseName)
 }
 
 func testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig(databaseName, endDate, startDate, time string) string {

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1201,7 +1201,7 @@ func TestAccSqlDatabaseInstance_SqlServerAuditConfig(t *testing.T) {
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval, false /*omitBucketField*/),
+				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1210,7 +1210,7 @@ func TestAccSqlDatabaseInstance_SqlServerAuditConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketNameUpdate, uploadIntervalUpdate, retentionIntervalUpdate, false /*omitBucketField*/),
+				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketNameUpdate, uploadIntervalUpdate, retentionIntervalUpdate),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1218,9 +1218,24 @@ func TestAccSqlDatabaseInstance_SqlServerAuditConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection"},
 			},
+		},
+	})
+}
+
+func TestAccSqlDatabaseInstance_SqlServerAuditOptionalBucket(t *testing.T) {
+	t.Parallel()
+	databaseName := "tf-test-" + randString(t, 10)
+	rootPassword := randString(t, 15)
+	uploadInterval := "900s"
+	retentionInterval := "86400s"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
-			  // No bucket field in sql_server_audit_config.
-				Config: testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval, true /*omitBucketField*/),
+				Config: testGoogleSqlDatabaseInstance_SqlServerAuditOptionalBucket(databaseName, rootPassword, uploadInterval, retentionInterval),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1465,13 +1480,7 @@ resource "google_sql_database_instance" "instance" {
 }`, databaseName, endDate, startDate, time)
 }
 
-func testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval string, omitBucketField bool) string {
-	auditConfig := fmt.Sprintf(`retention_interval = "%s"
-                upload_interval = "%s"
-               `, retentionInterval, uploadInterval)
-	if !omitBucketField {
-		auditConfig += fmt.Sprintf(`bucket = "gs://%s"`, bucketName)
-	}
+func testGoogleSqlDatabaseInstance_SqlServerAuditConfig(networkName, addressName, databaseName, rootPassword, bucketName, uploadInterval, retentionInterval string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "gs-bucket" {
   name                      	= "%s"
@@ -1511,11 +1520,32 @@ resource "google_sql_database_instance" "instance" {
       private_network    = data.google_compute_network.servicenet.self_link
     }
     sql_server_audit_config {
-      %s
+      bucket = "gs://%s"
+      retention_interval = "%s"
+      upload_interval = "%s"
     }
   }
 }
-`, bucketName, networkName, addressName, databaseName, rootPassword, auditConfig)
+`, bucketName, networkName, addressName, databaseName, rootPassword, bucketName, retentionInterval, uploadInterval)
+}
+
+func testGoogleSqlDatabaseInstance_SqlServerAuditOptionalBucket(databaseName, rootPassword, uploadInterval, retentionInterval string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "%s"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2017_STANDARD"
+  root_password    = "%s"
+  deletion_protection = false
+  settings {
+    tier = "db-custom-1-3840"
+    sql_server_audit_config {
+      retention_interval = "%s"
+      upload_interval = "%s"
+    }
+  }
+}
+`, databaseName, rootPassword, retentionInterval, uploadInterval)
 }
 
 func testGoogleSqlDatabaseInstance_Timezone(networkName, addressName, databaseName, rootPassword, timezone string) string {

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1154,30 +1154,6 @@ func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 	})
 }
 
-func TestAccSqlDatabaseInstance_ActiveDirectoryEmptyConfig(t *testing.T) {
-	t.Parallel()
-	rootPassword := randString(t, 15)
-	sqlServerDatabaseName := "tf-test-" + randString(t, 10)
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(sqlServerDatabaseName, rootPassword),
-			},
-			{
-				ResourceName:      "google_sql_database_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"root_password", "deletion_protection", "active_directory_config"},
-			},
-		},
-	})
-}
-
-
 func TestAccSQLDatabaseInstance_DenyMaintenancePeriod(t* testing.T){
 	t.Parallel()
 	databaseName := "tf-test-" + randString(t,10)
@@ -1468,37 +1444,6 @@ resource "google_sql_database_instance" "instance-with-ad" {
     }
   }
 }`, networkName, addressRangeName, databaseName, rootPassword, adDomainName)
-}
-
-func testGoogleSqlServerDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName, rootPassword string) string {
-	return fmt.Sprintf(`
-	resource "google_sql_database_instance" "instance" {
-		name                = "%s"
-		database_version    = "SQLSERVER_2019_STANDARD"
-		root_password       = "%s"
-		deletion_protection = false
-		settings {
-			tier = "db-custom-1-3840"
-			active_directory_config {}
-		}
-	}`, databaseName, rootPassword)
-}
-
-func testGoogleMySqlDatabaseInstance_ActiveDirectoryEmptyConfig(databaseName string) string {
-	return fmt.Sprintf(`
-		resource "google_sql_database_instance" "instance" {
-		name                = "%s"
-		database_version    = "MYSQL_5_7"
-		region              = "us-central1"
-		deletion_protection = false
-
-		settings {
-			tier = "db-f1-micro"
-			active_directory_config {
-				domain = "testdomain.com"
-			}
-		}
-	}`, databaseName)
 }
 
 func testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig(databaseName, endDate, startDate, time string) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -264,7 +264,7 @@ The optional `settings.database_flags` sublist supports:
 
 The optional `settings.active_directory_config` subblock supports:
 
-* `domain` - (Required) The domain name for the active directory (e.g., mydomain.com).
+* `domain` - (Optional) The domain name for the active directory (e.g., mydomain.com).
     Can only be used with SQL Server.
 
 The optional `settings.deny_maintenance_period` subblock supports:
@@ -277,7 +277,7 @@ The optional `settings.deny_maintenance_period` subblock supports:
 
 The optional `settings.sql_server_audit_config` subblock supports:
 
-* `bucket` - (Required) The name of the destination bucket (e.g., gs://mybucket).
+* `bucket` - (Optional) The name of the destination bucket (e.g., gs://mybucket).
 
 * `upload_interval` - (Optional) How often to upload generated audit files. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -264,7 +264,7 @@ The optional `settings.database_flags` sublist supports:
 
 The optional `settings.active_directory_config` subblock supports:
 
-* `domain` - (Optional) The domain name for the active directory (e.g., mydomain.com).
+* `domain` - (Required) The domain name for the active directory (e.g., mydomain.com).
     Can only be used with SQL Server.
 
 The optional `settings.deny_maintenance_period` subblock supports:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This change updates the bucket field in sql_server_audit_config to optional to sync with the API.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: made `settings.sql_server_audit_config.bucket` field in `google_sql_database_instance` to be optional.
```
