### PR TITLE
send disable_auto_scheduling

### DIFF
--- a/mmv1/products/bigquerydatatransfer/api.yaml
+++ b/mmv1/products/bigquerydatatransfer/api.yaml
@@ -103,6 +103,7 @@ objects:
         properties:
           - !ruby/object:Api::Type::Boolean
             name: 'disableAutoScheduling'
+            send_empty_value: true
             description: |
               If true, automatic scheduling of data transfer runs for this
               configuration will be disabled. The runs can be started on ad-hoc

--- a/mmv1/products/bigquerydatatransfer/terraform.yaml
+++ b/mmv1/products/bigquerydatatransfer/terraform.yaml
@@ -37,6 +37,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           to a different credential configuration in the config will require an apply to update state.
       sensitiveParams.secretAccessKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
+      # api does not send schedule_options.disable_auto_scheduling back when it is set to false b/262259565
+      scheduleOptions: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'emptyOrUnsetBlockDiffSuppress'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       resource_definition: templates/terraform/resource_definition/bigquery_data_transfer.go.erb
       constants: templates/terraform/constants/bigquery_data_transfer.go.erb


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13221


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquerydatatransfer: fixed a bug when updating`schedule_options.disable_auto_scheduling` with false on `google_bigquery_data_transfer_config`
```
