### PR TITLE
Support Cloud IDS Threat Exceptions

### DIFF
--- a/mmv1/products/cloudids/api.yaml
+++ b/mmv1/products/cloudids/api.yaml
@@ -48,7 +48,8 @@ objects:
     create_url: 'projects/{{project}}/locations/{{location}}/endpoints?endpointId={{name}}'
     self_link: 'projects/{{project}}/locations/{{location}}/endpoints/{{name}}'
     create_verb: :POST
-    input: true
+    update_verb: :PATCH
+    update_mask: true
     description: |
       Cloud IDS is an intrusion detection service that provides threat detection for intrusions, malware, spyware, and command-and-control attacks on your network.
     references: !ruby/object:Api::Resource::ReferenceLinks
@@ -86,6 +87,7 @@ objects:
           Name of the VPC network that is connected to the IDS endpoint. This can either contain the VPC network name itself (like "src-net") or the full URL to the network (like "projects/{project_id}/global/networks/src-net").
       - !ruby/object:Api::Type::String
         name: 'description'
+        input: true
         description: |
           An optional description of the endpoint.
       - !ruby/object:Api::Type::String
@@ -101,6 +103,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'severity'
         required: true
+        input: true
         description: |
           The minimum alert severity level that is reported by the endpoint.
         values:
@@ -109,3 +112,8 @@ objects:
           - :MEDIUM
           - :HIGH
           - :CRITICAL
+      - !ruby/object:Api::Type::Array
+        name: 'threatExceptions'
+        description: |
+          List of threat IDs to be excepted from alerting. Passing empty list clears the exceptions.
+        item_type: Api::Type::String

--- a/mmv1/third_party/terraform/tests/resource_cloudids_endpoint_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudids_endpoint_test.go
@@ -29,6 +29,50 @@ func TestAccCloudIdsEndpoint_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				ResourceName:      "google_compute_global_address.service_range",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_service_networking_connection.private_service_connection",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testCloudIds_updateThreatExceptions(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_ids_endpoint.endpoint", "threat_exceptions.#", "2"),
+					resource.TestCheckResourceAttr("google_cloud_ids_endpoint.endpoint", "threat_exceptions.0", "92006"),
+					resource.TestCheckResourceAttr("google_cloud_ids_endpoint.endpoint", "threat_exceptions.1", "83227"),
+				),
+			},
+			{
+				ResourceName:      "google_cloud_ids_endpoint.endpoint",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_compute_global_address.service_range",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_service_networking_connection.private_service_connection",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testCloudIds_clearThreatExceptions(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_ids_endpoint.endpoint", "threat_exceptions.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "google_cloud_ids_endpoint.endpoint",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -39,7 +83,7 @@ resource "google_compute_network" "default" {
 	name = "tf-test-my-network%{random_suffix}"
 }
 resource "google_compute_global_address" "service_range" {
-	name          = "address"
+	name          = "address-%{random_suffix}"
 	purpose       = "VPC_PEERING"
 	address_type  = "INTERNAL"
 	prefix_length = 16
@@ -52,11 +96,68 @@ resource "google_service_networking_connection" "private_service_connection" {
 }
   
 resource "google_cloud_ids_endpoint" "endpoint" {
-	name     = "cloud-ids-test-%{random_suffix}"
-	location = "us-central1-f"
-	network  = google_compute_network.default.id
-	severity = "INFORMATIONAL"
-	depends_on = [google_service_networking_connection.private_service_connection]
+	name        = "cloud-ids-test-%{random_suffix}"
+	location    = "us-central1-f"
+	network     = google_compute_network.default.id
+	severity    = "INFORMATIONAL"
+	depends_on  = [google_service_networking_connection.private_service_connection]
+}
+`, context)
+}
+
+func testCloudIds_updateThreatExceptions(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+	name = "tf-test-my-network%{random_suffix}"
+}
+resource "google_compute_global_address" "service_range" {
+	name          = "address-%{random_suffix}"
+	purpose       = "VPC_PEERING"
+	address_type  = "INTERNAL"
+	prefix_length = 16
+	network       = google_compute_network.default.id
+}
+resource "google_service_networking_connection" "private_service_connection" {
+	network                 = google_compute_network.default.id
+	service                 = "servicenetworking.googleapis.com"
+	reserved_peering_ranges = [google_compute_global_address.service_range.name]
+}
+  
+resource "google_cloud_ids_endpoint" "endpoint" {
+	name              = "cloud-ids-test-%{random_suffix}"
+	location          = "us-central1-f"
+	network           = google_compute_network.default.id
+	severity          = "INFORMATIONAL"
+	threat_exceptions = ["92006", "83227"]
+	depends_on        = [google_service_networking_connection.private_service_connection]
+}
+`, context)
+}
+
+func testCloudIds_clearThreatExceptions(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+	name = "tf-test-my-network%{random_suffix}"
+}
+resource "google_compute_global_address" "service_range" {
+	name          = "address-%{random_suffix}"
+	purpose       = "VPC_PEERING"
+	address_type  = "INTERNAL"
+	prefix_length = 16
+	network       = google_compute_network.default.id
+}
+resource "google_service_networking_connection" "private_service_connection" {
+	network                 = google_compute_network.default.id
+	service                 = "servicenetworking.googleapis.com"
+	reserved_peering_ranges = [google_compute_global_address.service_range.name]
+}
+  
+resource "google_cloud_ids_endpoint" "endpoint" {
+	name              = "cloud-ids-test-%{random_suffix}"
+	location          = "us-central1-f"
+	network           = google_compute_network.default.id
+	severity          = "INFORMATIONAL"
+	depends_on        = [google_service_networking_connection.private_service_connection]
 }
 `, context)
 }


### PR DESCRIPTION
Threat Exceptions for Cloud IDS just went GA. Added support for `threat_exceptions` field along with PATCH update for it. 

Note:
- `description` and `severity` cannot be updated without recreate, so marked them `input: true`
- Tests have been added into `TestAccCloudIdsEndpoint_basic` as parallel `servicenetworking` caused some internal errors from the VPC API

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudids: Added `threat_exceptions` field to `google_cloud_ids_endpoint`
```
