### PR TITLE
Adding version to infoTypes in data_loss_prevention_inspect_template

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -475,6 +475,10 @@ objects:
                           description: |
                             Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
                             at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+                        - !ruby/object:Api::Type::String
+                          name: 'version'
+                          description: |
+                            Version of the information type to use. By default, the version is set to stable
                     - !ruby/object:Api::Type::Integer
                       name: 'maxFindings'
                       description: Max findings limit for the given infoType.
@@ -667,10 +671,6 @@ objects:
                                       description: |
                                         Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
                                         at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
-                                    - !ruby/object:Api::Type::String
-                                      name: 'version'
-                                      description: |
-                                        Version of the information type to use. By default, the version is set to stable
           - !ruby/object:Api::Type::Array
             name: 'customInfoTypes'
             description: |

--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -688,6 +688,10 @@ objects:
                       description: |
                         Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names
                         listed at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+                    - !ruby/object:Api::Type::String
+                      name: 'version'
+                      description: |
+                        Version of the information type to use. By default, the version is set to stable
                 - !ruby/object:Api::Type::Enum
                   name: 'likelihood'
                   description: |

--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -667,6 +667,10 @@ objects:
                                       description: |
                                         Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
                                         at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'version'
+                                      description: |
+                                        Version of the information type to use. By default, the version is set to stable
           - !ruby/object:Api::Type::Array
             name: 'customInfoTypes'
             description: |
@@ -688,10 +692,6 @@ objects:
                       description: |
                         Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names
                         listed at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
-                    - !ruby/object:Api::Type::String
-                      name: 'version'
-                      description: |
-                        Version of the information type to use. By default, the version is set to stable
                 - !ruby/object:Api::Type::Enum
                   name: 'likelihood'
                   description: |

--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -475,10 +475,6 @@ objects:
                           description: |
                             Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
                             at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
-                        - !ruby/object:Api::Type::String
-                          name: 'version'
-                          description: |
-                            Version of the information type to use. By default, the version is set to stable
                     - !ruby/object:Api::Type::Integer
                       name: 'maxFindings'
                       description: Max findings limit for the given infoType.
@@ -499,6 +495,10 @@ objects:
                   description: |
                     Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
                     at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+                - !ruby/object:Api::Type::String
+                  name: 'version'
+                  description: |
+                    Version of the information type to use. By default, the version is set to stable
           - !ruby/object:Api::Type::Array
             name: 'contentOptions'
             description: |

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_inspect_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_inspect_template_test.go
@@ -52,6 +52,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 		}
 		info_types {
 			name = "PERSON_NAME"
+			version = "latest"
 		}
 		info_types {
 			name = "LAST_NAME"
@@ -158,6 +159,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 	inspect_config {
 		info_types {
 			name = "PERSON_NAME"
+			version = "stable"
 		}
 		info_types {
 			name = "LAST_NAME"

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_inspect_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_inspect_template_test.go
@@ -51,7 +51,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 			name = "EMAIL_ADDRESS"
 		}
 		info_types {
-			name = "PERSON_NAME"
+			name    = "PERSON_NAME"
 			version = "latest"
 		}
 		info_types {
@@ -158,7 +158,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 
 	inspect_config {
 		info_types {
-			name = "PERSON_NAME"
+			name    = "PERSON_NAME"
 			version = "stable"
 		}
 		info_types {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
`version` field added to `infoType` in resource `dataLossPreventionInspectTemplate`
fixes https://github.com/hashicorp/terraform-provider-google/issues/12171

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `version` field to `data_loss_prevention_inspect_template` resource
```
