### PR TITLE
Change the default for google_sql_database.deletion_policy to DELETE

### DIFF
--- a/mmv1/products/firebase/api.yaml
+++ b/mmv1/products/firebase/api.yaml
@@ -190,6 +190,7 @@ objects:
         path: 'error'
         message: 'message'
     parameters:
+      # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
       - !ruby/object:Api::Type::String
         name: 'deletion_policy'
         description: |
@@ -257,6 +258,7 @@ objects:
         path: 'error'
         message: 'message'
     parameters:
+      # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
       - !ruby/object:Api::Type::String
         name: 'deletion_policy'
         description: |

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -56,6 +56,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - project
           - deletion_policy
     virtual_fields:
+      # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
       - !ruby/object:Api::Type::String
         name: 'deletion_policy'
         description: |

--- a/mmv1/products/sql/terraform.yaml
+++ b/mmv1/products/sql/terraform.yaml
@@ -39,6 +39,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "sql_database_deletion_policy"
         primary_resource_id: "database_deletion_policy"
+        ignore_read_extra:
+          - "deletion_policy"
         vars:
           database_name: "my-database"
           database_instance_name: "my-database-instance"

--- a/mmv1/products/sql/terraform.yaml
+++ b/mmv1/products/sql/terraform.yaml
@@ -54,14 +54,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
         diff_suppress_func: 'caseDiffSuppress'
     virtual_fields:
+      # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
       - !ruby/object:Api::Type::String
         name: 'deletion_policy'
         description: |
           The deletion policy for the database. Setting ABANDON allows the resource 
           to be abandoned rather than deleted. This is useful for Postgres, where databases cannot be 
           deleted from the API if there are users other than cloudsqlsuperuser with access. Possible 
-          values are: "ABANDON".
-        default_value: "ABANDON"
+          values are: "ABANDON", "DELETE". Defaults to "DELETE".
+        default_value: "DELETE"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/sql_database_deletion_policy.erb
   SourceRepresentationInstance: !ruby/object:Overrides::Terraform::ResourceOverride


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13206

As mentioned in https://github.com/hashicorp/terraform-provider-google/issues/13206#issuecomment-1344615519, this change is technically a breaking change- but it's also fixing a regression in the resource, so it's being made in a minor version anyways. It will result in a diff, which I've called out in the changelog entry (intentionally included twice, as a bugfix and a note)

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # google_sql_database.database will be updated in-place
  ~ resource "google_sql_database" "database" {
      ~ deletion_policy = "ABANDON" -> "DELETE"
        id              = "projects/graphite-test-rileykarson/instances/myinstance/databases/mydb"
        name            = "mydb"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_sql_database.database: Modifying... [id=projects/myproject/instances/myinstance/databases/mydb]
google_sql_database.database: Modifications complete after 1s [id=projects/myproject/instances/myinstance/databases/mydb]
```

This wasn't caught by our tests because the testcheckdestroy runs after `terraform destroy`, and deleting the instance deleted the database.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
sql: fixed an issue where `google_sql_database` was abandoned by default as of version `4.45.0`. Users who have upgraded to `4.45.0` or `4.46.0` will see a diff when running their next `terraform apply` after upgrading this version, indicating the `deletion_policy` field's value has changed from `"ABANDON"` to `"DELETE"`. This will create a no-op call against the API, but can otherwise be safely applied.
```

```release-note:bug
sql: fixed an issue where `google_sql_database` was abandoned by default as of version `4.45.0`. Users who have upgraded to `4.45.0` or `4.46.0` will see a diff when running their next `terraform apply` after upgrading this version, indicating the `deletion_policy` field's value has changed from `"ABANDON"` to `"DELETE"`. This will create a no-op call against the API, but can otherwise be safely applied.
```
