### PR TITLE
Added Auto deploy config to google_compute_security_policy to support Cloud Armor

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -1164,7 +1164,6 @@ func expandAutoDeployConfig(configured []interface{}) *compute.SecurityPolicyAda
 		ConfidenceThreshold: data["confidence_threshold"].(float64),
 		ImpactedBaselineThreshold: data["impacted_baseline_threshold"].(float64),
 		ExpirationSec: int64(data["expiration_sec"].(int)),
-		ForceSendFields: []string{"Enable"},
 	}
 }
 <% end -%>

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -470,6 +470,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 							Type:        schema.TypeList,
 							Description: `Auto Deploy Config of this security policy`,
 							Optional:    true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"load_threshold": {

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -465,6 +465,37 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 								},
 							},
 						},
+						<% unless version == 'ga' -%>
+						"auto_deploy_config": {
+							Type:        schema.TypeList,
+							Description: `Auto Deploy Config of this security policy`,
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"load_threshold": {
+										Type:        schema.TypeFloat,
+										Optional:    true,
+										Description: `Identifies new attackers only when the load to the backend service that is under attack exceeds this threshold.`,
+									},
+									"confidence_threshold": {
+										Type:        schema.TypeFloat,
+										Optional:    true,
+										Description: `Rules are only automatically deployed for alerts on potential attacks with confidence scores greater than this threshold.`,
+									},
+									"impacted_baseline_threshold": {
+										Type:        schema.TypeFloat,
+										Optional:    true,
+										Description: `Rules are only automatically deployed when the estimated impact to baseline traffic from the suggested mitigation is below this threshold.`,
+									},
+									"expiration_sec": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `Google Cloud Armor stops applying the action in the automatically deployed rule to an identified attacker after this duration. The rule continues to operate against new requests.`,
+									},
+								},
+							},
+						},
+						<% end -%>
 					},
 				},
 			},
@@ -686,6 +717,9 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("adaptive_protection_config") {
 		securityPolicy.AdaptiveProtectionConfig = expandSecurityPolicyAdaptiveProtectionConfig(d.Get("adaptive_protection_config").([]interface{}))
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "AdaptiveProtectionConfig", "adaptiveProtectionConfig.layer7DdosDefenseConfig.enable", "adaptiveProtectionConfig.layer7DdosDefenseConfig.ruleVisibility")
+		<% unless version == 'ga' -%>
+		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "adaptiveProtectionConfig.autoDeployConfig.loadThreshold", "adaptiveProtectionConfig.autoDeployConfig.confidenceThreshold", "adaptiveProtectionConfig.autoDeployConfig.impactedBaselineThreshold", "adaptiveProtectionConfig.autoDeployConfig.expirationSec")
+		<% end -%>
 	}
 
 	if d.HasChange("recaptcha_options_config") {
@@ -1097,6 +1131,10 @@ func expandSecurityPolicyAdaptiveProtectionConfig(configured []interface{}) *com
 	data := configured[0].(map[string]interface{})
 	return &compute.SecurityPolicyAdaptiveProtectionConfig{
 		Layer7DdosDefenseConfig: expandLayer7DdosDefenseConfig(data["layer_7_ddos_defense_config"].([]interface{})),
+		<% unless version == 'ga' -%>
+		AutoDeployConfig: expandAutoDeployConfig(data["auto_deploy_config"].([]interface{})),
+		<% end -%>
+		
 	}
 }
 
@@ -1113,6 +1151,24 @@ func expandLayer7DdosDefenseConfig(configured []interface{}) *compute.SecurityPo
 	}
 }
 
+<% unless version == 'ga' -%>
+func expandAutoDeployConfig(configured []interface{}) *compute.SecurityPolicyAdaptiveProtectionConfigAutoDeployConfig {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	data := configured[0].(map[string]interface{})
+
+	return &compute.SecurityPolicyAdaptiveProtectionConfigAutoDeployConfig{
+		LoadThreshold:   data["load_threshold"].(float64),
+		ConfidenceThreshold:   data["confidence_threshold"].(float64),
+		ImpactedBaselineThreshold:   data["impacted_baseline_threshold"].(float64),
+		ExpirationSec:   int64(data["expiration_sec"].(int)),
+		ForceSendFields: []string{"Enable"},
+	}
+}
+<% end -%>
+
 func flattenSecurityPolicyAdaptiveProtectionConfig(conf *compute.SecurityPolicyAdaptiveProtectionConfig) []map[string]interface{} {
 	if conf == nil {
 		return nil
@@ -1120,6 +1176,9 @@ func flattenSecurityPolicyAdaptiveProtectionConfig(conf *compute.SecurityPolicyA
 
 	data := map[string]interface{}{
 		"layer_7_ddos_defense_config": flattenLayer7DdosDefenseConfig(conf.Layer7DdosDefenseConfig),
+		<% unless version == 'ga' -%>
+		"auto_deploy_config": flattenAutoDeployConfig(conf.AutoDeployConfig),
+		<% end -%>
 	}
 
 	return []map[string]interface{}{data}
@@ -1137,6 +1196,23 @@ func flattenLayer7DdosDefenseConfig(conf *compute.SecurityPolicyAdaptiveProtecti
 
 	return []map[string]interface{}{data}
 }
+
+<% unless version == 'ga' -%>
+func flattenAutoDeployConfig(conf *compute.SecurityPolicyAdaptiveProtectionConfigAutoDeployConfig) []map[string]interface{} {
+	if conf == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"load_threshold": conf.LoadThreshold,
+		"confidence_threshold": conf.ConfidenceThreshold,
+		"impacted_baseline_threshold": conf.ImpactedBaselineThreshold,
+		"expiration_sec": conf.ExpirationSec,
+	}
+
+	return []map[string]interface{}{data}
+}
+<% end -%>
 
 func expandSecurityPolicyRuleRateLimitOptions(configured []interface{}) *compute.SecurityPolicyRuleRateLimitOptions {
 	if len(configured) == 0 || configured[0] == nil {

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -1159,13 +1159,11 @@ func expandAutoDeployConfig(configured []interface{}) *compute.SecurityPolicyAda
 	}
 
 	data := configured[0].(map[string]interface{})
-
 	return &compute.SecurityPolicyAdaptiveProtectionConfigAutoDeployConfig{
-		LoadThreshold:   data["load_threshold"].(float64),
-		ConfidenceThreshold:   data["confidence_threshold"].(float64),
-		ImpactedBaselineThreshold:   data["impacted_baseline_threshold"].(float64),
-		ExpirationSec:   int64(data["expiration_sec"].(int)),
-		ForceSendFields: []string{"Enable"},
+		LoadThreshold: data["load_threshold"].(float64),
+		ConfidenceThreshold: data["confidence_threshold"].(float64),
+		ImpactedBaselineThreshold: data["impacted_baseline_threshold"].(float64),
+		ExpirationSec: int64(data["expiration_sec"].(int)),
 	}
 }
 <% end -%>

--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -1164,6 +1164,7 @@ func expandAutoDeployConfig(configured []interface{}) *compute.SecurityPolicyAda
 		ConfidenceThreshold: data["confidence_threshold"].(float64),
 		ImpactedBaselineThreshold: data["impacted_baseline_threshold"].(float64),
 		ExpirationSec: int64(data["expiration_sec"].(int)),
+		ForceSendFields: []string{"Enable"},
 	}
 }
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -234,7 +234,6 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *testing.T) {
 	t.Parallel()
 
-	fmt.Println("Running test with auto deploy config")
 	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -987,7 +987,7 @@ resource "google_compute_security_policy" "policy" {
   description = "updated description"
 
   adaptive_protection_config {
-    layer_7_ddos_defense_config {
+    layer_7_ddos_defense_config 
       enable = false
       rule_visibility = "STANDARD"
     }
@@ -1005,11 +1005,11 @@ resource "google_compute_security_policy" "policy" {
 
   adaptive_protection_config {
     auto_deploy_config {
-		load_threshold = 0.8
-		confidence_threshold = 0.5
-		impacted_baseline_threshold = 0.01
-		expiration_sec = 7200
-	}
+      load_threshold = 0.8
+      confidence_threshold = 0.5
+      impacted_baseline_threshold = 0.01
+      expiration_sec = 7200
+    }
   }
 }
 `, spName)

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -249,7 +249,7 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *test
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-						{
+			{
 				Config: testAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig_update(spName),
 			},
 			{

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -987,7 +987,7 @@ resource "google_compute_security_policy" "policy" {
   description = "updated description"
 
   adaptive_protection_config {
-    layer_7_ddos_defense_config 
+    layer_7_ddos_defense_config {
       enable = false
       rule_visibility = "STANDARD"
     }

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -230,6 +230,31 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *testing.T) {
+	t.Parallel()
+
+	fmt.Println("Running test with auto deploy config")
+	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccComputeSecurityPolicy_withRateLimitOptions(t *testing.T) {
 	t.Parallel()
 
@@ -971,6 +996,26 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  adaptive_protection_config {
+    auto_deploy_config {
+	  load_threshold = 0.8
+      confidence_threshold = 0.5
+	  impacted_baseline_threshold = 0.01
+	  expiration_sec = 7200
+	}
+  }
+}
+`, spName)
+}
+<% end -%>
 
 func testAccComputeSecurityPolicy_withRateLimitOptions(spName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -1031,10 +1031,10 @@ resource "google_compute_security_policy" "policy" {
 
   adaptive_protection_config {
     auto_deploy_config {
-		load_threshold = 0.8
-		confidence_threshold = 0.5
-		impacted_baseline_threshold = 0.01
-		expiration_sec = 8000
+      load_threshold = 0.8
+      confidence_threshold = 0.5
+      impacted_baseline_threshold = 0.01
+      expiration_sec = 8000
     }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -1031,9 +1031,9 @@ resource "google_compute_security_policy" "policy" {
 
   adaptive_protection_config {
     auto_deploy_config {
-      load_threshold = 0.8
-      confidence_threshold = 0.5
-      impacted_baseline_threshold = 0.01
+      load_threshold = 0.9
+      confidence_threshold = 0.6
+      impacted_baseline_threshold = 0.03
       expiration_sec = 8000
     }
   }

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -1006,9 +1006,9 @@ resource "google_compute_security_policy" "policy" {
   adaptive_protection_config {
     auto_deploy_config {
 		load_threshold = 0.8
-      	confidence_threshold = 0.5
-	  	impacted_baseline_threshold = 0.01
-	  	expiration_sec = 7200
+		confidence_threshold = 0.5
+		impacted_baseline_threshold = 0.01
+		expiration_sec = 7200
 	}
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -249,6 +249,14 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *test
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+						{
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig_update(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1009,6 +1017,24 @@ resource "google_compute_security_policy" "policy" {
       confidence_threshold = 0.5
       impacted_baseline_threshold = 0.01
       expiration_sec = 7200
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig_update(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  adaptive_protection_config {
+    auto_deploy_config {
+		load_threshold = 0.8
+		confidence_threshold = 0.5
+		impacted_baseline_threshold = 0.01
+		expiration_sec = 8000
     }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -1005,10 +1005,10 @@ resource "google_compute_security_policy" "policy" {
 
   adaptive_protection_config {
     auto_deploy_config {
-	  load_threshold = 0.8
-      confidence_threshold = 0.5
-	  impacted_baseline_threshold = 0.01
-	  expiration_sec = 7200
+		load_threshold = 0.8
+      	confidence_threshold = 0.5
+	  	impacted_baseline_threshold = 0.01
+	  	expiration_sec = 7200
 	}
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -320,9 +320,7 @@ The following arguments are supported:
 
 * `layer_7_ddos_defense_config` - (Optional) Configuration for [Google Cloud Armor Adaptive Protection Layer 7 DDoS Defense](https://cloud.google.com/armor/docs/adaptive-protection-overview?hl=en). Structure is [documented below](#nested_layer_7_ddos_defense_config).
 
-<% unless version == 'ga' -%>
 * `auto_deploy_config` - (Optional) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). 
-<% end -%>
 
 <a name="nested_layer_7_ddos_defense_config"></a>The `layer_7_ddos_defense_config` block supports:
 
@@ -330,7 +328,6 @@ The following arguments are supported:
 
 * `rule_visibility` - (Optional) Rule visibility can be one of the following: STANDARD - opaque rules. (default) PREMIUM - transparent rules.
 
-<% unless version == 'ga' -%>
 <a name="auto_deploy_config"></a>The `auto_deploy_config` block supports:
 
 * `load_threshold` - (Optional) Identifies new attackers only when the load to the backend service that is under attack exceeds this threshold.
@@ -340,7 +337,6 @@ The following arguments are supported:
 * `impacted_baseline_threshold` - (Optional) Rules are only automatically deployed when the estimated impact to baseline traffic from the suggested mitigation is below this threshold.
 
 * `expiration_sec` - (Optional) Google Cloud Armor stops applying the action in the automatically deployed rule to an identified attacker after this duration. The rule continues to operate against new requests.
-<% end -%>
 
 <a name="nested_recaptcha_options_config"></a>The `recaptcha_options_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -320,7 +320,7 @@ The following arguments are supported:
 
 * `layer_7_ddos_defense_config` - (Optional) Configuration for [Google Cloud Armor Adaptive Protection Layer 7 DDoS Defense](https://cloud.google.com/armor/docs/adaptive-protection-overview?hl=en). Structure is [documented below](#nested_layer_7_ddos_defense_config).
 
-* `auto_deploy_config` - Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). Structure is [documented below](#nested_auto_deploy_config).
+* `auto_deploy_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). Structure is [documented below](#nested_auto_deploy_config).
 
 <a name="nested_layer_7_ddos_defense_config"></a>The `layer_7_ddos_defense_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -320,11 +320,27 @@ The following arguments are supported:
 
 * `layer_7_ddos_defense_config` - (Optional) Configuration for [Google Cloud Armor Adaptive Protection Layer 7 DDoS Defense](https://cloud.google.com/armor/docs/adaptive-protection-overview?hl=en). Structure is [documented below](#nested_layer_7_ddos_defense_config).
 
+<% unless version == 'ga' -%>
+* `auto_deploy_config` - (Optional) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). 
+<% end -%>
+
 <a name="nested_layer_7_ddos_defense_config"></a>The `layer_7_ddos_defense_config` block supports:
 
 * `enable` - (Optional) If set to true, enables CAAP for L7 DDoS detection.
 
 * `rule_visibility` - (Optional) Rule visibility can be one of the following: STANDARD - opaque rules. (default) PREMIUM - transparent rules.
+
+<% unless version == 'ga' -%>
+<a name="auto_deploy_config"></a>The `auto_deploy_config` block supports:
+
+* `load_threshold` - (Optional) Identifies new attackers only when the load to the backend service that is under attack exceeds this threshold.
+
+* `confidence_threshold` - (Optional) Rules are only automatically deployed for alerts on potential attacks with confidence scores greater than this threshold.
+
+* `impacted_baseline_threshold` - (Optional) Rules are only automatically deployed when the estimated impact to baseline traffic from the suggested mitigation is below this threshold.
+
+* `expiration_sec` - (Optional) Google Cloud Armor stops applying the action in the automatically deployed rule to an identified attacker after this duration. The rule continues to operate against new requests.
+<% end -%>
 
 <a name="nested_recaptcha_options_config"></a>The `recaptcha_options_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -320,7 +320,7 @@ The following arguments are supported:
 
 * `layer_7_ddos_defense_config` - (Optional) Configuration for [Google Cloud Armor Adaptive Protection Layer 7 DDoS Defense](https://cloud.google.com/armor/docs/adaptive-protection-overview?hl=en). Structure is [documented below](#nested_layer_7_ddos_defense_config).
 
-* `auto_deploy_config` - (Optional) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). 
+* `auto_deploy_config` - (Optional) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). Structure is [documented below](#nested_auto_deploy_config).
 
 <a name="nested_layer_7_ddos_defense_config"></a>The `layer_7_ddos_defense_config` block supports:
 
@@ -328,7 +328,7 @@ The following arguments are supported:
 
 * `rule_visibility` - (Optional) Rule visibility can be one of the following: STANDARD - opaque rules. (default) PREMIUM - transparent rules.
 
-<a name="auto_deploy_config"></a>The `auto_deploy_config` block supports:
+<a name="nested_auto_deploy_config"></a>The `auto_deploy_config` block supports:
 
 * `load_threshold` - (Optional) Identifies new attackers only when the load to the backend service that is under attack exceeds this threshold.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -320,7 +320,7 @@ The following arguments are supported:
 
 * `layer_7_ddos_defense_config` - (Optional) Configuration for [Google Cloud Armor Adaptive Protection Layer 7 DDoS Defense](https://cloud.google.com/armor/docs/adaptive-protection-overview?hl=en). Structure is [documented below](#nested_layer_7_ddos_defense_config).
 
-* `auto_deploy_config` - (Optional) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). Structure is [documented below](#nested_auto_deploy_config).
+* `auto_deploy_config` - Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for [Automatically deploy Adaptive Protection suggested rules](https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy?hl=en). Structure is [documented below](#nested_auto_deploy_config).
 
 <a name="nested_layer_7_ddos_defense_config"></a>The `layer_7_ddos_defense_config` block supports:
 


### PR DESCRIPTION
API: https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies
 
https://cloud.google.com/armor/docs/adaptive-protection-auto-deploy
 
If this PR is for Terraform, I acknowledge that I have:
 
* [x]  Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
* [x]  [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
* [x]  Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
* [x]  [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
* [x]  Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
 
**Release Note Template for Downstream PRs (will be copied)**
 
```release-note:enhancement
compute: Added fields to resource `google_compute_security_policy` to support Cloud Armor Auto Deploy (beta)
```