### PR TITLE
check docker first for make-in-container.sh

### DIFF
--- a/scripts/make-in-container.sh
+++ b/scripts/make-in-container.sh
@@ -9,10 +9,10 @@ BUILDER_IMAGE="gcr.io/graphite-docker-images/downstream-builder:latest"
 DEV_IMAGE="gcr.io/graphite-docker-images/magic-modules-dev:latest"
 
 main() {
-    if which podman > /dev/null; then
-        CONTAINER_EXECUTABLE="podman"
-    elif which docker > /dev/null; then
+    if which docker > /dev/null; then
         CONTAINER_EXECUTABLE="docker"
+    elif which podman > /dev/null; then
+        CONTAINER_EXECUTABLE="podman"
     else
         echo "Unable to find podman or docker executable. Please install podman or docker and try again." && exit 1;
     fi


### PR DESCRIPTION
Podman has been difficult for some users to set up properly on OSX.

As a result, it would be best to prefer the stable, commonly working experience of Docker for running containers on OSX, and check for podman second.

This improves the experience for those that have a working docker but a non-working podman, while not impacted those who have a working podman installation they want to use exclusively.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
