### PR TITLE
Fix the logic to generate serviceHostName in KCC provider

### DIFF
--- a/mmv1/templates/kcc/product/service_mapping.yaml.erb
+++ b/mmv1/templates/kcc/product/service_mapping.yaml.erb
@@ -1,7 +1,7 @@
 <%
 autogen_exception
 -%>
-# Copyright 2023 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,11 +26,15 @@ spec:
   serviceHostName: <%= product.name.downcase %>.googleapis.com
   resources:
 <%
-  product.objects.reject { |r| r.exclude || r.not_in_version?(product.version_obj_or_closest(version)) }.each do |object|
-    if @config.legacy_name.nil?
-     terraform_name = "google_" + (product.name + object.name).underscore
+  product.objects.reject { |r| r.exclude || r.exclude_resource || r.not_in_version?(product.version_obj_or_closest(version)) }.each do |object|
+    if object.legacy_name.nil?
+      if @config.legacy_name.nil?
+        terraform_name = "google_" + (product.name + object.name).underscore
+      else
+        terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+      end
     else
-     terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+      terraform_name = object.legacy_name
     end
 -%>
     - name: <%= terraform_name %>
@@ -40,7 +44,7 @@ spec:
       # idTemplate is an import id fed into the provider, which is (slightly)
       # distinct from a Terraform id.
       # Select the first format, which will generally be the long form.
-      id_template = import_id_formats_from_resource(object)[0]
+      id_template = import_id_formats_from_resource(object)[0].gsub('%', '')
       name = guess_metadata_mapping_name(object)
       has_name = !name.nil?
       has_labels = object.all_user_properties.map(&:name).include?("labels")

--- a/mmv1/templates/kcc/samples/sample.tf.erb
+++ b/mmv1/templates/kcc/samples/sample.tf.erb
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Not every service has a corresponding host name. E.g. the API for tags resources are actually under cloudresourcemanager.googleapis.com: https://github.com/GoogleCloudPlatform/magic-modules/blob/a69f1150de76f2b2cd9d37faa6bd44c1fb8a460a/mmv1/products/tags/api.yaml#L19

So fixed the logic to use the host name in base_url as the serviceHostName in service mappings.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
