### PR TITLE
allow multi-setting

### DIFF
--- a/mmv1/products/osconfig/api.yaml
+++ b/mmv1/products/osconfig/api.yaml
@@ -380,10 +380,6 @@ objects:
             properties:
              - !ruby/object:Api::Type::Array
               name: 'classifications'
-              exactly_one_of:
-                - patch_config.0.windows_update.0.classifications
-                - patch_config.0.windows_update.0.excludes
-                - patch_config.0.windows_update.0.exclusive_patches
               description: |
                 Only apply updates of these windows update classifications. If empty, all updates are applied.
               item_type: !ruby/object:Api::Type::Enum
@@ -401,19 +397,11 @@ objects:
                   - :UPDATE
              - !ruby/object:Api::Type::Array
               name: 'excludes'
-              exactly_one_of:
-                - patch_config.0.windows_update.0.classifications
-                - patch_config.0.windows_update.0.excludes
-                - patch_config.0.windows_update.0.exclusive_patches
               description: |
                 List of KBs to exclude from update.
               item_type: Api::Type::String
              - !ruby/object:Api::Type::Array
               name: 'exclusivePatches'
-              exactly_one_of:
-                - patch_config.0.windows_update.0.classifications
-                - patch_config.0.windows_update.0.excludes
-                - patch_config.0.windows_update.0.exclusive_patches
               description: |
                 An exclusive list of kbs to be updated. These are the only patches that will be updated.
                 This field must not be used with other patch configurations.

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -40,6 +40,7 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
 
     windows_update {
       classifications = ["CRITICAL", "SECURITY", "UPDATE"]
+      excludes = ["5012170"]
     }
 
     pre_step {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13158


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
osconfig: fixed no more than one setting is allowed under `patch_config.windows_update` on `google_os_config_patch_deployment`
```
