### PR TITLE
Revert "Do not set header X-Goog-User-Project header for the resource google_client_openid_userinfo"

### DIFF
--- a/mmv1/third_party/terraform/utils/transport.go.erb
+++ b/mmv1/third_party/terraform/utils/transport.go.erb
@@ -50,9 +50,7 @@ func sendRequestWithTimeout(config *Config, method, project, rawurl, userAgent s
 	reqHeaders.Set("User-Agent", userAgent)
 	reqHeaders.Set("Content-Type", "application/json")
 
-	if !config.UserProjectOverride {
-		reqHeaders.Set("X-Goog-User-Project", "")
-	} else if config.UserProjectOverride && project != "" {
+	if config.UserProjectOverride && project != "" {
 		// Pass the project into this fn instead of parsing it from the URL because
 		// both project names and URLs can have colons in them.
 		reqHeaders.Set("X-Goog-User-Project", project)

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -514,17 +514,9 @@ func multiEnvSearch(ks []string) string {
 }
 
 func GetCurrentUserEmail(config *Config, userAgent string) (string, error) {
-	// When environment variables UserProjectOverride and BillingProject are set for the provider, the header X-Goog-User-Project is set for the API requests.
-	// But it causes an error when calling GetCurrentUserEmail. It makes sense to not set header X-Goog-User-Project by setting UserProjectOverride
-	// to false when calling GetCurrentUserEmail, because it does not create a bill.
-	origUserProjectOverride := config.UserProjectOverride
-	config.UserProjectOverride = false
-
 	// See https://github.com/golang/oauth2/issues/306 for a recommendation to do this from a Go maintainer
 	// URL retrieved from https://accounts.google.com/.well-known/openid-configuration
 	res, err := sendRequest(config, "GET", "", "https://openidconnect.googleapis.com/v1/userinfo", userAgent, nil)
-	config.UserProjectOverride = origUserProjectOverride
-
 	if err != nil {
 		return "", fmt.Errorf("error retrieving userinfo for your provider credentials. have you enabled the 'https://www.googleapis.com/auth/userinfo.email' scope? error: %s", err)
 	}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#6954

This causes ~40 tests to start failing including TestAccStorageBucketIam*

Reverting for safety, as it appears some resources stop working after this change.

I'm not sure why VCR didn't catch this, but it could be that the only change in the request is within the header information which we likely don't match on.

```release-note:none

```