### PR TITLE
Improve the documentation on the name property of Cloud Functions

### DIFF
--- a/mmv1/products/cloudfunctions/api.yaml
+++ b/mmv1/products/cloudfunctions/api.yaml
@@ -69,8 +69,9 @@ objects:
         name: 'name'
         required: true
         description: |
-          A user-defined name of the function. Function names must
-          be unique globally and match pattern `projects/*/locations/*/functions/*`.
+          A user-defined name of the function. The name is used to compute an internal resource name.
+          Such internal names match pattern `projects/{{project}}/locations/{{location}}/functions/{{name}}`
+          and must be unique globally.
         pattern: projects/{{project}}/locations/{{location}}/functions/{{name}}
       - !ruby/object:Api::Type::String
         name: 'description'

--- a/mmv1/products/cloudfunctions2/api.yaml
+++ b/mmv1/products/cloudfunctions2/api.yaml
@@ -75,8 +75,9 @@ objects:
         required: true
         input: true
         description: |
-          A user-defined name of the function. Function names must
-          be unique globally and match pattern `projects/*/locations/*/functions/*`.
+          A user-defined name of the function. The name is used to compute an internal resource name.
+          Such internal names match pattern `projects/{{project}}/locations/{{location}}/functions/{{name}}`
+          and must be unique globally.
         pattern: projects/{{project}}/locations/{{location}}/functions/{{name}}
       - !ruby/object:Api::Type::String
         name: 'description'


### PR DESCRIPTION
Signed-off-by: Ringo De Smet <ringo@de-smet.name>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The documentation for the `name` property of a Google Cloud Function (gen1 & 2) currently reads this:

https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/cloudfunctions2/api.yaml#L73-L80

The documentation states that function names must match the pattern. Some of our users follow this recommendation and set a string matching the pattern as the `name` property for a `Function` resource.

This should not be done because the string is calculated from the `project`, `location` and `name` properties.

To prevent this confusion, I did my best to rewrite it and explain that the calculated string matches that pattern and should be unique globally.

This is indeed for the Terraform provider. Given it is a change in the docs, I did not build this project. To remain true to my actions, I left (some of) the checkboxes below unchecked.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
