### PR TITLE
fix: google_container_cluster management correct default values

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -78,7 +78,7 @@ var (
 		"addons_config.0.istio_config",
 		"addons_config.0.kalm_config",
 		"addons_config.0.config_connector_config",
-		
+
 	<% end -%>
 	}
 
@@ -603,13 +603,13 @@ func resourceContainerCluster() *schema.Resource {
 												"auto_upgrade": {
 													Type:        schema.TypeBool,
 													Optional:    true,
-													Computed:    true,
+													Default:		 true,
 													Description: `Specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes.`,
 												},
 												"auto_repair": {
 													Type:        schema.TypeBool,
 													Optional:    true,
-													Computed:    true,
+													Default:		 true,
 													Description: `Specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered.`,
 												},
 												"upgrade_options": {
@@ -4119,7 +4119,7 @@ func expandStandardRolloutPolicy(configured interface{}) *container.StandardRoll
 func expandManagement(configured interface{}) *container.NodeManagement {
 	l, ok := configured.([]interface{})
 	if !ok || l == nil || len(l) == 0 || l[0] == nil {
-		return &container.NodeManagement{}
+		return nil
 	}
 	config := l[0].(map[string]interface{})
 


### PR DESCRIPTION
Default the auto_upgrade & auto_repair to true. 

```tf
resource "google_container_cluster" "primary" {
  provider   = google-beta

  name     = "testing-rene-nap-default-2"
  location = "us-central1"

  remove_default_node_pool = true
  initial_node_count       = 1

  cluster_autoscaling {
    enabled             = true
    resource_limits {
      resource_type = "cpu"
      minimum       = 1
      maximum       = 100
    }

    resource_limits {
      resource_type = "memory"
      minimum       = 1
      maximum       = 100
    }
    auto_provisioning_defaults {

    }
  }
}
```

```tf
resource "google_container_cluster" "primary" {
  provider   = google-beta

  name     = "testing-rene-nap-default-2"
  location = "us-central1"

  remove_default_node_pool = true
  initial_node_count       = 1

  cluster_autoscaling {
    enabled             = true
    resource_limits {
      resource_type = "cpu"
      minimum       = 1
      maximum       = 100
    }

    resource_limits {
      resource_type = "memory"
      minimum       = 1
      maximum       = 100
    }
    auto_provisioning_defaults {
      management {
      }
    }
  }
}
```


Fixes https://github.com/hashicorp/terraform-provider-google/issues/13341

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
fix: default `google_container_cluster.cluster_autoscaling.auto_provisioning_defaults.management` auto_repair & auto_upgrade to true
```
