### PR TITLE
Fix cloud_identity_group_membership to properly handle 403 responses

### DIFF
--- a/mmv1/products/cloudidentity/terraform.yaml
+++ b/mmv1/products/cloudidentity/terraform.yaml
@@ -42,6 +42,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       post_create: templates/terraform/post_create/set_computed_name.erb
       custom_import: templates/terraform/custom_import/set_id_name_with_slashes.go.erb
   GroupMembership: !ruby/object:Overrides::Terraform::ResourceOverride
+    read_error_transform: "transformCloudIdentityGroupMembershipReadError"
     docs: !ruby/object:Provider::Terraform::Docs
       warning: |
         If you are using User ADCs (Application Default Credentials) with this resource,

--- a/mmv1/third_party/terraform/tests/resource_cloud_identity_group_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_identity_group_membership_test.go.erb
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"google.golang.org/api/iam/v1"
 )
 
 func TestAccCloudIdentityGroupMembership_update(t *testing.T) {
@@ -171,6 +172,87 @@ resource "google_cloud_identity_group_membership" "basic" {
 
   roles {
     name = "MANAGER"
+  }
+}
+`, context)
+}
+
+func TestAccCloudIdentityGroupMembership_membershipDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_domain":    getTestOrgDomainFromEnv(t),
+		"cust_id":       getTestCustIdFromEnv(t),
+		"random_suffix": randString(t, 10),
+	}
+
+	saId := "tf-test-sa-" + randString(t, 10)
+	project := getTestProjectFromEnv()
+	config := BootstrapConfig(t)
+
+	r := &iam.CreateServiceAccountRequest{
+		AccountId:      saId,
+		ServiceAccount: &iam.ServiceAccount{},
+	}
+
+	sa, err := config.NewIamClient(config.userAgent).Projects.ServiceAccounts.Create("projects/" + project, r).Do()
+	if err != nil {
+		t.Errorf("Error creating service account: %s", err)
+	}
+
+	context["member_id"] = sa.Email
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: testAccCheckCloudIdentityGroupMembershipDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudIdentityGroupMembership_dne(context),
+			},
+			{
+				PreConfig: func() {
+					config := googleProviderConfig(t)
+
+					_, err := config.NewIamClient(config.userAgent).Projects.ServiceAccounts.Delete(sa.Name).Do()
+					if err != nil {
+						t.Errorf("cannot delete service account %s: %v", sa.Name, err)
+						return
+					}
+				},
+				Config:             testAccCloudIdentityGroupMembership_dne(context),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCloudIdentityGroupMembership_dne(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_cloud_identity_group" "group" {
+  display_name = "tf-test-my-identity-group-%{random_suffix}"
+
+  parent = "customers/%{cust_id}"
+
+  group_key {
+    id = "tf-test-my-identity-group-%{random_suffix}@%{org_domain}"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}
+
+resource "google_cloud_identity_group_membership" "basic" {
+  group = google_cloud_identity_group.group.id
+
+  preferred_member_key {
+    id = "%{member_id}"
+  }
+
+  roles {
+    name = "MEMBER"
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/tests/resource_cloud_identity_group_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_identity_group_membership_test.go.erb
@@ -178,6 +178,9 @@ resource "google_cloud_identity_group_membership" "basic" {
 }
 
 func TestAccCloudIdentityGroupMembership_membershipDoesNotExist(t *testing.T) {
+	// Skip VCR because the service account needs to be created/deleted out of
+	// band, and so those calls aren't recorded
+	skipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/tests/resource_cloud_identity_group_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_identity_group_membership_test.go.erb
@@ -197,7 +197,7 @@ func TestAccCloudIdentityGroupMembership_membershipDoesNotExist(t *testing.T) {
 
 	sa, err := config.NewIamClient(config.userAgent).Projects.ServiceAccounts.Create("projects/" + project, r).Do()
 	if err != nil {
-		t.Errorf("Error creating service account: %s", err)
+		t.Fatalf("Error creating service account: %s", err)
 	}
 
 	context["member_id"] = sa.Email

--- a/mmv1/third_party/terraform/utils/cloud_identity_group_membership_utils.go
+++ b/mmv1/third_party/terraform/utils/cloud_identity_group_membership_utils.go
@@ -1,0 +1,27 @@
+package google
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"google.golang.org/api/googleapi"
+)
+
+func transformCloudIdentityGroupMembershipReadError(err error) error {
+	if gErr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok {
+		if gErr.Code == 403 && strings.Contains(gErr.Message, "(or it may not exist)") {
+			// This error occurs when either the group membership does not exist, or permission is denied. It is
+			// deliberately ambiguous so that existence information is not revealed to the caller. However, for
+			// the Read function, we can only assume that the membership does not exist, and proceed with attempting
+			// other operations. Since handleNotFoundError(...) expects an error code of 404 when a resource does not
+			// exist, to get the desired behavior, we modify the error code to be 404.
+			gErr.Code = 404
+		}
+
+		log.Printf("[DEBUG] Transformed CloudIdentityGroupMembership error")
+		return gErr
+	}
+
+	return err
+}


### PR DESCRIPTION
Re-applying fix from https://github.com/GoogleCloudPlatform/magic-modules/pull/6999

The previous fix was deemed to be correct, but the tests caused our build to panic on subsequent PRs. As a mitigation, the original PR was reverted: https://github.com/GoogleCloudPlatform/magic-modules/pull/7032. It appears that this was happening because the test creates a service account out-of-band that is not recorded or replayed in VCR mode. This led to the service account getting created on each replay, but not deleted, and ultimately produced an error that the service account already existed.

The resolution here is simply to skip this test for VCR mode. I was unable to come up with a way to perform this test without the out-of-band service account, and trying to manage that service account during VCR runs became brittle.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
