### PR TITLE
Revert "Add support for reservation affinity, dataproc oss metric collection and node-group configs, also support 'SPOT' under preemptibility"

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -63,20 +63,12 @@ var (
 		"cluster_config.0.gce_cluster_config.0.internal_ip_only",
 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config",
 		"cluster_config.0.gce_cluster_config.0.metadata",
-		"cluster_config.0.gce_cluster_config.0.reservation_affinity",
-		"cluster_config.0.gce_cluster_config.0.node_group_affinity",
 	}
 
 	schieldedInstanceConfigKeys = []string{
 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_secure_boot",
 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_vtpm",
 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_integrity_monitoring",
-	}
-
-	reservationAffinityKeys = []string{
-		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.consume_reservation_type",
-		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.key",
-		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.values",
 	}
 
 	preemptibleWorkerDiskConfigKeys = []string{
@@ -90,17 +82,6 @@ var (
 		"cluster_config.0.software_config.0.override_properties",
 		"cluster_config.0.software_config.0.optional_components",
 	}
-
-<% if version == "ga" -%>
-	dataprocMetricConfigKeys = []string{
-		"cluster_config.0.dataproc_metric_config.0.metrics",
-	}
-
-	metricKeys = []string{
-		"cluster_config.0.dataproc_metric_config.0.metrics.0.metric_source",
-		"cluster_config.0.dataproc_metric_config.0.metrics.0.metric_overrides",
-	}
-<% end -%>
 
 	clusterConfigKeys = []string{
 		"cluster_config.0.staging_bucket",
@@ -117,9 +98,6 @@ var (
 		"cluster_config.0.metastore_config",
 		"cluster_config.0.lifecycle_config",
 		"cluster_config.0.endpoint_config",
-<% if version == "ga" -%>
-		"cluster_config.0.dataproc_metric_config",
-<% end -%>
 	}
 )
 
@@ -660,62 +638,6 @@ func resourceDataprocCluster() *schema.Resource {
 											},
 										},
 									},
-
-									"reservation_affinity": {
-										Type:         schema.TypeList,
-										Optional:     true,
-										AtLeastOneOf: gceClusterConfigKeys,
-										Computed:     true,
-										MaxItems:     1,
-										Description:  `Reservation Affinity for consuming Zonal reservation.`,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"consume_reservation_type": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													AtLeastOneOf: reservationAffinityKeys,
-													ForceNew:     true,
-													ValidateFunc: validation.StringInSlice([]string{"NO_RESERVATION", "ANY_RESERVATION", "SPECIFIC_RESERVATION"}, false),
-													Description:  `Type of reservation to consume.`,
-												},
-												"key": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													AtLeastOneOf: reservationAffinityKeys,
-													ForceNew:     true,
-													Description:  `Corresponds to the label key of reservation resource.`,
-												},
-												"values": {
-													Type:         schema.TypeSet,
-													Elem:         &schema.Schema{Type: schema.TypeString},
-													Optional:     true,
-													AtLeastOneOf: reservationAffinityKeys,
-													ForceNew:     true,
-													Description:  `Corresponds to the label values of reservation resource.`,
-												},
-											},
-										},
-									},
-
-									"node_group_affinity": {
-										Type:         schema.TypeList,
-										Optional:     true,
-										AtLeastOneOf: gceClusterConfigKeys,
-										Computed:     true,
-										MaxItems:     1,
-										Description:  `Node Group Affinity for sole-tenant clusters.`,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"node_group_uri": {
-													Type:         schema.TypeString,
-													ForceNew:     true,
-													Required:     true,
-													Description:  `The URI of a sole-tenant that the cluster will be created on.`,
-													DiffSuppressFunc: compareSelfLinkOrResourceName,
-												},
-											},
-										},
-									},
 								},
 							},
 						},
@@ -758,11 +680,7 @@ func resourceDataprocCluster() *schema.Resource {
 											"cluster_config.0.preemptible_worker_config.0.disk_config",
 										},
 										ForceNew:     true,
-										<% if version == "ga" -%>
-										ValidateFunc: validation.StringInSlice([]string{"PREEMPTIBILITY_UNSPECIFIED", "NON_PREEMPTIBLE", "PREEMPTIBLE", "SPOT"}, false),
-										<% else -%>
 										ValidateFunc: validation.StringInSlice([]string{"PREEMPTIBILITY_UNSPECIFIED", "NON_PREEMPTIBLE", "PREEMPTIBLE"}, false),
-										<% end -%>
 										Default:      "PREEMPTIBLE",
 									},
 
@@ -1115,25 +1033,6 @@ by Dataproc`,
 								},
 							},
 						},
-<% if version == "ga" -%>
-						"dataproc_metric_config": {
-							Type:        schema.TypeList,
-							Optional:    true,
-							MaxItems:    1,
-							Description: `The config for Dataproc metrics.`,
-							AtLeastOneOf: clusterConfigKeys,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"metrics": {
-										Type:         schema.TypeList,
-										Required:     true,
-										Description:  `Metrics sources to enable.`,
-										Elem:         metricsSchema(),
-									},
-								},
-							},
-						},
-<% end -%>
 					},
 				},
 			},
@@ -1141,30 +1040,6 @@ by Dataproc`,
 		UseJSONNumber: true,
 	}
 }
-
-<% if version == "ga" -%>
-// We need to pull metrics' schema out so we can use it to make a set hash func
-func metricsSchema() *schema.Resource {
-	return  &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"metric_source": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"MONITORING_AGENT_DEFAULTS", "HDFS", "SPARK", "YARN", "SPARK_HISTORY_SERVER", "HIVESERVER2"}, false),
-				Description:  `A source for the collection of Dataproc OSS metrics (see [available OSS metrics] (https://cloud.google.com//dataproc/docs/guides/monitoring#available_oss_metrics)).`,
-			},
-			"metric_overrides": {
-				Type:         schema.TypeSet,
-				Elem:         &schema.Schema{Type: schema.TypeString},
-				Optional:     true,
-				ForceNew:     true,
-				Description:  `Specify one or more [available OSS metrics] (https://cloud.google.com/dataproc/docs/guides/monitoring#available_oss_metrics) to collect.`,
-			},
-		},
-	}
-}
-<% end -%>
 
 func instanceConfigSchema(parent string) *schema.Schema {
 	var instanceConfigKeys = []string{
@@ -1622,12 +1497,6 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 		conf.EndpointConfig = expandEndpointConfig(cfg)
 	}
 
-<% if version == "ga" -%>
-	if cfg, ok := configOptions(d, "cluster_config.0.dataproc_metric_config"); ok {
-		conf.DataprocMetricConfig = expandDataprocMetricConfig(cfg)
-	}
-<% end -%>
-
 	if cfg, ok := configOptions(d, "cluster_config.0.master_config"); ok {
 		log.Println("[INFO] got master_config")
 		conf.MasterConfig = expandInstanceGroupConfig(cfg)
@@ -1704,26 +1573,6 @@ func expandGceClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.G
 		}
 		if v, ok := cfgSic["enable_vtpm"]; ok {
 			conf.ShieldedInstanceConfig.EnableVtpm = v.(bool)
-		}
-	}
-	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.reservation_affinity"); ok {
-		cfgRa := v.([]interface{})[0].(map[string]interface{})
-		conf.ReservationAffinity = &dataproc.ReservationAffinity{}
-		if v, ok := cfgRa["consume_reservation_type"]; ok {
-			conf.ReservationAffinity.ConsumeReservationType = v.(string)
-		}
-		if v, ok := cfgRa["key"]; ok {
-			conf.ReservationAffinity.Key = v.(string)
-		}
-		if v, ok := cfgRa["values"]; ok {
-			conf.ReservationAffinity.Values = convertStringSet(v.(*schema.Set))
-		}
-	}
-	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.node_group_affinity"); ok {
-		cfgNga := v.([]interface{})[0].(map[string]interface{})
-		conf.NodeGroupAffinity = &dataproc.NodeGroupAffinity{}
-		if v, ok := cfgNga["node_group_uri"]; ok {
-			conf.NodeGroupAffinity.NodeGroupUri = v.(string)
 		}
 	}
 	return conf, nil
@@ -1845,25 +1694,6 @@ func expandEndpointConfig(cfg map[string]interface{}) *dataproc.EndpointConfig {
 	}
 	return conf
 }
-
-<% if version == "ga" -%>
-func expandDataprocMetricConfig(cfg map[string]interface{}) *dataproc.DataprocMetricConfig {
-	conf := &dataproc.DataprocMetricConfig{}
-	metricsConfigs := cfg["metrics"].([]interface{})
-	metricsSet := make([]*dataproc.Metric, 0, len(metricsConfigs))
-
-	for _, raw := range metricsConfigs {
-		data := raw.(map[string]interface{})
-		metric := dataproc.Metric{
-			MetricSource: data["metric_source"].(string),
-			MetricOverrides: convertStringSet(data["metric_overrides"].(*schema.Set)),
-		}
-		metricsSet = append(metricsSet, &metric)
-	}
-	conf.Metrics = metricsSet
-	return conf
-}
-<% end -%>
 
 func expandMetastoreConfig(cfg map[string]interface{}) *dataproc.MetastoreConfig {
 	conf := &dataproc.MetastoreConfig{}
@@ -2289,9 +2119,6 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		"metastore_config":          flattenMetastoreConfig(d, cfg.MetastoreConfig),
 		"lifecycle_config":          flattenLifecycleConfig(d, cfg.LifecycleConfig),
 		"endpoint_config":           flattenEndpointConfig(d, cfg.EndpointConfig),
-<% if version == "ga" -%>
-		"dataproc_metric_config":    flattenDataprocMetricConfig(d, cfg.DataprocMetricConfig),
-<% end -%>
 	}
 
 	if len(cfg.InitializationActions) > 0 {
@@ -2398,28 +2225,6 @@ func flattenEndpointConfig(d *schema.ResourceData, ec *dataproc.EndpointConfig) 
 	return []map[string]interface{}{data}
 }
 
-<% if version == "ga" -%>
-func flattenDataprocMetricConfig(d *schema.ResourceData, dmc *dataproc.DataprocMetricConfig) []map[string]interface{} {
-	if dmc == nil {
-		return nil
-	}
-
-	data := map[string]interface{}{}
-	metricsTypeSet := schema.NewSet(schema.HashResource(metricsSchema()), []interface{}{})
-	for _, metric := range dmc.Metrics {
-		data := map[string]interface{}{
-			"metric_source":  metric.MetricSource,
-			"metric_overrides": metric.MetricOverrides,
-		}
-
-		metricsTypeSet.Add(data)
-	}
-	data["metrics"] = metricsTypeSet
-
-	return []map[string]interface{}{data}
-}
-<% end -%>
-
 func flattenMetastoreConfig(d *schema.ResourceData, ec *dataproc.MetastoreConfig) []map[string]interface{} {
 	if ec == nil {
 		return nil
@@ -2492,22 +2297,6 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
 				"enable_integrity_monitoring": gcc.ShieldedInstanceConfig.EnableIntegrityMonitoring,
 				"enable_secure_boot":          gcc.ShieldedInstanceConfig.EnableSecureBoot,
 				"enable_vtpm":                 gcc.ShieldedInstanceConfig.EnableVtpm,
-			},
-		}
-	}
-	if gcc.ReservationAffinity != nil {
-		gceConfig["reservation_affinity"] = []map[string]interface{}{
-			{
-				"consume_reservation_type":    gcc.ReservationAffinity.ConsumeReservationType,
-				"key":                         gcc.ReservationAffinity.Key,
-				"values":                      gcc.ReservationAffinity.Values,
-			},
-		}
-	}
-	if gcc.NodeGroupAffinity != nil {
-		gceConfig["node_group_affinity"] = []map[string]interface{}{
-			{
-				"node_group_uri":    gcc.NodeGroupAffinity.NodeGroupUri,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -372,79 +372,6 @@ func TestAccDataprocCluster_withMetadataAndTags(t *testing.T) {
 	})
 }
 
-func TestAccDataprocCluster_withReservationAffinity(t *testing.T) {
-	t.Parallel()
-
-	var cluster dataproc.Cluster
-	rnd := randString(t, 10)
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataprocCluster_withReservationAffinity(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
-
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.reservation_affinity.0.consume_reservation_type", "SPECIFIC_RESERVATION"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.reservation_affinity.0.key", "compute.googleapis.com/reservation-name"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.reservation_affinity.0.values.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-<% if version == "ga" -%>
-func TestAccDataprocCluster_withDataprocMetricConfig(t *testing.T) {
-	t.Parallel()
-
-	var cluster dataproc.Cluster
-	rnd := randString(t, 10)
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataprocCluster_withDataprocMetricConfig(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
-
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.dataproc_metric_config.0.metrics.#", "2"),
-
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.dataproc_metric_config.0.metrics.0.metric_source", "HDFS"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.dataproc_metric_config.0.metrics.0.metric_overrides.#", "1"),
-				),
-			},
-		},
-	})
-}
-<% end -%>
-
-func TestAccDataprocCluster_withNodeGroupAffinity(t *testing.T) {
-	t.Parallel()
-
-	var cluster dataproc.Cluster
-	rnd := randString(t, 10)
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataprocCluster_withNodeGroupAffinity(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
-
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.node_group_affinity.0.node_group_uri", "https://www.googleapis.com/compute/v1/projects/ci-test-project-188019/zones/us-central1-f/nodeGroups/test-nodegroup"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccDataprocCluster_singleNodeCluster(t *testing.T) {
 	t.Parallel()
 
@@ -529,29 +456,6 @@ func TestAccDataprocCluster_nonPreemptibleSecondary(t *testing.T) {
 		},
 	})
 }
-
-<% if version == "ga" -%>
-func TestAccDataprocCluster_spotSecondary(t *testing.T) {
-	t.Parallel()
-
-	rnd := randString(t, 10)
-	var cluster dataproc.Cluster
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataprocCluster_spotSecondary(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.spot_secondary", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.spot_secondary", "cluster_config.0.preemptible_worker_config.0.preemptibility", "SPOT"),
-				),
-			},
-		},
-	})
-}
-<% end -%>
 
 func TestAccDataprocCluster_withStagingBucket(t *testing.T) {
 	t.Parallel()
@@ -1425,114 +1329,6 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-func testAccDataprocCluster_withReservationAffinity(rnd string) string {
-	return fmt.Sprintf(`
-
-resource "google_compute_reservation" "reservation" {
-  name = "default"
-  zone = "us-central1-f"
-
-  specific_reservation {
-    count = 10
-    instance_properties {
-      machine_type = "n1-standard-2"
-    }
-  }
-  specific_reservation_required = true
-}
-
-resource "google_dataproc_cluster" "basic" {
-  name   = "tf-test-dproc-%s"
-  region = "us-central1"
-
-  cluster_config {
-
-    master_config {
-      machine_type  = "n1-standard-2"
-    }
-
-    worker_config {
-      machine_type  = "n1-standard-2"
-    }
-
-    gce_cluster_config {
-      zone = "us-central1-f"
-      reservation_affinity {      
-        consume_reservation_type = "SPECIFIC_RESERVATION"
-        key = "compute.googleapis.com/reservation-name"
-        values = [google_compute_reservation.reservation.name]
-      }
-    }
-  }
-}
-`, rnd)
-}
-
-<% if version == "ga" -%>
-func testAccDataprocCluster_withDataprocMetricConfig(rnd string) string {
-	return fmt.Sprintf(`
-resource "google_dataproc_cluster" "basic" {
-  name   = "tf-test-dproc-%s"
-  region = "us-central1"
-
-  cluster_config {
-    dataproc_metric_config {
-      metrics {
-        metric_source = "HDFS"
-        metric_overrides = ["yarn:ResourceManager:QueueMetrics:AppsCompleted"]
-      }
-
-      metrics {
-        metric_source = "SPARK"
-        metric_overrides = ["spark:driver:DAGScheduler:job.allJobs"]
-      }
-    }
-  }
-}
-`, rnd)
-}
-<% end -%>
-
-func testAccDataprocCluster_withNodeGroupAffinity(rnd string) string {
-	return fmt.Sprintf(`
-
-resource "google_compute_node_template" "nodetmpl" {
-  name   = "test-nodetmpl"
-  region = "us-central1"
-
-  node_affinity_labels = {
-    tfacc = "test"
-  }
-
-  node_type = "n1-node-96-624"
-
-  cpu_overcommit_type = "ENABLED"
-}
-
-resource "google_compute_node_group" "nodes" {
-  name = "test-nodegroup"
-  zone = "us-central1-f"
-
-  size          = 3
-  node_template = google_compute_node_template.nodetmpl.self_link
-}
-
-resource "google_dataproc_cluster" "basic" {
-  name   = "tf-test-dproc-%s"
-  region = "us-central1"
-
-  cluster_config {
-    gce_cluster_config {
-      zone = "us-central1-f"
-      node_group_affinity {
-        node_group_uri = google_compute_node_group.nodes.name
-      }
-    }
-  }
-}
-`, rnd)
-}
-
 func testAccDataprocCluster_singleNodeCluster(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "single_node_cluster" {
@@ -1712,43 +1508,6 @@ resource "google_dataproc_cluster" "non_preemptible_secondary" {
 }
 	`, rnd)
 }
-
-<% if version == "ga" -%>
-func testAccDataprocCluster_spotSecondary(rnd string) string {
-	return fmt.Sprintf(`
-resource "google_dataproc_cluster" "spot_secondary" {
-  name   = "tf-test-dproc-%s"
-  region = "us-central1"
-
-  cluster_config {
-    master_config {
-      num_instances = "1"
-      machine_type  = "e2-medium"
-      disk_config {
-        boot_disk_size_gb = 35
-      }
-    }
-
-    worker_config {
-      num_instances = "2"
-      machine_type  = "e2-medium"
-      disk_config {
-        boot_disk_size_gb = 35
-      }
-    }
-
-    preemptible_worker_config {
-      num_instances = "1"
-      preemptibility = "SPOT"
-      disk_config {
-        boot_disk_size_gb = 35
-      }
-    }
-  }
-}
-	`, rnd)
-}
-<% end -%>
 
 func testAccDataprocCluster_withStagingBucketOnly(bucketName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -372,14 +372,6 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 * `endpoint_config` (Optional) The config settings for port access on the cluster.
    Structure [defined below](#nested_endpoint_config).
 
-* `dataproc_metric_config` (Optional) The Compute Engine accelerator (GPU) configuration for these instances. Can be specified multiple times.
-
-    * `metrics` - (Required) Metrics sources to enable.
-
-        * `metric_source` - (Required) A source for the collection of Dataproc OSS metrics (see [available OSS metrics](https://cloud.google.com//dataproc/docs/guides/monitoring#available_oss_metrics)).
-
-        * `metric_overrides` - (Optional) One or more [available OSS metrics] (https://cloud.google.com/dataproc/docs/guides/monitoring#available_oss_metrics) to collect for the metric course.
-
 * `metastore_config` (Optional) The config setting for metastore service with the cluster.
    Structure [defined below](#nested_metastore_config).
 - - -
@@ -435,14 +427,6 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 
 * `metadata` - (Optional) A map of the Compute Engine metadata entries to add to all instances
    (see [Project and instance metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
-
-* `reservation_affinity` - (Optional) Reservation Affinity for consuming Zonal reservation.
-    * `consume_reservation_type` - (Optional) Metrics sources to enable.
-    * `key` - (Optional) Corresponds to the label key of reservation resource.
-    * `values` - (Optional) Corresponds to the label values of reservation resource.
-
-* `node_group_affinity` - (Optional) The name of the sole-tenant node group to create the cluster on.
-    * `node_group_uri` - (Required) The URI of a sole-tenant node group resource that the cluster will be created on.
 
 * `shielded_instance_config` (Optional) Shielded Instance Config for clusters using [Compute Engine Shielded VMs](https://cloud.google.com/security/shielded-cloud/shielded-vm).
 
@@ -620,7 +604,6 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
   * PREEMPTIBILITY_UNSPECIFIED
   * NON_PREEMPTIBLE
   * PREEMPTIBLE
-  * SPOT
 
 * `disk_config` (Optional) Disk Config
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#6889 - introduced GA-only fields, which we don't support, one of which had a crashing bug.

```release-note:none
Release note
```