### PR TITLE
Fix healthcare_fhir_store streaming example to include required permissions

### DIFF
--- a/mmv1/templates/terraform/examples/healthcare_fhir_store_streaming_config.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_fhir_store_streaming_config.tf.erb
@@ -21,6 +21,25 @@ resource "google_healthcare_fhir_store" "default" {
       }
     }
   }
+
+  depends_on = [
+    google_project_iam_member.bigquery_editor,
+    google_project_iam_member.bigquery_job_user
+  ]
+}
+
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "bigquery_editor" {
+  project = data.google_project.project.project_id
+  role    = "roles/bigquery.dataEditor"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "bigquery_job_user" {
+  project = data.google_project.project.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com"
 }
 
 resource "google_pubsub_topic" "topic" {


### PR DESCRIPTION
Per https://cloud.google.com/healthcare-api/docs/permissions-healthcare-api-gcp-products#fhir_store_bigquery_permissions, when using a BigQuery destination for `healthcare_fhir_store`, the healthcare service agent needs `bigquery.dataEditor` and `bigquery.jobUser` permissions. We happen to have them in our CI project already, but they should be added to the example for the sake of other users, and so that new test environments do not need a one-off permission to be added.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
