### PR TITLE
[#13215] Make metric_descriptor argument optional for google_logging_metric

### DIFF
--- a/mmv1/products/logging/api.yaml
+++ b/mmv1/products/logging/api.yaml
@@ -69,8 +69,10 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: metricDescriptor
         description: |
-          The metric descriptor associated with the logs-based metric.
-        required: true
+           The optional metric descriptor associated with the logs-based metric.
+           If unspecified, it uses a default metric descriptor with a DELTA metric kind,
+           INT64 value type, with no labels and a unit of "1". Such a metric counts the
+           number of log entries matching the filter expression.
         properties:
           - !ruby/object:Api::Type::String
             name: unit

--- a/mmv1/products/logging/terraform.yaml
+++ b/mmv1/products/logging/terraform.yaml
@@ -43,6 +43,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
     properties:
+      metricDescriptor: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       metricDescriptor.type: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
       metricDescriptor.labels: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/logging_metric_logging_bucket.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_metric_logging_bucket.tf.erb
@@ -8,10 +8,4 @@ resource "google_logging_metric" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]["logging_metric_name"] %>"
   filter      = "resource.type=gae_app AND severity>=ERROR"
   bucket_name = google_logging_project_bucket_config.<%= ctx[:primary_resource_id] %>.id
-
-  metric_descriptor {
-    metric_kind = "DELTA"
-    value_type  = "INT64"
-    unit        = "1"
-  }
 }

--- a/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_metric_test.go
@@ -173,12 +173,6 @@ func testAccLoggingMetric_loggingBucketBase(suffix string, filter string) string
 resource "google_logging_metric" "logging_metric" {
   name        = "my-custom-metric-%s"
   filter      = "%s"
-
-  metric_descriptor {
-    metric_kind = "DELTA"
-    unit        = "1"
-    value_type  = "INT64"
-  }
 }
 `, suffix, filter)
 }
@@ -195,12 +189,6 @@ resource "google_logging_metric" "logging_metric" {
   name        = "my-custom-metric-%s"
   bucket_name = google_logging_project_bucket_config.logging_bucket.id
   filter      = "%s"
-
-  metric_descriptor {
-    metric_kind = "DELTA"
-    unit        = "1"
-    value_type  = "INT64"
-  }
 }
 `, project_id, suffix, filter)
 }


### PR DESCRIPTION
Make metric_descriptor argument optional and computer for resource_logging_metric.
If not specified the field is automatically populated from Google APIs.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
logging: made `metric_descriptor` argument optional for `google_logging_metric`
```