### PR TITLE
[#13369] Format google_compute_network_firewall_policy_rule doc examples

### DIFF
--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global.tf.tmpl
@@ -1,45 +1,49 @@
 resource "google_compute_network_firewall_policy" "basic_network_firewall_policy" {
-  name = "{{policy}}"
-  project = "{{project}}"
+  name        = "{{policy}}"
   description = "Sample global network firewall policy"
+  project     = "{{project}}"
 }
 
 resource "google_compute_network_firewall_policy_rule" "primary" {
- firewall_policy = google_compute_network_firewall_policy.basic_network_firewall_policy.name
- action = "allow"
- direction = "INGRESS"
- priority = 1000
- rule_name = "test-rule"
- description = "This is a simple rule description" 
-match {
- src_secure_tags {
- name = "tagValues/${google_tags_tag_value.basic_value.name}"
- }
- src_ip_ranges = ["10.100.0.1/32"]
-layer4_configs {
-ip_protocol = "all"
- }
- }
- target_service_accounts = ["{{test_service_account}}"]
- enable_logging = true
- disabled = false
+  action                  = "allow"
+  description             = "This is a simple rule description"
+  direction               = "INGRESS"
+  disabled                = false
+  enable_logging          = true
+  firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.name
+  priority                = 1000
+  rule_name               = "test-rule"
+  target_service_accounts = ["{{test_service_account}}"]
+
+  match {
+    src_ip_ranges = ["10.100.0.1/32"]
+
+    src_secure_tags {
+      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+    }
+
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
 }
+
 resource "google_compute_network" "basic_network" {
   name = "{{network}}"
 }
+
 resource "google_tags_tag_key" "basic_key" {
-  parent = "organizations/{{org_id}}"
-  short_name = "{{tagkey}}"
-  purpose = "GCE_FIREWALL"
-  purpose_data = {
-  network= "{{project}}/${google_compute_network.basic_network.name}"
-  }
   description = "For keyname resources."
+  parent      = "organizations/{{org_id}}"
+  purpose     = "GCE_FIREWALL"
+  short_name  = "{{tagkey}}"
+  purpose_data = {
+    network = "{{project}}/${google_compute_network.basic_network.name}"
+  }
 }
 
-
 resource "google_tags_tag_value" "basic_value" {
-    parent = "tagKeys/${google_tags_tag_key.basic_key.name}"
-    short_name = "{{tagvalue}}"
-    description = "For valuename resources."
+  description = "For valuename resources."
+  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  short_name  = "{{tagvalue}}"
 }

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global_update.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global_update.tf.tmpl
@@ -1,45 +1,51 @@
 resource "google_compute_network_firewall_policy" "basic_network_firewall_policy" {
-  name = "{{policy}}"
-  project = "{{project}}"
+  name        = "{{policy}}"
   description = "Sample global network firewall policy"
+  project     = "{{project}}"
 }
 
 resource "google_compute_network_firewall_policy_rule" "primary" {
- firewall_policy = google_compute_network_firewall_policy.basic_network_firewall_policy.name
- action = "deny"
- direction = "EGRESS"
- priority = 1000
- rule_name = "updated-test-rule"
- description = "This is an updated rule description"
-match {
-layer4_configs {
-ip_protocol = "tcp"
-ports = ["123"]
- }
- dest_ip_ranges = ["0.0.0.0/0"]
- }
+  action          = "deny"
+  description     = "This is an updated rule description"
+  direction       = "EGRESS"
+  disabled        = true
+  enable_logging  = false
+  firewall_policy = google_compute_network_firewall_policy.basic_network_firewall_policy.name
+  priority        = 1000
+  rule_name       = "updated-test-rule"
+
+  match {
+    dest_ip_ranges = ["0.0.0.0/0"]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = ["123"]
+    }
+  }
+
   target_secure_tags {
- name = "tagValues/${google_tags_tag_value.basic_value.name}"
- }
- enable_logging = false
- disabled = true   
+    name = "tagValues/${google_tags_tag_value.basic_value.name}"
+  }
 }
+
 resource "google_compute_network" "basic_network" {
   name = "{{network}}"
 }
+
 resource "google_tags_tag_key" "basic_key" {
-  parent = "organizations/{{org_id}}"
-  short_name = "{{tagkey}}"
-  purpose = "GCE_FIREWALL"
-  purpose_data = {
-  network= "{{project}}/${google_compute_network.basic_network.name}"
-  }
   description = "For keyname resources."
+  parent      = "organizations/{{org_id}}"
+  purpose     = "GCE_FIREWALL"
+  short_name  = "{{tagkey}}"
+
+  purpose_data = {
+    network = "{{project}}/${google_compute_network.basic_network.name}"
+  }
 }
 
 
 resource "google_tags_tag_value" "basic_value" {
-    parent = "tagKeys/${google_tags_tag_key.basic_key.name}"
-    short_name = "{{tagvalue}}"
-    description = "For valuename resources."
+  description = "For valuename resources."
+  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  short_name  = "{{tagvalue}}"
 }

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional.tf.tmpl
@@ -1,48 +1,52 @@
 resource "google_compute_region_network_firewall_policy" "basic_regional_network_firewall_policy" {
-  name = "{{policy}}"
-  project = "{{project}}"
+  name        = "{{policy}}"
   description = "Sample regional network firewall policy"
-  region = "{{region}}"
+  project     = "{{project}}"
+  region      = "{{region}}"
 }
 
 resource "google_compute_region_network_firewall_policy_rule" "primary" {
- firewall_policy = google_compute_region_network_firewall_policy.basic_regional_network_firewall_policy.name
- action = "allow"
- direction = "INGRESS"
- priority = 1000
- rule_name = "test-rule"
- description = "This is a simple rule description"
-match {
- src_secure_tags {
- name = "tagValues/${google_tags_tag_value.basic_value.name}"
- }
- src_ip_ranges = ["10.100.0.1/32"]
-layer4_configs {
-ip_protocol = "all"
- }
- }
- target_service_accounts = ["{{test_service_account}}"]
- region = "{{region}}"
- enable_logging = true
- disabled = false
+  action                  = "allow"
+  description             = "This is a simple rule description"
+  direction               = "INGRESS"
+  disabled                = false
+  enable_logging          = true
+  firewall_policy         = google_compute_region_network_firewall_policy.basic_regional_network_firewall_policy.name
+  priority                = 1000
+  region                  = "{{region}}"
+  rule_name               = "test-rule"
+  target_service_accounts = ["{{test_service_account}}"]
+
+  match {
+    src_ip_ranges = ["10.100.0.1/32"]
+
+    layer4_configs {
+      ip_protocol = "all"
+    }
+
+    src_secure_tags {
+      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+    }
+  }
 }
 
 resource "google_compute_network" "basic_network" {
   name = "{{network}}"
 }
+
 resource "google_tags_tag_key" "basic_key" {
-  parent = "organizations/{{org_id}}"
-  short_name = "{{tagkey}}"
-  purpose = "GCE_FIREWALL"
-  purpose_data = {
-  network= "{{project}}/${google_compute_network.basic_network.name}"
-  }
   description = "For keyname resources."
+  parent      = "organizations/{{org_id}}"
+  purpose     = "GCE_FIREWALL"
+  short_name  = "{{tagkey}}"
+
+  purpose_data = {
+    network = "{{project}}/${google_compute_network.basic_network.name}"
+  }
 }
 
-
 resource "google_tags_tag_value" "basic_value" {
-    parent = "tagKeys/${google_tags_tag_key.basic_key.name}"
-    short_name = "{{tagvalue}}"
-    description = "For valuename resources."
+  description = "For valuename resources."
+  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  short_name  = "{{tagvalue}}"
 }

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional_update.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional_update.tf.tmpl
@@ -1,48 +1,52 @@
 resource "google_compute_region_network_firewall_policy" "basic_regional_network_firewall_policy" {
-  name = "{{policy}}"
-  project = "{{project}}"
+  name        = "{{policy}}"
   description = "Sample regional network firewall policy"
-  region = "{{region}}"
+  project     = "{{project}}"
+  region      = "{{region}}"
 }
 
 resource "google_compute_region_network_firewall_policy_rule" "primary" {
- firewall_policy = google_compute_region_network_firewall_policy.basic_regional_network_firewall_policy.name
- action = "deny"
- direction = "EGRESS"
- priority = 1000
- rule_name = "updated-test-rule"
- description = "This is an updated rule description"
-match {
-layer4_configs {
-ip_protocol = "tcp"
-ports = ["123"]
- }
- dest_ip_ranges = ["0.0.0.0/0"]
- }
+  action          = "deny"
+  description     = "This is an updated rule description"
+  direction       = "EGRESS"
+  disabled        = true
+  enable_logging  = false
+  firewall_policy = google_compute_region_network_firewall_policy.basic_regional_network_firewall_policy.name
+  priority        = 1000
+  region          = "{{region}}"
+  rule_name       = "updated-test-rule"
+
+  match {
+    dest_ip_ranges = ["0.0.0.0/0"]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = ["123"]
+    }
+  }
+
   target_secure_tags {
- name = "tagValues/${google_tags_tag_value.basic_value.name}"
- }
- region = "{{region}}"
- enable_logging = false
- disabled = true  
+    name = "tagValues/${google_tags_tag_value.basic_value.name}"
+  }
 }
 
 resource "google_compute_network" "basic_network" {
   name = "{{network}}"
 }
+
 resource "google_tags_tag_key" "basic_key" {
-  parent = "organizations/{{org_id}}"
-  short_name = "{{tagkey}}"
-  purpose = "GCE_FIREWALL"
-  purpose_data = {
-  network= "{{project}}/${google_compute_network.basic_network.name}"
-  }
   description = "For keyname resources."
+  parent      = "organizations/{{org_id}}"
+  purpose     = "GCE_FIREWALL"
+  short_name  = "{{tagkey}}"
+
+  purpose_data = {
+    network = "{{project}}/${google_compute_network.basic_network.name}"
+  }
 }
 
-
 resource "google_tags_tag_value" "basic_value" {
-    parent = "tagKeys/${google_tags_tag_key.basic_key.name}"
-    short_name = "{{tagvalue}}"
-    description = "For valuename resources."
+  description = "For valuename resources."
+  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  short_name  = "{{tagvalue}}"
 }


### PR DESCRIPTION
Formats [google_compute_network_firewall_policy_rule doc examples](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_firewall_policy_rule)

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:none
compute: format `google_compute_network_firewall_policy_rule` doc examples
```