### PR TITLE
Secret Manager Topics

### DIFF
--- a/mmv1/products/secretmanager/api.yaml
+++ b/mmv1/products/secretmanager/api.yaml
@@ -133,8 +133,6 @@ objects:
                             Describes the Cloud KMS encryption key that will be used to protect destination secret.  
       - !ruby/object:Api::Type::Array
         name: topics
-        required_with:
-          - rotation
         description: |
           A list of up to 10 Pub/Sub topics to which messages are published when control plane operations are called on the secret or its versions.
         item_type: !ruby/object:Api::Type::NestedObject


### PR DESCRIPTION
Rotation requires topics, however topics do not require rotation.

```bash
➜  test_secret git:(main) ✗ terraform plan -out test.out

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_secret_manager_secret.testsecret will be created
  + resource "google_secret_manager_secret" "testsecret" {
      + create_time = (known after apply)
      + expire_time = (known after apply)
      + id          = (known after apply)
      + name        = (known after apply)
      + project     = "leons-playground"
      + secret_id   = "test-secret"

      + replication {
          + user_managed {
              + replicas {
                  + location = "australia-southeast1"
                }
            }
        }

      + topics {
          + name = "projects/leons-playground/topics/testqueue"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: test.out

To perform exactly these actions, run the following command to apply:
    terraform apply "test.out"
➜  test_secret git:(main) ✗ terraform apply test.out 
google_secret_manager_secret.testsecret: Creating...
google_secret_manager_secret.testsecret: Creation complete after 2s [id=projects/leons-playground/secrets/test-secret]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

fixes hashicorp/terraform-provider-google#11413

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
    
```release-note:bug
secretmanager: fixed incorrect required_with for topics in `google_secret_managed_secret`
```