### PR TITLE
Add support for enabling/disabling Cloud Data Lineage integration in google-beta.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -49,6 +49,9 @@ var (
 		"config.0.software_config.0.image_version",
 		"config.0.software_config.0.python_version",
 		"config.0.software_config.0.scheduler_count",
+<% unless version == "ga" -%>
+		"config.0.software_config.0.cloud_data_lineage_integration",
+<% end -%>
 	}
 
 	composerConfigKeys = []string{
@@ -391,6 +394,25 @@ func resourceComposerEnvironment() *schema.Resource {
 										Computed:     true,
 										Description:  `The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.`,
 									},
+<% unless version == "ga" -%>
+									"cloud_data_lineage_integration": {
+										Type:        	schema.TypeList,
+										Optional:    	true,
+										Computed:    	true,
+										AtLeastOneOf:	composerSoftwareConfigKeys,
+										MaxItems:    	1,
+										Description: 	`The configuration for Cloud Data Lineage integration. Supported for Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and newer`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:        schema.TypeBool,
+													Required:    true,
+													Description: `Whether or not Cloud Data Lineage integration is enabled.`,
+												},
+											},
+										},
+									},
+<% end -%>
 								},
 							},
 						},
@@ -942,6 +964,23 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+<% unless version == "ga" -%>
+		if d.HasChange("config.0.software_config.0.cloud_data_lineage_integration") {
+			patchObj := &composer.Environment{
+				Config: &composer.EnvironmentConfig{
+					SoftwareConfig: &composer.SoftwareConfig{},
+				},
+			}
+			if config != nil && config.SoftwareConfig != nil {
+				patchObj.Config.SoftwareConfig.CloudDataLineageIntegration = config.SoftwareConfig.CloudDataLineageIntegration
+			}
+			err = resourceComposerEnvironmentPatchField("config.softwareConfig.cloudDataLineageIntegration", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
+<% end -%>
+
 		if d.HasChange("config.0.software_config.0.airflow_config_overrides") {
 			patchObj := &composer.Environment{
 				Config: &composer.EnvironmentConfig{
@@ -1427,8 +1466,24 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	transformed["pypi_packages"] = softwareCfg.PypiPackages
 	transformed["env_variables"] = softwareCfg.EnvVariables
 	transformed["scheduler_count"] = softwareCfg.SchedulerCount
+<% unless version == "ga" -%>
+	transformed["cloud_data_lineage_integration"] = flattenComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(softwareCfg.CloudDataLineageIntegration)
+<% end -%>
 	return []interface{}{transformed}
 }
+
+<% unless version == "ga" -%>
+func flattenComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(cloudDataLineageIntegration *composer.CloudDataLineageIntegration) interface{} {
+	if cloudDataLineageIntegration == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["enabled"] = cloudDataLineageIntegration.Enabled
+
+	return []interface{}{transformed}
+}
+<% end -%>
 
 func flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(masterAuthNetsCfg *composer.MasterAuthorizedNetworksConfig) interface{} {
 	if masterAuthNetsCfg == nil {
@@ -1983,6 +2038,15 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	transformed.PypiPackages = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "pypi_packages")
 	transformed.EnvVariables = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "env_variables")
 	transformed.SchedulerCount = int64(original["scheduler_count"].(int))
+
+<% unless version == "ga" -%>
+	transformedCloudDataLineageIntegration, err := expandComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(original["cloud_data_lineage_integration"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.CloudDataLineageIntegration = transformedCloudDataLineageIntegration
+<% end -%>
+
 	return transformed, nil
 }
 
@@ -1993,6 +2057,22 @@ func expandComposerEnvironmentConfigSoftwareConfigStringMap(softwareConfig map[s
 	}
 	return map[string]string{}
 }
+
+<% unless version == "ga" -%>
+func expandComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(v interface{}, d *schema.ResourceData, config *Config) (*composer.CloudDataLineageIntegration, error) {
+	l := v.([]interface{})
+	if len(l) == 0 {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	transformed := &composer.CloudDataLineageIntegration{}
+	transformed.Enabled = original["enabled"].(bool)
+
+	return transformed, nil
+}
+<% end -%>
 
 func validateComposerEnvironmentPypiPackages(v interface{}, k string) (ws []string, errors []error) {
 	if v == nil {

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1489,6 +1489,11 @@ resource "google_composer_environment" "test" {
 
       software_config {
         image_version = "composer-2-airflow-2"
+<% unless version == "ga" -%>
+        cloud_data_lineage_integration {
+          enabled = true
+        }
+<% end -%>
       }
 
       workloads_config {
@@ -1755,6 +1760,11 @@ resource "google_composer_environment" "test" {
 
       software_config {
         image_version = "composer-2-airflow-2"
+<% unless version == "ga" -%>
+        cloud_data_lineage_integration {
+          enabled = false
+        }
+<% end -%>
       }
 
       workloads_config {

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -784,7 +784,16 @@ The `software_config` block supports:
   `composer-1.16.x` to `composer-1.17.x`, or from `airflow-2.1.x` to `airflow-2.2.x`. You cannot upgrade between
   major Cloud Composer or Apache Airflow versions (from `1.x.x` to `2.x.x`). To do so, create a new environment.
 
+* `cloud_data_lineage_integration` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html),
+  Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and newer)
+  The configuration for Cloud Data Lineage integration. Structure is
+  [documented below](#nested_cloud_data_lineage_integration).
 
+<a name="nested_cloud_data_lineage_integration"></a>The `cloud_data_lineage_integration` block supports:
+* `enabled` -
+  (Required)
+  Whether or not Cloud Data Lineage integration is enabled.
 
 See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. The `private_environment_config` block supports:
 


### PR DESCRIPTION
Add support for enabling/disabling Cloud Data Lineage integration in google-beta.

fixes https://github.com/hashicorp/terraform-provider-google/issues/13431

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: Added field `cloud_data_lineage_integration` to resource `google_composer_environment` (beta)
```
