### PR TITLE
machine_type validated, only changes when allowStoppingForUpdate is true

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -98,8 +98,9 @@ func machineTypeIfAllowStoppingForUpdateFalseFunc(diff TerraformResourceDiff) er
 	old, new := diff.GetChange("machine_type")
 	if old.(string) != new.(string) && old.(string) != "" {
 		allowUpdate := diff.Get("allow_stopping_for_update")
-		if allowUpdate == false {
-			return fmt.Errorf("allow_stopping_for_update is false hence updating machine_type isn't possible.")
+		desiredStatus := diff.Get("desired_status")
+		if !(allowUpdate.(bool)) || (desiredStatus != "TERMINATED") {
+			return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", allowUpdate)
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -99,7 +99,7 @@ func machineTypeIfAllowStoppingForUpdateFalseFunc(diff TerraformResourceDiff) er
 	if old.(string) != new.(string) && old.(string) != "" {
 		allowUpdate := diff.Get("allow_stopping_for_update")
 		oldStatus, newStatus := diff.GetChange("desired_status")
-		if (allowUpdate.(bool) == false || ) {
+		if !(allowUpdate.(bool)) {
 			if oldStatus == "" {
 				if newStatus != "TERMINATED" {
 					return fmt.Errorf("allow_stopping_for_update is %v and %v hence updating machine_type isn't possible.",allowUpdate, newStatus)

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -98,10 +98,16 @@ func machineTypeIfAllowStoppingForUpdateFalseFunc(diff TerraformResourceDiff) er
 	old, new := diff.GetChange("machine_type")
 	if old.(string) != new.(string) && old.(string) != "" {
 		allowUpdate := diff.Get("allow_stopping_for_update")
-		desiredStatus := diff.Get("desired_status")
+		oldStatus, newStatus := diff.GetChange("desired_status")
 		if !(allowUpdate.(bool)) {
-			if (desiredStatus != "TERMINATED"){
-			  return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", allowUpdate)
+			if oldStatus == "" {
+				if newStatus != "TERMINATED" {
+					return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", newStatus)
+				}
+			} else {
+				if oldStatus != "TERMINATED" {
+					return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", oldStatus)
+				}
 			}
 		}
 	}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -99,14 +99,14 @@ func machineTypeIfAllowStoppingForUpdateFalseFunc(diff TerraformResourceDiff) er
 	if old.(string) != new.(string) && old.(string) != "" {
 		allowUpdate := diff.Get("allow_stopping_for_update")
 		oldStatus, newStatus := diff.GetChange("desired_status")
-		if !(allowUpdate.(bool)) {
+		if (allowUpdate.(bool) == false || ) {
 			if oldStatus == "" {
 				if newStatus != "TERMINATED" {
-					return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", newStatus)
+					return fmt.Errorf("allow_stopping_for_update is %v and %v hence updating machine_type isn't possible.",allowUpdate, newStatus)
 				}
 			} else {
 				if oldStatus != "TERMINATED" {
-					return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", oldStatus)
+					return fmt.Errorf("allow_stopping_for_update is %v and %v hence updating machine_type isn't possible.",allowUpdate, oldStatus)
 				}
 			}
 		}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -93,6 +93,23 @@ func forceNewIfNetworkIPNotUpdatableFunc(d TerraformResourceDiff) error {
 	return nil
 }
 
+func machineTypeIfAllowStoppingForUpdateFalseFunc(diff TerraformResourceDiff) error {
+
+	old, new := diff.GetChange("machine_type")
+	if old.(string) != new.(string) && old.(string) != "" {
+		allowUpdate := diff.Get("allow_stopping_for_update")
+		if allowUpdate == false {
+			return fmt.Errorf("allow_stopping_for_update is false hence updating machine_type isn't possible.")
+		}
+	}
+
+	return nil
+}
+
+func machineTypeIfAllowStoppingForUpdateFalse(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	return machineTypeIfAllowStoppingForUpdateFalseFunc(d)
+}
+
 func resourceComputeInstance() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComputeInstanceCreate,
@@ -911,6 +928,7 @@ func resourceComputeInstance() *schema.Resource {
 			),
 			desiredStatusDiff,
 			forceNewIfNetworkIPNotUpdatable,
+			machineTypeIfAllowStoppingForUpdateFalse,
 		),
 		UseJSONNumber: true,
 	}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -99,8 +99,10 @@ func machineTypeIfAllowStoppingForUpdateFalseFunc(diff TerraformResourceDiff) er
 	if old.(string) != new.(string) && old.(string) != "" {
 		allowUpdate := diff.Get("allow_stopping_for_update")
 		desiredStatus := diff.Get("desired_status")
-		if !(allowUpdate.(bool)) || (desiredStatus != "TERMINATED") {
-			return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", allowUpdate)
+		if !(allowUpdate.(bool)) {
+			if (desiredStatus != "TERMINATED"){
+			  return fmt.Errorf("allow_stopping_for_update is %v hence updating machine_type isn't possible.", allowUpdate)
+			}
 		}
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1810,7 +1810,8 @@ func TestAccComputeInstance_updateRunning_desiredStatusRunning_allowStoppingForU
 	})
 }
 
-const errorAllowStoppingMsg = "please set allow_stopping_for_update"
+const errorAllowStoppingMsgAPI = "please set allow_stopping_for_update"
+const errorAllowStoppingMsg = "allow_stopping_for_update is false hence updating machine_type isn't possible."
 
 func TestAccComputeInstance_updateRunning_desiredStatusNotSet_notAllowStoppingForUpdate(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
machine_type changes only when allowStoppingForUpdate is true, validated using terraform
fixes @https://github.com/hashicorp/terraform-provider-google/issues/4076
b/262529153



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: validated `machine_type` in `google_compute_instance`
```
