### PR TITLE
support node group affinity for dataproc cluster

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -58,6 +58,7 @@ var (
 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config",
 		"cluster_config.0.gce_cluster_config.0.metadata",
 		"cluster_config.0.gce_cluster_config.0.reservation_affinity",
+		"cluster_config.0.gce_cluster_config.0.node_group_affinity",
 	}
 
 	schieldedInstanceConfigKeys = []string{
@@ -667,6 +668,26 @@ func resourceDataprocCluster() *schema.Resource {
 													AtLeastOneOf: reservationAffinityKeys,
 													ForceNew:     true,
 													Description:  `Corresponds to the label values of reservation resource.`,
+												},
+											},
+										},
+									},
+
+									"node_group_affinity": {
+										Type:         schema.TypeList,
+										Optional:     true,
+										AtLeastOneOf: gceClusterConfigKeys,
+										Computed:     true,
+										MaxItems:     1,
+										Description:  `Node Group Affinity for sole-tenant clusters.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"node_group_uri": {
+													Type:         schema.TypeString,
+													ForceNew:     true,
+													Required:     true,
+													Description:  `The URI of a sole-tenant that the cluster will be created on.`,
+													DiffSuppressFunc: compareSelfLinkOrResourceName,
 												},
 											},
 										},
@@ -1615,6 +1636,13 @@ func expandGceClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.G
 			conf.ReservationAffinity.Values = convertStringSet(v.(*schema.Set))
 		}
 	}
+	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.node_group_affinity"); ok {
+		cfgNga := v.([]interface{})[0].(map[string]interface{})
+		conf.NodeGroupAffinity = &dataproc.NodeGroupAffinity{}
+		if v, ok := cfgNga["node_group_uri"]; ok {
+			conf.NodeGroupAffinity.NodeGroupUri = v.(string)
+		}
+	}
 	return conf, nil
 }
 
@@ -2331,6 +2359,13 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
 				"consume_reservation_type":    gcc.ReservationAffinity.ConsumeReservationType,
 				"key":                         gcc.ReservationAffinity.Key,
 				"values":                      gcc.ReservationAffinity.Values,
+			},
+		}
+	}
+	if gcc.NodeGroupAffinity != nil {
+		gceConfig["node_group_affinity"] = []map[string]interface{}{
+			{
+				"node_group_uri":    gcc.NodeGroupAffinity.NodeGroupUri,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -392,6 +392,28 @@ func TestAccDataprocCluster_withReservationAffinity(t *testing.T) {
 	})
 }
 
+func TestAccDataprocCluster_withNodeGroupAffinity(t *testing.T) {
+	t.Parallel()
+
+	var cluster dataproc.Cluster
+	rnd := randString(t, 10)
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withNodeGroupAffinity(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
+
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.node_group_affinity.0.node_group_uri", "https://www.googleapis.com/compute/v1/projects/ci-test-project-188019/zones/us-central1-f/nodeGroups/test-nodegroup"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataprocCluster_singleNodeCluster(t *testing.T) {
 	t.Parallel()
 
@@ -1411,6 +1433,46 @@ resource "google_dataproc_cluster" "basic" {
   }
 }
 `, rnd, rnd)
+}
+
+func testAccDataprocCluster_withNodeGroupAffinity(rnd string) string {
+	return fmt.Sprintf(`
+
+resource "google_compute_node_template" "nodetmpl" {
+  name   = "test-nodetmpl"
+  region = "us-central1"
+
+  node_affinity_labels = {
+    tfacc = "test"
+  }
+
+  node_type = "n1-node-96-624"
+
+  cpu_overcommit_type = "ENABLED"
+}
+
+resource "google_compute_node_group" "nodes" {
+  name = "test-nodegroup"
+  zone = "us-central1-f"
+
+  size          = 3
+  node_template = google_compute_node_template.nodetmpl.self_link
+}
+
+resource "google_dataproc_cluster" "basic" {
+  name   = "tf-test-dproc-%s"
+  region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      zone = "us-central1-f"
+      node_group_affinity {
+        node_group_uri = google_compute_node_group.nodes.name
+      }
+    }
+  }
+}
+`, rnd)
 }
 
 func testAccDataprocCluster_singleNodeCluster(rnd string) string {

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -407,7 +407,7 @@ func TestAccDataprocCluster_withNodeGroupAffinity(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.node_group_affinity.0.node_group_uri", "https://www.googleapis.com/compute/v1/projects/ci-test-project-188019/zones/us-central1-f/nodeGroups/test-nodegroup"),
+					resource.TestMatchResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.node_group_affinity.0.node_group_uri", regexp.MustCompile("test-nodegroup")),
 				),
 			},
 		},
@@ -1439,7 +1439,7 @@ func testAccDataprocCluster_withNodeGroupAffinity(rnd string) string {
 	return fmt.Sprintf(`
 
 resource "google_compute_node_template" "nodetmpl" {
-  name   = "test-nodetmpl"
+  name   = "test-nodetmpl-%s"
   region = "us-central1"
 
   node_affinity_labels = {
@@ -1452,7 +1452,7 @@ resource "google_compute_node_template" "nodetmpl" {
 }
 
 resource "google_compute_node_group" "nodes" {
-  name = "test-nodegroup"
+  name = "test-nodegroup-%s"
   zone = "us-central1-f"
 
   size          = 3
@@ -1472,7 +1472,7 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd)
+`, rnd, rnd, rnd)
 }
 
 func testAccDataprocCluster_singleNodeCluster(rnd string) string {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -433,7 +433,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     * `key` - (Optional) Corresponds to the label key of reservation resource.
     * `values` - (Optional) Corresponds to the label values of reservation resource.
 
-* `node_group_affinity` - (Optional) The name of the sole-tenant node group to create the cluster on.
+* `node_group_affinity` - (Optional) Node Group Affinity for sole-tenant clusters.
     * `node_group_uri` - (Required) The URI of a sole-tenant node group resource that the cluster will be created on.
 
 * `shielded_instance_config` (Optional) Shielded Instance Config for clusters using [Compute Engine Shielded VMs](https://cloud.google.com/security/shielded-cloud/shielded-vm).

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -433,6 +433,9 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     * `key` - (Optional) Corresponds to the label key of reservation resource.
     * `values` - (Optional) Corresponds to the label values of reservation resource.
 
+* `node_group_affinity` - (Optional) The name of the sole-tenant node group to create the cluster on.
+    * `node_group_uri` - (Required) The URI of a sole-tenant node group resource that the cluster will be created on.
+
 * `shielded_instance_config` (Optional) Shielded Instance Config for clusters using [Compute Engine Shielded VMs](https://cloud.google.com/security/shielded-cloud/shielded-vm).
 
 - - -


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/12848

Adds the support of creating cluster config with node group affinity.

If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


Release Note Template for Downstream PRs (will be copied)

```release-note:enhancement
dataproc: added support for `node_group_affinity.` in `google_dataproc_cluster`
```
