### PR TITLE
Add support for L4 Internal Loadbalancer with IPv6

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -4220,7 +4220,6 @@ objects:
           The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6.
 
           If not set, the default value is IPV4.
-        default_value: :IPV4
         values:
           - :IPV4
           - :IPV6

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -4214,6 +4214,15 @@ objects:
           The internal fully qualified service name for this Forwarding Rule.
           This field is only used for INTERNAL load balancing.
         output: true
+      - !ruby/object:Api::Type::Enum
+        name: 'ipVersion'
+        description: |
+          The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6.
+
+          If not set, the default value is IPV4.
+        values:
+          - :IPV4
+          - :IPV6
   - !ruby/object:Api::Resource
     name: 'GlobalAddress'
     kind: 'compute#address'

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -4217,9 +4217,10 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'ipVersion'
         description: |
-          The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6.
+          The IP address version that will be used by this forwarding rule.
+          Valid options are IPV4 or IPV6.
 
-          If not set, the default value is IPV4.
+          If not set, the IPv4 address will be used by default.
         values:
           - :IPV4
           - :IPV6

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -4218,7 +4218,7 @@ objects:
         name: 'ipVersion'
         description: |
           The IP address version that will be used by this forwarding rule.
-          Valid options are IPV4 or IPV6.
+          Valid options are IPV4 and IPV6.
 
           If not set, the IPv4 address will be used by default.
         values:

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -4220,6 +4220,7 @@ objects:
           The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6.
 
           If not set, the default value is IPV4.
+        default_value: :IPV4
         values:
           - :IPV4
           - :IPV6

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1031,6 +1031,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       serviceLabel: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCEName'
+      ipVersion: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
   GlobalAddress: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1032,7 +1032,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCEName'
       ipVersion: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
+        default_value: :IPV4
   GlobalAddress: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -979,6 +979,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "port_range"
           - "target"
           - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "forwarding_rule_internallb_ipv6"
+        primary_resource_id: "default"
+        vars:
+          forwarding_rule_name: "ilb-ipv6-forwarding-rule"
+          backend_name: "ilb-ipv6-backend"
+          network_name: "net-ipv6"
+          subnet_name:  "subnet-internal-ipv6"
+        ignore_read_extra:
+          - "port_range"
+          - "target"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/labels.erb
     properties:

--- a/mmv1/templates/terraform/examples/forwarding_rule_internallb_ipv6.tf.erb
+++ b/mmv1/templates/terraform/examples/forwarding_rule_internallb_ipv6.tf.erb
@@ -1,0 +1,43 @@
+// Forwarding rule for Internal Load Balancing
+resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
+  name   = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  region = "us-central1"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.backend.id
+  all_ports             = true
+  network               = google_compute_network.default.name
+  subnetwork            = google_compute_subnetwork.default.name
+  ip_version            = "IPV6"
+}
+
+resource "google_compute_region_backend_service" "backend" {
+  name          = "<%= ctx[:vars]['backend_name'] %>"
+  region        = "us-central1"
+  health_checks = [google_compute_health_check.hc.id]
+}
+
+resource "google_compute_health_check" "hc" {
+  name               = "check-<%= ctx[:vars]['backend_name'] %>"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_network" "default" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+  enable_ula_internal_ipv6 = true
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "<%= ctx[:vars]['subnet_name'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "INTERNAL"
+  network       = google_compute_network.default.id
+}


### PR DESCRIPTION
Added the 'ipVersion' field to the forwarding-rule resource. The new field accept enum from one of ['IPV4', 'IPV6']. If not specified, the `IPV4` value will be used.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


```release-note:enhancement
compute: add support for L4 Internal Loadbalancer with IPv6

```
