### PR TITLE
make version mutable & ga for test

### DIFF
--- a/mmv1/products/datafusion/api.yaml
+++ b/mmv1/products/datafusion/api.yaml
@@ -161,7 +161,6 @@ objects:
           Endpoint on which the Data Fusion UI and REST APIs are accessible.
       - !ruby/object:Api::Type::String
         name: 'version'
-        input: true
         description: |
           Current version of the Data Fusion.
       - !ruby/object:Api::Type::String

--- a/mmv1/third_party/terraform/tests/resource_data_fusion_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_fusion_instance_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -139,6 +137,58 @@ resource "google_data_fusion_instance" "foobar" {
 }
 `, instanceName)
 }
-<% else %>
-// Data Fusion is not GA at the time of writing.
-<% end -%>
+
+func TestAccDataFusionInstanceVersion_dataFusionInstanceUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"version":       "6.7.2",
+	}
+
+	contextUpdate := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"version":       "6.8.0",
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataFusionInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataFusionInstanceVersion_dataFusionInstanceUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_fusion_instance.basic_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+			{
+				Config: testAccDataFusionInstanceVersion_dataFusionInstanceUpdate(contextUpdate),
+			},
+			{
+				ResourceName:            "google_data_fusion_instance.basic_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+		},
+	})
+}
+
+func testAccDataFusionInstanceVersion_dataFusionInstanceUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_fusion_instance" "basic_instance" {
+  name   = "tf-test-my-instance%{random_suffix}"
+  region = "us-central1"
+  type   = "BASIC"
+  # Mark for testing to avoid service networking connection usage that is not cleaned up
+  options = {
+    prober_test_run = "true"
+  }
+  version = "%{version}"
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13576


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
datafusion: fixed `version` can't be updated on `google_data_fusion_instance`
```
