### PR TITLE
Adds support for github enterprise configs inside git_file_source and source…

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -146,6 +146,11 @@ objects:
               The branch, tag, arbitrary ref, or SHA version of the repo to use when resolving the 
               filename (optional). This field respects the same syntax/resolution as described here: https://git-scm.com/docs/gitrevisions 
               If unspecified, the revision from which the trigger invocation originated is assumed to be the revision from which to read the specified path.
+          - !ruby/object:Api::Type::String
+            name: 'githubEnterpriseConfig'
+            description: |
+              The full resource name of the github enterprise config.
+              Format: projects/{project}/locations/{location}/githubEnterpriseConfigs/{id}. projects/{project}/githubEnterpriseConfigs/{id}.
       - !ruby/object:Api::Type::NestedObject
         name: 'sourceToBuild'
         description: |
@@ -181,6 +186,11 @@ objects:
                   - :CLOUD_SOURCE_REPOSITORIES
                   - :GITHUB
                   - :BITBUCKET_SERVER
+          - !ruby/object:Api::Type::String
+            name: 'githubEnterpriseConfig'
+            description: |
+              The full resource name of the github enterprise config.
+              Format: projects/{project}/locations/{location}/githubEnterpriseConfigs/{id}. projects/{project}/githubEnterpriseConfigs/{id}.
       - !ruby/object:Api::Type::Array
         name: 'ignoredFiles'
         item_type: Api::Type::String

--- a/mmv1/products/cloudbuild/terraform.yaml
+++ b/mmv1/products/cloudbuild/terraform.yaml
@@ -49,6 +49,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "cloudbuild_trigger_manual"
         primary_resource_id: "manual-trigger"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloudbuild_trigger_manual_github_enterprise"
+        primary_resource_id: "manual-ghe-trigger"
+        skip_test: true
 
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_manual_github_enterprise.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_manual_github_enterprise.tf.erb
@@ -1,0 +1,18 @@
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  name        = "terraform-manual-ghe-trigger"
+
+  source_to_build {
+    uri       = "https://hashicorp/terraform-provider-google-beta"
+    ref       = "refs/heads/main"
+    repo_type = "GITHUB"
+    github_enterprise_config = "projects/myProject/locations/global/githubEnterpriseConfigs/configID"
+}
+
+git_file_source {
+    path      = "cloudbuild.yaml"
+    uri       = "https://hashicorp/terraform-provider-google-beta"
+    revision  = "refs/heads/main"
+    repo_type = "GITHUB"
+    github_enterprise_config = "projects/myProject/locations/global/githubEnterpriseConfigs/configID"
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds support for github enterprise configs inside git_file_source and source_to_build fields for cloudbuild trigger resource.
New fields added for cloudbuild trigger:

- trigger.git_file_source.**github_enterprise_config**
- trigger.source_to_build.**github_enterprise_config**


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: added `github_enterprise_config` fields to `google_cloudbuild_trigger` resource.
```
