### PR TITLE
Adding Datasource for Pub/Sub Subscription

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_pubsub_subscription.go
@@ -1,0 +1,30 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGooglePubsubSubscription() *schema.Resource {
+
+	dsSchema := datasourceSchemaFromResourceSchema(resourcePubsubSubscription().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name")
+	addOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceGooglePubsubSubscriptionRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGooglePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	id, err := replaceVars(d, config, "projects/{{project}}/subscriptions/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourcePubsubSubscriptionRead(d, meta)
+}

--- a/mmv1/third_party/terraform/tests/data_source_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_pubsub_subscription_test.go
@@ -57,8 +57,8 @@ resource "google_pubsub_topic" "foo" {
 }
 
 resource "google_pubsub_subscription" "foo" {
-	name     = "tf-test-pubsub-subscription-%{random_suffix}"
-	topic    = google_pubsub_topic.foo.name
+  name     = "tf-test-pubsub-subscription-%{random_suffix}"
+  topic    = google_pubsub_topic.foo.name
 }
 
 data "google_pubsub_subscription" "foo" {
@@ -75,8 +75,8 @@ resource "google_pubsub_topic" "foo" {
 }
 
 resource "google_pubsub_subscription" "foo" {
-	name     = "tf-test-pubsub-subscription-%{random_suffix}"
-	topic    = google_pubsub_topic.foo.name
+  name     = "tf-test-pubsub-subscription-%{random_suffix}"
+  topic    = google_pubsub_topic.foo.name
 }
 
 data "google_pubsub_subscription" "foo" {

--- a/mmv1/third_party/terraform/tests/data_source_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_pubsub_subscription_test.go
@@ -1,0 +1,86 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGooglePubsubSubscription_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGooglePubsubSubscription_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_pubsub_subscription.foo", "google_pubsub_subscription.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceGooglePubsubSubscription_optionalProject(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGooglePubsubSubscription_optionalProject(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_pubsub_subscription.foo", "google_pubsub_subscription.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGooglePubsubSubscription_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_pubsub_topic" "foo" {
+  name     = "tf-test-pubsub-%{random_suffix}"
+}
+
+resource "google_pubsub_subscription" "foo" {
+	name     = "tf-test-pubsub-subscription-%{random_suffix}"
+	topic    = google_pubsub_topic.foo.name
+}
+
+data "google_pubsub_subscription" "foo" {
+  name     = google_pubsub_subscription.foo.name
+  project  = google_pubsub_subscription.foo.project
+}
+`, context)
+}
+
+func testAccDataSourceGooglePubsubSubscription_optionalProject(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_pubsub_topic" "foo" {
+  name     = "tf-test-pubsub-%{random_suffix}"
+}
+
+resource "google_pubsub_subscription" "foo" {
+	name     = "tf-test-pubsub-subscription-%{random_suffix}"
+	topic    = google_pubsub_topic.foo.name
+}
+
+data "google_pubsub_subscription" "foo" {
+  name     = google_pubsub_subscription.foo.name
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -291,6 +291,7 @@ func Provider() *schema.Provider {
 			"google_project":                                   dataSourceGoogleProject(),
 			"google_projects":                                  dataSourceGoogleProjects(),
 			"google_project_organization_policy":               dataSourceGoogleProjectOrganizationPolicy(),
+			"google_pubsub_subscription":                       dataSourceGooglePubsubSubscription(),
 			"google_pubsub_topic":                              dataSourceGooglePubsubTopic(),
 			<% unless version == 'ga' -%>
 			"google_runtimeconfig_config":                      dataSourceGoogleRuntimeconfigConfig(),

--- a/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Cloud Pub/Sub"
+page_title: "Google: google_pubsub_subscription"
+description: |-
+  Get information about a Google Cloud Pub/Sub Subscription.
+---
+
+# google\_pubsub\subscription
+
+Get information about a Google Cloud Pub/Sub Subscription. For more information see
+the [official documentation](https://cloud.google.com/pubsub/docs/)
+and [API](https://cloud.google.com/pubsub/docs/apis).
+
+## Example Usage
+
+```hcl
+data "google_pubsub_subscription" "my-pubsub-subscription" {
+  name = "my-pubsub-subscription"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Cloud Pub/Sub Subscription.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_pubsub_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#argument-reference) resource for details of the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Get information about a Google Cloud Pub/Sub Subscription.
 ---
 
-# google\_pubsub\subscription
+# google\_pubsub\_subscription
 
 Get information about a Google Cloud Pub/Sub Subscription. For more information see
 the [official documentation](https://cloud.google.com/pubsub/docs/)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/12932



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`data_source_google_pubsub_subscription`
```
