### PR TITLE
Remove binary_authorization from Cloud run v2 basic example

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_service_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_basic.tf.erb
@@ -3,10 +3,6 @@ resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
   location = "us-central1"
   ingress = "INGRESS_TRAFFIC_ALL"
   
-  binary_authorization {
-    use_default = true
-    breakglass_justification = "Some justification"
-  }
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"


### PR DESCRIPTION
Fix https://github.com/hashicorp/terraform-provider-google/issues/13416

```release-note:none
```