### PR TITLE
Revert "Use "Cloud Run" instead of "Cloud Run (2nd gen)""

### DIFF
--- a/mmv1/products/cloudrunv2/api.yaml
+++ b/mmv1/products/cloudrunv2/api.yaml
@@ -14,7 +14,7 @@
 ---
 !ruby/object:Api::Product
 name: CloudRunV2
-display_name: Cloud Run
+display_name: Cloud Run (2nd gen)
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#7098

```release-note:none
```