### PR TITLE
Fix KCC provider based on rubocop suggestions

### DIFF
--- a/mmv1/provider/terraform_kcc.rb
+++ b/mmv1/provider/terraform_kcc.rb
@@ -35,7 +35,7 @@ module Provider
                      .reject { |e| @version < @api.version_obj_or_closest(e.min_version) }
 
       examples.each do |example|
-        folder_name = data.product.name + '-' + kind + '-' + example.name
+        folder_name = "#{data.product.name}-#{kind}-#{example.name}"
         folder_name += '-skipped' if example.skip_test
         target_folder = File.join('samples', folder_name)
 
@@ -120,6 +120,8 @@ module Provider
       end
 
       return nil if raw_value_template.nil?
+
+      "#{raw_value_template}/{{value}}"
     end
 
     def get_container(id_template, is_server_generated_name, object)
@@ -179,7 +181,7 @@ module Provider
 
     def get_hierarchical_reference(container)
       hierarchical_reference = []
-      hierarchical_reference += [container[0], container[0] + 'Ref'] if container.length == 2
+      hierarchical_reference += [container[0], "#{container[0]}Ref"] if container.length == 2
       hierarchical_reference
     end
   end


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Ran rubocop locally to fix some other style issues in the KCC provider, also added back the removed code in https://github.com/GoogleCloudPlatform/magic-modules/pull/7122


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
