### PR TITLE
Do not set header X-Goog-User-Project header for the resource google_client_openid_userinfo

### DIFF
--- a/mmv1/third_party/terraform/utils/transport.go.erb
+++ b/mmv1/third_party/terraform/utils/transport.go.erb
@@ -51,9 +51,15 @@ func sendRequestWithTimeout(config *Config, method, project, rawurl, userAgent s
 	reqHeaders.Set("Content-Type", "application/json")
 
 	if config.UserProjectOverride && project != "" {
-		// Pass the project into this fn instead of parsing it from the URL because
-		// both project names and URLs can have colons in them.
-		reqHeaders.Set("X-Goog-User-Project", project)
+		// When project is "NO_BILLING_PROJECT_OVERRIDE" in the function GetCurrentUserEmail,
+		// set the header X-Goog-User-Project to be empty string.
+		if project == "NO_BILLING_PROJECT_OVERRIDE" {
+			reqHeaders.Set("X-Goog-User-Project", "")
+		} else {
+			// Pass the project into this fn instead of parsing it from the URL because
+			// both project names and URLs can have colons in them.
+			reqHeaders.Set("X-Goog-User-Project", project)
+		}
 	}
 
 	if timeout == 0 {

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -514,9 +514,15 @@ func multiEnvSearch(ks []string) string {
 }
 
 func GetCurrentUserEmail(config *Config, userAgent string) (string, error) {
+	// When environment variables UserProjectOverride and BillingProject are set for the provider,
+	// the header X-Goog-User-Project is set for the API requests.
+	// But it causes an error when calling GetCurrentUserEmail. Set the project to be "NO_BILLING_PROJECT_OVERRIDE".
+	// And then it triggers the header X-Goog-User-Project to be set to empty string.
+
 	// See https://github.com/golang/oauth2/issues/306 for a recommendation to do this from a Go maintainer
 	// URL retrieved from https://accounts.google.com/.well-known/openid-configuration
-	res, err := sendRequest(config, "GET", "", "https://openidconnect.googleapis.com/v1/userinfo", userAgent, nil)
+	res, err := sendRequest(config, "GET", "NO_BILLING_PROJECT_OVERRIDE", "https://openidconnect.googleapis.com/v1/userinfo", userAgent, nil)
+
 	if err != nil {
 		return "", fmt.Errorf("error retrieving userinfo for your provider credentials. have you enabled the 'https://www.googleapis.com/auth/userinfo.email' scope? error: %s", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/10260

https://b.corp.google.com/issues/202287364

When the environment variable USER_PROJECT_OVERRIDE is set to true and GOOGLE_BILLING_PROJECT is set to some project, first the header X-Goog-User-Project is set in provider config.
https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/utils/config.go.erb#L307-L311

When the header X-Goog-User-Project is set for [the call to get user info](https://github.com/hashicorp/terraform-provider-google/blob/release-3.81.0/google/data_source_google_client_openid_userinfo.go#L28), it returns an error. Maybe the API openidconnect.googleapis.com does not handle the header X-Goog-User-Project properly. The error does not occur with other APIs. So don't set the header `X-Goog-User-Project` for the resource google_client_openid_userinfo.

To not set header X-Goog-User-Project for the resource google_client_openid_userinfo, we need to override the header value in the resource level.  First pass the project as "NO_BILLING_PROJECT_OVERRIDE" when calling sendRequest  inside the function GetCurrentUserEmail. And inside sendRequest function, the header `X-Goog-User-Project` is set to empty string by checking the project value. 

The [previous PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/6954) is reverted because if breaks some resources. 

Feel free to add comment if you have any concerns about this solution.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

-[X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudplatform: fixed the error with header `X-Goog-User-Project` on `google_client_openid_userinfo`
```
