### PR TITLE
Promote GKE Backup BackupPlan to GA

### DIFF
--- a/mmv1/products/gkebackup/api.yaml
+++ b/mmv1/products/gkebackup/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://gkebackup.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://gkebackup.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync
@@ -43,7 +46,6 @@ apis_required:
     url: https://console.cloud.google.com/apis/library/gkebackup.googleapis.com
 objects:
   - !ruby/object:Api::Resource
-    min_version: beta
     name: 'BackupPlan'
     base_url: "projects/{{project}}/locations/{{location}}/backupPlans"
     create_url: projects/{{project}}/locations/{{location}}/backupPlans?backupPlanId={{name}}

--- a/mmv1/products/gkebackup/terraform.yaml
+++ b/mmv1/products/gkebackup/terraform.yaml
@@ -19,7 +19,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "gkebackup_backupplan_basic"
-        min_version: beta
         primary_resource_id: "basic"
         vars:
           name: "basic-plan"
@@ -28,14 +27,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
       - !ruby/object:Provider::Terraform::Examples
         name: "gkebackup_backupplan_autopilot"
-        min_version: beta
         primary_resource_id: "autopilot"
         vars:
           name: "autopilot-plan"
           cluster_name: "autopilot-cluster"
       - !ruby/object:Provider::Terraform::Examples
         name: "gkebackup_backupplan_cmek"
-        min_version: beta
         primary_resource_id: "cmek"
         vars:
           name: "cmek-plan"
@@ -45,7 +42,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
       - !ruby/object:Provider::Terraform::Examples
         name: "gkebackup_backupplan_full"
-        min_version: beta
         primary_resource_id: "full"
         vars:
           name: "full-plan"

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_autopilot.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_autopilot.tf.erb
@@ -1,5 +1,4 @@
 resource "google_container_cluster" "primary" {
-  provider = google-beta
   name               = "<%= ctx[:vars]['cluster_name'] %>"
   location           = "us-central1"
   enable_autopilot = true
@@ -16,7 +15,6 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_gke_backup_backup_plan" "autopilot" {
-  provider = google-beta
   name = "<%= ctx[:vars]['name'] %>"
   cluster = google_container_cluster.primary.id
   location = "us-central1"

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_container_cluster" "primary" {
-  provider = google-beta
   name               = "<%= ctx[:vars]['cluster_name'] %>"
   location           = "us-central1"
   initial_node_count = 1
@@ -14,7 +13,6 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_gke_backup_backup_plan" "basic" {
-  provider = google-beta
   name = "<%= ctx[:vars]['name'] %>"
   cluster = google_container_cluster.primary.id
   location = "us-central1"

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_cmek.tf.erb
@@ -1,5 +1,4 @@
 resource "google_container_cluster" "primary" {
-  provider = google-beta
   name               = "<%= ctx[:vars]['cluster_name'] %>"
   location           = "us-central1"
   initial_node_count = 1
@@ -14,7 +13,6 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_gke_backup_backup_plan" "cmek" {
-  provider = google-beta
   name = "<%= ctx[:vars]['name'] %>"
   cluster = google_container_cluster.primary.id
   location = "us-central1"
@@ -31,13 +29,11 @@ resource "google_gke_backup_backup_plan" "cmek" {
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['key_name'] %>"
   key_ring = google_kms_key_ring.key_ring.id
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['key_name'] %>"
   location = "us-central1"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_container_cluster" "primary" {
-  provider = google-beta
   name               = "<%= ctx[:vars]['cluster_name'] %>"
   location           = "us-central1"
   initial_node_count = 1
@@ -14,7 +13,6 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_gke_backup_backup_plan" "full" {
-  provider = google-beta
   name = "<%= ctx[:vars]['name'] %>"
   cluster = google_container_cluster.primary.id
   location = "us-central1"

--- a/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"testing"
@@ -118,4 +117,3 @@ resource "google_gke_backup_backup_plan" "backupplan" {
 }
 `, context)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
@@ -43,7 +43,6 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 func testAccGKEBackupBackupPlan_basic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_container_cluster" "primary" {
-  provider = google-beta
   name               = "tf-test-testcluster%{random_suffix}"
   location           = "us-central1"
   initial_node_count = 1
@@ -58,7 +57,6 @@ resource "google_container_cluster" "primary" {
 }
 	
 resource "google_gke_backup_backup_plan" "backupplan" {
-  provider = google-beta
   name = "tf-test-testplan%{random_suffix}"
   cluster = google_container_cluster.primary.id
   location = "us-central1"
@@ -74,7 +72,6 @@ resource "google_gke_backup_backup_plan" "backupplan" {
 func testAccGKEBackupBackupPlan_full(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_container_cluster" "primary" {
-  provider = google-beta
   name               = "tf-test-testcluster%{random_suffix}"
   location           = "us-central1"
   initial_node_count = 1
@@ -89,7 +86,6 @@ resource "google_container_cluster" "primary" {
 }
 	
 resource "google_gke_backup_backup_plan" "backupplan" {
-  provider = google-beta
   name = "tf-test-testplan%{random_suffix}"
   cluster = google_container_cluster.primary.id
   location = "us-central1"

--- a/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
@@ -17,7 +17,7 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGKEBackupBackupPlanDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13195


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
promoted `google_gke_backup_backup_plan` to ga (ga only)

```
