### PR TITLE
Relabel Cloud Run v2 as "v2 API" over "2nd gen"

### DIFF
--- a/mmv1/products/cloudrunv2/api.yaml
+++ b/mmv1/products/cloudrunv2/api.yaml
@@ -14,7 +14,7 @@
 ---
 !ruby/object:Api::Product
 name: CloudRunV2
-display_name: Cloud Run (2nd gen)
+display_name: Cloud Run (v2 API)
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13414, followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/7098, https://github.com/GoogleCloudPlatform/magic-modules/pull/7103

We labeled the Cloud Run v2 resources as "2nd gen" when introducing them, in line with Cloud Functions' v2 API. However, in Cloud Functions that was product naming (https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available) while Cloud Run's v2 API is a new interface that it compatible with v1 resources and not a new product. Correct this by renaming them to `v2 API` instead.

We could take the approach proposed in https://github.com/hashicorp/terraform-provider-google/issues/13414 and consolidate the headings into just `Cloud Run`, mixing the resources together, but that level of customization is something we'd like to avoid. Outside of the legacy "Cloud Platform" heading (which maps to Resource Manager), each section in our sidebar corresponds to an endpoint + version pair.

The introduction of v2 APIs is fairly new, so we're treading somewhat new ground. Cloud Functions 2nd gen represents a new product, while org policy v2 used different endpoints. Similar cases where resources are grouped by endpoint are `Bigquery` and `Bigquery Reservations` and `Dialogflow` and `Dialogflow CX`. We've discussed our approach to these kinds of cases in the context of a v2 that didn't move forward, and separating the products is consistent with that.

/cc @melinath @shuyama1 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
