### PR TITLE
Remove unneeded Optional schema behaviour in `email` field of `google_project_service_identity`

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_project_service_identity.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_project_service_identity.go.erb
@@ -36,7 +36,6 @@ func resourceProjectServiceIdentity() *schema.Resource {
 			},
 			"email": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		},

--- a/mmv1/third_party/terraform/tests/resource_project_service_identity_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_project_service_identity_test.go.erb
@@ -17,6 +17,11 @@ func TestAccProjectServiceIdentity_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleProjectServiceIdentity_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Email field for logging service identity will be empty for as long as
+					// `gcloud beta services identity create --service=logging.googleapis.com` doesn't return an email address
+					resource.TestCheckNoResourceAttr("google_project_service_identity.log_sa", "email"),
+				),
 			},
 		},
 	})
@@ -26,6 +31,7 @@ func testGoogleProjectServiceIdentity_basic() string {
 	return `
 data "google_project" "project" {}
 
+# Service which has an email returned from service identity API
 resource "google_project_service_identity" "hc_sa" {
   project = data.google_project.project.project_id
   service = "healthcare.googleapis.com"
@@ -35,6 +41,14 @@ resource "google_project_iam_member" "hc_sa_bq_jobuser" {
   project = data.google_project.project.project_id
   role    = "roles/bigquery.jobUser"
   member  = "serviceAccount:${google_project_service_identity.hc_sa.email}"
-}`
+}
+
+# Service which does NOT have email returned from service identity API
+# Email attribute will be null - correct as of 2022-12-13
+resource "google_project_service_identity" "log_sa" {
+  project = data.google_project.project.project_id
+  service = "logging.googleapis.com"
+}
+`
 }
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13227

In the `google_project_service_identity` resource the email is computed but the field has `Optional: true` set in the schema. 

I added this mistakenly in https://github.com/GoogleCloudPlatform/magic-modules/pull/6192 when I changed the resource to handle scenarios when the API did not return a value for the email field


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: removed unneeded Optional schema behaviour from `email` field in `google_project_service_identity` (beta)
```
