### PR TITLE
dataproc use v1 only

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -13,11 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 var (

--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -19,7 +19,6 @@ import (
 var (
 	resolveDataprocImageVersion = regexp.MustCompile(`(?P<Major>[^\s.-]+)\.(?P<Minor>[^\s.-]+)(?:\.(?P<Subminor>[^\s.-]+))?(?:\-(?P<Distr>[^\s.-]+))?`)
 
-<% if version == "ga" -%>
 	virtualClusterConfigKeys = []string{
 		"virtual_cluster_config.0.staging_bucket",
 		"virtual_cluster_config.0.auxiliary_services_config",
@@ -47,7 +46,6 @@ var (
 		"virtual_cluster_config.0.kubernetes_cluster_config.0.gke_cluster_config.0.gke_cluster_target",
 		"virtual_cluster_config.0.kubernetes_cluster_config.0.gke_cluster_config.0.node_pool_target",
 	}
-<% end -%>
 
 	gceClusterConfigKeys = []string{
 		"cluster_config.0.gce_cluster_config.0.zone",
@@ -113,7 +111,6 @@ func resourceDataprocLabelDiffSuppress(k, old, new string, d *schema.ResourceDat
 	return false
 }
 
-<% if version == "ga" -%>
 const resourceDataprocGoogleProvidedDPGKEPrefix = "virtual_cluster_config.0.kubernetes_cluster_config.0.kubernetes_software_config.0.properties.dpgke"
 const resourceDataprocGoogleProvidedSparkPrefix = "virtual_cluster_config.0.kubernetes_cluster_config.0.kubernetes_software_config.0.properties.spark"
 
@@ -130,7 +127,6 @@ func resourceDataprocPropertyDiffSuppress(k, old, new string, d *schema.Resource
 	// For other keys, don't suppress diff.
 	return false
 }
-<% end -%>
 
 func resourceDataprocCluster() *schema.Resource {
 	return &schema.Resource{
@@ -207,7 +203,6 @@ func resourceDataprocCluster() *schema.Resource {
 				Description: `The list of labels (key/value pairs) to be applied to instances in the cluster. GCP generates some itself including goog-dataproc-cluster-name which is the name of the cluster.`,
 			},
 
-<% if version == "ga" -%>
 			"virtual_cluster_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -469,7 +464,6 @@ func resourceDataprocCluster() *schema.Resource {
 					},
 				},
 			},
-<% end -%>
 
 			"cluster_config": {
 				Type:        schema.TypeList,
@@ -1202,15 +1196,11 @@ func resourceDataprocClusterCreate(d *schema.ResourceData, meta interface{}) err
 		ProjectId:   project,
 	}
 
-<% if version == "ga" -%>
 	if _, ok := d.GetOk("virtual_cluster_config"); ok {
 		cluster.VirtualClusterConfig, err = expandVirtualClusterConfig(d, config)
 	} else {
 		cluster.Config, err = expandClusterConfig(d, config)
 	}
-<% else -%>
-	cluster.Config, err = expandClusterConfig(d, config)
-<% end -%>
 
 	if err != nil {
 		return err
@@ -1249,7 +1239,6 @@ func resourceDataprocClusterCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceDataprocClusterRead(d, meta)
 }
 
-<% if version == "ga" -%>
 func expandVirtualClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.VirtualClusterConfig, error) {
 	conf := &dataproc.VirtualClusterConfig{}
 
@@ -1431,7 +1420,6 @@ func expandGkeNodePoolAutoscalingConfig(cfg map[string]interface{}) *dataproc.Gk
 	}
 	return conf
 }
-<% end -%>
 
 func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.ClusterConfig, error) {
 	conf := &dataproc.ClusterConfig{
@@ -1942,7 +1930,6 @@ func resourceDataprocClusterRead(d *schema.ResourceData, meta interface{}) error
 
 	var cfg []map[string]interface{}
 
-<% if version == "ga" -%>
 	if cluster.Config != nil {
 		cfg, err = flattenClusterConfig(d, cluster.Config)
 
@@ -1964,22 +1951,9 @@ func resourceDataprocClusterRead(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
-<% else -%>
-	cfg, err = flattenClusterConfig(d, cluster.Config)
-
-	if err != nil {
-		return err
-	}
-
-	err = d.Set("cluster_config", cfg)
-	if err != nil {
-		return err
-	}
-<% end -%>
 	return nil
 }
 
-<% if version == "ga" -%>
 func flattenVirtualClusterConfig(d *schema.ResourceData, cfg *dataproc.VirtualClusterConfig) ([]map[string]interface{}, error) {
 	data := map[string]interface{}{
 		"staging_bucket":            d.Get("virtual_cluster_config.0.staging_bucket"),
@@ -2095,7 +2069,6 @@ func flattenKubernetesSoftwareConfig(d *schema.ResourceData, cfg *dataproc.Kuber
 
 	return []map[string]interface{}{data}
 }
-<% end -%>
 
 func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) ([]map[string]interface{}, error) {
 

--- a/mmv1/third_party/terraform/resources/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_job.go.erb
@@ -9,11 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 var jobTypes = []string{"pyspark_config", "spark_config", "hadoop_config", "hive_config", "pig_config", "sparksql_config", "presto_config"}

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -708,8 +708,8 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
-					// We only provide one, but GCP adds three, so expect 4.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "4"),
+					// We only provide one, but GCP adds three and we added goog-dataproc-autozone internally, so expect 5.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "5"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key1", "value1"),
 				),
 			},

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -16,11 +16,7 @@ import (
 
 	"google.golang.org/api/googleapi"
 
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 func TestDataprocExtractInitTimeout(t *testing.T) {

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -216,6 +216,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 	})
 }
 
+<% if version == "ga" -%>
 func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	t.Parallel()
 
@@ -252,6 +253,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 	t.Parallel()
@@ -1129,6 +1131,7 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
+<% if version == "ga" -%>
 func testAccDataprocVirtualCluster_basic(projectID string, rnd string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {
@@ -1187,6 +1190,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
   }
 `, projectID, rnd, projectID, rnd, rnd, rnd, rnd, rnd, rnd)
 }
+<% end -%>
 
 func testAccCheckDataprocGkeClusterNodePoolsHaveRoles(cluster *dataproc.Cluster, roles ...string) func(s *terraform.State) error {
 	return func(s *terraform.State) error {

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -216,7 +216,6 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 	})
 }
 
-<% if version == "ga" -%>
 func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	t.Parallel()
 
@@ -253,7 +252,6 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 	t.Parallel()
@@ -1131,7 +1129,6 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-<% if version == "ga" -%>
 func testAccDataprocVirtualCluster_basic(projectID string, rnd string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {
@@ -1203,7 +1200,6 @@ func testAccCheckDataprocGkeClusterNodePoolsHaveRoles(cluster *dataproc.Cluster,
 		return fmt.Errorf("Cluster NodePools does not contain expected roles : %v", roles)
 	}
 }
-<% end -%>
 
 func testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_dataproc_job_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_job_test.go.erb
@@ -15,11 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/googleapi"
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 type jobTestField struct {

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -53,11 +53,7 @@ import (
 	container "google.golang.org/api/container/v1beta1"
 <% end -%>
 	dataflow "google.golang.org/api/dataflow/v1b3"
-<% unless version == 'ga' -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% else -%>
 	"google.golang.org/api/dataproc/v1"
-<% end -%>
 	"google.golang.org/api/dns/v1"
 	healthcare "google.golang.org/api/healthcare/v1"
 	"google.golang.org/api/iam/v1"

--- a/mmv1/third_party/terraform/utils/dataproc_cluster_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/dataproc_cluster_operation.go.erb
@@ -5,12 +5,7 @@ import (
 	"fmt"
 	"time"
 
-
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 type DataprocClusterOperationWaiter struct {

--- a/mmv1/third_party/terraform/utils/dataproc_job_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/dataproc_job_operation.go.erb
@@ -6,11 +6,7 @@ import (
 	"net/http"
 	"time"
 
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 type DataprocJobOperationWaiter struct {

--- a/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go.erb
@@ -7,11 +7,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/cloudresourcemanager/v1"
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 var IamDataprocClusterSchema = map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go.erb
@@ -87,9 +87,7 @@ func DataprocClusterIdParseFunc(d *schema.ResourceData, config *Config) error {
 }
 
 func (u *DataprocClusterIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-<% if version == "ga" -%>
 	req := &dataproc.GetIamPolicyRequest{}
-<% end -%>
 
 	userAgent, err := generateUserAgentString(u.d, u.Config.userAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go.erb
@@ -96,7 +96,7 @@ func (u *DataprocClusterIamUpdater) GetResourceIamPolicy() (*cloudresourcemanage
 		return nil, err
 	}
 
-	p, err := u.Config.NewDataprocClient(userAgent).Projects.Regions.Clusters.GetIamPolicy(u.GetResourceId()<% if version == "ga" -%>, req<% end -%>).Do()
+	p, err := u.Config.NewDataprocClient(userAgent).Projects.Regions.Clusters.GetIamPolicy(u.GetResourceId(), req).Do()
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}

--- a/mmv1/third_party/terraform/utils/iam_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_job.go.erb
@@ -7,11 +7,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/cloudresourcemanager/v1"
-<% if version == "ga" -%>
 	"google.golang.org/api/dataproc/v1"
-<% else -%>
-	dataproc "google.golang.org/api/dataproc/v1beta2"
-<% end -%>
 )
 
 var IamDataprocJobSchema = map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/utils/iam_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_job.go.erb
@@ -87,9 +87,7 @@ func DataprocJobIdParseFunc(d *schema.ResourceData, config *Config) error {
 }
 
 func (u *DataprocJobIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-<% if version == "ga" -%>
 	req := &dataproc.GetIamPolicyRequest{}
-<% end -%>
 
 	userAgent, err := generateUserAgentString(u.d, u.Config.userAgent)
 	if err != nil {
@@ -97,7 +95,7 @@ func (u *DataprocJobIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Po
 	}
 
 <%# GetIamPolicy signature changes between beta and GA clients %>
-	p, err := u.Config.NewDataprocClient(userAgent).Projects.Regions.Jobs.GetIamPolicy(u.GetResourceId()<% if version == "ga" -%>, req<% end -%>).Do()
+	p, err := u.Config.NewDataprocClient(userAgent).Projects.Regions.Jobs.GetIamPolicy(u.GetResourceId(), req).Do()
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -11,7 +11,7 @@ Creates a job on Dataflow, which is an implementation of Apache Beam running on 
 the official documentation for
 [Beam](https://beam.apache.org) and [Dataflow](https://cloud.google.com/dataflow/).
 
-## Example Usage 
+## Example Usage
 
 ```hcl
 resource "google_dataflow_job" "big_data_job" {

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -11,7 +11,7 @@ Creates a job on Dataflow, which is an implementation of Apache Beam running on 
 the official documentation for
 [Beam](https://beam.apache.org) and [Dataflow](https://cloud.google.com/dataflow/).
 
-## Example Usage
+## Example Usage 
 
 ```hcl
 resource "google_dataflow_job" "big_data_job" {


### PR DESCRIPTION
dataproc use v1 only



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
dataproc: deprecate the v1beta2 API.
```
