### PR TITLE
[#12620] Allow gke nodepool labels to be updated

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -91,7 +91,7 @@ var (
 	}
 
 	forceNewClusterNodeConfigFields = []string{
-		"node_config.0.labels",
+		"labels",
 		"workload_metadata_config",
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -91,6 +91,7 @@ var (
 	}
 
 	forceNewClusterNodeConfigFields = []string{
+		"node_config.0.labels",
 		"workload_metadata_config",
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -1312,7 +1312,45 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 
 			log.Printf("[INFO] Updated resource labels for node pool %s", name)
 		}
-		
+
+		if d.HasChange(prefix + "node_config.0.labels") {
+			req := &container.UpdateNodePoolRequest{
+				Name: name,
+			}
+
+			if v, ok := d.GetOk(prefix + "node_config.0.labels"); ok {
+				labels := v.(map[string]interface{})
+				req.Labels = &container.NodeLabels{
+					Labels: convertStringMap(labels),
+				}
+			}
+				
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name), req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+	
+				// Wait until it's updated
+				return containerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool labels", userAgent,
+					timeout)
+			}
+
+			// Call update serially.
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+
+			log.Printf("[INFO] Updated labels for node pool %s", name)
+		}
+
 		if d.HasChange(prefix + "node_config.0.image_type") {
 			req := &container.UpdateClusterRequest{
 				Update: &container.ClusterUpdate{

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -5043,7 +5043,7 @@ resource "google_container_cluster" "with_sandbox_config" {
 
     labels = {
       "test.terraform.io/gke-sandbox" = "true"
-	  "test.terraform.io/gke-sandbox-amended" = "also-true"
+      "test.terraform.io/gke-sandbox-amended" = "also-true"
     }
 
     taint {

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1888,12 +1888,6 @@ resource "google_container_node_pool" "np_with_node_config" {
     ]
     preemptible      = true
     min_cpu_platform = "Intel Broadwell"
-	
-    tags = ["ga"]
-
-	resource_labels = {
-      "key1" = "value"
-    }
 
     taint {
       key    = "taint_key"
@@ -1909,6 +1903,16 @@ resource "google_container_node_pool" "np_with_node_config" {
 
     // Updatable fields
     image_type = "COS_CONTAINERD"
+
+    tags = ["foo"]
+
+    labels = {
+      "test.terraform.io/key1" = "foo"
+    }
+
+    resource_labels = {
+      "key1" = "foo"
+    }
   }
 }
 `, cluster, nodePool)
@@ -1939,13 +1943,6 @@ resource "google_container_node_pool" "np_with_node_config" {
     preemptible      = true
     min_cpu_platform = "Intel Broadwell"
 
-    tags = ["beta"]
-
-	resource_labels = {
-      "key1" = "value1"
-	  "key2" = "value2"
-    }
-
     taint {
       key    = "taint_key"
       value  = "taint_value"
@@ -1960,6 +1957,18 @@ resource "google_container_node_pool" "np_with_node_config" {
 
     // Updatable fields
     image_type = "UBUNTU_CONTAINERD"
+
+    tags = ["bar", "foobar"]
+
+    labels = {
+      "test.terraform.io/key1" = "bar"
+      "test.terraform.io/key2" = "foo"
+    }
+
+    resource_labels = {
+      "key1" = "bar"
+      "key2" = "foo"
+    }
   }
 }
 `, cluster, nodePool)

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -153,7 +153,6 @@ func schemaNodeConfig() *schema.Schema {
 					Optional: true,
 					// Computed=true because GKE Sandbox will automatically add labels to nodes that can/cannot run sandboxed pods.
 					Computed: true,
-					ForceNew: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 					Description: `The map of Kubernetes labels (key/value pairs) to be applied to each node. These will added in addition to any default label(s) that Kubernetes may apply to the node.`,
 	<% unless version.nil? || version == 'ga' -%>


### PR DESCRIPTION
Allow GKE nodepool labels to be updated without causing nodepools disruption.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
container: supported in-place update for `labels` in `google_container_node_pool`
```