### PR TITLE
Add datasource for hosting channel

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_firebase_hosting_channel.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_firebase_hosting_channel.go.erb
@@ -1,0 +1,34 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleFirebaseHostingChannel() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := datasourceSchemaFromResourceSchema(resourceFirebaseHostingChannel().Schema)
+
+	// Set 'Required' schema elements
+	addRequiredFieldsToSchema(dsSchema, "site_id", "channel_id")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleFirebaseHostingChannelRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleFirebaseHostingChannelRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	id, err := replaceVars(d, config, "sites/{{site_id}}/channels/{{channel_id}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceFirebaseHostingChannelRead(d, meta)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_hosting_channel_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_hosting_channel_test.go.erb
@@ -1,0 +1,55 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGoogleFirebaseHostingChannel(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":    getTestProjectFromEnv(),
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleFirebaseHostingChannel(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState(
+						"data.google_firebase_hosting_channel.channel",
+						"google_firebase_hosting_channel.channel",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleFirebaseHostingChannel(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_firebase_hosting_site" "default" {
+	project  = "%{project_id}"
+	site_id = "tf-test-site-with-channel%{random_suffix}"
+}
+	
+resource "google_firebase_hosting_channel" "channel" {
+	site_id = google_firebase_hosting_site.default.site_id
+	channel_id = "tf-test-channel%{random_suffix}"
+}
+
+data "google_firebase_hosting_channel" "channel" {
+	site_id = google_firebase_hosting_site.default.site_id
+	channel_id = "tf-test-channel%{random_suffix}"
+
+	depends_on = [google_firebase_hosting_channel.channel]
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -274,10 +274,11 @@ func Provider() *schema.Provider {
 			"google_kms_secret":                                dataSourceGoogleKmsSecret(),
 			"google_kms_secret_ciphertext":                     dataSourceGoogleKmsSecretCiphertext(),
 			<% unless version == 'ga' -%>
-                        "google_kms_secret_asymmetric":                     dataSourceGoogleKmsSecretAsymmetric(),
-                        "google_firebase_android_app":                      dataSourceGoogleFirebaseAndroidApp(),
-      			"google_firebase_apple_app":                        dataSourceGoogleFirebaseAppleApp(),
+			"google_kms_secret_asymmetric":                     dataSourceGoogleKmsSecretAsymmetric(),
+			"google_firebase_android_app":                      dataSourceGoogleFirebaseAndroidApp(),
+			"google_firebase_apple_app":                        dataSourceGoogleFirebaseAppleApp(),
 			"google_firebase_apple_app_config":                 dataSourceGoogleFirebaseAppleAppConfig(),
+			"google_firebase_hosting_channel":                  dataSourceGoogleFirebaseHostingChannel(),
 			"google_firebase_web_app":                          dataSourceGoogleFirebaseWebApp(),
 			"google_firebase_web_app_config":                   dataSourceGoogleFirebaseWebappConfig(),
 			<% end -%>

--- a/mmv1/third_party/terraform/website/docs/d/firebase_hosting_channel.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_hosting_channel.html.markdown
@@ -29,6 +29,6 @@ The following arguments are supported:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `id` - an identifier for the resource with format `sites/{{site_id}}/channels/{{channel_id}}`
+* `id` - An identifier for the resource with format `sites/{{site_id}}/channels/{{channel_id}}`. Same as `name`
 
-* `name` - The fully-qualified resource name for the channel, in the format: `sites/SITE_ID/channels/CHANNEL_ID`
+* `name` - The fully-qualified resource name for the channel, in the format: `sites/{{site_id}}/channels/{{channel_id}}`.

--- a/mmv1/third_party/terraform/website/docs/d/firebase_hosting_channel.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_hosting_channel.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Firebase"
+page_title: "Google: google_firebase_hosting_channel"
+description: |-
+  A Google Cloud Firebase Hosting Channel instance
+---
+
+# google\_firebase\_hosting\_channel
+
+A Google Cloud Firebase Hosting Channel instance
+
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `site_id` - 
+  (Required)
+  The ID of the site this channel belongs to.
+
+* `channel_id` - 
+  (Required)
+  The ID of the channel. Use `channel_id = "live"` for the default channel of a site.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `sites/{{site_id}}/channels/{{channel_id}}`
+
+* `name` - The fully-qualified resource name for the channel, in the format: `sites/SITE_ID/channels/CHANNEL_ID`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add datasource for Firebase Hosting Channel. This is helpful for any existing channels created outsite of Terraform, such as the default "live" channel for any Hosting Site. [Learn more](https://firebase.google.com/docs/hosting/test-preview-deploy#deploy-live)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_firebase_hosting_channel`
```
