### PR TITLE
Add `richtextValue` to `google_data_catalog_tag`.

### DIFF
--- a/mmv1/products/datacatalog/api.yaml
+++ b/mmv1/products/datacatalog/api.yaml
@@ -473,6 +473,10 @@ objects:
               name: stringValue
               description: |
                 Holds the value for a tag field with string type.
+            - !ruby/object:Api::Type::String
+              name: richtextValue
+              description: |
+                Holds the value for a tag field with richtext type.
             - !ruby/object:Api::Type::Boolean
               name: boolValue
               send_empty_value: true

--- a/mmv1/products/datacatalog/api.yaml
+++ b/mmv1/products/datacatalog/api.yaml
@@ -362,6 +362,7 @@ objects:
                     - :STRING
                     - :BOOL
                     - :TIMESTAMP
+                    - :RICHTEXT
                 - !ruby/object:Api::Type::NestedObject
                   name: enumType
                   description: |

--- a/mmv1/templates/terraform/examples/data_catalog_entry_tag_full.tf.erb
+++ b/mmv1/templates/terraform/examples/data_catalog_entry_tag_full.tf.erb
@@ -64,6 +64,14 @@ resource "google_data_catalog_tag_template" "tag_template" {
   }
 
   fields {
+    field_id = "description"
+    display_name = "Small description of the column"
+    type {
+      primitive_type = "RICHTEXT"
+    }
+  }
+
+  fields {
     field_id = "num_rows"
     display_name = "Number of rows in the data asset"
     type {
@@ -121,6 +129,11 @@ resource "google_data_catalog_tag" "second-tag" {
   fields {
     field_name   = "source"
     string_value = "my-string"
+  }
+
+  fields {
+    field_name   = "description"
+    richtext_value = "The first name of our client"
   }
 
   fields {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Hello!

This PR tries to add the `richtext_value` into the `google_data_catalog_tag` resource for terraform. The option is available in the `POST https://datacatalog.googleapis.com/v1/{parent}/tags` endpoint documented here: 
https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.entryGroups.tags/create

If I have missed something please let me know! 😇 

Kind Regard,
David


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or 
contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure 
it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note 
below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datacatalog: Added `richtext_value` to `google_data_catalog_tag`.
```
