### PR TITLE
Remove `page_title` attribute from frontmatter in resource documentation, update external link

### DIFF
--- a/mmv1/templates/terraform/resource.html.markdown.erb
+++ b/mmv1/templates/terraform/resource.html.markdown.erb
@@ -172,7 +172,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
 - `create` - Default is <%= timeouts.insert_minutes -%> minutes.
 <% if updatable?(object, properties) -%>

--- a/mmv1/templates/terraform/resource.html.markdown.erb
+++ b/mmv1/templates/terraform/resource.html.markdown.erb
@@ -50,7 +50,6 @@
 ---
 <%= lines(autogen_notice(:yaml, pwd)) -%>
 subcategory: "<%= tf_subcategory -%>"
-page_title: "Google: <%= terraform_name -%>"
 description: |-
 <%= indent(object.description.first_sentence, 2) %>
 ---

--- a/mmv1/templates/terraform/resource_iam.html.markdown.erb
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.erb
@@ -52,7 +52,6 @@
 ---
 <%= lines(autogen_notice(:yaml, pwd)) -%>
 subcategory: "<%= tf_subcategory -%>"
-page_title: "Google: <%= resource_ns_iam -%>"
 description: |-
   Collection of resources to manage IAM policy for <%= product.display_name -%> <%= object.name %>
 ---

--- a/mmv1/third_party/terraform/website/docs/d/access_approval_folder_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/access_approval_folder_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Access Approval"
-page_title: "Google: google_access_approval_folder_service_account"
 description: |-
   Get the email address of a folder's Access Approval service account.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/access_approval_organization_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/access_approval_organization_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Access Approval"
-page_title: "Google: google_access_approval_organization_service_account"
 description: |-
   Get the email address of an organization's Access Approval service account.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/access_approval_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/access_approval_project_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Access Approval"
-page_title: "Google: google_access_approval_project_service_account"
 description: |-
   Get the email address of a project's Access Approval service account.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/active_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/active_folder.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_active_folder"
 description: |-
   Get a folder within GCP.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/app_engine_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/app_engine_default_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "App Engine"
-page_title: "Google: google_app_engine_default_service_account"
 description: |-
   Retrieve the default App Engine service account used in this project
 ---

--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_repository.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_repository.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Artifact Registry Repository"
-page_title: "Google: google_artifact_registry_repository"
 description: |-
   Get information about a Google Artifact Registry Repository.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connection.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "BeyondCorp"
-page_title: "Google: google_beyondcorp_app_connection"
 description: |-
   Get information about a Google BeyondCorp App Connection.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connector.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "BeyondCorp"
-page_title: "Google: google_beyondcorp_app_connector"
 description: |-
   Get information about a Google BeyondCorp App Connector.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_gateway.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "BeyondCorp"
-page_title: "Google: google_beyondcorp_app_gateway"
 description: |-
   Get information about a Google BeyondCorp App Gateway.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/bigquery_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/bigquery_default_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "BigQuery"
-page_title: "Google: google_bigquery_default_service_account"
 description: |-
   Get the email address of the project's BigQuery service account
 ---

--- a/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Billing"
-page_title: "Google: google_billing_account"
 description: |-
   Get information about a Google Billing Account.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/client_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/client_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_client_config"
 description: |-
   Get information about the configuration of the Google Cloud provider.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/client_openid_userinfo.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/client_openid_userinfo.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_client_openid_userinfo"
 description: |-
   Get OpenID userinfo about the credentials used with the Google provider, specifically the email.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloud_asset_resources_search_all.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_asset_resources_search_all.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Asset Inventory"
-page_title: "Google: google_cloud_asset_resources_search_all"
 description: |-
   Retrieve all the resources within a given accessible CRM scope (project/folder/organization).
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloud_identity_group_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_identity_group_membership.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Identity"
-page_title: "Google: google_cloud_identity_group_memberships"
 description: |-
   Get list of the Cloud Identity Group Memberships within a Group.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloud_identity_groups.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_identity_groups.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Identity"
-page_title: "Google: google_cloud_identity_groups"
 description: |-
   Get list of the Cloud Identity Groups under a customer or namespace.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloud_run_locations.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_run_locations.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Run"
-page_title: "Google: google_cloud_run_locations"
 description: |-
   Get Cloud Run locations available for a project.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloud_run_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_run_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Run"
-page_title: "Google: google_cloud_run_service"
 description: |-
   Get information about a Google Cloud Run Service.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloudbuild_trigger.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudbuild_trigger.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Build"
-page_title: "Google: google_cloudbuild_trigger"
 description: |-
   Get information about a Google CloudBuild Trigger.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloudfunctions2_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudfunctions2_function.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Functions (2nd gen)"
-page_title: "Google: google_cloudfunctions2_function"
 description: |-
   Get information about a Google Cloud Function (2nd gen).
 ---

--- a/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Functions"
-page_title: "Google: google_cloudfunctions_function"
 description: |-
   Get information about a Google Cloud Function.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Composer"
-page_title: "Google: google_composer_environment"
 description: |-
   Provides Cloud Composer environment configuration data.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Composer"
-page_title: "Google: google_composer_image_versions"
 description: |-
   Provides available Cloud Composer versions.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_address.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_address.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_address"
 description: |-
   Get the IP address from a static address.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_addresses.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_addresses.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_addresses"
 description: |-
   List google compute addresses.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_backend_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_backend_bucket.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_backend_bucket"
 description: |-
   Get information about a BackendBucket.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_backend_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_backend_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_backend_service"
 description: |-
   Get information about a Backend Service.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_default_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_default_service_account"
 description: |-
   Retrieve default service account used by VMs running in this project
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_disk.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_disk"
 description: |-
   Get information about a Google Compute Persistent disks.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_forwarding_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_forwarding_rule.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_forwarding_rule"
 description: |-
   Get a regional forwarding rule within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_global_address.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_global_address.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_global_address"
 description: |-
   Get the IP address from a static address reserved for a Global Forwarding Rule.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_global_forwarding_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_global_forwarding_rule.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_global_forwarding_rule"
 description: |-
   Get a global forwarding rule within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_ha_vpn_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_ha_vpn_gateway.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_ha_vpn_gateway"
 description: |-
   Get a HA VPN Gateway within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_health_check.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_health_check.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_health_check"
 description: |-
   Get information about a HealthCheck.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_image"
 description: |-
   Get information about a Google Compute Image.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance"
 description: |-
   Get a VM instance within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_group.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_group"
 description: |-
   Get a Compute Instance Group within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_group_manager.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_group_manager"
 description: |-
   Get a Compute Instance Group within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_serial_port.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_serial_port.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_serial_port"
 description: |-
   Get the serial port output from a Compute Instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_template"
 description: |-
   Get a VM instance template within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_lb_ip_ranges.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_lb_ip_ranges.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_lb_ip_ranges"
 description: |-
   Get information about the IP ranges used when health-checking load balancers.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_network"
 description: |-
   Get a network within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_network_endpoint_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network_endpoint_group.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_network_endpoint_group"
 description: |-
   Retrieve Network Endpoint Group's details.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
@@ -56,6 +56,6 @@ See [google_compute_network_peering](https://registry.terraform.io/providers/has
 ## Timeouts
 
 This datasource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `read` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_network_peering"
 description: |-
   Get information of a specified compute network peering.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_node_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_node_types.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_node_types"
 description: |-
   Provides list of available Google Compute Engine node types for
   sole-tenant nodes.

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_region_instance_group"
 description: |-
   Get the instances inside a Compute Region Instance Group within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_network_endpoint_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_network_endpoint_group.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_region_network_endpoint_group"
 description: |-
   Retrieve Region Network Endpoint Group's details.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_ssl_certificate.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_ssl_certificate.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_region_ssl_certificate"
 description: |-
   Get info about a Regional Google Compute SSL Certificate.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_regions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_regions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_regions"
 description: |-
   Provides a list of available Google Compute regions
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_resource_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_resource_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_resource_policy"
 description: |-
   Provide access to a Resource Policy's attributes
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_router.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_router.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_router"
 description: |-
   Get a Cloud Router within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_router_nat.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_router_nat.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_router_nat"
 description: |-
   Get information about a Google Compute Router NAT.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_router_status.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_router_status.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_router_status"
 description: |-
   Get a Cloud Router's Status.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_snapshot.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_snapshot.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_snapshot"
 description: |-
   Get information about a Google Compute Snapshot.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_ssl_certificate.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_ssl_certificate.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_ssl_certificate"
 description: |-
   Get info about a Google Compute SSL Certificate.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_ssl_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_ssl_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_ssl_policy"
 description: |-
   Gets an SSL Policy within GCE, for use with Target HTTPS and Target SSL Proxies.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_subnetwork"
 description: |-
   Get a subnetwork within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_vpn_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_vpn_gateway.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_vpn_gateway"
 description: |-
   Get a VPN gateway within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/compute_zones.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_zones.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_zones"
 description: |-
   Provides a list of available Google Compute zones
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_attached_install_manifest.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_attached_install_manifest.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "ContainerAttached"
-page_title: "Google: google_container_attached_install_manifest"
 description: |-
   Generates a YAML manifest for boot-strapping an Attached cluster registration.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_attached_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_attached_versions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "ContainerAttached"
-page_title: "Google: google_container_attached_versions"
 description: |-
   Provides lists of available platform versions for the Container Attached resources.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_aws_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_aws_versions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "ContainerAws"
-page_title: "Google: google_container_aws_versions"
 description: |-
   Provides lists of available Kubernetes versions for the Container AWS resources.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_azure_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_azure_versions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "ContainerAzure"
-page_title: "Google: google_container_azure_versions"
 description: |-
   Provides lists of available Kubernetes versions for the Container Azure resources.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_cluster.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Kubernetes (Container) Engine"
-page_title: "Google: google_container_cluster"
 description: |-
   Get info about a Google Kubernetes Engine cluster.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Kubernetes (Container) Engine"
-page_title: "Google: google_container_engine_versions"
 description: |-
   Provides lists of available Google Kubernetes Engine versions for masters and nodes.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_registry_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_registry_image.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Container Registry"
-page_title: "Google: google_container_registry_image"
 description: |-
   Get URLs for a given project's container registry image.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/container_registry_repository.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_registry_repository.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Container Registry"
-page_title: "Google: google_container_registry_repository"
 description: |-
   Get URLs for a given project's container registry repository.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/data_source_dataproc_metastore_service.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/data_source_dataproc_metastore_service.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataproc"
-page_title: "Google: google_dataproc_metastore_service"
 description: |-
   Get a Dataproc Metastore Service from Google Cloud
 ---

--- a/mmv1/third_party/terraform/website/docs/d/data_source_sourcerepo_repository.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/data_source_sourcerepo_repository.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Source Repositories"
-page_title: "Google: google_sourcerepo_repository"
 description: |-
   Get information about a Google Cloud Source Repository.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/dns_keys.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_keys.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud DNS"
-page_title: "Google: google_dns_keys"
 description: |-
   Get DNSKEY and DS records of DNSSEC-signed managed zones.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud DNS"
-page_title: "Google: google_dns_managed_zone"
 description: |-
   Provides access to the attributes of a zone within Google Cloud DNS
 ---

--- a/mmv1/third_party/terraform/website/docs/d/dns_record_set.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_record_set.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud DNS"
-page_title: "Google: google_dns_record_set"
 description: |-
   Get a DNS record set within Google Cloud DNS
 ---

--- a/mmv1/third_party/terraform/website/docs/d/firebase_android_app.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_android_app.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Firebase"
-page_title: "Google: google_firebase_android_app"
 description: |-
   A Google Cloud Firebase Android application instance
 ---

--- a/mmv1/third_party/terraform/website/docs/d/firebase_apple_app.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_apple_app.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Firebase"
-page_title: "Google: google_firebase_apple_app"
 description: |-
   A Google Cloud Firebase Apple application instance
 ---

--- a/mmv1/third_party/terraform/website/docs/d/firebase_apple_app_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_apple_app_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Firebase"
-page_title: "Google: google_firebase_apple_app_config"
 description: |-
   A Google Cloud Firebase Apple application configuration
 ---

--- a/mmv1/third_party/terraform/website/docs/d/firebase_web_app.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_web_app.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Firebase"
-page_title: "Google: google_firebase_web_app"
 description: |-
   A Google Cloud Firebase web application instance
 ---

--- a/mmv1/third_party/terraform/website/docs/d/firebase_web_app_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_web_app_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Firebase"
-page_title: "Google: google_firebase_web_app_config"
 description: |-
   A Google Cloud Firebase web application configuration
 ---

--- a/mmv1/third_party/terraform/website/docs/d/folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folder.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_folder"
 description: |-
   Get information about a Google Cloud Folder.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/folder_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folder_organization_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_folder_organization_policy"
 description: |-
   Retrieve Organization policies for a Google Folder
 ---

--- a/mmv1/third_party/terraform/website/docs/d/folders.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folders.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_folders"
 description: |-
   Retrieve a set of folders based on a parent ID.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/game_services_game_server_deployment_rollout.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/game_services_game_server_deployment_rollout.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Game Servers"
-page_title: "Google: google_game_services_game_server_deployment_rollout"
 description: |-
   Get the rollout state.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/google_project_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_service"
 description: |-
  Verify the API service for the Google Cloud Platform project to see if it is enabled or not.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/iam_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_iam_policy"
 description: |-
   Generates an IAM policy that can be referenced by other resources, applying
   the policy to them.

--- a/mmv1/third_party/terraform/website/docs/d/iam_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_role.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_iam_role"
 description: |-
   Get information about a Google IAM Role.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/iam_testable_permissions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_testable_permissions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_iam_testable_permissions"
 description: |-
   Retrieve a list of testable permissions for a resource. Testable permissions mean the permissions that user can add or remove in a role at a given resource. The resource can be referenced either via the full resource name or via a URI.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud IAM"
-page_title: "Google: google_iam_workload_identity_pool"
 description: |-
   Get a IAM workload identity pool from Google Cloud
 ---

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_provider.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_provider.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud IAM"
-page_title: "Google: google_iam_workload_identity_pool_provider"
 description: |-
   Get a IAM workload identity pool provider from Google Cloud
 ---

--- a/mmv1/third_party/terraform/website/docs/d/iap_client.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iap_client.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Identity-Aware Proxy"
-page_title: "Google: google_iap_client"
 description: |-
   Contains the data that describes an Identity Aware Proxy owned client.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_crypto_key"
 description: |-
  Provides access to KMS key data with Google Cloud KMS.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_crypto_key_version"
 description: |-
  Provides access to KMS key version data with Google Cloud KMS.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/kms_key_ring.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_key_ring.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_key_ring"
 description: |-
  Provides access to KMS key ring data with Google Cloud KMS.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_secret"
 description: |-
   Provides access to secret data encrypted with Google Cloud KMS
 ---

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret_asymmetric.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret_asymmetric.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_secret_asymmetric"
 description: |-
   Provides access to secret data encrypted with Google Cloud KMS asymmetric key
 ---

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_secret_ciphertext"
 description: |-
   Encrypts secret data with Google Cloud KMS and provides access to the ciphertext
 ---

--- a/mmv1/third_party/terraform/website/docs/d/logging_project_cmek_settings.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/logging_project_cmek_settings.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_project_cmek_settings"
 description: |-
   Describes the customer-managed encryption key (CMEK) settings associated with a project.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_app_engine_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_app_engine_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_app_engine_service"
 description: |-
   An Monitoring Service resource created automatically by GCP to monitor an
   App Engine service.

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_cluster_istio_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_cluster_istio_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_cluster_istio_service"
 description: |-
   An Monitoring Service resource created automatically by GCP to monitor an
   Cluster Istio service.

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_istio_canonical_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_istio_canonical_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_istio_canonical_service"
 description: |-
   An Monitoring Service resource created automatically by GCP to monitor an
   Istio Canonical service.

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_mesh_istio_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_mesh_istio_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_mesh_istio_service"
 description: |-
   An Monitoring Service resource created automatically by GCP to monitor an
   Mesh Istio service.

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_notification_channel.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_notification_channel.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_notification_channel"
 description: |-
   A NotificationChannel is a medium through which an alert is delivered
   when a policy violation is detected.

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_uptime_check_ips.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_uptime_check_ips.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_uptime_check_ips"
 description: |-
   Returns the list of IP addresses Stackdriver Monitoring uses for uptime checking.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/netblock_ip_ranges.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/netblock_ip_ranges.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_netblock_ip_ranges"
 description: |-
   Use this data source to get the IP addresses from different special IP ranges on Google Cloud Platform.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/organization.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/organization.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_organization"
 description: |-
   Get information about a Google Cloud Organization.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/privateca_certificate_authority.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/privateca_certificate_authority.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Certificate Authority Service"
-page_title: "Google: google_privateca_certificate_authority"
 description: |-
   Contains the data that describes a Certificate Authority
 ---

--- a/mmv1/third_party/terraform/website/docs/d/project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/project.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project"
 description: |-
   Retrieve project details
 ---

--- a/mmv1/third_party/terraform/website/docs/d/project_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/project_organization_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_organization_policy"
 description: |-
   Retrieve Organization policies for a Google Project.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/projects.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/projects.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_projects"
 description: |-
   Retrieve a set of projects based on a filter.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Pub/Sub"
-page_title: "Google: google_pubsub_subscription"
 description: |-
   Get information about a Google Cloud Pub/Sub Subscription.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/pubsub_topic.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/pubsub_topic.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Pub/Sub"
-page_title: "Google: google_pubsub_topic"
 description: |-
   Get information about a Google Cloud Pub/Sub Topic.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/redis_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/redis_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Memorystore (Redis)"
-page_title: "Google: google_redis_instance"
 description: |-
   Get information about a Google Cloud Redis instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/runtimeconfig_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/runtimeconfig_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Runtime Configurator"
-page_title: "Google: google_runtimeconfig_config"
 description: |-
   Get information about a Google Cloud RuntimeConfig.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/runtimeconfig_variable.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/runtimeconfig_variable.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Runtime Configurator"
-page_title: "Google: google_runtimeconfig_variable"
 description: |-
   Get information about a Google Cloud RuntimeConfig variable.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Secret Manager"
-page_title: "Google: google_secret_manager_secret"
 description: |-
   Get information about a Secret Manager Secret
 ---

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Secret Manager"
-page_title: "Google: google_secret_manager_secret_version"
 description: |-
   Get a Secret Manager secret's version.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account"
 description: |-
   Get the service account from a project.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/service_account_access_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_access_token.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account_access_token"
 description: |-
   Produces access_token for impersonated service accounts
 ---

--- a/mmv1/third_party/terraform/website/docs/d/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_id_token.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account_id_token"
 description: |-
   Produces OpenID Connect token for service accounts
 ---

--- a/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
@@ -1,7 +1,6 @@
 ---
 subcategory: "Cloud Platform"
 layout: "google"
-page_title: "Google: google_service_account_jwt"
 sidebar_current: "docs-google-service-account-jwt"
 description: |-
   Produces an arbitrary self-signed JWT for service accounts

--- a/mmv1/third_party/terraform/website/docs/d/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_key.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account_key"
 description: |-
   Get a Google Cloud Platform service account Public Key
 ---

--- a/mmv1/third_party/terraform/website/docs/d/signed_url.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/signed_url.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_object_signed_url"
 description: |-
     Provides signed URL to Google Cloud Storage object.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/spanner_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/spanner_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Spanner"
-page_title: "Google: google_spanner_instance"
 description: |-
   Get a spanner instance from Google Cloud
 ---

--- a/mmv1/third_party/terraform/website/docs/d/sql_backup_run.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_backup_run.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_backup_run"
 description: |-
   Get a  SQL backup run in Google Cloud SQL.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/sql_ca_certs.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_ca_certs.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_ca_certs"
 description: |-
   Get all of the trusted Certificate Authorities (CAs) for the specified SQL database instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/sql_database.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_database"
 description: |-
   Get a database in a Cloud SQL database instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_database_instance"
 description: |-
   Get a SQL database instance in Google Cloud SQL.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/sql_database_instances.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database_instances.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_database_instances"
 description: |-
   Get a list of SQL database instances in a project in Google Cloud SQL.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_bucket"
 description: |-
   Get information about a Google Cloud Storage bucket.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_bucket_object"
 description: |-
   Get information about a Google Cloud Storage bucket object.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_bucket_object_content"
 description: |-
   Get content of a Google Cloud Storage bucket object.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/storage_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_project_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_project_service_account"
 description: |-
   Get the email address of the project's Google Cloud Storage service account
 ---

--- a/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Storage Transfer Service"
-page_title: "Google: google_storage_transfer_project_service_account"
 description: |-
   Retrieve default service account used by Storage Transfer Jobs running in this project
 ---

--- a/mmv1/third_party/terraform/website/docs/d/tags_tag_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tags_tag_key.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Tags"
-page_title: "Google: google_tags_tag_key"
 description: |-
   Get a tag key within a GCP organization.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/tags_tag_value.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tags_tag_value.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Tags"
-page_title: "Google: google_tags_tag_value"
 description: |-
   Get a tag value from the parent key and short_name.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/tpu_tensorflow_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_tensorflow_versions.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud TPU"
-page_title: "Google: google_tpu_tensorflow_versions"
 description: |-
   Get available TensorFlow versions.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Serverless VPC Access"
-page_title: "Google: google_vpc_access_connector"
 description: |-
   Get a Serverless VPC Access connector.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "App Engine"
-page_title: "Google: google_app_engine_application"
 description: |-
  Allows management of an App Engine application.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -94,7 +94,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `update` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_dataset_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_dataset_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "BigQuery"
-page_title: "Google: google_bigquery_dataset_iam"
 description: |-
  Collection of resources to manage IAM policy for a BigQuery dataset.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "BigQuery"
-page_title: "Google: google_bigquery_table"
 description: |-
   Creates a table resource in a dataset for Google BigQuery.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Bigtable"
-page_title: "Google: google_bigtable_gc_policy"
 description: |-
   Creates a Google Cloud Bigtable GC Policy inside a family.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Bigtable"
-page_title: "Google: google_bigtable_instance"
 description: |-
   Creates a Google Bigtable instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Bigtable"
-page_title: "Google: google_bigtable_instance_iam"
 description: |-
  Collection of resources to manage IAM policy for a Bigtable instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Bigtable"
-page_title: "Google: google_bigtable_table"
 description: |-
   Creates a Google Cloud Bigtable table inside an instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_table_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_table_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Bigtable"
-page_title: "Google: google_bigtable_table_iam"
 description: |-
  Collection of resources to manage IAM policy for a Bigtable Table.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/billing_account_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/billing_account_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Billing"
-page_title: "Google: google_billing_account_iam"
 description: |-
  Collection of resources to manage IAM policy for a Billing Account.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Build"
-page_title: "Google: google_cloudbuild_worker_pool"
 description: |-
   Configuration for custom WorkerPool to run builds
 ---

--- a/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
@@ -136,7 +136,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `update` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Functions"
-page_title: "Google: google_cloudfunctions_function"
 description: |-
   Creates a new Cloud Function.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -233,7 +233,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 5 minutes.
 - `update` - Default is 5 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -988,7 +988,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 60 minutes.
 - `update` - Default is 60 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Composer"
-page_title: "Google: google_composer_environment"
 description: |-
   An environment for running orchestration tasks.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
@@ -110,7 +110,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 5 minutes.
 - `delete` - Default is 5 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_attached_disk"
 description: |-
   Resource that allows attaching existing persistent disks to compute instances.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy.html.markdown
@@ -14,7 +14,6 @@
 #
 # ----------------------------------------------------------------------------
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_firewall_policy"
 description: |-
   Creates a hierarchical firewall policy
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy.html.markdown
@@ -88,7 +88,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `update` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_association.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_association.html.markdown
@@ -14,7 +14,6 @@
 #
 # ----------------------------------------------------------------------------
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_firewall_policy_association"
 description: |-
   Applies a hierarchical firewall policy to a target resource
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_association.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_association.html.markdown
@@ -75,7 +75,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `delete` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_rule.html.markdown
@@ -140,7 +140,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `update` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_rule.html.markdown
@@ -14,7 +14,6 @@
 #
 # ----------------------------------------------------------------------------
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_firewall_policy_rule"
 description: |-
   Specific rules to add to a hierarchical firewall policy
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance"
 description: |-
   Manages a VM instance resource within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -495,7 +495,7 @@ The field is output only, an IPv6 address from a subnetwork associated with the 
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `update` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_from_machine_image"
 description: |-
   Manages a VM instance resource within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
@@ -67,7 +67,7 @@ for details.
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 6 minutes.
 - `update` - Default is 6 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -97,7 +97,7 @@ This resource does not support import.
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 6 minutes.
 - `update` - Default is 6 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_from_template"
 description: |-
   Manages a VM instance resource within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -166,7 +166,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is `6 minutes`
 - `update` - Default is `6 minutes`

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_group"
 description: |-
   Manages an Instance Group within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -332,7 +332,7 @@ The `per_instance_configs` block holds:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 15 minutes.
 - `update` - Default is 15 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_group_manager"
 description: |-
   Manages an Instance Group within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -647,7 +647,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_instance_template"
 description: |-
   Manages a VM instance template resource within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -80,7 +80,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_network_peering"
 description: |-
   Manages a network peering within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_project_default_network_tier"
 description: |-
  Configures the default network tier for a project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
@@ -42,7 +42,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes (also used for update).
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
@@ -66,7 +66,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes (also used for update).
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_project_metadata"
 description: |-
   Manages common instance metadata
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
@@ -50,7 +50,7 @@ $ terraform import google_compute_project_metadata_item.default my_metadata
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 5 minutes.
 - `update` - Default is 5 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_project_metadata_item"
 description: |-
   Manages a single key/value pair on common instance metadata
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -340,7 +340,7 @@ The `per_instance_configs` block holds:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 15 minutes.
 - `update` - Default is 15 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_region_instance_group_manager"
 description: |-
   Manages an Regional Instance Group within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -75,7 +75,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_router_interface"
 description: |-
   Manages a Cloud Router interface.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_security_policy"
 description: |-
   Creates a Security Policy resource for Google Compute Engine.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -50,7 +50,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_shared_vpc_host_project"
 description: |-
  Enables the Google Compute Engine Shared VPC feature for a project, assigning it as a host project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_shared_vpc_service_project"
 description: |-
  Enables the Google Compute Engine Shared VPC feature for a project, assigning it as a service project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -46,7 +46,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_target_pool"
 description: |-
   Manages a Target Pool within GCE.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
@@ -85,7 +85,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `update` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Kubernetes (Container) Engine"
-page_title: "Google: google_container_cluster"
 description: |-
   Creates a Google Kubernetes Engine (GKE) cluster.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1182,7 +1182,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 40 minutes.
 - `read`   - Default is 40 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Kubernetes (Container) Engine"
-page_title: "Google: google_container_node_pool"
 description: |-
   Manages a GKE NodePool resource.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -255,7 +255,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 `google_container_node_pool` provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - (Default `30 minutes`) Used for adding node pools
 - `update` - (Default `30 minutes`) Used for updates to node pools

--- a/mmv1/third_party/terraform/website/docs/r/container_registry.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_registry.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Container Registry"
-page_title: "Google: google_container_registry"
 description: |-
   Ensures the GCS bucket backing Google Container Registry exists.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataflow"
-page_title: "Google: google_dataflow_flex_template_job"
 description: |-
   Creates a job in Dataflow based on a Flex Template.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataflow"
-page_title: "Google: google_dataflow_job"
 description: |-
   Creates a job in Dataflow according to a provided config file.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -898,7 +898,7 @@ This resource does not support import.
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 45 minutes.
 - `update` - Default is 45 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataproc"
-page_title: "Google: google_dataproc_cluster"
 description: |-
   Manages a Cloud Dataproc cluster resource.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataproc"
-page_title: "Google: google_dataproc_cluster_iam"
 description: |-
  Collection of resources to manage IAM policy for a Dataproc cluster.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataproc"
-page_title: "Google: google_dataproc_job"
 description: |-
   Manages a job resource within a Dataproc cluster.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -376,7 +376,7 @@ This resource does not support import.
 ## Timeouts
 
 `google_dataproc_cluster` provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - (Default `10 minutes`) Used for submitting a job to a dataproc cluster.
 - `delete` - (Default `10 minutes`) Used for deleting a job from a dataproc cluster.

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataproc"
-page_title: "Google: google_dataproc_job_iam"
 description: |-
  Collection of resources to manage IAM policy for a Dataproc job.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dataproc"
-page_title: "Google: google_dataproc_workflow_template"
 description: |-
   A Workflow Template is a reusable workflow configuration.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
@@ -934,7 +934,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `delete` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_environment.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dialogflow CX"
-page_title: "Google: google_dialogflow_cx_environment"
 description: |-
   Represents an environment for an agent.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_environment.html.markdown
@@ -107,7 +107,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 40 minutes.
 - `update` - Default is 40 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_version.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Dialogflow CX"
-page_title: "Google: google_dialogflow_cx_version"
 description: |-
   You can create multiple versions of your agent flows and deploy them to separate serving environments.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_version.html.markdown
@@ -118,7 +118,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 40 minutes.
 - `update` - Default is 40 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud DNS"
-page_title: "Google: google_dns_record_set"
 description: |-
   Manages a set of DNS records within Google Cloud DNS.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/endpoints_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/endpoints_service.html.markdown
@@ -81,7 +81,7 @@ This resource does not support import.
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 10 minutes.
 - `update` - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/endpoints_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/endpoints_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Endpoints"
-page_title: "Google: google_endpoints_service"
 description: |-
   Creates and rolls out a Google Endpoints service.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "GKEHub"
-page_title: "Google: google_gke_hub_feature"
 description: |-
   Contains information about a GKEHub Feature.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature.html.markdown
@@ -127,7 +127,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `update` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -355,7 +355,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `update` - Default is 20 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "GKEHub"
-page_title: "Google: google_gke_hub_feature_membership"
 description: |-
   Contains information about a GKEHub Feature Memberships.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_billing_subaccount.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_billing_subaccount.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_billing_subaccount"
 description: |-
  Allows management of a Google Cloud Billing Subaccount.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_folder"
 description: |-
  Allows management of a Google Cloud Platform folder.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_folder_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_folder_iam"
 description: |-
  Collection of resources to manage IAM policy for a folder.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_folder_organization_policy"
 description: |-
  Allows management of Organization policies for a Google Folder.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_crypto_key_iam"
 description: |-
  Collection of resources to manage IAM policy for a Google Cloud KMS crypto key.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Key Management Service"
-page_title: "Google: google_kms_key_ring_iam"
 description: |-
  Collection of resources to manage IAM policy for a Google Cloud KMS key ring.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_organization_iam"
 description: |-
  Collection of resources to manage IAM policy for a organization.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_organization_iam_custom_role"
 description: |-
  Allows management of a customized Cloud IAM organization role.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_organization_policy"
 description: |-
  Allows management of Organization policies for a Google Organization.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -100,7 +100,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 10 minutes.
 - `update` - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project"
 description: |-
  Allows management of a Google Cloud Platform project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -65,7 +65,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 10 minutes.
 - `update` - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_default_service_accounts"
 description: |-
   Allows management of Google Cloud Platform project default service accounts.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_iam"
 description: |-
  Collection of resources to manage IAM policy for a project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_iam_custom_role"
 description: |-
  Allows management of a customized Cloud IAM project role.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_organization_policy"
 description: |-
  Allows management of Organization policies for a Google Project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_service"
 description: |-
  Allows management of a single API service for a Google Cloud Platform project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -65,7 +65,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `read`   - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account"
 description: |-
  Allows management of a Google Cloud Platform service account.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -71,7 +71,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 5 minutes.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account_iam"
 description: |-
  Collection of resources to manage IAM policy for a service account.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_account_key"
 description: |-
   Allows management of a Google Cloud Platform service account Key
 ---

--- a/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
@@ -47,7 +47,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 20 minutes.
 - `read`   - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_service_networking_peered_dns_domain"
 description: |-
  Allows management of a single peered DNS domain on a project.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_dataset_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_dataset_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Healthcare"
-page_title: "Google: google_healthcare_dataset_iam"
 description: |-
  Collection of resources to manage IAM policy for a Google Cloud Healthcare dataset.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_dicom_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_dicom_store_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Healthcare"
-page_title: "Google: google_healthcare_dicom_store_iam"
 description: |-
  Collection of resources to manage IAM policy for a Google Cloud Healthcare DICOM store.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_fhir_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_fhir_store_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Healthcare"
-page_title: "Google: google_healthcare_fhir_store_iam"
 description: |-
  Collection of resources to manage IAM policy for a Google Cloud Healthcare FHIR store.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Healthcare"
-page_title: "Google: google_healthcare_hl7_v2_store_iam"
 description: |-
  Collection of resources to manage IAM policy for a Google Cloud Healthcare HL7v2 store.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_billing_account_bucket_config"
 description: |-
   Manages a billing account level logging bucket config.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_billing_account_exclusion"
 description: |-
   Manages a billing_account-level logging exclusion.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_billing_account_sink"
 description: |-
   Manages a billing account logging sink.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_folder_bucket_config"
 description: |-
   Manages a folder-level logging bucket config.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_folder_exclusion"
 description: |-
   Manages a folder-level logging exclusion.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_folder_sink"
 description: |-
   Manages a folder-level logging sink.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_organization_bucket_config"
 description: |-
   Manages a organization-level logging bucket config.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_organization_exclusion"
 description: |-
   Manages a organization-level logging exclusion.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_organization_sink"
 description: |-
   Manages a organization-level logging sink.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_project_bucket_config"
 description: |-
   Manages a project-level logging bucket config.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_project_exclusion"
 description: |-
   Manages a project-level logging exclusion.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Logging"
-page_title: "Google: google_logging_project_sink"
 description: |-
   Manages a project-level logging sink.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
@@ -130,7 +130,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `update` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud (Stackdriver) Monitoring"
-page_title: "Google: google_monitoring_dashboard"
 description: |-
   A Google Stackdriver dashboard.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/project_service_identity.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/project_service_identity.html.markdown
@@ -67,7 +67,7 @@ This resource does not support import.
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 * `create` - Default is 20 minutes.
 

--- a/mmv1/third_party/terraform/website/docs/r/project_service_identity.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/project_service_identity.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Platform"
-page_title: "Google: google_project_service_identity"
 description: |-
  Generate service identity for a service.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Pub/Sub"
-page_title: "Google: google_pubsub_subscription_iam"
 description: |-
  Collection of resources to manage IAM policy for a Pubsub subscription.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Runtime Configurator"
-page_title: "Google: google_runtimeconfig_config"
 description: |-
   Manages a RuntimeConfig resource in Google Cloud.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Runtime Configurator"
-page_title: "Google: google_runtimeconfig_variable"
 description: |-
   Manages a RuntimeConfig variable in Google Cloud.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Service Networking"
-page_title: "Google: google_service_networking_connection"
 description: |-
   Manages creating a private VPC connection to a service provider.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Spanner"
-page_title: "Google: google_spanner_database_iam"
 description: |-
  Collection of resources to manage IAM policy for a Spanner database.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Spanner"
-page_title: "Google: google_spanner_instance_iam"
 description: |-
  Collection of resources to manage IAM policy for a Spanner instance.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_database_instance"
 description: |-
   Creates a new SQL database instance in Google Cloud SQL.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -66,7 +66,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 10 minutes.
 - `delete` - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_ssl_cert"
 description: |-
   Creates a new SQL Ssl Cert in Google Cloud SQL.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -123,7 +123,7 @@ Only the arguments listed above are exposed as attributes.
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 10 minutes.
 - `update` - Default is 10 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud SQL"
-page_title: "Google: google_sql_user"
 description: |-
   Creates a new SQL user in Google Cloud SQL.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -236,7 +236,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `update` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_bucket"
 description: |-
   Creates a new bucket in Google Cloud Storage.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_bucket_acl"
 description: |-
   Creates a new bucket ACL in Google Cloud Storage.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_bucket_object"
 description: |-
   Creates a new object inside a specified bucket
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -98,7 +98,7 @@ exported:
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `update` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_default_object_acl"
 description: |-
   Authoritatively manages the default object ACLs for a Google Cloud Storage bucket
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_notification.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_notification.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_notification"
 description: |-
   Creates a new notification configuration on a specified bucket.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Cloud Storage"
-page_title: "Google: google_storage_object_acl"
 description: |-
   Creates a new object ACL in Google Cloud Storage.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Storage Transfer Service"
-page_title: "Google: google_storage_transfer_job"
 description: |-
   Creates a new Transfer Job in Google Cloud Storage Transfer.
 ---

--- a/mmv1/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
@@ -39,7 +39,7 @@ resource "google_project_usage_export_bucket" "usage_export" {
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
 - `create` - Default is 4 minutes.
 - `delete` - Default is 4 minutes.

--- a/mmv1/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_project_usage_export_bucket"
 description: |-
   Manages a project's usage export bucket.
 ---

--- a/tpgtools/templates/resource.html.markdown.tmpl
+++ b/tpgtools/templates/resource.html.markdown.tmpl
@@ -131,7 +131,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
 - `create` - Default is {{$.InsertTimeoutMinutes}} minutes.
 {{- if $.Updatable }}

--- a/tpgtools/templates/resource.html.markdown.tmpl
+++ b/tpgtools/templates/resource.html.markdown.tmpl
@@ -27,7 +27,6 @@
 #
 # ----------------------------------------------------------------------------
 subcategory: "{{$.DocsSection}}"
-page_title: "Google: {{$.TerraformName}}"
 description: |-
   {{$.Description}}
 ---


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR removes a line from the template used to generated markdown files documenting MMv1 resources. Currently the template adds a `page_title` attribute in the YAML frontmatter of each resource's markdown file, but this field is not required for resource documentation. [The documentation for provider documentation](https://developer.hashicorp.com/terraform/registry/providers/docs#supported-attributes) describes how this attribute is only needed for files in the `/guides` folder. Those files are all handwritten and not related to this template, so it's safe to remove this field from the template.

This PR also updates a link in the `Timeouts` section in the docs ([example here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/app_engine_service_split_traffic#timeouts)) . The template currently includes a link to the old documentation that was hosted at terraform.io. Although the old link is redirected to the new developer.hashicorp.com website, the docs have changed and the link doesn't send users to a relevant page.


___
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- ~~[x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~
- [x] ~~[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
