### PR TITLE
Local IP Range support in compute_firewall

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -3742,9 +3742,6 @@ objects:
           traffic that has destination IP address in these ranges. These ranges
           must be expressed in CIDR format. Only IPv4 is supported.
         item_type: Api::Type::String
-        conflicts:
-          - source_ranges
-          - source_tags
       - !ruby/object:Api::Type::Enum
         name: 'direction'
         description: |
@@ -3840,8 +3837,6 @@ objects:
           connection does not need to match both properties for the firewall to
           apply. Only IPv4 is supported. For INGRESS traffic, one of `source_ranges`,
           `source_tags` or `source_service_accounts` is required.
-        conflicts:
-          - destination_ranges
         item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'sourceServiceAccounts'
@@ -3879,7 +3874,6 @@ objects:
         item_type: Api::Type::String
         conflicts:
           - source_service_accounts
-          - destination_ranges
           - target_service_accounts
       - !ruby/object:Api::Type::Array
         name: 'targetServiceAccounts'

--- a/mmv1/third_party/terraform/tests/resource_compute_firewall_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_firewall_test.go.erb
@@ -48,6 +48,45 @@ func TestAccComputeFirewall_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeFirewall_localRanges(t *testing.T) {
+	t.Parallel()
+
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeFirewallDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeFirewall_localRanges(networkName, firewallName),
+			},
+			{
+				ResourceName:      "google_compute_firewall.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeFirewall_localRangesUpdate(networkName, firewallName),
+			},
+			{
+				ResourceName:      "google_compute_firewall.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeFirewall_localRanges(networkName, firewallName),
+			},
+			{
+				ResourceName:      "google_compute_firewall.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeFirewall_priority(t *testing.T) {
 	t.Parallel()
 
@@ -275,6 +314,53 @@ resource "google_compute_firewall" "foobar" {
   description = "Resource created for Terraform acceptance testing"
   network     = google_compute_network.foobar.name
   source_tags = ["foo"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+`, network, firewall)
+}
+
+func testAccComputeFirewall_localRanges(network, firewall string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_firewall" "foobar" {
+  name        = "%s"
+  description = "Resource created for Terraform acceptance testing"
+  network     = google_compute_network.foobar.name
+  source_tags = ["foo"]
+
+  source_ranges      = ["10.0.0.0/8"]
+  destination_ranges = ["192.168.1.0/24"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+`, network, firewall)
+}
+
+
+func testAccComputeFirewall_localRangesUpdate(network, firewall string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_firewall" "foobar" {
+  name        = "%s"
+  description = "Resource created for Terraform acceptance testing"
+  network     = google_compute_network.foobar.name
+  source_tags = ["foo"]
+
+  source_ranges      = ["192.168.1.0/24"]
+  destination_ranges = ["10.0.0.0/8"]
 
   allow {
     protocol = "icmp"


### PR DESCRIPTION
Remove conflicts between source/destination IP ranges from google_compute_firewall to support Local IP Range Support Preview.

Documentation of the feature: https://cloud.google.com/vpc/docs/firewall-policies-rule-details#targets_and_ips_ingress

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Add support for Local IP Ranges in `google_compute_firewall`
```
