### PR TITLE
Revert "retrieve project from the name"

### DIFF
--- a/mmv1/templates/terraform/custom_import/data_catalog_taxonomy.go.erb
+++ b/mmv1/templates/terraform/custom_import/data_catalog_taxonomy.go.erb
@@ -8,10 +8,4 @@
     name := d.Get("name").(string)
     d.SetId(name)
 
-    re := regexp.MustCompile("projects/(.+)/(?:locations|regions)/(.+)/taxonomies/(.+)")
-    if matches := re.FindStringSubmatch(name); matches != nil {
-        d.Set("project", matches[1])
-        d.Set("locations", matches[2])
-    }
-
     return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#7063


```release-note:bug
REVERT: datacatalog: fixed the import failure when the `project` is different from the default on `google_data_catalog_taxonomy`
```
