### PR TITLE
Fix privateca_certificate tests using static-ca-pool to use bootstrap function

### DIFF
--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -136,7 +136,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
         test_vars_overrides:
-          pool: "\"static-ca-pool\""
+          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_with_template"
         primary_resource_id: "default"
@@ -147,7 +147,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
         test_vars_overrides:
-          pool: "\"static-ca-pool\""
+          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_csr"
         primary_resource_id: "default"
@@ -157,7 +157,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
         test_vars_overrides:
-          pool: "\"static-ca-pool\""
+          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_no_authority"
         primary_resource_id: "default"
@@ -167,7 +167,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
         test_vars_overrides:
-          pool: "\"static-ca-pool\""
+          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/privateca_certificate.go.erb
       test_check_destroy: templates/terraform/custom_check_destroy/privateca_certificate.go.erb


### PR DESCRIPTION
Some of our `privateca_certificate` tests have been using `static-ca-pool` as a hardcoded value, which is a persistent pool we use in the test environment. These tests pass because it already exists in our existing environment, but if they are attempted before the pool is bootstrapped in a new environment, then they fail. Ideally, we should use the bootstrap function for each of these, to ensure the pool will exist for each test, and allow our tests to be run in a non-deterministic order.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
