### PR TITLE
Add repository_event_config field to google_cloudbuild_trigger (beta)

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://cloudbuild.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://cloudbuild.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:
@@ -152,6 +155,84 @@ objects:
               The full resource name of the github enterprise config.
               Format: projects/{project}/locations/{location}/githubEnterpriseConfigs/{id}. projects/{project}/githubEnterpriseConfigs/{id}.
       - !ruby/object:Api::Type::NestedObject
+        name: "repositoryEventConfig"
+        min_version: beta
+        description: |
+          The configuration of a trigger that creates a build whenever an event from Repo API is received.
+        at_least_one_of:
+          - trigger_template
+          - github
+          - pubsub_config
+          - webhook_config
+          - source_to_build
+          - repository_event_config
+        properties:
+          - !ruby/object:Api::Type::String
+            name: "repository"
+            description: |
+              The resource name of the Repo API resource.
+          - !ruby/object:Api::Type::NestedObject
+            name: "pullRequest"
+            description: |
+              Contains filter properties for matching Pull Requests.
+            exactly_one_of:
+              - pull_request
+              - push
+            properties:
+              - !ruby/object:Api::Type::String
+                name: "branch"
+                description: |
+                  Regex of branches to match.
+
+                  The syntax of the regular expressions accepted is the syntax accepted by
+                  RE2 and described at https://github.com/google/re2/wiki/Syntax
+                exactly_one_of:
+                  - branch
+              - !ruby/object:Api::Type::Boolean
+                name: "invertRegex"
+                description: |
+                  If true, branches that do NOT match the git_ref will trigger a build.
+              - !ruby/object:Api::Type::Enum
+                name: "commentControl"
+                description: |
+                  Configure builds to run whether a repository owner or collaborator need to comment `/gcbrun`.
+                values:
+                  - :COMMENTS_DISABLED
+                  - :COMMENTS_ENABLED
+                  - :COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+          - !ruby/object:Api::Type::NestedObject
+            name: "push"
+            description: |
+              Contains filter properties for matching git pushes.
+            exactly_one_of:
+              - pull_request
+              - push
+            properties:
+              - !ruby/object:Api::Type::String
+                name: "branch"
+                description: |
+                  Regex of branches to match.
+
+                  The syntax of the regular expressions accepted is the syntax accepted by
+                  RE2 and described at https://github.com/google/re2/wiki/Syntax
+                exactly_one_of:
+                  - branch
+                  - tag
+              - !ruby/object:Api::Type::String
+                name: "tag"
+                description: |
+                  Regex of tags to match.
+
+                  The syntax of the regular expressions accepted is the syntax accepted by
+                  RE2 and described at https://github.com/google/re2/wiki/Syntax
+                exactly_one_of:
+                  - branch
+                  - tag
+              - !ruby/object:Api::Type::Boolean
+                name: "invertRegex"
+                description: |
+                  If true, only trigger a build if the revision regex does NOT match the git_ref regex.
+      - !ruby/object:Api::Type::NestedObject
         name: 'sourceToBuild'
         description: |
           The repo and ref of the repository from which to build. 
@@ -164,6 +245,7 @@ objects:
           - pubsub_config
           - webhook_config
           - source_to_build
+          - repository_event_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'uri'
@@ -233,6 +315,7 @@ objects:
           - pubsub_config
           - webhook_config
           - source_to_build
+          - repository_event_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'projectId'
@@ -293,6 +376,7 @@ objects:
           - pubsub_config
           - webhook_config
           - source_to_build
+          - repository_event_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'owner'
@@ -366,6 +450,7 @@ objects:
           - pubsub_config
           - webhook_config
           - source_to_build
+          - repository_event_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'subscription'
@@ -398,6 +483,7 @@ objects:
           - pubsub_config
           - webhook_config
           - source_to_build
+          - repository_event_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'secret'

--- a/mmv1/products/cloudbuild/terraform.yaml
+++ b/mmv1/products/cloudbuild/terraform.yaml
@@ -53,6 +53,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "cloudbuild_trigger_manual_github_enterprise"
         primary_resource_id: "manual-ghe-trigger"
         skip_test: true
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloudbuild_trigger_repo"
+        min_version: beta
+        primary_resource_id: "repo-trigger"
+        vars:
+          installation_id: "123123"
+          pat_secret: "projects/my-project/secrets/github-pat-secret/versions/latest"
+          repo_uri: "https://github.com/myuser/my-repo.git"
+        test_vars_overrides:
+          installation_id: 31300675
+          pat_secret: '"projects/gcb-terraform-creds/secrets/github-pat/versions/latest"'
+          repo_uri: '"https://github.com/gcb-repos-robot/tf-demo.git"'
 
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_repo.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_repo.tf.erb
@@ -1,0 +1,33 @@
+resource "google_cloudbuildv2_connection" "my-connection" {
+  provider = google-beta
+  location = "us-central1"
+  name = "my-connection"
+
+  github_config {
+    app_installation_id = <%= ctx[:vars]['installation_id'] %>
+    authorizer_credential {
+      oauth_token_secret_version = "<%= ctx[:vars]['pat_secret'] %>"
+    }
+  }
+}
+
+resource "google_cloudbuildv2_repository" "my-repository" {
+  provider = google-beta
+  name = "my-repo"
+  parent_connection = google_cloudbuildv2_connection.my-connection.id
+  remote_uri = "<%= ctx[:vars]['repo_uri'] %>"
+}
+
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  location = "us-central1"
+
+  repository_event_config {
+    repository = google_cloudbuildv2_repository.my-repository.id
+    push {
+      branch = "feature-.*"
+    }
+  }
+
+  filename = "cloudbuild.yaml"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Field repository_event_config which allows to create triggers with 2nd-gen repositories.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: added field `repository_event_config` to resource `trigger` (beta)
```
