### PR TITLE
Adding support for concurrency

### DIFF
--- a/mmv1/products/cloudfunctions2/api.yaml
+++ b/mmv1/products/cloudfunctions2/api.yaml
@@ -224,6 +224,12 @@ objects:
               The amount of memory available for a function.
               Defaults to 256M. Supported units are k, M, G, Mi, Gi. If no unit is
               supplied the value is interpreted as bytes.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxInstanceRequestConcurrency'
+            description: 'Sets the maximum number of concurrent requests that each instance can receive. Defaults to 1.'
+          - !ruby/object:Api::Type::String
+            name: 'availableCpu'
+            description: 'The number of CPUs used in a single container instance. Default value is calculated from available memory.'
           - !ruby/object:Api::Type::KeyValuePairs
             name: 'environmentVariables'
             description: 'Environment variables that shall be available during function execution.'

--- a/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
@@ -46,8 +46,10 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
   service_config {
     max_instance_count  = 3
     min_instance_count = 1
-    available_memory    = "256M"
+    available_memory    = "4Gi"
     timeout_seconds     = 60
+    max_instance_request_concurrency = 80
+    available_cpu = "4"
     environment_variables = {
         SERVICE_CONFIG_TEST = "config_test"
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding support to 2nd Gen Cloud Functions Terraform Provider for: max_instance_request_concurrency and available_cpu to allow for setting concurrency.
fixes https://github.com/hashicorp/terraform-provider-google/issues/12489


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Adding support to 2nd Gen Cloud Functions Terraform Provider for: max_instance_request_concurrency and available_cpu to allow for setting concurrency.
```
