### PR TITLE
datacatalog - bump Taxonomy and PolicyTag to ga

### DIFF
--- a/mmv1/products/datacatalog/api.yaml
+++ b/mmv1/products/datacatalog/api.yaml
@@ -504,7 +504,6 @@ objects:
     name: Taxonomy
     base_url: projects/{{project}}/locations/{{region}}/taxonomies
     self_link: "{{name}}"
-    min_version: beta
     update_verb: :PATCH
     update_mask: true
     description: |
@@ -563,7 +562,6 @@ objects:
     name: PolicyTag
     base_url: "{{taxonomy}}/policyTags"
     self_link: "{{name}}"
-    min_version: beta
     update_verb: :PATCH
     update_mask: true
     description: |

--- a/mmv1/products/datacatalog/api.yaml
+++ b/mmv1/products/datacatalog/api.yaml
@@ -511,7 +511,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation': https://cloud.google.com/data-catalog/docs
-      api: https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.taxonomies
+      api: https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.taxonomies
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       skip_import_test: true
       method_name_separator: ':'
@@ -569,7 +569,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation': https://cloud.google.com/data-catalog/docs
-      api: https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.taxonomies.policyTags
+      api: https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.taxonomies.policyTags
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       skip_import_test: true
       method_name_separator: ':'

--- a/mmv1/products/datacatalog/terraform.yaml
+++ b/mmv1/products/datacatalog/terraform.yaml
@@ -208,7 +208,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "basic_taxonomy"
         primary_resource_name: "fmt.Sprintf(\"tf_test_my_taxonomy%s\", context[\"random_suffix\"])"
         vars:
-          display_name: "my_display_name"
+          display_name: "my_taxonomy"
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false

--- a/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_basic.tf.erb
@@ -5,7 +5,6 @@ resource "google_data_catalog_policy_tag" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_data_catalog_taxonomy" "my_taxonomy" {
-  region = "us"
   display_name =  "<%= ctx[:vars]['taxonomy_display_name'] %>"
   description = "A collection of policy tags"
   activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]

--- a/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_basic.tf.erb
@@ -1,12 +1,10 @@
 resource "google_data_catalog_policy_tag" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   taxonomy = google_data_catalog_taxonomy.my_taxonomy.id
   display_name = "Low security"
   description = "A policy tag normally associated with low security items"
 }
 
 resource "google_data_catalog_taxonomy" "my_taxonomy" {
-  provider = google-beta
   region = "us"
   display_name =  "<%= ctx[:vars]['taxonomy_display_name'] %>"
   description = "A collection of policy tags"

--- a/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_child_policies.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_child_policies.tf.erb
@@ -21,7 +21,6 @@ resource "google_data_catalog_policy_tag" "child_policy2" {
 }
 
 resource "google_data_catalog_taxonomy" "my_taxonomy" {
-  region = "us"
   display_name =  "<%= ctx[:vars]['taxonomy_display_name'] %>"
   description = "A collection of policy tags"
   activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]

--- a/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_child_policies.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_taxonomies_policy_tag_child_policies.tf.erb
@@ -1,12 +1,10 @@
 resource "google_data_catalog_policy_tag" "parent_policy" {
-  provider = google-beta
   taxonomy = google_data_catalog_taxonomy.my_taxonomy.id
   display_name = "High"
   description = "A policy tag category used for high security access"
 }
 
 resource "google_data_catalog_policy_tag" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   taxonomy = google_data_catalog_taxonomy.my_taxonomy.id
   display_name = "ssn"
   description = "A hash of the users ssn"
@@ -14,7 +12,6 @@ resource "google_data_catalog_policy_tag" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_data_catalog_policy_tag" "child_policy2" {
-  provider = google-beta
   taxonomy = google_data_catalog_taxonomy.my_taxonomy.id
   display_name = "dob"
   description = "The users date of birth"
@@ -24,7 +21,6 @@ resource "google_data_catalog_policy_tag" "child_policy2" {
 }
 
 resource "google_data_catalog_taxonomy" "my_taxonomy" {
-  provider = google-beta
   region = "us"
   display_name =  "<%= ctx[:vars]['taxonomy_display_name'] %>"
   description = "A collection of policy tags"

--- a/mmv1/templates/terraform/examples/data_catalog_taxonomy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_taxonomy_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_data_catalog_taxonomy" "<%= ctx[:primary_resource_id] %>" {
-  region = "us"
   display_name =  "<%= ctx[:vars]['display_name'] %>"
   description = "A collection of policy tags"
   activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]

--- a/mmv1/templates/terraform/examples/data_catalog_taxonomy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_taxonomy_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_data_catalog_taxonomy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   region = "us"
   display_name =  "<%= ctx[:vars]['display_name'] %>"
   description = "A collection of policy tags"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datacatalog - bump Taxonomy and PolicyTag to ga
```
