### PR TITLE
Fix issue where breaking change message was corrupted.

### DIFF
--- a/tools/breaking-change-detector/rules/rules_field.go
+++ b/tools/breaking-change-detector/rules/rules_field.go
@@ -224,7 +224,7 @@ func (fr FieldRule) IsRuleBreak(old, new *schema.Schema, mc MessageContext) stri
 		return ""
 	}
 	mc.identifier = fr.identifier
-	mc.message = fr.identifier
+	mc.message = fr.message
 	return fr.isRuleBreak(old, new, mc)
 }
 

--- a/tools/breaking-change-detector/rules/rules_field_test.go
+++ b/tools/breaking-change-detector/rules/rules_field_test.go
@@ -439,3 +439,25 @@ func (tc *fieldTestCase) check(rule FieldRule, t *testing.T) {
 		t.Errorf("Test `%s` failed: expected %v violations, got %v", tc.name, tc.expectedViolation, violation)
 	}
 }
+
+func TestBreakingMessage(t *testing.T) {
+	breakageMessage := fieldRule_OptionalComputedToOptional.IsRuleBreak(
+		&schema.Schema{
+			Optional: true,
+			Computed: true,
+		},
+		&schema.Schema{
+			Optional: true,
+		},
+		MessageContext{
+			Resource: "a",
+			Field:    "b",
+			Version:  "beta",
+		},
+	)
+
+	if !strings.Contains(breakageMessage, "Field `b` transitioned from optional+computed to optional `a`") {
+		t.Errorf("Test `%s` failed: replacements for `{{<val>}}` not successful ", "TestBreakingMessage")
+	}
+
+}


### PR DESCRIPTION
breaking change detection message was printing a truncated message for field changes.

https://github.com/GoogleCloudPlatform/magic-modules/pull/7035#issuecomment-1363434009

updated this to read correctly
```release-note:none

```
