### PR TITLE
Data Source for google_compute_security_policy

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_security_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_security_policy.go
@@ -1,0 +1,92 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleComputeSecurityPolicy() *schema.Resource {
+	dsSchema := datasourceSchemaFromResourceSchema(resourceComputeSecurityPolicy().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name", "project")
+
+	return &schema.Resource{
+		Read:   dataSourceComputeecurityPolicyRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceComputeecurityPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return err
+	}
+
+	projectGetCall := config.NewResourceManagerClient(userAgent).Projects.Get(project)
+
+	if config.UserProjectOverride {
+		billingProject := project
+
+		// err == nil indicates that the billing_project value was found
+		if bp, err := getBillingProject(d, config); err == nil {
+			billingProject = bp
+		}
+		projectGetCall.Header().Add("X-Goog-User-Project", billingProject)
+	}
+
+	id, err := replaceVars(d, config, "projects/{{project}}/global/securityPolicies/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	sp := d.Get("name").(string)
+
+	client := config.NewComputeClient(userAgent)
+
+	securityPolicy, err := client.SecurityPolicies.Get(project, sp).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("SecurityPolicy %q", d.Id()))
+	}
+
+	if err := d.Set("name", securityPolicy.Name); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
+	if err := d.Set("description", securityPolicy.Description); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("type", securityPolicy.Type); err != nil {
+		return fmt.Errorf("Error setting type: %s", err)
+	}
+	if err := d.Set("rule", flattenSecurityPolicyRules(securityPolicy.Rules)); err != nil {
+		return err
+	}
+	if err := d.Set("fingerprint", securityPolicy.Fingerprint); err != nil {
+		return fmt.Errorf("Error setting fingerprint: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("self_link", ConvertSelfLinkToV1(securityPolicy.SelfLink)); err != nil {
+		return fmt.Errorf("Error setting self_link: %s", err)
+	}
+	if err := d.Set("advanced_options_config", flattenSecurityPolicyAdvancedOptionsConfig(securityPolicy.AdvancedOptionsConfig)); err != nil {
+		return fmt.Errorf("Error setting advanced_options_config: %s", err)
+	}
+
+	if err := d.Set("adaptive_protection_config", flattenSecurityPolicyAdaptiveProtectionConfig(securityPolicy.AdaptiveProtectionConfig)); err != nil {
+		return fmt.Errorf("Error setting adaptive_protection_config: %s", err)
+	}
+
+	if err := d.Set("recaptcha_options_config", flattenSecurityPolicyRecaptchaOptionConfig(securityPolicy.RecaptchaOptionsConfig)); err != nil {
+		return fmt.Errorf("Error setting recaptcha_options_config: %s", err)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_security_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_security_policy.go
@@ -11,12 +11,12 @@ func dataSourceGoogleComputeSecurityPolicy() *schema.Resource {
 	addRequiredFieldsToSchema(dsSchema, "name", "project")
 
 	return &schema.Resource{
-		Read:   dataSourceComputeecurityPolicyRead,
+		Read:   dataSourceComputSecurityPolicyRead,
 		Schema: dsSchema,
 	}
 }
 
-func dataSourceComputeecurityPolicyRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceComputSecurityPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_security_policy_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_security_policy_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceGoogleComputeSecurityPolicy_basic(t *testing.T) {
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudRunServiceDestroyProducer(t),
+		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceGoogleComputeSecurityPolicy_basic(context),

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_security_policy_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_security_policy_test.go
@@ -1,0 +1,66 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGoogleComputeSecurityPolicy_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudRunServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleComputeSecurityPolicy_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_compute_security_policy.foo", "google_compute_security_policy.policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleComputeSecurityPolicy_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_security_policy" "policy" {
+   name = "my-policy%{random_suffix}"
+
+   rule {
+     action   = "deny(403)"
+     priority = "1000"
+     match {
+       versioned_expr = "SRC_IPS_V1"
+       config {
+	    src_ip_ranges = ["9.9.9.0/24"]
+       }
+      }
+     description = "Deny access to IPs in 9.9.9.0/24"
+    }
+
+   rule {
+     action   = "allow"
+     priority = "2147483647"
+     match {
+     versioned_expr = "SRC_IPS_V1"
+     config {
+	   src_ip_ranges = ["*"]
+     }
+     }
+     description = "default rule"
+    }
+}
+
+data "google_compute_security_policy" "foo" {
+  name = google_compute_security_policy.policy.name
+  project = google_compute_security_policy.policy.project
+}`, context)
+
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -241,6 +241,7 @@ func Provider() *schema.Provider {
 			"google_compute_resource_policy":                   dataSourceGoogleComputeResourcePolicy(),
 			"google_compute_router":                            dataSourceGoogleComputeRouter(),
 			"google_compute_router_status":                     dataSourceGoogleComputeRouterStatus(),
+			"google_compute_security_policy":                   dataSourceGoogleComputeSecurityPolicy(),
 			"google_compute_snapshot":                          dataSourceGoogleComputeSnapshot(),
 			"google_compute_ssl_certificate":                   dataSourceGoogleComputeSslCertificate(),
 			"google_compute_ssl_policy":                        dataSourceGoogleComputeSslPolicy(),

--- a/mmv1/third_party/terraform/website/docs/d/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_security_policy.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Compute Engine"
+page_title: "Google: google_compute_security_policy"
+description: |-
+  Get information about a Google Compute Security Policy.
+---
+
+# google\_compute\_security\_policy
+
+To get more information about Snapshot, see:
+
+* [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/armor/docs/configure-security-policies)
+
+## Example Usage
+
+```hcl
+data "google_compute_security_policy" "foo" {
+  name = "my-policy"
+  project = "my-project"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the security policy.
+
+* `project` - (Required) The project in which the resource belongs. If it is not provided, the provider project is used.
+
+- - -
+
+## Attributes Reference
+
+See [google_compute_security_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_security_policy) resource for details of the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_security_policy.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # google\_compute\_security\_policy
 
-To get more information about Snapshot, see:
+To get more information about Google Compute Security Policy, see:
 
 * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies)
 * How-to Guides


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes the issue : [add google_compute_security_policy data source](https://github.com/hashicorp/terraform-provider-google/issues/3321)
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
google_compute_security_policy
```
