### PR TITLE
Add tf-test prefix to some test names

### DIFF
--- a/mmv1/products/cloudfunctions2/terraform.yaml
+++ b/mmv1/products/cloudfunctions2/terraform.yaml
@@ -41,9 +41,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "function"
         vars:
           bucket_name: "gcf-source"
-          service_account: "sa"
+          service_account: "gcf-sa"
           topic: "functions2-topic"
-          function: "function"
+          function: "gcf-function"
           zip_path: "function-source.zip"
         test_env_vars:
           project: :PROJECT_NAME
@@ -61,8 +61,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           bucket_name_source: "gcf-source-bucket"
           bucket_name_trigger: "gcf-trigger-bucket"
-          service_account: "sa"
-          function_name: "function"
+          service_account: "gcf-sa"
+          function_name: "gcf-function"
           zip_path: "function-source.zip"
         test_env_vars:
           project: :PROJECT_NAME

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_global_address_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_global_address_test.go
@@ -15,6 +15,7 @@ func TestAccDataSourceComputeGlobalAddress(t *testing.T) {
 	rsFullName := fmt.Sprintf("google_compute_global_address.%s", rsName)
 	dsName := "my_address"
 	dsFullName := fmt.Sprintf("data.google_compute_global_address.%s", dsName)
+	addressName := fmt.Sprintf("tf-test-address-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccDataSourceComputeGlobalAddress(t *testing.T) {
 		CheckDestroy: testAccCheckComputeGlobalAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceComputeGlobalAddressConfig(rsName, dsName),
+				Config: testAccDataSourceComputeGlobalAddressConfig(rsName, dsName, addressName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceComputeGlobalAddressCheck(dsFullName, rsFullName),
 				),
@@ -74,14 +75,14 @@ func testAccDataSourceComputeGlobalAddressCheck(data_source_name string, resourc
 	}
 }
 
-func testAccDataSourceComputeGlobalAddressConfig(rsName, dsName string) string {
+func testAccDataSourceComputeGlobalAddressConfig(rsName, dsName, addressName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_address" "%s" {
-  name = "address-test"
+  name = "%s"
 }
 
 data "google_compute_global_address" "%s" {
   name = google_compute_global_address.%s.name
 }
-`, rsName, dsName, rsName)
+`, rsName, addressName, dsName, rsName)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_address_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_address_test.go
@@ -60,7 +60,7 @@ func TestAccComputeAddress_internal(t *testing.T) {
 func testAccComputeAddress_internal(i string) string {
 	return fmt.Sprintf(`
 resource "google_compute_address" "internal" {
-  name         = "address-test-internal-%s"
+  name         = "tf-test-address-internal-%s"
   address_type = "INTERNAL"
   region       = "us-east1"
 }
@@ -77,7 +77,7 @@ resource "google_compute_subnetwork" "foo" {
 }
 
 resource "google_compute_address" "internal_with_subnet" {
-  name         = "address-test-internal-with-subnet-%s"
+  name         = "tf-test-address-internal-with-subnet-%s"
   subnetwork   = google_compute_subnetwork.foo.self_link
   address_type = "INTERNAL"
   region       = "us-east1"
@@ -86,7 +86,7 @@ resource "google_compute_address" "internal_with_subnet" {
 // We can't test the address alone, because we don't know what IP range the
 // default subnetwork uses.
 resource "google_compute_address" "internal_with_subnet_and_address" {
-  name         = "address-test-internal-with-subnet-and-address-%s"
+  name         = "tf-test-address-internal-with-subnet-and-address-%s"
   subnetwork   = google_compute_subnetwork.foo.self_link
   address_type = "INTERNAL"
   address      = "10.0.42.42"
@@ -104,7 +104,7 @@ resource "google_compute_address" "internal_with_subnet_and_address" {
 func testAccComputeAddress_networkTier(i string) string {
 	return fmt.Sprintf(`
 resource "google_compute_address" "foobar" {
-  name         = "address-test-%s"
+  name         = "tf-test-address-%s"
   network_tier = "STANDARD"
 }
 `, i)

--- a/mmv1/third_party/terraform/tests/resource_compute_global_address_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_global_address_test.go.erb
@@ -51,7 +51,7 @@ func TestAccComputeGlobalAddress_internal(t *testing.T) {
 func testAccComputeGlobalAddress_ipv6(addressName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_address" "foobar" {
-  name        = "address-test-%s"
+  name        = "tf-test-address-%s"
   description = "Created for Terraform acceptance testing"
   ip_version  = "IPV6"
 }
@@ -61,11 +61,11 @@ resource "google_compute_global_address" "foobar" {
 func testAccComputeGlobalAddress_internal(networkName, addressName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name = "address-test-%s"
+  name = "tf-test-address-%s"
 }
 
 resource "google_compute_global_address" "foobar" {
-  name          = "address-test-%s"
+  name          = "tf-test-address-%s"
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 24

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -910,18 +910,20 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	t.Parallel()
 
 	pid := getTestProjectFromEnv()
-	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/metastore-srv", pid)
-	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/metastore-srv-update", pid)
+	basicServiceId := "tf-test-metastore-srv-" + randString(t, 10)
+	updateServiceId := "tf-test-metastore-srv-update-" + randString(t, 10)
+	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
+	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
 	
 	var cluster dataproc.Cluster
-	rnd := randString(t, 10)
+	clusterName := "tf-test-" + randString(t, 10)
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig(rnd),
+				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service",msName_basic),
@@ -929,7 +931,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig_update(rnd),
+				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
@@ -2119,10 +2121,10 @@ resource "google_dataproc_autoscaling_policy" "asp" {
 `, rnd, rnd)
 }
 
-func testAccDataprocCluster_withMetastoreConfig(rnd string) string {
+func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
-	name                  = "tf-test-%s"
+	name                  = "%s"
 	region                = "us-central1"
 
 	cluster_config {
@@ -2133,7 +2135,7 @@ resource "google_dataproc_cluster" "with_metastore_config" {
 }
 
 resource "google_dataproc_metastore_service" "ms" {
-	service_id = "metastore-srv"
+	service_id = "%s"
 	location   = "us-central1"
 	port       = 9080
 	tier       = "DEVELOPER"
@@ -2147,13 +2149,13 @@ resource "google_dataproc_metastore_service" "ms" {
 		version = "3.1.2"
 	}
 }
-`, rnd)
+`, clusterName, serviceId)
 }
 
-func testAccDataprocCluster_withMetastoreConfig_update(rnd string) string {
+func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
-	name                  = "tf-test-%s"
+	name                  = "%s"
 	region                = "us-central1"
 
 	cluster_config {
@@ -2164,7 +2166,7 @@ resource "google_dataproc_cluster" "with_metastore_config" {
 }
 
 resource "google_dataproc_metastore_service" "ms" {
-	service_id = "metastore-srv-update"
+	service_id = "%s"
 	location   = "us-central1"
 	port       = 9080
 	tier       = "DEVELOPER"
@@ -2178,5 +2180,5 @@ resource "google_dataproc_metastore_service" "ms" {
 		version = "3.1.2"
 	}
 }
-`, rnd)
+`, clusterName, serviceId)
 }

--- a/mmv1/third_party/terraform/tests/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_metastore_service_test.go.erb
@@ -11,7 +11,7 @@ import (
 func TestAccDataprocMetastoreService_updateAndImport(t *testing.T) {
 	t.Parallel()
 
-	name := "tf-metastore-" + randString(t, 10)
+	name := "tf-test-metastore-" + randString(t, 10)
 	tier := [2]string{"DEVELOPER", "ENTERPRISE"}
 
 	vcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/resource_vertex_ai_index_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vertex_ai_index_test.go
@@ -47,7 +47,7 @@ func TestAccVertexAIIndex_updated(t *testing.T) {
 func testAccVertexAIIndex_basic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_storage_bucket" "bucket" {
-  name     = "%{project}-tf-test-vertex-ai-index-test%{random_suffix}"  # Every bucket name must be globally unique
+  name     = "tf-test-%{project}-vertex-ai-index-test%{random_suffix}"  # Every bucket name must be globally unique
   location = "us-central1"
   uniform_bucket_level_access = true
 }
@@ -101,7 +101,7 @@ resource "google_vertex_ai_index" "index" {
 func testAccVertexAIIndex_updated(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_storage_bucket" "bucket" {
-  name     = "%{project}-tf-test-vertex-ai-index-test%{random_suffix}"  # Every bucket name must be globally unique
+  name     = "tf-test-%{project}-vertex-ai-index-test%{random_suffix}"  # Every bucket name must be globally unique
   location = "us-central1"
   uniform_bucket_level_access = true
 }

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -664,7 +664,7 @@ provider "google" {
 
 resource "google_compute_address" "default" {
   provider = google.compute_custom_endpoint
-  name     = "address-test-%s"
+  name     = "tf-test-address-%s"
 }`, endpoint, name)
 }
 
@@ -677,7 +677,7 @@ terraform {
 }
 
 resource "google_compute_address" "default" {
-	name = "address-test-%s"
+	name = "tf-test-address-%s"
 }`, key, name)
 }
 


### PR DESCRIPTION
Most of our sweepers target resources with the `tf-test` or `tf_test` prefix, but not all of our tests use this naming convention. This PR updates some of those tests so that resources they leave behind will be picked up by the sweeper.

Note that after this change is deployed, we can manually remove resources using the old names.

The specific resources included in this change were chosen because they seem to have accumulated the most in our test environment:
- service accounts named `sa*`
- cloud functions named `function*`
- addresses named `address-*`
- dataproc metastore services named `metastore-srv*` or `tf-metastore*` (which create storage buckets that also don't get swept)
- vertex ai indexes named `<project>-tf-test-*`

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
