### PR TITLE
Update ldflags in .goreleaser.yml.erb so user agent is set correctly in future releases

### DIFF
--- a/mmv1/third_party/terraform/.goreleaser.yml.erb
+++ b/mmv1/third_party/terraform/.goreleaser.yml.erb
@@ -30,7 +30,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X version.ProviderVersion={{.Version}}
+      - -s -w -X github.com/hashicorp/terraform-provider-google/version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   extra_files:

--- a/mmv1/third_party/terraform/.goreleaser.yml.erb
+++ b/mmv1/third_party/terraform/.goreleaser.yml.erb
@@ -30,7 +30,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X github.com/hashicorp/terraform-provider-google/version.ProviderVersion={{.Version}}
+      - -s -w -X github.com/hashicorp/terraform-provider-google<%= "-" + version unless version == 'ga' -%>/version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   extra_files:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Repeating the changes in this TPG PR [#13197](https://github.com/hashicorp/terraform-provider-google/pull/13197) (and equiv in TPGB). I didn't realise that those files were defined in MM and would get overwritten 😅 

~~**Not sure how this file is used between TPG and TPGB** - if it's used exactly the same for both then we need to add some templating to make sure the correct repo names are included in the final files~~

I added templating so that the correct path is set in both downstreams


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] ~~Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).~~
- [x] ~~[Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.~~
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~
- [x] ~~[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~
- [x] ~~Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.~~

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
