### PR TITLE
Fix documentation and command for contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,9 @@ your code to be reviewed.
 If this PR is for Terraform, I acknowledge that I have:
 
 - [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
-- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
 - [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
-- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
+- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
+- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
 - [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
 
 <!-- AUTOCHANGELOG for Downstream PRs.
@@ -27,7 +27,7 @@ Please select one of the following "release-note:" headings:
     - release-note:deprecation
     - release-note:breaking-change
     - release-note:none
-    
+
 Unless you choose release-note:none, please add a release note.
 
 See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,6 +75,11 @@ validator:
 		bundle; \
 		bundle exec compiler -e terraform -f validator -o $(OUTPUT_PATH) $(mmv1_compile);
 
+test:
+	cd mmv1; \
+		bundle; \
+		bundle exec rake test
+
 serialize:
 	cd tpgtools;\
 		cp -f serialization.go.base serialization.go &&\
@@ -102,5 +107,4 @@ validate_environment:
 doctor:
 	./scripts/doctor
 
-.PHONY: mmv1 tpgtools
-
+.PHONY: mmv1 tpgtools test

--- a/docs/content/docs/getting-started/run-provider-tests.md
+++ b/docs/content/docs/getting-started/run-provider-tests.md
@@ -34,7 +34,15 @@ GOOGLE_BILLING_ACCOUNT
 Unit tests (that is, tests that do not interact with the GCP API) are very fast and you can generally run them all if you have changed any of them:
 
 ```bash
+# for ga provider
+cd $GOPATH/src/github.com/hashicorp/terraform-provider-google
 make test
+make lint
+
+# for beta provider
+cd $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
+make test
+make lint
 ```
 
 ## Run acceptance tests


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

As a new contributor who recently submitted a couple of pull requests to this repository, I was at a bit confused by the broken links in the pull request template and the missing `test` make command.

Although the [setup instruction](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/setup/) and the [test instruction](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) explain that

> [scripts/make-in-container.sh](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/scripts/make-in-container.sh) includes all the instructions to build and run containers by hand. Refer to the script for individual steps, but for most users you only have to run the script directly, as a replacement for make. ...
> Generally, you can replace any reference to make in this guide with scripts/make-in-container.sh.

and

> Run unit tests
> Unit tests (that is, tests that do not interact with the GCP API) are very fast and you can generally run them all if you have changed any of them:
> `make test`

the equivalent command for within-container execution is missing, which led me into thinking that "Do I really need to install the legacy Ruby 2.6.0 and run `cd mmv1 && bundle exec rake test`?"

Combined with the missing links in the PR template, it took me more than expected to grasp the overall workflow of the magic-modules development.

This PR addresses confusion like above by updating the PR template and adding the `test` make command. 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
chore: fix documentation and command for contributors
```
