### PR TITLE
Use "Cloud Run" instead of "Cloud Run (2nd gen)"

### DIFF
--- a/mmv1/products/cloudrunv2/api.yaml
+++ b/mmv1/products/cloudrunv2/api.yaml
@@ -14,7 +14,7 @@
 ---
 !ruby/object:Api::Product
 name: CloudRunV2
-display_name: Cloud Run (2nd gen)
+display_name: Cloud Run
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:


### PR DESCRIPTION
Fix https://github.com/hashicorp/terraform-provider-google/issues/13414

```release-note:none
```

Same PR as https://github.com/hashicorp/terraform-provider-google/pull/13415
