### PR TITLE
Adding google_compute_network_peering datasource

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
@@ -16,24 +16,6 @@ func dataSourceComputeNetworkPeering() *schema.Resource {
 
 	dsSchema["name"].ValidateFunc = validateRegexp(regexGCEName)
 	dsSchema["network"].ValidateFunc = validateRegexp(peerNetworkLinkRegex)
-
-	dsSchema["network"].DiffSuppressFunc = func(_, old, new string, _ *schema.ResourceData) bool {
-		oldStripped, err := getRelativePath(old)
-		if err != nil {
-			return false
-		}
-
-		newStripped, err := getRelativePath(new)
-		if err != nil {
-			return false
-		}
-
-		if oldStripped == newStripped {
-			return true
-		}
-
-		return false
-	}
 	return &schema.Resource{
 		Read:   dataSourceComputeNetworkPeeringRead,
 		Schema: dsSchema,

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
@@ -1,0 +1,56 @@
+package google
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const regexGCEName = "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
+
+func dataSourceComputeNetworkPeering() *schema.Resource {
+
+	dsSchema := datasourceSchemaFromResourceSchema(resourceComputeNetworkPeering().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name", "network")
+
+	dsSchema["name"].ValidateFunc = validateRegexp(regexGCEName)
+	dsSchema["network"].ValidateFunc = validateRegexp(peerNetworkLinkRegex)
+
+	dsSchema["network"].DiffSuppressFunc = func(_, old, new string, _ *schema.ResourceData) bool {
+		oldStripped, err := getRelativePath(old)
+		if err != nil {
+			return false
+		}
+
+		newStripped, err := getRelativePath(new)
+		if err != nil {
+			return false
+		}
+
+		if oldStripped == newStripped {
+			return true
+		}
+
+		return false
+	}
+	return &schema.Resource{
+		Read:   dataSourceComputeNetworkPeeringRead,
+		Schema: dsSchema,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(4 * time.Minute),
+		},
+	}
+}
+
+func dataSourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	networkFieldValue, err := ParseNetworkFieldValue(d.Get("network").(string), d, config)
+	if err != nil {
+		return err
+	}
+	d.SetId(fmt.Sprintf("%s/%s", networkFieldValue.Name, d.Get("name").(string)))
+
+	return resourceComputeNetworkPeeringRead(d, meta)
+}

--- a/mmv1/third_party/terraform/tests/data_source_compute_network_peering_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_compute_network_peering_test.go
@@ -1,0 +1,60 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceComputeNetworkPeering_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComputeNetworkPeeringDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComputeNetworkPeering_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_compute_network_peering.peering1_ds", "google_compute_network_peering.peering1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeNetworkPeering_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network_peering" "peering1" {
+  name         = "peering1-%{random_suffix}"
+  network      = google_compute_network.default.self_link
+  peer_network = google_compute_network.other.self_link
+}
+
+resource "google_compute_network_peering" "peering2" {
+  name         = "peering2-%{random_suffix}"
+  network      = google_compute_network.other.self_link
+  peer_network = google_compute_network.default.self_link
+}
+
+resource "google_compute_network" "default" {
+  name                    = "foobar-%{random_suffix}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_network" "other" {
+  name                    = "other-%{random_suffix}"
+  auto_create_subnetworks = "false"
+}
+
+data "google_compute_network_peering" "peering1_ds" {
+  name       = google_compute_network_peering.peering1.name
+  network    = google_compute_network_peering.peering1.network
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -235,6 +235,7 @@ func Provider() *schema.Provider {
 			"google_compute_lb_ip_ranges":                      dataSourceGoogleComputeLbIpRanges(),
 			"google_compute_network":                           dataSourceGoogleComputeNetwork(),
 			"google_compute_network_endpoint_group":            dataSourceGoogleComputeNetworkEndpointGroup(),
+			"google_compute_network_peering":                   dataSourceComputeNetworkPeering(),
 			"google_compute_node_types":                        dataSourceGoogleComputeNodeTypes(),
 			"google_compute_regions":                           dataSourceGoogleComputeRegions(),
 			"google_compute_region_network_endpoint_group":     dataSourceGoogleComputeRegionNetworkEndpointGroup(),

--- a/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Compute Engine"
+page_title: "Google: google_compute_network_peering"
+description: |-
+  Get information of a specified compute network peering.
+---
+
+# google\_compute\_network\_peering
+
+Get information of a specified compute network peering. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/vpc/vpc-peering)
+and
+[API](https://cloud.google.com/compute/docs/reference/latest/networks).
+
+## Example Usage
+
+```hcl
+resource "google_compute_network_peering" "peering1" {
+  name         = "peering1"
+  network      = google_compute_network.default.self_link
+  peer_network = google_compute_network.other.self_link
+}
+
+resource "google_compute_network_peering" "peering2" {
+  name         = "peering2"
+  network      = google_compute_network.other.self_link
+  peer_network = google_compute_network.default.self_link
+}
+
+resource "google_compute_network" "default" {
+  name                    = "foobar"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_network" "other" {
+  name                    = "other"
+  auto_create_subnetworks = "false"
+}
+data "google_compute_network_peering" "peering1_ds" {
+  name       = google_compute_network_peering.peering1.name
+  network    = google_compute_network_peering.peering1.network
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the peering.
+
+* `network` - (Required) The primary network of the peering.
+
+## Attributes Reference
+
+See [google_compute_network_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#argument-reference) resource for details of the available attributes.
+
+## Timeouts
+
+This datasource provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `read` - Default is 4 minutes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/5248



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_compute_network_peering`
```
