### PR TITLE
Adds GRPC probe support to `google_cloud_run_v2_service` resource

### DIFF
--- a/mmv1/products/cloudrunv2/api.yaml
+++ b/mmv1/products/cloudrunv2/api.yaml
@@ -977,9 +977,12 @@ objects:
                     - !ruby/object:Api::Type::NestedObject
                         name: "httpGet"
                         description: |-
-                          HTTPGet specifies the http request to perform.
+                          HTTPGet specifies the http request to perform. Exactly one of httpGet or grpc must be specified.
                         send_empty_value: true
                         allow_empty_object: true
+                        # exactly_one_of:
+                        #   - template.0.containers.0.livenessProbe.0.httpGet
+                        #   - template.0.containers.0.livenessProbe.0.grpc
                         properties:
                           - !ruby/object:Api::Type::String
                             name: "path"
@@ -1014,7 +1017,25 @@ objects:
                           - !ruby/object:Api::Type::Integer
                             name: port
                             description: |-
-                              Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to 8080.
+                              Port number to access on the container. Must be in the range 1 to 65535.
+                    - !ruby/object:Api::Type::NestedObject
+                        name: "grpc"
+                        description: |-
+                          GRPC specifies an action involving a gRPC port. Exactly one of httpGet or grpc must be specified.
+                        send_empty_value: true
+                        allow_empty_object: true
+                        # exactly_one_of:
+                        #   - template.0.containers.0.livenessProbe.0.httpGet
+                        #   - template.0.containers.0.livenessProbe.0.grpc
+                        properties:
+                          - !ruby/object:Api::Type::Integer
+                            name: port
+                            description: |-
+                              Port number of the gRPC service. Must be in the range 1 to 65535.
+                          - !ruby/object:Api::Type::String
+                            name: service
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
                 - !ruby/object:Api::Type::NestedObject
                   name: "startupProbe"
                   description: |-
@@ -1043,12 +1064,13 @@ objects:
                     - !ruby/object:Api::Type::NestedObject
                         name: "httpGet"
                         description: |-
-                          HTTPGet specifies the http request to perform. Exactly one of HTTPGet or TCPSocket must be specified.
+                          HTTPGet specifies the http request to perform. Exactly one of httpGet, tcpSocket, or grpc must be specified.
                         send_empty_value: true
                         allow_empty_object: true
                         # exactly_one_of:
                         #   - template.0.containers.0.startupProbe.0.httpGet
                         #   - template.0.containers.0.startupProbe.0.tcpSocket
+                        #   - template.0.containers.0.startupProbe.0.grpc
                         properties:
                           - !ruby/object:Api::Type::String
                             name: "path"
@@ -1075,17 +1097,37 @@ objects:
                     - !ruby/object:Api::Type::NestedObject
                         name: "tcpSocket"
                         description: |-
-                          TCPSocket specifies an action involving a TCP port. Exactly one of HTTPGet or TCPSocket must be specified.
+                          TCPSocket specifies an action involving a TCP port. Exactly one of httpGet, tcpSocket, or grpc must be specified.
                         send_empty_value: true
                         allow_empty_object: true
                         # exactly_one_of:
                         #   - template.0.containers.0.startupProbe.0.httpGet
                         #   - template.0.containers.0.startupProbe.0.tcpSocket
+                        #   - template.0.containers.0.startupProbe.0.grpc
                         properties:
                           - !ruby/object:Api::Type::Integer
                             name: port
                             description: |-
-                              Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to 8080. 
+                              Port number to access on the container. Must be in the range 1 to 65535.
+                    - !ruby/object:Api::Type::NestedObject
+                        name: "grpc"
+                        description: |-
+                          GRPC specifies an action involving a gRPC port. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+                        send_empty_value: true
+                        allow_empty_object: true
+                        # exactly_one_of:
+                        #   - template.0.containers.0.startupProbe.0.httpGet
+                        #   - template.0.containers.0.startupProbe.0.tcpSocket
+                        #   - template.0.containers.0.startupProbe.0.grpc
+                        properties:
+                          - !ruby/object:Api::Type::Integer
+                            name: port
+                            description: |-
+                              Port number of the gRPC service. Must be in the range 1 to 65535.
+                          - !ruby/object:Api::Type::String
+                            name: service
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
           - !ruby/object:Api::Type::Array
             name: "volumes"
             description: |-

--- a/mmv1/products/cloudrunv2/terraform.yaml
+++ b/mmv1/products/cloudrunv2/terraform.yaml
@@ -155,6 +155,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       template.containers.startupProbe.tcpSocket.port: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      template.containers.startupProbe.grpc.port: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      template.containers.livenessProbe.grpc.port: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       template.scaling: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       traffic: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

A follow-up of #6850. Similar to #6781.

NOTE: I added a test in https://github.com/GoogleCloudPlatform/magic-modules/compare/main...yanweiguo:magic-modules:grpc_v2_with_test and made sure it passed locally. However there's no public GRPC app so I deleted the test after local testing.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added field `liveness_probe.grpc` and `startup_probe.grpc` to resource `google_cloud_run_v2_service` 
```
