### PR TITLE
Document that `auto_create_network` on `google_project` enables GCE service

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -19,7 +19,7 @@ doc for more information.
 
 ~> This resource reads the specified billing account on every terraform apply and plan operation so you must have permissions on the specified billing account.
 
-~> It is recommended to use the `constraints/compute.skipDefaultNetworkCreation` [constraint](/docs/providers/google/r/google_organization_policy.html) to remove the default network instead of setting `auto_create_network` to false.
+~> It is recommended to use the `constraints/compute.skipDefaultNetworkCreation` [constraint](/docs/providers/google/r/google_organization_policy.html) to remove the default network instead of setting `auto_create_network` to false, when possible.
 
 To get more information about projects, see:
 
@@ -84,10 +84,12 @@ The following arguments are supported:
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the project.
 
-* `auto_create_network` - (Optional) Create the 'default' network automatically.  Default `true`.
-    If set to `false`, the default network will be deleted.  Note that, for quota purposes, you
-    will still need to have 1 network slot available to create the project successfully, even if
-    you set `auto_create_network` to `false`, since the network will exist momentarily.
+* `auto_create_network` - (Optional) Controls whether the 'default' network exists on the project. Defaults
+    to `true`, where it is created. If set to `false`, the default network will still be created by GCP but
+    will be deleted immediately by Terraform. Therefore, for quota purposes, you will still need to have 1 
+    network slot available to create the project successfully, even if you set `auto_create_network` to
+    `false`. Note that when `false`, Terraform enables `compute.googleapis.com` on the project to interact
+    with the GCE API and currently leaves it enabled.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/13534


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
