### PR TITLE
Fixes terraform-provider-google#13266 Add Firebase label for all examples that creates a new Firebase Project

### DIFF
--- a/mmv1/templates/terraform/examples/firebase_project_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_project_basic.tf.erb
@@ -4,6 +4,10 @@ resource "google_project" "default" {
   project_id = "tf-test%{random_suffix}"
   name       = "tf-test%{random_suffix}"
   org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+
+  labels = {
+    "firebase" = "enabled"
+  }
 }
 
 resource "google_firebase_project" "default" {

--- a/mmv1/templates/terraform/examples/firebase_project_location_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_project_location_basic.tf.erb
@@ -4,6 +4,10 @@ resource "google_project" "default" {
   project_id = "tf-test%{random_suffix}"
   name       = "tf-test%{random_suffix}"
   org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+
+  labels = {
+    "firebase" = "enabled"
+  }
 }
 
 resource "google_firebase_project" "default" {

--- a/mmv1/templates/terraform/examples/firebase_web_app_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_web_app_basic.tf.erb
@@ -4,6 +4,10 @@ resource "google_project" "default" {
 	project_id = "tf-test%{random_suffix}"
 	name       = "tf-test%{random_suffix}"
 	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+
+	labels = {
+		"firebase" = "enabled"
+	}
 }
 
 resource "google_firebase_project" "default" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13266

When `google_firebase_project` is used, it adds a label `firebase:enabled` to the underlying GCP project. This label will be accidentally deleted when running `terraform apply` again because the label isn't present in the `google_project` resource block. This has caused Firebase projects created in Terraform to not show in the Firebase Console and Firebase CLI.

While we can't 100% prevent users from deleting the label, at least the examples should be correct.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
google_project: fixes misleading examples that could cause `firebase:enabled` label to be accidentally removed.
```
