### PR TITLE
Configuring a pathlen of 0 requires zero_max_issuer_path_length to be true

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -208,14 +208,15 @@ objects:
                     input: true
                     description: |
                       Refers to the "path length constraint" in Basic Constraints extension. For a CA certificate, this value describes the depth of
-                      subordinate CA certificates that are allowed. If this value is less than 0, the request will fail.
+                      subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. Setting the value to 0
+                      requires setting `zero_max_issuer_path_length = true`.
                   - !ruby/object:Api::Type::Boolean
                     name: 'zeroMaxIssuerPathLength'
                     input: true
                     url_param_only: true
                     description: |
                       When true, the "path length constraint" in Basic Constraints extension will be set to 0.
-                      if both `max_issuer_path_length` and `zero_max_issuer_path_length` are unset,
+                      If both `max_issuer_path_length` and `zero_max_issuer_path_length` are unset,
                       the max path length will be omitted from the CA certificate.
               - !ruby/object:Api::Type::NestedObject
                 name: 'keyUsage'


### PR DESCRIPTION
While the gcloud cli accepts a yaml file with `maxIssuerPathLength: 0`, the provider code treats that as a default, and omits it. Make it clear that if you want to have a `pathlen:0` attribute on your certificate (quite common for an intermediate CA), you must set `zero_max_issuer_path_length = true`.

Signed-off-by: Sven Höxter <sven@stormbind.net>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
