### PR TITLE
Share settings for sole-tenant node groups.

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8928,6 +8928,7 @@ objects:
             properties:
             - !ruby/object:Api::Type::String
               name: 'projectId'
+              required: true
               description: |
                 The project id/number should be the same as the key of this project config in the project map.
   - !ruby/object:Api::Resource

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8902,6 +8902,34 @@ objects:
               Maximum size of the node group. Set to a value less than or equal
               to 100 and greater than or equal to min-nodes.
             required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'shareSettings'
+        description: |
+          Share settings for the node group.
+        properties:
+        - !ruby/object:Api::Type::Enum
+          name: 'shareType'
+          required: true
+          description: |
+            Node group sharing type.
+          values:
+          - :ORGANIZATION
+          - :SPECIFIC_PROJECTS
+          - :LOCAL
+        - !ruby/object:Api::Type::Map
+          name: 'projectMap'
+          description: |
+            A map of project id and project config. This is only valid when shareType's value is SPECIFIC_PROJECTS.
+          key_name: id
+          key_description: |
+            The project ID.
+          value_type: !ruby/object:Api::Type::NestedObject
+            name: projectConfig
+            properties:
+            - !ruby/object:Api::Type::String
+              name: 'projectId'
+              description: |
+                The project id/number should be the same as the key of this project config in the project map.
   - !ruby/object:Api::Resource
     name: 'NetworkPeeringRoutesConfig'
     base_url:  'projects/{{project}}/global/networks/{{network}}'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1776,6 +1776,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           group_name: "soletenant-group"
           template_name: "soletenant-tmpl"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "node_group_share_settings"
+        primary_resource_id: "nodes"
+        vars:
+          group_name: "soletenant-group"
+          template_name: "soletenant-tmpl"
     properties:
       zone: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
@@ -1796,6 +1802,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       autoscalingPolicy.maxNodes: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      shareSettings: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+        ignore_read: true
+      shareSettings.shareType: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      shareSettings.projectMap: !ruby/object:Overrides::Terraform::PropertyOverride
+        key_description: |
+          The project ID.
+      shareSettings.projectMap.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The project id/number, should be same as the key of this project config in the project map.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/compute_node_group_url_replace.go.erb
   NodeTemplate: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1782,6 +1782,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           group_name: "soletenant-group"
           template_name: "soletenant-tmpl"
+          guest_project_id: "project-id"
+          guest_project_name: "project-name"
+        test_env_vars:
+          org_id: :ORG_ID
     properties:
       zone: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
@@ -1804,15 +1808,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       shareSettings: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-        ignore_read: true
-      shareSettings.shareType: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-      shareSettings.projectMap: !ruby/object:Overrides::Terraform::PropertyOverride
-        key_description: |
-          The project ID.
-      shareSettings.projectMap.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
-        description: |
-          The project id/number, should be same as the key of this project config in the project map.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/compute_node_group_url_replace.go.erb
   NodeTemplate: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/templates/terraform/examples/node_group_share_settings.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_share_settings.tf.erb
@@ -1,25 +1,16 @@
-resource "google_project" "owner_project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
-
 resource "google_project" "guest_project" {
-  project_id      = "tf-test-2%{random_suffix}"
-  name            = "tf-test-2%{random_suffix}"
+  project_id      = "<%= ctx[:vars]['guest_project_id'] %>"
+  name            = "<%= ctx[:vars]['guest_project_name'] %>"
   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
 }
 
 resource "google_compute_node_template" "soletenant-tmpl" {
-  project = google_project.owner_project.project_id
   name      = "<%= ctx[:vars]['template_name'] %>"
   region    = "us-central1"
   node_type = "n1-node-96-624"
 }
 
 resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
-  project = google_project.owner_project.project_id
   name        = "<%= ctx[:vars]['group_name'] %>"
   zone        = "us-central1-f"
   description = "example google_compute_node_group for Terraform Google Provider"

--- a/mmv1/templates/terraform/examples/node_group_share_settings.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_share_settings.tf.erb
@@ -1,0 +1,38 @@
+resource "google_project" "owner_project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project" "guest_project" {
+  project_id      = "tf-test-2%{random_suffix}"
+  name            = "tf-test-2%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_compute_node_template" "soletenant-tmpl" {
+  project = google_project.owner_project.project_id
+  name      = "<%= ctx[:vars]['template_name'] %>"
+  region    = "us-central1"
+  node_type = "n1-node-96-624"
+}
+
+resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
+  project = google_project.owner_project.project_id
+  name        = "<%= ctx[:vars]['group_name'] %>"
+  zone        = "us-central1-f"
+  description = "example google_compute_node_group for Terraform Google Provider"
+
+  size          = 1
+  node_template = google_compute_node_template.soletenant-tmpl.id
+
+  share_settings {
+    share_type = "SPECIFIC_PROJECTS"
+    project_map {
+      id = google_project.guest_project.project_id
+      project_id = google_project.guest_project.project_id
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR introduces support for cross-project sharing of Node Groups.
This PR resolves [Issue 13281](https://github.com/hashicorp/terraform-provider-google/issues/13281).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Note on acceptance tests**
I ran the acceptance tests locally with my own projects instead of automatically created projects due to some limitations in my organisation.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `share_settings` field to the `google_compute_node_group` resource.
```
