### PR TITLE
Added MD5 authentication support to the google_compute_router_peer resource

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -616,7 +616,7 @@ objects:
       min_version: beta
       exclude: false
       parent_resource_attribute: 'name'
-      import_format: ["projects/{{project}}/global/backendBuckets/{{name}}", "{{name}}"]    
+      import_format: ["projects/{{project}}/global/backendBuckets/{{name}}", "{{name}}"]
     properties:
       - !ruby/object:Api::Type::String
         name: 'bucketName'
@@ -711,7 +711,7 @@ objects:
           send_empty_value: true
           description: |
             Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
-        - !ruby/object:Api::Type::Boolean        
+        - !ruby/object:Api::Type::Boolean
           name: 'requestCoalescing'
           send_empty_value: true
           description: |
@@ -720,7 +720,7 @@ objects:
           name: 'bypassCacheOnRequestHeaders'
           description: |
             Bypass the cache when the specified request headers are matched - e.g. Pragma or Authorization headers. Up to 5 headers can be specified. The cache is bypassed for all cdnPolicy.cacheMode settings.
-          max_size: 5  
+          max_size: 5
           item_type: !ruby/object:Api::Type::NestedObject
             properties:
               - !ruby/object:Api::Type::String
@@ -4173,10 +4173,10 @@ objects:
         name: 'serviceDirectoryRegistrations'
         description: |
           Service Directory resources to register this forwarding rule with. Currently,
-          only supports a single Service Directory resource.  
+          only supports a single Service Directory resource.
         min_size: 0
         max_size: 1
-        input: true         
+        input: true
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String
@@ -8195,16 +8195,16 @@ objects:
       - !ruby/object:Api::Type::Boolean
         name: 'enableUlaInternalIpv6'
         description: |
-          Enable ULA internal ipv6 on this network. Enabling this feature will assign 
+          Enable ULA internal ipv6 on this network. Enabling this feature will assign
           a /48 from google defined ULA prefix fd20::/20.
         input: true
       - !ruby/object:Api::Type::String
         name: 'internalIpv6Range'
         description: |
-          When enabling ula internal ipv6, caller optionally can specify the /48 range 
-          they want from the google defined ULA prefix fd20::/20. The input must be a 
-          valid /48 ULA IPv6 address and must be within the fd20::/20. Operation will 
-          fail if the speficied /48 is already in used by another resource. 
+          When enabling ula internal ipv6, caller optionally can specify the /48 range
+          they want from the google defined ULA prefix fd20::/20. The input must be a
+          valid /48 ULA IPv6 address and must be within the fd20::/20. Operation will
+          fail if the speficied /48 is already in used by another resource.
           If the field is not speficied, then a /48 range will be randomly allocated from fd20::/20 and returned via this field.
         input: true
   - !ruby/object:Api::Resource
@@ -13483,8 +13483,8 @@ objects:
               - !ruby/object:Api::Type::String
                 name: 'chainName'
                 description: |
-                  Creates the new snapshot in the snapshot chain labeled with the 
-                  specified name. The chain name must be 1-63 characters long and comply 
+                  Creates the new snapshot in the snapshot chain labeled with the
+                  specified name. The chain name must be 1-63 characters long and comply
                   with RFC1035.
       - !ruby/object:Api::Type::NestedObject
         name: 'groupPlacementPolicy'
@@ -13910,6 +13910,25 @@ objects:
           Interconnect Attachment (IPsec-encrypted Cloud Interconnect feature).
 
           Not currently available publicly.
+      - !ruby/object:Api::Type::Array
+        name: md5AuthenticationKeys
+        description: |
+          An array of MD5 keys that are provided for MD5 authentication.
+        send_empty_value: false
+        item_type: !ruby/object:Api::Type::NestedObject
+            properties:
+              - !ruby/object:Api::Type::String
+                name: name
+                required: true
+                description: |
+                  Must be unique within a router. Must be referenced by at least one bgpPeer.
+                  Must comply with RFC1035.
+              - !ruby/object:Api::Type::String
+                name: key
+                description: |
+                  For patch and update calls, it can be skipped to copy the value from the previous configuration.
+                  This is allowed if the key with the same name existed before the operation.
+                  Maximum length is 80 characters. Can only contain printable ASCII characters.
   - !ruby/object:Api::Resource
     name: 'RouterNat'
     base_url: projects/{{project}}/regions/{{region}}/routers/{{router}}
@@ -14274,6 +14293,11 @@ objects:
           IP address of the BGP interface outside Google Cloud Platform.
           Only IPv4 is supported.
         required: true
+      - !ruby/object:Api::Type::String
+        name: 'md5AuthenticationKeyName'
+        description: |
+          Present if MD5 authentication is enabled for the peering. Must be
+          the name of one of the entries in the Router.md5_authentication_keys array.
       - !ruby/object:Api::Type::Integer
         name: 'peerAsn'
         description: |
@@ -14515,7 +14539,7 @@ objects:
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       exclude: false
       parent_resource_attribute: 'name'
-      import_format: ["projects/{{project}}/global/snapshots/{{name}}", "{{name}}"]      
+      import_format: ["projects/{{project}}/global/snapshots/{{name}}", "{{name}}"]
     description: |
       Represents a Persistent Disk Snapshot resource.
 
@@ -14651,11 +14675,11 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'chainName'
         description: |
-          Creates the new snapshot in the snapshot chain labeled with the 
-          specified name. The chain name must be 1-63 characters long and 
-          comply with RFC1035. This is an uncommon option only for advanced 
-          service owners who needs to create separate snapshot chains, for 
-          example, for chargeback tracking.  When you describe your snapshot 
+          Creates the new snapshot in the snapshot chain labeled with the
+          specified name. The chain name must be 1-63 characters long and
+          comply with RFC1035. This is an uncommon option only for advanced
+          service owners who needs to create separate snapshot chains, for
+          example, for chargeback tracking.  When you describe your snapshot
           resource, this field is visible only if it has a non-empty value.
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -15999,7 +16023,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'certificateMap'
         description: |
-          A reference to the CertificateMap resource uri that identifies a certificate map 
+          A reference to the CertificateMap resource uri that identifies a certificate map
           associated with the given target proxy. This field can only be set for global target proxies.
           Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificateMaps/{resourceName}`.
         update_verb: :POST
@@ -16206,7 +16230,7 @@ objects:
         name: 'sslPolicy'
         resource: 'RegionSslPolicy'
         imports: 'selfLink'
-        min_version: beta 
+        min_version: beta
         description: |
           A reference to the Region SslPolicy resource that will be associated with
           the TargetHttpsProxy resource. If not set, the TargetHttpsProxy

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2595,18 +2595,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "my-network"
       - !ruby/object:Provider::Terraform::Examples
         name: "router_md5_authentication"
-        primary_resource_id: "peer"
-        vars:
-          router_name: "my-router"
-          peer_name: "my-router-peer"
-          network_name: "my-network"
-          interface_name: "interface-name"
-          subnetwork_name: "my-subnetwork"
-          vpn_tunnel_name: "my-vpn-tunnel"
-          vpn_gateway_name: "my-vpn-gateway"
-          ha_vpn_gateway_name: "my-ha-vpn-gateway"
-          md5_key1: "md5 original key 1"
-          md5_key2: "md5 original key 2"
       - !ruby/object:Provider::Terraform::Examples
         name: "compute_router_encrypted_interconnect"
         primary_resource_id: "encrypted-interconnect-router"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2594,6 +2594,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           router_name: "my-router"
           network_name: "my-network"
       - !ruby/object:Provider::Terraform::Examples
+        name: "router_md5_authentication"
+        primary_resource_id: "peer"
+        vars:
+          router_name: "my-router"
+          peer_name: "my-router-peer"
+          network_name: "my-network"
+          interface_name: "interface-name"
+          subnetwork_name: "my-subnetwork"
+          vpn_tunnel_name: "my-vpn-tunnel"
+          vpn_gateway_name: "my-vpn-gateway"
+          ha_vpn_gateway_name: "my-ha-vpn-gateway"
+          md5_key1: "md5 original key 1"
+          md5_key2: "md5 original key 2"
+      - !ruby/object:Provider::Terraform::Examples
         name: "compute_router_encrypted_interconnect"
         primary_resource_id: "encrypted-interconnect-router"
         vars:

--- a/mmv1/templates/terraform/examples/router_md5_authentication.tf.erb
+++ b/mmv1/templates/terraform/examples/router_md5_authentication.tf.erb
@@ -1,78 +1,287 @@
-resource "google_compute_router" "default" {
-    name                        = "<%= ctx[:vars]['router_name'] %>"
-    network                     = google_compute_network.default.name
-    region                      = google_compute_subnetwork.default.region
-    encrypted_interconnect_router = true
-    bgp {
-        asn                     = 64514
-    }
-
-    md5_authentication_keys {
-        name                    = "<%= ctx[:vars]['md5_name1'] %>"
-        key                     = "key value for md5 entry 1"
-    }
-
-    md5_authentication_keys {
-        name                    = "<%= ctx[:vars]['md5_name2'] %>"
-        key                     = "key value for md5 entry 2"
-    }
-}
-
-resource "google_compute_router_peer" "<%= ctx[:primary_resource_id] %>" {
-    name                            = "<%= ctx[:vars]['peer_name'] %>"
-    router                          = google_compute_router.default.name
-    region                          = google_compute_router.default.region
-    ip_address                      = "169.254.3.1"
-    peer_ip_address                 = "169.254.3.2"
-    peer_asn                        = 65515
-    advertised_route_priority       = 100
-    interface                       = google_compute_router_interface.default.name
-    md5_authentication_key_name     = "key1"
-}
-
-resource "google_compute_network" "default" {
-  name                    = "<%= ctx[:vars]['network_name'] %>"
+resource "google_compute_network" "network_havpn_ic" {
+  name                    = "network-havpn-ic%{random_suffix}"
   auto_create_subnetworks = false
+  routing_mode            = "GLOBAL"
 }
 
-resource "google_compute_subnetwork" "default" {
-  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
-  network       = google_compute_network.default.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
+resource "google_compute_subnetwork" "subnet_havpn_ic" {
+  name          = "subnet-havpn-ic%{random_suffix}"
+  ip_cidr_range = "192.168.1.0/24"
+  network       = google_compute_network.network_havpn_ic.self_link
 }
 
-resource "google_compute_vpn_tunnel" "default" {
-  name                              = "<%= ctx[:vars]['vpn_tunnel_name'] %>"
-  region                            = google_compute_subnetwork.default.region
-  vpn_gateway                       = google_compute_ha_vpn_gateway.default.id
-  peer_external_gateway             = google_compute_external_vpn_gateway.default.id
-  peer_external_gateway_interface   = 0
-  shared_secret                     = "unguessable"
-  router                            = google_compute_router.default.name
-  vpn_gateway_interface             = 0
-}
-
-resource "google_compute_router_interface" "default" {
-  name                      = "<%= ctx[:vars]['interface_name'] %>"
-  router                    = google_compute_router.default.name
-  region                    = google_compute_router.default.region
-  ip_range                  = "169.254.3.1/30"
-  vpn_tunnel                = google_compute_vpn_tunnel.default.name
-}
-
-resource "google_compute_external_vpn_gateway" "default" {
-  name                      = "<%= ctx[:vars]['vpn_gateway_name'] %>"
-  redundancy_type           = "SINGLE_IP_INTERNALLY_REDUNDANT"
-  description               = "An externally managed VPN gateway"
-  interface {
-    id          = 0
-    ip_address  = "8.8.8.8"
+resource "google_compute_router" "ic_router" {
+  name                          = "ic-router%{random_suffix}"
+  network                       = google_compute_network.network_havpn_ic.self_link
+  encrypted_interconnect_router = true
+  bgp {
+    asn = 65000
   }
 }
 
-resource "google_compute_ha_vpn_gateway" "default" {
-  name    = "<%= ctx[:vars]['ha_vpn_gateway_name'] %>"
-  network = google_compute_network.default.self_link
-  region  = google_compute_subnetwork.default.region
+resource "google_compute_address" "address_vpn_ia_1" {
+  name          = "address-vpn-ia-1%{random_suffix}"
+  address_type  = "INTERNAL"
+  purpose       = "IPSEC_INTERCONNECT"
+  address       = "192.168.20.0"
+  prefix_length = 29 # Allows you to reserve up to 8 IP addresses
+  network       = google_compute_network.network_havpn_ic.self_link
 }
+
+resource "google_compute_address" "address_vpn_ia_2" {
+  name          = "address-vpn-ia-2-%{random_suffix}"
+  address_type  = "INTERNAL"
+  purpose       = "IPSEC_INTERCONNECT"
+  address       = "192.168.21.0"
+  prefix_length = 29 # Allows you to reserve up to 8 IP addresses
+  network       = google_compute_network.network_havpn_ic.self_link
+}
+
+data "google_project" "project" {
+}
+
+resource "google_compute_interconnect_attachment" "ia_1" {
+  name    = "ia-1-%{random_suffix}"
+  project = data.google_project.project.project_id
+  router  = google_compute_router.ic_router.self_link
+  # If you use the same project for your Dedicated Interconnect connection and attachments, you can keep the variable in the following URL.
+  # If not, replace the URL and variable.
+  interconnect = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.project_id}/global/interconnects/interconnect-zone1"
+  description  = ""
+  bandwidth    = "BPS_5G"
+  type         = "DEDICATED"
+  encryption   = "IPSEC"
+  ipsec_internal_addresses = [
+    google_compute_address.address_vpn_ia_1.self_link,
+  ]
+  vlan_tag8021q = 2001
+}
+
+resource "google_compute_interconnect_attachment" "ia_2" {
+  name    = "ia-2-%{random_suffix}"
+  project = data.google_project.project.project_id
+  router  = google_compute_router.ic_router.self_link
+  # If you use the same project for your Dedicated Interconnect connection and attachments, you can keep the variable in the following URL.
+  # If not, replace the URL and variable.
+  interconnect = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.project_id}/global/interconnects/interconnect-zone2"
+  description  = ""
+  bandwidth    = "BPS_5G"
+  type         = "DEDICATED"
+  encryption   = "IPSEC"
+  ipsec_internal_addresses = [
+    google_compute_address.address_vpn_ia_2.self_link,
+  ]
+  vlan_tag8021q = 2002
+}
+
+resource "google_compute_router_interface" "ic_if_1" {
+  name                    = "ic-if-1-%{random_suffix}"
+  router                  = google_compute_router.ic_router.name
+  ip_range                = google_compute_interconnect_attachment.ia_1.cloud_router_ip_address
+  interconnect_attachment = google_compute_interconnect_attachment.ia_1.self_link
+}
+
+resource "google_compute_router_interface" "ic_if_2" {
+  name                    = "ic-if-2-%{random_suffix}"
+  router                  = google_compute_router.ic_router.name
+  ip_range                = google_compute_interconnect_attachment.ia_2.cloud_router_ip_address
+  interconnect_attachment = google_compute_interconnect_attachment.ia_2.self_link
+}
+
+resource "google_compute_router_peer" "ic_peer_1" {
+  name            = "ic-peer-1-%{random_suffix}"
+  router          = google_compute_router.ic_router.name
+  peer_ip_address = trimsuffix(google_compute_interconnect_attachment.ia_1.customer_router_ip_address, "/29")
+  interface       = google_compute_router_interface.ic_if_1.name
+  peer_asn        = 65098
+}
+
+resource "google_compute_router_peer" "ic_peer_2" {
+  name            = "ic-peer-2-%{random_suffix}"
+  router          = google_compute_router.ic_router.name
+  peer_ip_address = trimsuffix(google_compute_interconnect_attachment.ia_2.customer_router_ip_address, "/29")
+  interface       = google_compute_router_interface.ic_if_2.name
+  peer_asn        = 65099
+}
+
+resource "google_compute_ha_vpn_gateway" "vpngw_1" {
+  name    = "vpngw-1-%{random_suffix}"
+  network = google_compute_network.network_havpn_ic.id
+  vpn_interfaces {
+    id                      = 0
+    interconnect_attachment = google_compute_interconnect_attachment.ia_1.self_link
+  }
+  vpn_interfaces {
+    id                      = 1
+    interconnect_attachment = google_compute_interconnect_attachment.ia_2.self_link
+  }
+}
+
+resource "google_compute_ha_vpn_gateway" "vpngw_2" {
+  name    = "vpngw-2-%{random_suffix}"
+  network = google_compute_network.network_havpn_ic.id
+  vpn_interfaces {
+    id                      = 0
+    interconnect_attachment = google_compute_interconnect_attachment.ia_1.self_link
+  }
+  vpn_interfaces {
+    id                      = 1
+    interconnect_attachment = google_compute_interconnect_attachment.ia_2.self_link
+  }
+}
+
+resource "google_compute_external_vpn_gateway" "external_vpngw_1" {
+  name            = "external-vpngw-1-%{random_suffix}"
+  redundancy_type = "TWO_IPS_REDUNDANCY"
+  interface {
+    id         = 0
+    ip_address = "192.25.67.3"
+  }
+  interface {
+    id         = 1
+    ip_address = "192.25.67.4"
+  }
+}
+
+resource "google_compute_external_vpn_gateway" "external_vpngw_2" {
+  name            = "external-vpngw-2-%{random_suffix}"
+  redundancy_type = "TWO_IPS_REDUNDANCY"
+  interface {
+    id         = 0
+    ip_address = "192.25.68.5"
+  }
+  interface {
+    id         = 1
+    ip_address = "192.25.68.6"
+  }
+}
+
+resource "google_compute_router" "vpn_router" {
+  name    = "vpn-router-%{random_suffix}"
+  network = google_compute_network.network_havpn_ic.self_link
+  bgp {
+    asn = 65010
+  }
+
+  md5_authentication_keys {
+    name                    = "name1"
+    key                     = "shared key 1"
+  }
+  md5_authentication_keys {
+    name                    = "name2"
+    key                     = "shared key 2"
+  }
+  md5_authentication_keys {
+    name                    = "name2"
+    key                     = "shared key 2"
+  }
+  md5_authentication_keys {
+    name                    = "name3"
+    key                     = "shared key 3"
+  }
+}
+
+resource "google_compute_vpn_tunnel" "tunnel_1" {
+  name                            = "tunnel-1-%{random_suffix}"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.vpngw_1.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_vpngw_1.id
+  shared_secret                   = "shhhhh"
+  router                          = google_compute_router.vpn_router.id
+  vpn_gateway_interface           = 0
+  peer_external_gateway_interface = 0
+}
+
+resource "google_compute_vpn_tunnel" "tunnel_2" {
+  name                            = "tunnel-2-%{random_suffix}"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.vpngw_1.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_vpngw_1.id
+  shared_secret                   = "shhhhh"
+  router                          = google_compute_router.vpn_router.id
+  vpn_gateway_interface           = 1
+  peer_external_gateway_interface = 1
+}
+
+resource "google_compute_vpn_tunnel" "tunnel_3" {
+  name                            = "tunnel-3-%{random_suffix}"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.vpngw_2.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_vpngw_2.id
+  shared_secret                   = "shhhhh"
+  router                          = google_compute_router.vpn_router.id
+  vpn_gateway_interface           = 0
+  peer_external_gateway_interface = 0
+}
+
+resource "google_compute_vpn_tunnel" "tunnel_4" {
+  name                            = "tunnel-4-%{random_suffix}"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.vpngw_2.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_vpngw_2.id
+  shared_secret                   = "shhhhh"
+  router                          = google_compute_router.vpn_router.id
+  vpn_gateway_interface           = 1
+  peer_external_gateway_interface = 1
+}
+
+resource "google_compute_router_interface" "vpn_1_if_0" {
+  name       = "vpn-1-if-0-%{random_suffix}"
+  router     = google_compute_router.vpn_router.name
+  ip_range   = "169.254.1.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel_1.self_link
+}
+
+resource "google_compute_router_interface" "vpn_1_if_1" {
+  name       = "vpn-1-if-1-%{random_suffix}"
+  router     = google_compute_router.vpn_router.name
+  ip_range   = "169.254.2.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel_2.self_link
+}
+
+resource "google_compute_router_interface" "vpn_2_if_0" {
+  name       = "vpn-2-if-0-%{random_suffix}"
+  router     = google_compute_router.vpn_router.name
+  ip_range   = "169.254.3.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel_3.self_link
+}
+
+resource "google_compute_router_interface" "vpn_2_if_1" {
+  name       = "vpn-2-if-1-%{random_suffix}"
+  router     = google_compute_router.vpn_router.name
+  ip_range   = "169.254.4.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel_4.self_link
+}
+
+resource "google_compute_router_peer" "vpn_peer_1" {
+  name            = "vpn-peer-1-%{random_suffix}"
+  router          = google_compute_router.vpn_router.name
+  peer_ip_address = "169.254.1.2"
+  interface       = google_compute_router_interface.vpn_1_if_0.name
+  peer_asn        = 65011
+  md5_authentication_key_name     = google_compute_router.vpn_router.md5_authentication_keys[0].name
+}
+
+resource "google_compute_router_peer" "vpn_peer_2" {
+  name            = "vpn-peer-2-%{random_suffix}"
+  router          = google_compute_router.vpn_router.name
+  peer_ip_address = "169.254.2.2"
+  interface       = google_compute_router_interface.vpn_1_if_1.name
+  peer_asn        = 65011
+  md5_authentication_key_name     = google_compute_router.vpn_router.md5_authentication_keys[1].name
+}
+
+resource "google_compute_router_peer" "vpn_peer_3" {
+  name            = "vpn-peer-3-%{random_suffix}"
+  router          = google_compute_router.vpn_router.name
+  peer_ip_address = "169.254.3.2"
+  interface       = google_compute_router_interface.vpn_2_if_0.name
+  peer_asn        = 65034
+  md5_authentication_key_name     = google_compute_router.vpn_router.md5_authentication_keys[2].name
+}
+
+resource "google_compute_router_peer" "vpn_peer_4" {
+  name            = "vpn-peer-4-%{random_suffix}"
+  router          = google_compute_router.vpn_router.name
+  peer_ip_address = "169.254.4.2"
+  interface       = google_compute_router_interface.vpn_2_if_1.name
+  peer_asn        = 65034
+  md5_authentication_key_name     = google_compute_router.vpn_router.md5_authentication_keys[3].name
+}
+

--- a/mmv1/templates/terraform/examples/router_md5_authentication.tf.erb
+++ b/mmv1/templates/terraform/examples/router_md5_authentication.tf.erb
@@ -165,19 +165,19 @@ resource "google_compute_router" "vpn_router" {
 
   md5_authentication_keys {
     name                    = "name1"
-    key                     = "shared key 1"
+    key                     = "shared key 1-%{random_suffix}"
   }
   md5_authentication_keys {
     name                    = "name2"
-    key                     = "shared key 2"
-  }
-  md5_authentication_keys {
-    name                    = "name2"
-    key                     = "shared key 2"
+    key                     = "shared key 2-%{random_suffix}"
   }
   md5_authentication_keys {
     name                    = "name3"
-    key                     = "shared key 3"
+    key                     = "shared key 3-%{random_suffix}"
+  }
+  md5_authentication_keys {
+    name                    = "name4"
+    key                     = "shared key 4-%{random_suffix}"
   }
 }
 

--- a/mmv1/templates/terraform/examples/router_md5_authentication.tf.erb
+++ b/mmv1/templates/terraform/examples/router_md5_authentication.tf.erb
@@ -1,0 +1,78 @@
+resource "google_compute_router" "default" {
+    name                        = "<%= ctx[:vars]['router_name'] %>"
+    network                     = google_compute_network.default.name
+    region                      = google_compute_subnetwork.default.region
+    encrypted_interconnect_router = true
+    bgp {
+        asn                     = 64514
+    }
+
+    md5_authentication_keys {
+        name                    = "<%= ctx[:vars]['md5_name1'] %>"
+        key                     = "key value for md5 entry 1"
+    }
+
+    md5_authentication_keys {
+        name                    = "<%= ctx[:vars]['md5_name2'] %>"
+        key                     = "key value for md5 entry 2"
+    }
+}
+
+resource "google_compute_router_peer" "<%= ctx[:primary_resource_id] %>" {
+    name                            = "<%= ctx[:vars]['peer_name'] %>"
+    router                          = google_compute_router.default.name
+    region                          = google_compute_router.default.region
+    ip_address                      = "169.254.3.1"
+    peer_ip_address                 = "169.254.3.2"
+    peer_asn                        = 65515
+    advertised_route_priority       = 100
+    interface                       = google_compute_router_interface.default.name
+    md5_authentication_key_name     = "key1"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
+  network       = google_compute_network.default.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_vpn_tunnel" "default" {
+  name                              = "<%= ctx[:vars]['vpn_tunnel_name'] %>"
+  region                            = google_compute_subnetwork.default.region
+  vpn_gateway                       = google_compute_ha_vpn_gateway.default.id
+  peer_external_gateway             = google_compute_external_vpn_gateway.default.id
+  peer_external_gateway_interface   = 0
+  shared_secret                     = "unguessable"
+  router                            = google_compute_router.default.name
+  vpn_gateway_interface             = 0
+}
+
+resource "google_compute_router_interface" "default" {
+  name                      = "<%= ctx[:vars]['interface_name'] %>"
+  router                    = google_compute_router.default.name
+  region                    = google_compute_router.default.region
+  ip_range                  = "169.254.3.1/30"
+  vpn_tunnel                = google_compute_vpn_tunnel.default.name
+}
+
+resource "google_compute_external_vpn_gateway" "default" {
+  name                      = "<%= ctx[:vars]['vpn_gateway_name'] %>"
+  redundancy_type           = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description               = "An externally managed VPN gateway"
+  interface {
+    id          = 0
+    ip_address  = "8.8.8.8"
+  }
+}
+
+resource "google_compute_ha_vpn_gateway" "default" {
+  name    = "<%= ctx[:vars]['ha_vpn_gateway_name'] %>"
+  network = google_compute_network.default.self_link
+  region  = google_compute_subnetwork.default.region
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding support for the 'md5_authentication_key_name' field to the 'google_compute_router_peer' resource
Fixes hashicorp github issue https://github.com/hashicorp/terraform-provider-google/issues/13103
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added MD5 authentication support to `google_compute_router_peer`

```
