### PR TITLE
Added `export_subnet_routes_with_public_ip` and `import_subnet_routes_with_public_ip` fields to `google_compute_network_peering_routes_config` resource

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8977,6 +8977,7 @@ objects:
           IPv4 special-use ranges are always exported to peers and 
           are not controlled by this field.
         default_value: true
+        input: true
       - !ruby/object:Api::Type::Boolean
         name: 'importSubnetRoutesWithPublicIp'
         description: |
@@ -8984,6 +8985,7 @@ objects:
           The default value is false. IPv4 special-use ranges are always 
           imported from peers and are not controlled by this field.
         default_value: false
+        input: true
   - !ruby/object:Api::Resource
     name: 'NodeTemplate'
     kind: 'compute#nodeTemplate'

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8969,6 +8969,21 @@ objects:
         required: true
         description: |
           Whether to import the custom routes to the peer network.
+      - !ruby/object:Api::Type::Boolean
+        name: 'exportSubnetRoutesWithPublicIp'
+        description: |
+          Whether subnet routes with public IP range are exported. 
+          The default value is true, all subnet routes are exported. 
+          IPv4 special-use ranges are always exported to peers and 
+          are not controlled by this field.
+        default_value: true
+      - !ruby/object:Api::Type::Boolean
+        name: 'importSubnetRoutesWithPublicIp'
+        description: |
+          Whether subnet routes with public IP range are imported. 
+          The default value is false. IPv4 special-use ranges are always 
+          imported from peers and are not controlled by this field.
+        default_value: false
   - !ruby/object:Api::Resource
     name: 'NodeTemplate'
     kind: 'compute#nodeTemplate'

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.erb
@@ -4,6 +4,8 @@ resource "google_compute_network_peering_routes_config" "<%= ctx[:primary_resour
 
   import_custom_routes = true
   export_custom_routes = true
+  export_subnet_routes_with_public_ip = true 
+  import_subnet_routes_with_public_ip = true
 }
 
 resource "google_compute_network_peering" "peering_primary" {
@@ -13,6 +15,8 @@ resource "google_compute_network_peering" "peering_primary" {
 
   import_custom_routes = true
   export_custom_routes = true
+  export_subnet_routes_with_public_ip = true 
+  import_subnet_routes_with_public_ip = true
 }
 
 resource "google_compute_network_peering" "peering_secondary" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes : [Add the fields to google_compute_network_peering_routes_config](https://github.com/hashicorp/terraform-provider-google/issues/11573)
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `export_subnet_routes_with_public_ip` and `import_subnet_routes_with_public_ip` fields to `google_compute_network_peering_routes_config` resource
```
