### PR TITLE
Adding 'state' and 'topicMessageRetentionDuration' output-only fields to google_pubsub_subscription resource

### DIFF
--- a/mmv1/products/pubsub/api.yaml
+++ b/mmv1/products/pubsub/api.yaml
@@ -394,6 +394,19 @@ objects:
 
           Note that subscribers may still receive multiple copies of a message when `enable_exactly_once_delivery`
           is true if the message was published multiple times by a publisher client. These copies are considered distinct by Pub/Sub and have distinct messageId values
+      - !ruby/object:Api::Type::String
+        name: 'topicMessageRetentionDuration'
+        output: true
+        description: |
+          Indicates the minimum duration for which a message is retained after it is published to the subscription's topic.
+          If this field is set, messages published to the subscription's topic in the last topicMessageRetentionDuration are always available to subscribers.
+          See the messageRetentionDuration field in Topic. This field is set only in responses from the server; it is ignored if it is set in any requests.
+          A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+      - !ruby/object:Api::Type::String
+        name: 'state'
+        output: true
+        description: |
+          An output-only field indicating whether or not the subscription can receive messages.
   - !ruby/object:Api::Resource
     name: 'Schema'
     input: true


### PR DESCRIPTION
part of https://github.com/hashicorp/terraform-provider-google/issues/12932

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: Added output only fields `state` and `topicMessageRetentionDuration` to `google_pubsub_subscription`
```
