### PR TITLE
Check for errors in `google_project` datasource Read results 

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_project.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project.go
@@ -33,5 +33,15 @@ func datasourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error
 		d.SetId(fmt.Sprintf("projects/%s", project))
 	}
 
-	return resourceGoogleProjectRead(d, meta)
+	id := d.Id()
+
+	if err := resourceGoogleProjectRead(d, meta); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found or not in ACTIVE state", id)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/12873, may address the issues encountered in https://github.com/hashicorp/terraform-provider-google/issues/10587

We handle `403`s in `google_project` with an error, which is not entirely correct to do. It's `google_project` so it's probably fine- if any resource acts weird on not founds, it's that one! However, there are a few cases where we *do* clear the resource out in the resource's read func:

- If the API returns a 404. This is *very* unlikely to happen. That would imply a user has permissions on a project but it doesn't exist. Because projects are namespaced globally, they have to exist to have permissions attached, and if they don't exist, nobody has permissions, and they'll always 403. Maybe I'm missing a case.
- If a project is not in the ACTIVE state. The only other valid state these days is DELETE_REQUESTED. For the project resource, clearing it from state is reasonabl. For the datasource, however, silently dropping it is not what we want to happen-that can inadvertently cause interpolations or references to see null or empty instead of a valid value, and recreate resources. Instead, returning an error is appropriate. (The blast radius is smaller than you may think- since projects are sticky in state, a resource seeing `data.google_project.foobar.project_id` as `""` will actually just keep using the project in state. That's a mechanic to resolve another time w/ https://github.com/hashicorp/terraform-provider-google/issues/11339)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resourcemanager: fixed the `google_project` datasource silently returning empty results when the project was not found or not in the ACTIVE state. Now, an error will be surfaced instead.
```
