### PR TITLE
Update composer sweeper to include us-east1 resources

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -2014,22 +2014,27 @@ func testSweepComposerResources(region string) error {
 		log.Fatalf("error loading: %s", err)
 	}
 
-	// Environments need to be cleaned up because the service is flaky.
-	if err := testSweepComposerEnvironments(config); err != nil {
-		log.Printf("[WARNING] unable to clean up all environments: %s", err)
-	}
+	// us-central is passed as the region for our sweepers, but there are also
+	// many tests that use the us-east1 region
+	regions := []string{"us-central1", "us-east1"}
+	for _, r := range regions {
+		// Environments need to be cleaned up because the service is flaky.
+		if err := testSweepComposerEnvironments(config, r); err != nil {
+			log.Printf("[WARNING] unable to clean up all environments: %s", err)
+		}
 
-	// Buckets need to be cleaned up because they just don't get deleted on purpose.
-	if err := testSweepComposerEnvironmentBuckets(config); err != nil {
-		log.Printf("[WARNING] unable to clean up all environment storage buckets: %s", err)
+		// Buckets need to be cleaned up because they just don't get deleted on purpose.
+		if err := testSweepComposerEnvironmentBuckets(config, r); err != nil {
+			log.Printf("[WARNING] unable to clean up all environment storage buckets: %s", err)
+		}
 	}
 
 	return nil
 }
 
-func testSweepComposerEnvironments(config *Config) error {
+func testSweepComposerEnvironments(config *Config, region string) error {
 	found, err := config.NewComposerClient(config.userAgent).Projects.Locations.Environments.List(
-		fmt.Sprintf("projects/%s/locations/%s", config.Project, config.Region)).Do()
+		fmt.Sprintf("projects/%s/locations/%s", config.Project, region)).Do()
 	if err != nil {
 		return fmt.Errorf("error listing storage buckets for composer environment: %s", err)
 	}
@@ -2080,7 +2085,7 @@ func testSweepComposerEnvironments(config *Config) error {
 	return allErrors
 }
 
-func testSweepComposerEnvironmentBuckets(config *Config) error {
+func testSweepComposerEnvironmentBuckets(config *Config, region string) error {
 	artifactsBName := fmt.Sprintf("artifacts.%s.appspot.com", config.Project)
 	artifactBucket, err := config.NewStorageClient(config.userAgent).Buckets.Get(artifactsBName).Do()
 	if err != nil {
@@ -2093,7 +2098,7 @@ func testSweepComposerEnvironmentBuckets(config *Config) error {
 		return err
 	}
 
-	found, err := config.NewStorageClient(config.userAgent).Buckets.List(config.Project).Prefix(config.Region).Do()
+	found, err := config.NewStorageClient(config.userAgent).Buckets.List(config.Project).Prefix(region).Do()
 	if err != nil {
 		return fmt.Errorf("error listing storage buckets created when testing composer environment: %s", err)
 	}


### PR DESCRIPTION
Our sweepers only run on us-central1, but we have some composer tests that use us-east1 and can leave a lot of resources in the instance when they fail.

This change updates the sweeper to sweep both of these regions, similar to what we do for the ComputeDisk sweeper.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
