### PR TITLE
Update datastream_stream resource to include kms fields

### DIFF
--- a/mmv1/products/datastream/api.yaml
+++ b/mmv1/products/datastream/api.yaml
@@ -722,6 +722,14 @@ objects:
                         description: |
                           If supplied, every created dataset will have its name prefixed by the provided value.
                           The prefix and name will be separated by an underscore. i.e. _.
+                      - !ruby/object:Api::Type::String
+                        name: 'kmsKeyName'
+                        input: true
+                        description: |
+                          Describes the Cloud KMS encryption key that will be used to protect destination BigQuery
+                          table. The BigQuery Service Account associated with your project requires access to this
+                          encryption key. i.e. projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{cryptoKey}.
+                          See https://cloud.google.com/bigquery/docs/customer-managed-encryption for more information.
       - !ruby/object:Api::Type::String
         name: 'state'
         description: The state of the stream.
@@ -819,3 +827,9 @@ objects:
         description: |
           Backfill strategy to disable automatic backfill for the Stream's objects.
         properties: []
+      - !ruby/object:Api::Type::String
+        name: 'customerManagedEncryptionKey'
+        input: true
+        description: |
+          A reference to a KMS encryption key. If provided, it will be used to encrypt the data. If left blank, data
+          will be encrypted using an internal Stream-specific encryption key provisioned through KMS.

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -151,7 +151,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         pull_external: true
         primary_resource_id: "default"
         # Random provider
-        # skip_vcr: true
+        skip_vcr: true
         vars:
           stream_id: "my-stream"
           private_connection_id: "my-connection"
@@ -170,7 +170,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         pull_external: true
         primary_resource_id: "default"
         # Random provider
-        # skip_vcr: true
+        skip_vcr: true
         vars:
           stream_id: "my-stream"
           private_connection_id: "my-connection"

--- a/mmv1/products/datastream/terraform.yaml
+++ b/mmv1/products/datastream/terraform.yaml
@@ -151,7 +151,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         pull_external: true
         primary_resource_id: "default"
         # Random provider
-        skip_vcr: true
+        # skip_vcr: true
         vars:
           stream_id: "my-stream"
           private_connection_id: "my-connection"
@@ -161,8 +161,28 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           deletion_protection: "true"
           bucket_name: "my-bucket"
           destination_connection_profile_id: "destination-profile"
+          stream_cmek: "kms-name"
         test_vars_overrides:
           deletion_protection: "false"
+          stream_cmek: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+      - !ruby/object:Provider::Terraform::Examples
+        name: "datastream_stream_bigquery"
+        pull_external: true
+        primary_resource_id: "default"
+        # Random provider
+        # skip_vcr: true
+        vars:
+          stream_id: "my-stream"
+          private_connection_id: "my-connection"
+          network_name: "my-network"
+          source_connection_profile_id: "source-profile"
+          database_instance_name: "my-instance"
+          deletion_protection: "true"
+          destination_connection_profile_id: "destination-profile"
+          bigquery_destination_table_kms_key_name: "bigquery-kms-name"
+        test_vars_overrides:
+          deletion_protection: "false"
+          bigquery_destination_table_kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/mmv1/templates/terraform/examples/datastream_stream_bigquery.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_bigquery.tf.erb
@@ -1,0 +1,114 @@
+data "google_project" "project" {
+}
+
+resource "google_sql_database_instance" "instance" {
+    name             = "<%= ctx[:vars]['database_instance_name'] %>"
+    database_version = "MYSQL_8_0"
+    region           = "us-central1"
+    settings {
+        tier = "db-f1-micro"
+        backup_configuration {
+            enabled            = true
+            binary_log_enabled = true
+        }
+
+        ip_configuration {
+
+            // Datastream IPs will vary by region.
+            authorized_networks {
+                value = "34.71.242.81"
+            }
+
+            authorized_networks {
+                value = "34.72.28.29"
+            }
+
+            authorized_networks {
+                value = "34.67.6.157"
+            }
+
+            authorized_networks {
+                value = "34.67.234.134"
+            }
+
+            authorized_networks {
+                value = "34.72.239.218"
+            }
+        }
+    }
+
+    deletion_protection  = <%= ctx[:vars]['deletion_protection'] %>
+}
+
+resource "google_sql_database" "db" {
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    name     = "user"
+    instance = google_sql_database_instance.instance.name
+    host     = "%"
+    password = random_password.pwd.result
+}
+
+resource "google_datastream_connection_profile" "source_connection_profile" {
+    display_name          = "Source connection profile"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+
+    mysql_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        username = google_sql_user.user.name
+        password = google_sql_user.user.password
+    }
+}
+
+data "google_bigquery_default_service_account" "bq_sa" {
+}
+
+resource "google_kms_crypto_key_iam_member" "bigquery_key_user" {
+  crypto_key_id = "<%= ctx[:vars]['bigquery_destination_table_kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${data.google_bigquery_default_service_account.bq_sa.email}"
+}
+
+resource "google_datastream_connection_profile" "destination_connection_profile" {
+    display_name          = "Connection profile"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
+
+    bigquery_profile {}
+}
+
+resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
+    depends_on = [
+        google_kms_crypto_key_iam_member.bigquery_key_user
+    ]
+    stream_id = "<%= ctx[:vars]['stream_id'] %>"
+    location = "us-central1"
+    display_name = "my stream"
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.source_connection_profile.id
+        mysql_source_config {}
+    }
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.destination_connection_profile.id
+        bigquery_destination_config {
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = "us-central1"
+                    kms_key_name = "<%= ctx[:vars]['bigquery_destination_table_kms_key_name'] %>"
+                }
+            }
+        }
+    }
+
+    backfill_none {
+    }
+}

--- a/mmv1/templates/terraform/examples/datastream_stream_full.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_full.tf.erb
@@ -93,6 +93,12 @@ resource "google_storage_bucket_iam_member" "reader" {
     member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-datastream.iam.gserviceaccount.com"
 }
 
+resource "google_kms_crypto_key_iam_member" "key_user" {
+    crypto_key_id = "<%= ctx[:vars]['stream_cmek'] %>"
+    role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+    member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-datastream.iam.gserviceaccount.com"
+}
+
 resource "google_datastream_connection_profile" "destination_connection_profile" {
     display_name          = "Connection profile"
     location              = "us-central1"
@@ -105,6 +111,9 @@ resource "google_datastream_connection_profile" "destination_connection_profile"
 }
 
 resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
+    depends_on = [
+        google_kms_crypto_key_iam_member.key_user
+    ]
     stream_id = "<%= ctx[:vars]['stream_id'] %>"
     desired_state = "NOT_STARTED"
     location = "us-central1"
@@ -181,4 +190,6 @@ resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
             }
         }
     }
+
+    customer_managed_encryption_key = "<%= ctx[:vars]['stream_cmek'] %>"
 }


### PR DESCRIPTION
b/233804820
Relates to https://github.com/hashicorp/terraform-provider-google/issues/10810

The `datastream_stream` resource was initially implemented [here](https://github.com/hashicorp/terraform-provider-google/pull/13385), and the kms-related fields were meant to be added in a follow-up. This PR contains those kms fields:
* `customer_managed_encryption_key`
* `destination_config.bigquery_destination_config.source_hierarchy_datasets.dataset_template.kms_key_name`

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datastream: add `customer_managed_encryption_key` and `destination_config.bigquery_destination_config.source_hierarchy_datasets.dataset_template.kms_key_name` fields to `datastream_stream` resource
```
