### PR TITLE
[WIP] Add Firestore database CRU, beta only

### DIFF
--- a/mmv1/products/firestore/api.yaml
+++ b/mmv1/products/firestore/api.yaml
@@ -17,9 +17,115 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://firestore.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://firestore.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Google Cloud Firestore API
+    url: https://console.cloud.google.com/apis/library/firestore.googleapis.com
 objects:
+  - !ruby/object:Api::Resource
+    name: 'Database'
+    min_version: beta
+    base_url: 'projects/{{project}}/databases'
+    create_url: 'projects/{{project}}/databases?databaseId={{name}}'
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      A Cloud Firestore Database. Currently only one database is allowed per
+      cloud project; this database must have a `database_id` of '(default)'.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/firestore/docs/'
+      api: 'https://cloud.google.com/firestore/docs/reference/rest/v1/projects.databases'
+    async: !ruby/object:Api::OpAsync
+      actions: ['create','update']
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        required: true
+        description: |
+          Required. The ID to use for the database, which will become the final
+          component of the database's resource name. This value should be 4-63
+          characters. Valid characters are /[a-z][0-9]-/ with first character
+          a letter and the last a letter or a number. Must not be
+          UUID-like /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/.
+          "(default)" database id is also valid.
+        input: true
+      - !ruby/object:Api::Type::String
+        name: locationId
+        required: true
+        description: |
+          The location of the database. Available databases are listed at
+          https://cloud.google.com/firestore/docs/locations.
+        input: true
+      - !ruby/object:Api::Type::Enum
+        name: type
+        required: true
+        description: |
+          The type of the database.
+          See https://cloud.google.com/datastore/docs/firestore-or-datastore
+          for information about how to choose.
+        values:
+          - :FIRESTORE_NATIVE
+          - :DATASTORE_MODE
+      - !ruby/object:Api::Type::Enum
+        name: concurrencyMode
+        description: |
+          The concurrency control mode to use for this database.
+        values:
+          - :OPTIMISTIC
+          - :PESSIMISTIC
+          - :OPTIMISTIC_WITH_ENTITY_GROUPS
+      - !ruby/object:Api::Type::Enum
+        name: appEngineIntegrationMode
+        description: |
+          The App Engine integration mode to use for this database.
+        values:
+          - :ENABLED
+          - :DISABLED
+        default_value: :DISABLED
+      - !ruby/object:Api::Type::String
+        name: key_prefix
+        description: |
+          Output only. The keyPrefix for this database.
+          This keyPrefix is used, in combination with the project id ("~") to construct the application id
+          that is returned from the Cloud Datastore APIs in Google App Engine first generation runtimes.
+          This value may be empty in which case the appid to use for URL-encoded keys is the project_id (eg: foo instead of v~foo).
+        output: true
+      - !ruby/object:Api::Type::String
+        name: etag
+        description: |
+          This checksum is computed by the server based on the value of other fields,
+          and may be sent on update and delete requests to ensure the client has an
+          up-to-date value before proceeding.
+        output: true
+      - !ruby/object:Api::Type::Enum
+        name: delete_protection_state
+        description: 'State of delete protection for the database.'
+        values:
+          - :DELETE_PROTECTION_DISABLED
+          - :DELETE_PROTECTION_ENABLED
+        default_value: :DELETE_PROTECTION_DISABLED
   - !ruby/object:Api::Resource
     name: 'Index'
     base_url: projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/indexes

--- a/mmv1/products/firestore/terraform.yaml
+++ b/mmv1/products/firestore/terraform.yaml
@@ -13,6 +13,51 @@
 
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Database: !ruby/object:Overrides::Terraform::ResourceOverride
+    skip_delete: True
+    autogen_async: True
+    id_format: "projects/{{project}}/databases/{{name}}"
+    import_format:
+      - "projects/{{project}}/databases/{{name}}"
+      - "{{project}}/{{name}}"
+      - "{{name}}"
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firestore_database_default"
+        primary_resource_id: "default_database"
+        test_env_vars:
+          org_id: :ORG_ID
+        ignore_read_extra:
+          - project
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firestore_database_full_nondefault"
+        primary_resource_id: "database"
+        test_env_vars:
+          org_id: :ORG_ID
+        ignore_read_extra:
+          - project
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firestore_database_datastore_mode_default"
+        primary_resource_id: "datastore_mode_default_database"
+        test_env_vars:
+          org_id: :ORG_ID
+        ignore_read_extra:
+          - project
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firestore_database_datastore_mode"
+        primary_resource_id: "datastore_mode_database"
+        test_env_vars:
+          org_id: :ORG_ID
+        ignore_read_extra:
+          - project
+    properties:
+      concurrencyMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: True
+      delete_protection_state: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      decoder: templates/terraform/decoders/firestore_database.go.erb
+      encoder: templates/terraform/encoders/firestore_database.go.erb
   Index: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: true
     # This resource is a child resource

--- a/mmv1/templates/terraform/decoders/firestore_database.go.erb
+++ b/mmv1/templates/terraform/decoders/firestore_database.go.erb
@@ -1,0 +1,13 @@
+config := meta.(*Config)
+d.SetId(res["name"].(string))
+if err := parseImportId([]string{"projects/(?P<project>[^/]+)/databases/(?P<name>[^/]+)"}, d, config); err != nil {
+	return nil, err
+}
+res["project"] = d.Get("project").(string)
+res["name"] = d.Get("name").(string)
+id, err := replaceVars(d, config, "projects/{{project}}/databases/{{name}}")
+if err != nil {
+	return nil, err
+}
+d.SetId(id)
+return res, nil

--- a/mmv1/templates/terraform/encoders/firestore_database.go.erb
+++ b/mmv1/templates/terraform/encoders/firestore_database.go.erb
@@ -1,0 +1,7 @@
+project, err := getProject(d, meta.(*Config))
+if err != nil {
+	return nil, err
+}
+obj["name"] = fmt.Sprintf("projects/%s/databases/%s", project, obj["name"])
+
+return obj, nil

--- a/mmv1/templates/terraform/examples/firestore_database_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_datastore_mode.tf.erb
@@ -1,0 +1,16 @@
+resource "google_project" "default" {
+	provider = google-beta
+
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+    provider = "google-beta"
+
+    project                     = google_project.default.project_id
+    name                        = "datastore-mode-database"
+    location_id                 = "nam5"
+    type                        = "DATASTORE_MODE"
+}

--- a/mmv1/templates/terraform/examples/firestore_database_datastore_mode_default.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_datastore_mode_default.tf.erb
@@ -1,0 +1,19 @@
+resource "google_project" "default" {
+	provider = google-beta
+
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+    provider = "google-beta"
+
+    project = google_project.default.project_id
+
+    # For Datastore Mode databases, use the empty string rather than "default" for the default database
+    name = ""
+
+    location_id = "nam5"
+    type        = "DATASTORE_MODE"
+}

--- a/mmv1/templates/terraform/examples/firestore_database_default.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_default.tf.erb
@@ -1,0 +1,16 @@
+resource "google_project" "default" {
+	provider = google-beta
+
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+    provider = "google-beta"
+
+    project     = google_project.default.project_id
+    name        = "(default)"
+    location_id = "nam5"
+    type        = "FIRESTORE_NATIVE"
+}

--- a/mmv1/templates/terraform/examples/firestore_database_full_nondefault.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_full_nondefault.tf.erb
@@ -1,0 +1,19 @@
+resource "google_project" "default" {
+	provider = google-beta
+
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+    provider = "google-beta"
+
+    project                     = google_project.default.project_id
+    name                        = "firestore-native-database"
+    location_id                 = "nam5"
+    type                        = "FIRESTORE_NATIVE"
+    concurrency_mode            = "OPTIMISTIC"
+    app_engine_integration_mode = "DISABLED"
+    delete_protection_state     = "DELETE_PROTECTION_ENABLED"
+}

--- a/mmv1/third_party/terraform/tests/resource_firestore_database_update_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firestore_database_update_test.go.erb
@@ -1,0 +1,51 @@
+<% autogen_exception -%>
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFirestoreDatabase_update(t *testing.T) {
+	t.Parallel()
+
+	dbName := "db-to-update"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirestoreDatabase_concurrencyMode(dbName, "OPTIMISTIC"),
+			},
+			{
+				ResourceName:      "google_firestore_database.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"etag", "delete_protection_state"},
+			},
+			{
+				Config: testAccFirestoreDatabase_concurrencyMode(dbName, "PESSIMISTIC"),
+			},
+			{
+				ResourceName:      "google_firestore_database.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"etag", "delete_protection_state"},
+			},
+		},
+	})
+}
+
+func testAccFirestoreDatabase_concurrencyMode(dbName, concurrencyMode string) string {
+	return fmt.Sprintf(`
+resource "google_firestore_database" "foobar" {
+  name             = "%s"
+  type             = "DATASTORE_MODE"
+  location_id      = "nam5"
+  concurrency_mode = "%s"
+}
+`, dbName, concurrencyMode)
+}


### PR DESCRIPTION
(No delete support at this time)

This includes support for both Firestore Native and Datastore mode databases.

part of https://github.com/hashicorp/terraform-provider-google/issues/12294

I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_firestore_database
```
