### PR TITLE
Deprecate liveness_probe.tcp_socket field from google_cloud_run_v2_service

### DIFF
--- a/mmv1/products/cloudrunv2/api.yaml
+++ b/mmv1/products/cloudrunv2/api.yaml
@@ -977,12 +977,9 @@ objects:
                     - !ruby/object:Api::Type::NestedObject
                         name: "httpGet"
                         description: |-
-                          HTTPGet specifies the http request to perform. Exactly one of HTTPGet or TCPSocket must be specified.
+                          HTTPGet specifies the http request to perform.
                         send_empty_value: true
                         allow_empty_object: true
-                        # exactly_one_of:
-                        #   - template.0.containers.0.livenessProbe.0.httpGet
-                        #   - template.0.containers.0.livenessProbe.0.tcpSocket
                         properties:
                           - !ruby/object:Api::Type::String
                             name: "path"
@@ -1009,12 +1006,10 @@ objects:
                     - !ruby/object:Api::Type::NestedObject
                         name: "tcpSocket"
                         description: |-
-                          TCPSocket specifies an action involving a TCP port. Exactly one of HTTPGet or TCPSocket must be specified.
+                          TCPSocket specifies an action involving a TCP port. This field is not supported in liveness probe currently.
+                        deprecation_message: Cloud Run does not support tcp socket in liveness probe and `liveness_probe.tcp_socket` field will be removed in a future major release.
                         send_empty_value: true
                         allow_empty_object: true
-                        # exactly_one_of:
-                        #   - template.0.containers.0.livenessProbe.0.httpGet
-                        #   - template.0.containers.0.livenessProbe.0.tcpSocket
                         properties:
                           - !ruby/object:Api::Type::Integer
                             name: port

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
@@ -230,15 +230,6 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceProbesUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name", "location"},
 			},
 			{
-				Config: testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithHTTPStartupProbeAndTCPLivenessProbe(context),
-			},
-			{
-				ResourceName:            "google_cloud_run_v2_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location"},
-			},
-			{
 				Config: testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithEmptyHTTPStartupProbe(context),
 			},
 			{
@@ -327,49 +318,6 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 
-func testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithHTTPStartupProbeAndTCPLivenessProbe(context map[string]interface{}) string {
-	return Nprintf(`
-resource "google_cloud_run_v2_service" "default" {
-  name     = "tf-test-cloudrun-service%{random_suffix}"
-  location = "us-central1"
-  
-  template {
-    containers {
-      image = "us-docker.pkg.dev/cloudrun/container/hello"
-      ports {
-        container_port = 8080
-      }
-      startup_probe {
-        initial_delay_seconds = 3
-        period_seconds = 2
-        timeout_seconds = 6
-        failure_threshold = 3
-        http_get {
-          path = "/some-path"
-          http_headers {
-            name = "User-Agent"
-            value = "magic-modules"
-          }
-          http_headers {
-            name = "Some-Name"
-          }
-        }
-      }
-      liveness_probe {
-        initial_delay_seconds = 3
-        period_seconds = 2
-        timeout_seconds = 6
-        failure_threshold = 3
-        tcp_socket {
-          port = 8080
-        }
-      }
-    }
-  }
-}
-`, context)
-}
-
 func testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithEmptyHTTPStartupProbe(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_cloud_run_v2_service" "default" {
@@ -398,6 +346,10 @@ resource "google_cloud_run_v2_service" "default" {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
       startup_probe {
+        initial_delay_seconds = 3
+        period_seconds = 2
+        timeout_seconds = 6
+        failure_threshold = 3
         http_get {
           path = "/some-path"
           http_headers {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/13506


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.


You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
cloudrunv2: deprecated `liveness_probe.tcp_socket` field from `google_cloud_run_v2_service` resource as it is not supported by the API and it will be removed in a future major release
```
