### PR TITLE
Add `record_suppressions` field to `google_data_loss_prevention_deidentify_template` resource

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -1344,8 +1344,7 @@ objects:
                 description: Transform the record by applying various field transformations.
                 at_least_one_of:
                   - deidentify_config.0.record_transformations.0.field_transformations
-                  # Uncomment below when field(s) are implemented
-                  # - deidentify_config.0.record_transformations.0.record_suppressions
+                  - deidentify_config.0.record_transformations.0.record_suppressions
                 item_type: !ruby/object:Api::Type::NestedObject
                   properties:
                     - !ruby/object:Api::Type::Array
@@ -1602,3 +1601,115 @@ objects:
                                       - :ALPHA_LOWER_CASE
                                       - :PUNCTUATION
                                       - :WHITESPACE
+              - !ruby/object:Api::Type::Array
+                name: 'recordSuppressions'
+                description: Configuration defining which records get suppressed entirely. Records that match any suppression rule are omitted from the output.
+                at_least_one_of:
+                  - deidentify_config.0.record_transformations.0.field_transformations
+                  - deidentify_config.0.record_transformations.0.record_suppressions
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: condition
+                      description: A condition that when it evaluates to true will result in the record being evaluated to be suppressed from the transformed content.
+                      properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: expressions
+                          description: An expression, consisting of an operator and conditions.
+                          properties:
+                            - !ruby/object:Api::Type::Enum
+                              name: logicalOperator
+                              description: The operator to apply to the result of conditions. Default and currently only supported value is AND.
+                              default_value: :AND
+                              values:
+                                - :AND
+                            - !ruby/object:Api::Type::NestedObject
+                              name: conditions
+                              description: Conditions to apply to the expression.
+                              properties:
+                                - !ruby/object:Api::Type::Array
+                                  name: conditions
+                                  description: A collection of conditions.
+                                  item_type: !ruby/object:Api::Type::NestedObject
+                                    properties:
+                                      - !ruby/object:Api::Type::NestedObject
+                                        name: field
+                                        description: Field within the record this condition is evaluated against.
+                                        required: true
+                                        properties:
+                                          - !ruby/object:Api::Type::String
+                                            name: name
+                                            description: Name describing the field.
+                                      - !ruby/object:Api::Type::Enum
+                                        name: operator
+                                        description: Operator used to compare the field or infoType to the value.
+                                        required: true
+                                        values:
+                                          - :EQUAL_TO
+                                          - :NOT_EQUAL_TO
+                                          - :GREATER_THAN
+                                          - :LESS_THAN
+                                          - :GREATER_THAN_OR_EQUALS
+                                          - :LESS_THAN_OR_EQUALS
+                                          - :EXISTS
+                                      - !ruby/object:Api::Type::NestedObject
+                                        name: value
+                                        description: Value to compare against. [Mandatory, except for EXISTS tests.]
+                                        properties:
+                                          - !ruby/object:Api::Type::String
+                                            name: integerValue
+                                            description: An integer value (int64 format)
+                                          - !ruby/object:Api::Type::Double
+                                            name: floatValue
+                                            description: A float value.
+                                          - !ruby/object:Api::Type::String
+                                            name: stringValue
+                                            description: A string value.
+                                          - !ruby/object:Api::Type::Boolean
+                                            name: booleanValue
+                                            description: A boolean value.
+                                          - !ruby/object:Api::Type::String
+                                            name: timestampValue
+                                            description: |
+                                              A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+                                          - !ruby/object:Api::Type::NestedObject
+                                            name: timeValue
+                                            description: Represents a time of day.
+                                            properties:
+                                              - !ruby/object:Api::Type::Integer
+                                                name: hours
+                                                description: |
+                                                  Hours of day in 24 hour format. Should be from 0 to 23. An API may choose to allow the value "24:00:00" for scenarios like business closing time.
+                                              - !ruby/object:Api::Type::Integer
+                                                name: minutes
+                                                description: Minutes of hour of day. Must be from 0 to 59.
+                                              - !ruby/object:Api::Type::Integer
+                                                name: seconds
+                                                description: Seconds of minutes of the time. Must normally be from 0 to 59. An API may allow the value 60 if it allows leap-seconds.
+                                              - !ruby/object:Api::Type::Integer
+                                                name: nanos
+                                                description: Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999.
+                                          - !ruby/object:Api::Type::NestedObject
+                                            name: dateValue
+                                            description: Represents a whole or partial calendar date.
+                                            properties:
+                                              - !ruby/object:Api::Type::Integer
+                                                name: year
+                                                description: Year of the date. Must be from 1 to 9999, or 0 to specify a date without a year.
+                                              - !ruby/object:Api::Type::Integer
+                                                name: month
+                                                description: Month of a year. Must be from 1 to 12, or 0 to specify a year without a month and day.
+                                              - !ruby/object:Api::Type::Integer
+                                                name: day
+                                                description: Day of a month. Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant.
+                                          - !ruby/object:Api::Type::Enum
+                                            name: dayOfWeekValue
+                                            description: Represents a day of the week.
+                                            values:
+                                              - :MONDAY
+                                              - :TUESDAY
+                                              - :WEDNESDAY
+                                              - :THURSDAY
+                                              - :FRIDAY
+                                              - :SATURDAY
+                                              - :SUNDAY

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -444,6 +444,42 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
 
   deidentify_config {
     record_transformations {
+      record_suppressions {
+        condition {
+          expressions {
+            logical_operator = "AND"
+            conditions {
+              conditions {
+                field {
+                  name = "field3"
+                }
+                operator = "EQUAL_TO"
+                value {
+                  string_value = "FOO-BAR"
+                }
+              }
+              conditions {
+                field {
+                  name = "field2"
+                }
+                operator = "EQUAL_TO"
+                value {
+                  string_value = "foobar"
+                }
+              }
+              conditions {
+                field {
+                  name = "field1"
+                }
+                operator = "EQUAL_TO"
+                value {
+                  string_value = "fizzbuzz"
+                }
+              }
+            }
+          }
+        }
+      }
       field_transformations {
         fields {
           name = "details.pii.email"
@@ -521,6 +557,36 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
 
   deidentify_config {
     record_transformations {
+      record_suppressions {
+        condition {
+          expressions {
+            logical_operator = "AND"
+            conditions {
+              conditions {
+                field {
+                  name = "field3"
+                }
+                operator = "EQUAL_TO"
+                value {
+                  string_value = "FOO-BAR-updated"
+                }
+              }
+
+              # update includes deleting condition affecting field2
+
+              conditions {
+                field {
+                  name = "field1"
+                }
+                operator = "EQUAL_TO"
+                value {
+                  string_value = "fizzbuzz-updated"
+                }
+              }
+            }
+          }
+        }
+      }
       field_transformations {
         fields {
           name = "details.pii.email"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/9836

This PR adds the record suppressions field within the [deidentify_template.record_transformations](https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#DeidentifyTemplate.RecordTransformations) field of the `google_data_loss_prevention_deidentify_template` resource

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: Added field `deidentify_config.record_transformations.record_suppressions` to `google_data_loss_prevention_deidentify_template`
```
