### PR TITLE
Make storage transfer job schedule updatable

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -181,7 +181,6 @@ func resourceStorageTransferJob() *schema.Resource {
 						"schedule_start_date": {
 							Type:        schema.TypeList,
 							Required:    true,
-							ForceNew:    true,
 							MaxItems:    1,
 							Elem:        dateObjectSchema(),
 							Description: `The first day the recurring transfer is scheduled to run. If schedule_start_date is in the past, the transfer will run for the first time on the following day.`,
@@ -189,7 +188,6 @@ func resourceStorageTransferJob() *schema.Resource {
 						"schedule_end_date": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							ForceNew:    true,
 							MaxItems:    1,
 							Elem:        dateObjectSchema(),
 							Description: `The last day the recurring transfer will be run. If schedule_end_date is the same as schedule_start_date, the transfer will be executed only once.`,
@@ -197,7 +195,6 @@ func resourceStorageTransferJob() *schema.Resource {
 						"start_time_of_day": {
 							Type:             schema.TypeList,
 							Optional:         true,
-							ForceNew:         true,
 							MaxItems:         1,
 							Elem:             timeObjectSchema(),
 							DiffSuppressFunc: diffSuppressEmptyStartTimeOfDay,
@@ -334,28 +331,24 @@ func timeObjectSchema() *schema.Resource {
 			"hours": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(0, 24),
 				Description:  `Hours of day in 24 hour format. Should be from 0 to 23.`,
 			},
 			"minutes": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(0, 59),
 				Description:  `Minutes of hour of day. Must be from 0 to 59.`,
 			},
 			"seconds": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(0, 60),
 				Description:  `Seconds of minutes of the time. Must normally be from 0 to 59.`,
 			},
 			"nanos": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(0, 999999999),
 				Description:  `Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999.`,
 			},
@@ -369,7 +362,6 @@ func dateObjectSchema() *schema.Resource {
 			"year": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(0, 9999),
 				Description:  `Year of date. Must be from 1 to 9999.`,
 			},
@@ -377,7 +369,6 @@ func dateObjectSchema() *schema.Resource {
 			"month": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1, 12),
 				Description:  `Month of year. Must be from 1 to 12.`,
 			},
@@ -385,7 +376,6 @@ func dateObjectSchema() *schema.Resource {
 			"day": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(0, 31),
 				Description:  `Day of month. Must be from 1 to 31 and valid for the year and month.`,
 			},
@@ -638,29 +628,29 @@ func resourceStorageTransferJobUpdate(d *schema.ResourceData, meta interface{}) 
 	fieldMask := []string{}
 
 	if d.HasChange("description") {
+		fieldMask = append(fieldMask, "description")
 		if v, ok := d.GetOk("description"); ok {
-			fieldMask = append(fieldMask, "description")
 			transferJob.Description = v.(string)
 		}
 	}
 
 	if d.HasChange("status") {
+		fieldMask = append(fieldMask, "status")
 		if v, ok := d.GetOk("status"); ok {
-			fieldMask = append(fieldMask, "status")
 			transferJob.Status = v.(string)
 		}
 	}
 
 	if d.HasChange("schedule") {
+		fieldMask = append(fieldMask, "schedule")
 		if v, ok := d.GetOk("schedule"); ok {
-			fieldMask = append(fieldMask, "schedule")
 			transferJob.Schedule = expandTransferSchedules(v.([]interface{}))
 		}
 	}
 
 	if d.HasChange("transfer_spec") {
+		fieldMask = append(fieldMask, "transfer_spec")
 		if v, ok := d.GetOk("transfer_spec"); ok {
-			fieldMask = append(fieldMask, "transfer_spec")
 			transferJob.TransferSpec = expandTransferSpecs(v.([]interface{}))
 		}
 	}
@@ -672,6 +662,10 @@ func resourceStorageTransferJobUpdate(d *schema.ResourceData, meta interface{}) 
 		} else {
 			transferJob.NotificationConfig = nil
 		}
+	}
+
+	if len(fieldMask) == 0 {
+		return nil
 	}
 
 	updateRequest := &storagetransfer.UpdateTransferJobRequest{

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -276,11 +276,11 @@ func testAccStorageTransferJobDestroyProducer(t *testing.T) func(s *terraform.St
 			}
 
 			res, err := config.NewStorageTransferClient(config.userAgent).TransferJobs.Get(name, project).Do()
-			if res.Status != "DELETED" {
-				return fmt.Errorf("Transfer Job not set to DELETED")
-			}
 			if err != nil {
 				return fmt.Errorf("Transfer Job does not exist, should exist and be DELETED")
+			}
+			if res.Status != "DELETED" {
+				return fmt.Errorf("Transfer Job not set to DELETED")
 			}
 		}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Also fix an issue with updating storage transfer job fields to empty objects.

fixes https://github.com/hashicorp/terraform-provider-google/issues/10967


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storagetransfer: made storage_transfer_job schedule field mutable
```
