### PR TITLE
Promote Workforce Pool resources to GA from beta

### DIFF
--- a/mmv1/products/iamworkforcepool/api.yaml
+++ b/mmv1/products/iamworkforcepool/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://iam.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://iam.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/iam
 apis_required:
@@ -48,7 +51,6 @@ objects:
     create_url: locations/{{location}}/workforcePools?workforcePoolId={{workforce_pool_id}}
     update_verb: :PATCH
     update_mask: true
-    min_version: beta
     description: |
       Represents a collection of external workforces. Provides namespaces for
       federated users that can be referenced in IAM policies.
@@ -133,7 +135,6 @@ objects:
     create_url: locations/{{location}}/workforcePools/{{workforce_pool_id}}/providers?workforcePoolProviderId={{provider_id}}
     update_verb: :PATCH
     update_mask: true
-    min_version: beta
     description: |
       A configuration for an external identity provider.
       ~> **Note:** Ask your Google Cloud account team to request access to workforce identity

--- a/mmv1/products/iamworkforcepool/terraform.yaml
+++ b/mmv1/products/iamworkforcepool/terraform.yaml
@@ -20,7 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "iam_workforce_pool_basic"
-        min_version: beta
         primary_resource_id: "example"
         vars:
           workforce_pool_id: "example-pool"
@@ -28,7 +27,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
       - !ruby/object:Provider::Terraform::Examples
         name: "iam_workforce_pool_full"
-        min_version: beta
         primary_resource_id: "example"
         vars:
           workforce_pool_id: "example-pool"
@@ -48,7 +46,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "iam_workforce_pool_provider_saml_basic"
-        min_version: beta
         primary_resource_id: "example"
         vars:
           workforce_pool_id: "example-pool"
@@ -57,7 +54,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
       - !ruby/object:Provider::Terraform::Examples
         name: "iam_workforce_pool_provider_saml_full"
-        min_version: beta
         primary_resource_id: "example"
         vars:
           workforce_pool_id: "example-pool"
@@ -66,7 +62,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
       - !ruby/object:Provider::Terraform::Examples
         name: "iam_workforce_pool_provider_oidc_basic"
-        min_version: beta
         primary_resource_id: "example"
         vars:
           workforce_pool_id: "example-pool"
@@ -75,7 +70,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
       - !ruby/object:Provider::Terraform::Examples
         name: "iam_workforce_pool_provider_oidc_full"
-        min_version: beta
         primary_resource_id: "example"
         vars:
           workforce_pool_id: "example-pool"

--- a/mmv1/templates/terraform/examples/iam_workforce_pool_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_workforce_pool_basic.tf.erb
@@ -1,6 +1,4 @@
 resource "google_iam_workforce_pool" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   workforce_pool_id = "<%= ctx[:vars]["workforce_pool_id"] %>"
   parent            = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
   location          = "global"

--- a/mmv1/templates/terraform/examples/iam_workforce_pool_full.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_workforce_pool_full.tf.erb
@@ -1,6 +1,4 @@
 resource "google_iam_workforce_pool" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   workforce_pool_id = "<%= ctx[:vars]["workforce_pool_id"] %>"
   parent            = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
   location          = "global"

--- a/mmv1/templates/terraform/examples/iam_workforce_pool_provider_oidc_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_workforce_pool_provider_oidc_basic.tf.erb
@@ -1,14 +1,10 @@
 resource "google_iam_workforce_pool" "pool" {
-  provider = google-beta
-
   workforce_pool_id = "<%= ctx[:vars]["workforce_pool_id"] %>"
   parent            = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
   location          = "global"
 }
 
 resource "google_iam_workforce_pool_provider" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   workforce_pool_id  = google_iam_workforce_pool.pool.workforce_pool_id
   location           = google_iam_workforce_pool.pool.location
   provider_id        = "<%= ctx[:vars]["provider_id"] %>"

--- a/mmv1/templates/terraform/examples/iam_workforce_pool_provider_oidc_full.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_workforce_pool_provider_oidc_full.tf.erb
@@ -1,14 +1,10 @@
 resource "google_iam_workforce_pool" "pool" {
-  provider = google-beta
-
   workforce_pool_id = "<%= ctx[:vars]["workforce_pool_id"] %>"
   parent            = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
   location          = "global"
 }
 
 resource "google_iam_workforce_pool_provider" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   workforce_pool_id   = google_iam_workforce_pool.pool.workforce_pool_id
   location            = google_iam_workforce_pool.pool.location
   provider_id         = "<%= ctx[:vars]["provider_id"] %>"

--- a/mmv1/templates/terraform/examples/iam_workforce_pool_provider_saml_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_workforce_pool_provider_saml_basic.tf.erb
@@ -1,14 +1,10 @@
 resource "google_iam_workforce_pool" "pool" {
-  provider = google-beta
-
   workforce_pool_id = "<%= ctx[:vars]["workforce_pool_id"] %>"
   parent            = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
   location          = "global"
 }
 
 resource "google_iam_workforce_pool_provider" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   workforce_pool_id  = google_iam_workforce_pool.pool.workforce_pool_id
   location           = google_iam_workforce_pool.pool.location
   provider_id        = "<%= ctx[:vars]["provider_id"] %>"

--- a/mmv1/templates/terraform/examples/iam_workforce_pool_provider_saml_full.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_workforce_pool_provider_saml_full.tf.erb
@@ -1,14 +1,10 @@
 resource "google_iam_workforce_pool" "pool" {
-  provider = google-beta
-
   workforce_pool_id = "<%= ctx[:vars]["workforce_pool_id"] %>"
   parent            = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
   location          = "global"
 }
 
 resource "google_iam_workforce_pool_provider" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   workforce_pool_id   = google_iam_workforce_pool.pool.workforce_pool_id
   location            = google_iam_workforce_pool.pool.location
   provider_id         = "<%= ctx[:vars]["provider_id"] %>"

--- a/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_id_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_id_test.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
-
 import (
 	"strings"
 	"testing"
@@ -33,5 +31,3 @@ func TestValidateIAMWorkforcePoolWorkforcePoolId(t *testing.T) {
 		t.Errorf("Failed to validate WorkforcePool names: %v", es)
 	}
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_provider_id_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_provider_id_test.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
-
 import (
 	"strings"
 	"testing"
@@ -31,5 +29,3 @@ func TestValidateIAMWorkforcePoolWorkforcePoolProviderId(t *testing.T) {
 		t.Errorf("Failed to validate WorkforcePoolProvider names: %v", es)
 	}
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_provider_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_provider_test.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
-
 import (
     "fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -294,4 +292,3 @@ resource "google_iam_workforce_pool" "my_pool" {
 }
 `, context)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_iam_workforce_pool_workforce_pool_test.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
-
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
@@ -111,4 +109,3 @@ resource "google_iam_workforce_pool" "my_pool" {
 }
 `, context)
 }
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Promote Workforce Pool resources to GA from beta.

Fixed: https://github.com/hashicorp/terraform-provider-google/issues/13290

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_iam_workforce_pool` (ga only)
```

```release-note:new-resource
`google_iam_workforce_pool_provider` (ga only)
```