### PR TITLE
Added the resource `google_clouddeploy_delivery_pipeline' with IAM permission support

### DIFF
--- a/mmv1/products/clouddeploy/api.yaml
+++ b/mmv1/products/clouddeploy/api.yaml
@@ -1,0 +1,139 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: CloudDeploy
+display_name: Cloud Deploy
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://clouddeploy.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Cloud Deploy API
+    url: https://pantheon.corp.google.com/apis/library/clouddeploy.googleapis.com
+objects:
+  - !ruby/object:Api::Resource
+    name: 'DeliveryPipeline'
+    base_url: projects/{{project}}/locations/{{location}}/deliveryPipelines
+    create_verb: :POST
+    description: |
+      A DeliveryPipeline defines a pipeline through which a Skaffold configuration can progress
+    collection_url_key: 'deliveryPipelines'
+    update_mask: true
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        required: true
+        description: The location of this cloud function.
+        # This is not a real API field.
+        # This is a more user-centric way for users to specify
+        # that they want to use a HTTP Trigger rather than
+        # send httpsTrigger with an empty dictionary.
+      - !ruby/object:Api::Type::Boolean
+        name: 'trigger_http'
+        description: 'Use HTTP to trigger this function'
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      exclude: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        required: true
+        description: |
+          Name of the DeliveryPipeline.
+          Format is projects/{project}/locations/{location}/deliveryPipelines/[a-z][a-z0-9-]{0,62}.
+        pattern: projects/{{project}}/locations/{{location}}/deliveryPipelines/{{name}}
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: 'Description of the Release. Max length is 255 characters.'
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'annotations'
+        description: |
+          User annotations. These attributes can only be set and used by the user,
+          and not by Google Cloud Deploy. See https://google.aip.dev/128#annotations for more details
+          such as format and size limitations.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Labels are attributes that can be set and used by both the user and by Google Cloud Deploy.
+          Labels must meet the following constraints: Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes.
+          All characters must use UTF-8 encoding, and international characters are allowed.
+          Keys must start with a lowercase letter or international character.
+          Each resource is limited to a maximum of 64 labels.
+          Both keys and values are additionally constrained to be <= 128 bytes.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        output: true
+        description: |
+          This checksum is computed by the server based on the value of other fields, and may be sent on update and delete requests to ensure the
+          client has an up-to-date value before proceeding.'
+      - !ruby/object:Api::Type::Boolean
+        name: 'suspended'
+        description: |
+          When suspended, no new releases or rollouts can be created, but in-progress ones will complete.'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'serialPipeline'
+        description: |
+          SerialPipeline defines a sequential set of stages for a DeliveryPipeline.
+        properties:
+        - !ruby/object:Api::Type::Array
+          name: 'stages'
+          required: true
+          description: |
+            Each stage specifies configuration for a Target. The ordering of this list defines the promotion flow.
+          item_type: !ruby/object:Api::Type::NestedObject
+            properties:
+            - !ruby/object:Api::Type::String
+              name: 'targetId'
+              description: |
+                The targetId to which this stage points. This field refers exclusively to the last segment of a target name.
+                For example, this field would just be my-target (rather than projects/project/locations/location/targets/my-target).
+                The location of the Target is inferred to be the same as the location of the DeliveryPipeline that contains this Stage.
+            - !ruby/object:Api::Type::Array
+              name: 'profiles'
+              item_type: Api::Type::String
+              description: |
+                Skaffold profiles to use when rendering the manifest for this stage's Target.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'strategy'
+              description: |
+                Optional. The strategy to use for a Rollout to this stage.
+              properties:
+              - !ruby/object:Api::Type::NestedObject
+                  name: 'standard'
+                  description: |
+                    Standard deployment strategy executes a single deploy and allows verifying the deployment.
+                  properties:
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'verify'
+                    description: |
+                      Whether to verify a deployment.

--- a/mmv1/products/clouddeploy/terraform.yaml
+++ b/mmv1/products/clouddeploy/terraform.yaml
@@ -1,0 +1,36 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+legacy_name: 'clouddeploy'
+overrides: !ruby/object:Overrides::ResourceOverrides
+  DeliveryPipeline: !ruby/object:Overrides::Terraform::ResourceOverride
+    legacy_name: 'google_clouddeploy_delivery_pipeline'
+    id_format: 'projects/{{project}}/locations/{{region}}/deliveryPipelines/{{delivery_pipeline}}'
+    base_url: projects/{{project}}/locations/{{region}}/deliveryPipelines
+    import_format: ["projects/{{project}}/locations/{{region}}/deliveryPipelines/{{delivery_pipeline}}"]
+    autogen_async: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "clouddeploy_delivery_pipeline_basic"
+        primary_resource_id: "default"
+        primary_resource_name: "fmt.Sprintf(\"tf-dp-%s\", context[\"random_suffix\"])"
+        vars:
+          deploy_pipeline_name: "dp-name"
+    properties:
+      location: !ruby/object:Overrides::Terraform::PropertyOverride
+        name: 'region'
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      parent_resource_attribute: 'delivery_pipeline'
+      method_name_separator: ':'
+      exclude: false

--- a/mmv1/templates/terraform/examples/clouddeploy_delivery_pipeline_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/clouddeploy_delivery_pipeline_basic.tf.erb
@@ -1,0 +1,68 @@
+resource "google_clouddeploy_delivery_pipeline" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['deploy_pipeline_name'] %>"
+  description = "My cloud deploy delivery pipeline"
+  location = "us-west1"
+
+  labels        = {
+    label1 = "labelvalue1"
+  }
+
+  annotations   = {
+    annotation1 = "annotation1 value"
+  }
+
+  serial_pipeline = {
+    stages = {
+      profiles = [
+        "stg1-profile1",
+        "stg1-profile2",
+      ]
+      strategy = {
+        standard = {
+          verify = "false"
+        }
+      }
+      targetId = "stg1-targetid"
+    }
+
+    stages = {
+      profiles = [
+        "stg2-profile1",
+        "stg2-profile2",
+      ]
+      strategy = {
+        standard = {
+          verify = "false"
+        }
+      }
+      targetId = "stg2-targetid"
+    }
+  }
+}
+
+resource "google_clouddeploy_delivery_pipeline_iam_member" "member" {
+  location = google_clouddeploy_delivery_pipeline.default.location
+  project = google_clouddeploy_delivery_pipeline.default.project
+  delivery_pipeline = google_clouddeploy_delivery_pipeline.default.name
+  role = "roles/viewer"
+  member = "user:jane@example.com"
+}
+
+resource "google_clouddeploy_delivery_pipeline_iam_binding" "binding" {
+  location = google_clouddeploy_delivery_pipeline.default.location
+  project = google_clouddeploy_delivery_pipeline.default.project
+  delivery_pipeline = google_clouddeploy_delivery_pipeline.default.name
+  role = "roles/viewer"
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/viewer"
+    members = [
+      "user:jane@example.com",
+    ]
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adding support for the IAM permissions to the 'google_clouddeploy_delivery_pipeline' resource
[Fixes hashicorp github issue](https://github.com/hashicorp/terraform-provider-google/issues/13042)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
Added the resource `google_clouddeploy_delivery_pipeling` with IAM permission support
```
