### PR TITLE
containerattached: Add deletion policy.

### DIFF
--- a/mmv1/products/containerattached/api.yaml
+++ b/mmv1/products/containerattached/api.yaml
@@ -25,7 +25,7 @@ objects:
     name: 'Cluster'
     base_url: projects/{{project}}/locations/{{location}}/attachedClusters
     create_url: projects/{{project}}/locations/{{location}}/attachedClusters?attached_cluster_id={{name}}
-    delete_url: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}
+    delete_url: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}?ignore_errors=true
     update_url: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}
     self_link: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}
     update_verb: :PATCH

--- a/mmv1/products/containerattached/api.yaml
+++ b/mmv1/products/containerattached/api.yaml
@@ -25,7 +25,7 @@ objects:
     name: 'Cluster'
     base_url: projects/{{project}}/locations/{{location}}/attachedClusters
     create_url: projects/{{project}}/locations/{{location}}/attachedClusters?attached_cluster_id={{name}}
-    delete_url: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}?ignore_errors=true
+    delete_url: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}
     update_url: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}
     self_link: projects/{{project}}/locations/{{location}}/attachedClusters/{{name}}
     update_verb: :PATCH

--- a/mmv1/products/containerattached/terraform.yaml
+++ b/mmv1/products/containerattached/terraform.yaml
@@ -31,6 +31,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "primary"
         vars:
           name: "basic"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "container_attached_cluster_ignore_errors"
+        primary_resource_name: "fmt.Sprintf(\"basic%s\", context[\"random_suffix\"])"
+        primary_resource_id: "primary"
+        vars:
+          name: "basic"
+        ignore_read_extra:
+          - "deletion_policy"
     properties:
       # The proto format of the authorization field is cumbersome to express in TF, so use a custom expander
       # and flattener to massage the data.
@@ -59,6 +67,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/containerattached_cluster_diff.go
       pre_update: templates/terraform/pre_update/containerattached_update.go.erb
+      pre_delete: templates/terraform/pre_delete/container_attached_deletion_policy.go.erb
+    virtual_fields:
+      - !ruby/object:Api::Type::Enum
+        name: 'deletion_policy'
+        description: 'Policy to determine what flags to send on delete.'
+        values:
+          - :DELETE
+          - :DELETE_IGNORE_ERRORS
+        default_value: :DELETE
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/templates/terraform/examples/container_attached_cluster_ignore_errors.tf.erb
+++ b/mmv1/templates/terraform/examples/container_attached_cluster_ignore_errors.tf.erb
@@ -1,0 +1,24 @@
+data "google_project" "project" {
+}
+
+data "google_container_attached_versions" "versions" {
+	location       = "us-west1"
+	project        = data.google_project.project.project_id
+}
+
+resource "google_container_attached_cluster" "primary" {
+  name     = "<%= ctx[:vars]['name'] %>"
+  location = "us-west1"
+  project = data.google_project.project.project_id
+  description = "Test cluster"
+  distribution = "aks"
+  oidc_config {
+      issuer_url = "https://oidc.issuer.url"
+  }
+  platform_version = data.google_container_attached_versions.versions.valid_versions[0]
+  fleet {
+    project = "projects/${data.google_project.project.number}"
+  }
+
+  deletion_policy = "DELETE_IGNORE_ERRORS"
+}

--- a/mmv1/templates/terraform/pre_delete/container_attached_deletion_policy.go.erb
+++ b/mmv1/templates/terraform/pre_delete/container_attached_deletion_policy.go.erb
@@ -1,0 +1,8 @@
+if v, ok := d.GetOk("deletion_policy"); ok {
+    if v == "DELETE_IGNORE_ERRORS" {
+        url, err = addQueryParams(url, map[string]string{"ignore_errors": "true"})
+        if err != nil {
+            return err
+        }
+    }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add a deletion policy to enable using the ignore_errors parameter.

The attached clusters service attaches customer-owned third-party clusters to Anthos. If those clusters are deleted out of band, the service will fail to delete the Anthos resources and return a non-actionable error. This new field enables a flow where those errors would be ignored.




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
containerattached: Add a deletion policy enum field.
```
