### PR TITLE
Make billing budget filter credit_types and subaccounts updatable

### DIFF
--- a/mmv1/products/billingbudget/api.yaml
+++ b/mmv1/products/billingbudget/api.yaml
@@ -123,8 +123,10 @@ objects:
             description: |
               Optional. If creditTypesTreatment is INCLUDE_SPECIFIED_CREDITS,
               this is a list of credit types to be subtracted from gross cost to determine the spend for threshold calculations. See a list of acceptable credit type values.
-              If creditTypesTreatment is not INCLUDE_SPECIFIED_CREDITS, this field must be empty. 
-            item_type: Api::Type::String 
+              If creditTypesTreatment is not INCLUDE_SPECIFIED_CREDITS, this field must be empty.
+
+              **Note:** If the field has a value in the config and needs to be removed, the field has to be an emtpy array in the config.
+            item_type: Api::Type::String
             at_least_one_of:
               - budget_filter.0.projects
               - budget_filter.0.credit_types_treatment
@@ -142,6 +144,8 @@ objects:
               the parent account, usage from the parent account will be included.
               If the field is omitted, the report will include usage from the parent
               account and all subaccounts, if they exist.
+
+              **Note:** If the field has a value in the config and needs to be removed, the field has to be an emtpy array in the config.
             item_type: Api::Type::String
             at_least_one_of:
               - budget_filter.0.projects

--- a/mmv1/products/billingbudget/terraform.yaml
+++ b/mmv1/products/billingbudget/terraform.yaml
@@ -104,6 +104,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
          - "budgetFilter.customPeriod"
          - "budgetFilter.services"
          - "budgetFilter.creditTypesTreatment"   
+         - "budgetFilter.creditTypes"
+         - "budgetFilter.subaccounts"
       budgetFilter.services: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       budgetFilter.subaccounts: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/billing_budget_filter.tf.erb
+++ b/mmv1/templates/terraform/examples/billing_budget_filter.tf.erb
@@ -10,9 +10,10 @@ resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
   display_name = "<%= ctx[:vars]['display_name'] %>"
 
   budget_filter {
-    projects = ["projects/${data.google_project.project.number}"]
-    credit_types_treatment = "EXCLUDE_ALL_CREDITS"
-    services = ["services/24E6-581D-38E5"] # Bigquery
+    projects               = ["projects/${data.google_project.project.number}"]
+    credit_types_treatment = "INCLUDE_SPECIFIED_CREDITS"
+    services               = ["services/24E6-581D-38E5"] # Bigquery
+    credit_types           = ["PROMOTION", "FREE_TIER"]
   }
 
   amount {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://b.corp.google.com/issues/242945866

Make fields `credit_types` and `subaccounts` updatable


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
billingbudget: Make fields `credit_types` and `subaccounts` updatable for `google_billing_budget`
```
