### PR TITLE
Add Azure odic support for BQ Omni connections

### DIFF
--- a/mmv1/products/bigqueryconnection/api.yaml
+++ b/mmv1/products/bigqueryconnection/api.yaml
@@ -168,6 +168,10 @@ objects:
             description: The id of customer's directory that host the data.
             required: true
           - !ruby/object:Api::Type::String
+            name: 'federatedApplicationClientId'
+            description: The Azure Application (client) ID where the federated credentials will be hosted.
+            required: false
+          - !ruby/object:Api::Type::String
             name: 'redirectUri'
             output: true
             description: The URL user will be redirected to after granting consent during connection setup.

--- a/mmv1/products/bigqueryconnection/api.yaml
+++ b/mmv1/products/bigqueryconnection/api.yaml
@@ -170,7 +170,6 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'federatedApplicationClientId'
             description: The Azure Application (client) ID where the federated credentials will be hosted.
-            required: false
           - !ruby/object:Api::Type::String
             name: 'redirectUri'
             output: true

--- a/mmv1/products/bigqueryconnection/terraform.yaml
+++ b/mmv1/products/bigqueryconnection/terraform.yaml
@@ -26,6 +26,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       aws: !ruby/object:Overrides::Terraform::PropertyOverride
         update_mask_fields:
           - "aws.access_role.iam_role_id"
+      azure: !ruby/object:Overrides::Terraform::PropertyOverride
+        update_mask_fields:
+          - "azure.customer_tenant_id"
+          - "azure.federated_application_client_id"
     id_format: "projects/{{project}}/locations/{{location}}/connections/{{connection_id}}"
     import_format: ["projects/{{project}}/locations/{{location}}/connections/{{connection_id}}", "{{project}}/{{location}}/{{connection_id}}", "{{location}}/{{connection_id}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/products/bigqueryconnection/terraform.yaml
+++ b/mmv1/products/bigqueryconnection/terraform.yaml
@@ -87,6 +87,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           connection_id: "my-connection"
           customer_tenant_id: "customer-tenant-id"
+          federated_application_client_id: "b43eeeee-eeee-eeee-eeee-a480155501ce"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_connection_cloudspanner"
         pull_external: true

--- a/mmv1/templates/terraform/examples/bigquery_connection_azure.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_azure.tf.erb
@@ -5,5 +5,6 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
    description   = "a riveting description"
    azure {
       customer_tenant_id = "<%= ctx[:vars]['customer_tenant_id'] %>"
+      federated_application_client_id = "<%= ctx[:vars]['federated_application_client_id'] %>"
    }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for federated Azure connection set up for Big Query Omni.  


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: Added support for federated Azure identities to BigQuery Omni connections.
```
