### PR TITLE
Modify max_instances to take API's result as default value

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -320,7 +320,7 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"max_instances": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      0,
+				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  `The limit on the maximum number of function instances that may coexist at a given time.`,
 			},

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -306,6 +306,10 @@ func TestAccCloudFunctionsFunction_pubsub(t *testing.T) {
 			{
 				Config: testAccCloudFunctionsFunction_pubsub(functionName, bucketName,
 					topicName, zipFilePath),
+				Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr(funcResourceName,
+            "max_instances", "3000"),
+        ),
 			},
 			{
 				ResourceName:            funcResourceName,

--- a/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
@@ -54,7 +54,7 @@ exported:
 * `service_account_email` - The service account email to be assumed by the cloud function.
 * `vpc_connector` - The VPC Network Connector that this cloud function can connect to. 
 * `vpc_connector_egress_settings` - The egress settings for the connector, controlling what traffic is diverted through it.
-* `max_instances` - The limit on the maximum number of function instances that may coexist at a given time. This is optional field. If value is not provided by user, a default value will be assigned by cloud function automatically. 
+* `max_instances` - The limit on the maximum number of function instances that may coexist at a given time. If unset or set to `0`, the API default will be used. 
 * `source_repository` - The URL of the Cloud Source Repository that the function is deployed from. Structure is [documented below](#nested_source_repository).
 
 <a name="nested_event_trigger"></a>The `event_trigger` block contains:

--- a/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
@@ -54,7 +54,7 @@ exported:
 * `service_account_email` - The service account email to be assumed by the cloud function.
 * `vpc_connector` - The VPC Network Connector that this cloud function can connect to. 
 * `vpc_connector_egress_settings` - The egress settings for the connector, controlling what traffic is diverted through it.
-* `max_instances` - The limit on the maximum number of function instances that may coexist at a given time.
+* `max_instances` - The limit on the maximum number of function instances that may coexist at a given time. This is optional field. If value is not provided by user, a default value will be assigned by cloud function automatically. 
 * `source_repository` - The URL of the Cloud Source Repository that the function is deployed from. Structure is [documented below](#nested_source_repository).
 
 <a name="nested_event_trigger"></a>The `event_trigger` block contains:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/13543
GCF: modify max_instances field to take API's result as default value


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:


    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
GCF: modify max_instances field to take API's result as default value
```
