### PR TITLE
Suppress diff from GKE default taints

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -2830,3 +2830,75 @@ resource "google_container_node_pool" "np2" {
   }
 `, cluster, np1, np2)
 }
+
+func testAccContainerNodePool_withDefaultTaintSuppress(cluster, np string, add_custom_taint bool) string {
+	custom_taint := ""
+	if add_custom_taint {
+		custom_taint = `
+taint {
+	key = "custom_taint"
+	value = "test"
+	effect = "NO_SCHEDULE"
+}`
+	}
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_container_node_pool" "with_default_gpu_taint" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    machine_type = "n1-standard-1"
+    image_type = "COS_CONTAINERD"
+
+    taint {
+      key    = "nvidia.com/gpu"
+      value  = "present"
+      effect = "NO_SCHEDULE"
+    }
+
+	%s
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+`, cluster, np, custom_taint)
+}
+
+func TestAccContainerNodePool_withDefaultTaintSuppress(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withDefaultTaintSuppress(cluster, np, false),
+			},
+			{
+				Config: testAccContainerNodePool_withDefaultTaintSuppress(cluster, np, true),
+			},
+			{
+				Config: testAccContainerNodePool_withDefaultTaintSuppress(cluster, np, false),
+			},
+		},
+	})
+}

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -2,9 +2,7 @@
 package google
 
 import (
-<% unless version == "ga" -%>
 	"strings"
-<% end -%>
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -360,9 +358,7 @@ func schemaNodeConfig() *schema.Schema {
 					// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
 					ConfigMode: schema.SchemaConfigModeAttr,
 					Description: `List of Kubernetes taints to be applied to each node.`,
-	<% unless version.nil? || version == 'ga' -%>
 					DiffSuppressFunc: containerNodePoolTaintSuppress,
-	<% end -%>
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"key": {
@@ -976,6 +972,7 @@ func flattenWorkloadMetadataConfig(c *container.WorkloadMetadataConfig) []map[st
 	}
 	return result
 }
+
 <% unless version.nil? || version == 'ga' -%>
 func flattenSandboxConfig(c *container.SandboxConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
@@ -1033,7 +1030,11 @@ func containerNodePoolLabelsSuppress(k, old, new string, d *schema.ResourceData)
 
 	return true
 }
+<% end -%>
 
+// containerNodePoolTaintSuppress builds a map of taints that represents the diff between
+// the existing and new configuration. Then GKE default taints are removed from the diff
+// and if the resulting diff is empty, the diff is suppressed.
 func containerNodePoolTaintSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// Node configs are embedded into multiple resources (container cluster and
 	// container node pool) so we determine the node config key dynamically.
@@ -1044,17 +1045,9 @@ func containerNodePoolTaintSuppress(k, old, new string, d *schema.ResourceData) 
 
 	root := k[:idx]
 
-	// Right now, GKE only applies its own out-of-band labels when you enable
-	// Sandbox. We only need to perform diff suppression in this case;
-	// otherwise, the default Terraform behavior is fine.
-	o, n := d.GetChange(root + ".sandbox_config.0.sandbox_type")
-	if o == nil || n == nil {
-		return false
-	}
-
 	// Pull the entire changeset as a list rather than trying to deal with each
 	// element individually.
-	o, n = d.GetChange(root + ".taint")
+	o, n := d.GetChange(root + ".taint")
 	if o == nil || n == nil {
 		return false
 	}
@@ -1063,21 +1056,8 @@ func containerNodePoolTaintSuppress(k, old, new string, d *schema.ResourceData) 
 		Key, Value, Effect string
 	}
 
-	taintSet := make(map[taintType]struct{})
-
-	// Add all new taints to set.
-	for _, raw := range n.([]interface{}) {
-		data := raw.(map[string]interface{})
-		taint := taintType{
-			Key:    data["key"].(string),
-			Value:  data["value"].(string),
-			Effect: data["effect"].(string),
-		}
-		taintSet[taint] = struct{}{}
-	}
-
-	// Remove all current taints, skipping GKE-managed keys if not present in
-	// the new configuration.
+	// Populate a map of existing taints
+	oldTaints := make(map[taintType]struct{})
 	for _, raw := range o.([]interface{}) {
 		data := raw.(map[string]interface{})
 		taint := taintType{
@@ -1085,23 +1065,63 @@ func containerNodePoolTaintSuppress(k, old, new string, d *schema.ResourceData) 
 			Value:  data["value"].(string),
 			Effect: data["effect"].(string),
 		}
-		if _, ok := taintSet[taint]; ok {
-			delete(taintSet, taint)
-		} else if !strings.HasPrefix(taint.Key, "sandbox.gke.io/") {
-			// User-provided taint removed in new configuration.
-			return false
+		oldTaints[taint] = struct{}{}
+	}
+
+	// Populate the diff of new taints
+	newTaints := make(map[taintType]struct{})
+	for _, raw := range n.([]interface{}) {
+		data := raw.(map[string]interface{})
+		taint := taintType{
+			Key:    data["key"].(string),
+			Value:  data["value"].(string),
+			Effect: data["effect"].(string),
 		}
+		newTaints[taint] = struct{}{}
+	}
+
+	// Populate the diff of added and removed taints
+	diff := make(map[taintType]struct{})
+	for taint := range newTaints {
+		if _, ok := oldTaints[taint]; !ok {
+			diff[taint] = struct{}{}
+		}
+	}
+	for taint := range oldTaints {
+		if _, ok := newTaints[taint]; !ok {
+			diff[taint] = struct{}{}
+		}
+	}
+
+	gkeDefaultTaints := map[taintType]struct{}{
+		taintType{
+			Key: "nvidia.com/gpu",
+			Value: "present",
+			Effect: "NO_SCHEDULE",
+		} : struct{}{},
+	}
+
+	// Remove GKE default taints
+	for taint := range diff {
+		if _, ok := gkeDefaultTaints[taint]; ok {
+			delete(diff, taint)
+		}
+	<% unless version.nil? || version == 'ga' -%>
+		// Remove sandbox specific taints from the diff.
+		if strings.HasPrefix(taint.Key, "sandbox.gke.io/") {
+			delete(diff, taint)
+		}
+	<% end -%>
 	}
 
 	// If, at this point, the set still has elements, the new configuration
 	// added an additional taint.
-	if len(taintSet) > 0 {
+	if len(diff) > 0 {
 		return false
 	}
 
 	return true
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface{} {


### PR DESCRIPTION
This extends beta provider behavior to suppress diffs that include GKE default applied taints.

fixes https://github.com/hashicorp/terraform-provider-google/issues/7928

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: Added diff suppression for GKE GPU default taints.
```
