### PR TITLE
Added new Cloud armor network type and add ddosProtectionConfig for google_compute_security_policy to support Cloud Armor

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -63,7 +63,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: `The type indicates the intended use of the security policy. CLOUD_ARMOR - Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. CLOUD_ARMOR_EDGE - Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache.`,
-				ValidateFunc: validation.StringInSlice([]string{"CLOUD_ARMOR", "CLOUD_ARMOR_EDGE", "CLOUD_ARMOR_INTERNAL_SERVICE"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"CLOUD_ARMOR", "CLOUD_ARMOR_EDGE", "CLOUD_ARMOR_INTERNAL_SERVICE", "CLOUD_ARMOR_NETWORK"}, false),
 			},
 
 			"rule": {
@@ -393,6 +393,27 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 				Description: `The URI of the created resource.`,
 			},
 
+			<% unless version == 'ga' -%>
+			"ddos_protection_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: `Ddos Protection Config of this security policy.`,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ddos_protection": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "STANDARD",
+							ValidateFunc: validation.StringInSlice([]string{"STANDARD", "ADVANCED"}, false),
+							Description:  `DDOS protection. Supported values include: "STANDARD", "ADVANCED".`,
+						},
+					},
+				},
+			},
+			<% end -%>
+
 			"advanced_options_config": {
 				Type: schema.TypeList,
 				Optional: true,
@@ -588,6 +609,12 @@ func resourceComputeSecurityPolicyCreate(d *schema.ResourceData, meta interface{
 		securityPolicy.Rules = expandSecurityPolicyRules(v.(*schema.Set).List())
 	}
 
+	<% unless version == 'ga' -%>
+	if v, ok := d.GetOk("ddos_protection_config"); ok {
+		securityPolicy.DdosProtectionConfig = expandSecurityPolicyDdosProtectionConfig(v.([]interface{}))
+	}
+	<% end -%>
+
 	if v, ok := d.GetOk("advanced_options_config"); ok{
 		securityPolicy.AdvancedOptionsConfig = expandSecurityPolicyAdvancedOptionsConfig(v.([]interface{}))
 	}
@@ -666,6 +693,11 @@ func resourceComputeSecurityPolicyRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("self_link", ConvertSelfLinkToV1(securityPolicy.SelfLink)); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
+	<% unless version == 'ga' -%>
+	if err := d.Set("ddos_protection_config", flattenSecurityPolicyDdosProtectionConfig(securityPolicy.DdosProtectionConfig)); err != nil {
+		return fmt.Errorf("Error setting ddos_protection_config: %s", err)
+	}
+	<% end -%>
 	if err := d.Set("advanced_options_config", flattenSecurityPolicyAdvancedOptionsConfig(securityPolicy.AdvancedOptionsConfig)); err != nil {
 		return fmt.Errorf("Error setting advanced_options_config: %s", err)
 	}
@@ -709,6 +741,13 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 		securityPolicy.Description = d.Get("description").(string)
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "Description")
 	}
+
+	<% unless version == 'ga' -%>
+	if d.HasChange("ddos_protection_config") {
+		securityPolicy.DdosProtectionConfig = expandSecurityPolicyDdosProtectionConfig(d.Get("ddos_protection_config").([]interface{}))
+		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "DdosProtectionConfig", "ddosProtectionConfig.jsonParsing", "ddosProtectionConfig.jsonCustomConfig", "ddosProtectionConfig.logLevel")
+	}
+	<% end -%>
 
 	if d.HasChange("advanced_options_config") {
 		securityPolicy.AdvancedOptionsConfig = expandSecurityPolicyAdvancedOptionsConfig(d.Get("advanced_options_config").([]interface{}))
@@ -1070,6 +1109,32 @@ func flattenPreconfiguredWafConfigExclusionField(fieldParams []*compute.Security
 		fieldSchema = append(fieldSchema, data)
 	}
 	return fieldSchema
+}
+<% end -%>
+
+<% unless version == 'ga' -%>
+func expandSecurityPolicyDdosProtectionConfig(configured []interface{}) *compute.SecurityPolicyDdosProtectionConfig {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	data := configured[0].(map[string]interface{})
+	return &compute.SecurityPolicyDdosProtectionConfig {
+		DdosProtection:  data["ddos_protection"].(string),
+		ForceSendFields: []string{"Enable"},
+	}
+}
+
+func flattenSecurityPolicyDdosProtectionConfig(conf *compute.SecurityPolicyDdosProtectionConfig) []map[string]interface{} {
+	if conf == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"ddos_protection": conf.DdosProtection,
+	}
+
+	return []map[string]interface{}{data}
 }
 <% end -%>
 

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -32,6 +32,30 @@ func TestAccComputeSecurityPolicy_basic(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeSecurityPolicy_withCloudArmorNetwork_basic(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withCloudArmorNetwork_basic(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})	
+}
+<% end -%>
+
 func TestAccComputeSecurityPolicy_withRule(t *testing.T) {
 	t.Parallel()
 
@@ -160,6 +184,30 @@ func TestAccComputeSecurityPolicy_update(t *testing.T) {
 		},
 	})
 }
+
+<% unless version == 'ga' -%>
+func TestAccComputeSecurityPolicy_withDdosProtectionConfig(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withDdosProtectionConfig(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})	
+}
+<% end -%>
 
 func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 	t.Parallel()
@@ -514,6 +562,46 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeSecurityPolicy_withCloudArmorNetwork_basic(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "policy for internal test users"
+  type = "CLOUD_ARMOR_NETWORK"
+  
+  rule {
+    action   = "deny-502"
+    priority = "2147483647"
+
+	match {
+		versioned_expr = "SRC_IPS_V1"
+		config {
+		  src_ip_ranges = ["*"]
+		}
+	  }
+  }
+
+  rule {
+    action   = "allow"
+    priority = "1000"
+	description = "allow traffic from 192.0.2.0/24"
+	match {
+		versioned_expr = "SRC_IPS_V1"
+		config {
+		  src_ip_ranges = ["192.0.2.0/24"]
+		}
+		expr {
+			expression = "US"
+			location = "us-central1"
+		}
+	  }
+  }
+}
+`, spName)
+}
+<% end -%>
 
 func testAccComputeSecurityPolicy_withRule(spName string) string {
 	return fmt.Sprintf(`
@@ -949,6 +1037,39 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeSecurityPolicy_withDdosProtectionConfig(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "default rule"
+  type = "CLOUD_ARMOR_NETWORK"
+  
+  rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+	  expr {
+		expression = "US"
+		location = "us-central1"
+	}
+	  
+    }
+    description = "default rule"
+  }
+
+  ddos_protection_config {
+    ddos_protection = "STANDARD"
+  }
+}
+`, spName)
+}
+<% end -%>
 
 func testAccComputeSecurityPolicy_withAdvancedOptionsConfig(spName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -1046,19 +1046,30 @@ resource "google_compute_security_policy" "policy" {
   type = "CLOUD_ARMOR_NETWORK"
   
   rule {
-    action   = "allow"
+    action   = "deny-502"
     priority = "2147483647"
-    match {
-      versioned_expr = "SRC_IPS_V1"
-      config {
-        src_ip_ranges = ["*"]
-      }
-	  expr {
-		expression = "us-central1"
-	}
-	  
-    }
-    description = "default rule"
+
+	match {
+		versioned_expr = "SRC_IPS_V1"
+		config {
+		  src_ip_ranges = ["*"]
+		}
+	  }
+  }
+
+  rule {
+    action   = "allow"
+    priority = "1000"
+	description = "allow traffic from 192.0.2.0/24"
+	match {
+		versioned_expr = "SRC_IPS_V1"
+		config {
+		  src_ip_ranges = ["192.0.2.0/24"]
+		}
+		expr {
+			expression = "us-central1"
+		}
+	  }
   }
 
   ddos_protection_config {

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -32,30 +32,6 @@ func TestAccComputeSecurityPolicy_basic(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
-func TestAccComputeSecurityPolicy_withCloudArmorNetwork_basic(t *testing.T) {
-	t.Parallel()
-
-	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeSecurityPolicy_withCloudArmorNetwork_basic(spName),
-			},
-			{
-				ResourceName:      "google_compute_security_policy.policy",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})	
-}
-<% end -%>
-
 func TestAccComputeSecurityPolicy_withRule(t *testing.T) {
 	t.Parallel()
 
@@ -198,6 +174,14 @@ func TestAccComputeSecurityPolicy_withDdosProtectionConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeSecurityPolicy_withDdosProtectionConfig(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicy_withDdosProtectionConfig_update(spName),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -562,45 +546,6 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
-
-<% unless version == 'ga' -%>
-func testAccComputeSecurityPolicy_withCloudArmorNetwork_basic(spName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_security_policy" "policy" {
-  name        = "%s"
-  description = "policy for internal test users"
-  type = "CLOUD_ARMOR_NETWORK"
-  
-  rule {
-    action   = "deny-502"
-    priority = "2147483647"
-
-	match {
-		versioned_expr = "SRC_IPS_V1"
-		config {
-		  src_ip_ranges = ["*"]
-		}
-	  }
-  }
-
-  rule {
-    action   = "allow"
-    priority = "1000"
-	description = "allow traffic from 192.0.2.0/24"
-	match {
-		versioned_expr = "SRC_IPS_V1"
-		config {
-		  src_ip_ranges = ["192.0.2.0/24"]
-		}
-		expr {
-			expression = "us-central1"
-		}
-	  }
-  }
-}
-`, spName)
-}
-<% end -%>
 
 func testAccComputeSecurityPolicy_withRule(spName string) string {
 	return fmt.Sprintf(`
@@ -1074,6 +1019,47 @@ resource "google_compute_security_policy" "policy" {
 
   ddos_protection_config {
     ddos_protection = "STANDARD"
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withDdosProtectionConfig_update(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "default rule"
+  type = "CLOUD_ARMOR_NETWORK"
+  
+  rule {
+    action   = "deny-502"
+    priority = "2147483647"
+
+	match {
+		versioned_expr = "SRC_IPS_V1"
+		config {
+		  src_ip_ranges = ["*"]
+		}
+	  }
+  }
+
+  rule {
+    action   = "allow"
+    priority = "1000"
+	description = "allow traffic from 192.0.2.0/24"
+	match {
+		versioned_expr = "SRC_IPS_V1"
+		config {
+		  src_ip_ranges = ["192.0.2.0/24"]
+		}
+		expr {
+			expression = "us-central1"
+		}
+	  }
+  }
+
+  ddos_protection_config {
+    ddos_protection = "ADVANCED"
   }
 }
 `, spName)

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -593,8 +593,7 @@ resource "google_compute_security_policy" "policy" {
 		  src_ip_ranges = ["192.0.2.0/24"]
 		}
 		expr {
-			expression = "US"
-			location = "us-central1"
+			expression = "us-central1"
 		}
 	  }
   }
@@ -1055,8 +1054,7 @@ resource "google_compute_security_policy" "policy" {
         src_ip_ranges = ["*"]
       }
 	  expr {
-		expression = "US"
-		location = "us-central1"
+		expression = "us-central1"
 	}
 	  
     }

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -133,6 +133,8 @@ The following arguments are supported:
     rule (rule with priority 2147483647 and match "\*"). If no rules are provided when creating a
     security policy, a default rule with action "allow" will be added. Structure is [documented below](#nested_rule).
 
+* `ddos_protection_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for [Google Cloud Armor DDOS Proctection Config](https://cloud.google.com/armor/docs/advanced-network-ddos). Structure is [documented below](#nested_ddos_protection_config).
+
 * `advanced_options_config` - (Optional) [Advanced Configuration Options](https://cloud.google.com/armor/docs/security-policy-overview#json-parsing).
     Structure is [documented below](#nested_advanced_options_config).
 
@@ -143,11 +145,16 @@ The following arguments are supported:
 * `type` - The type indicates the intended use of the security policy. This field can be set only at resource creation time.
   * CLOUD_ARMOR - Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services.
     They filter requests before they hit the origin servers.
+  * CLOUD_ARMOR_NETWORK security policies. If it matches, the corresponding 'action' is enforced. The match criteria for a rule consists of built-in match fields and potentially multiple user-defined match fields.
   * CLOUD_ARMOR_EDGE - Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services
     (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage).
     They filter requests before the request is served from Google's cache.
   * CLOUD_ARMOR_INTERNAL_SERVICE - Cloud Armor internal service policies can be configured to filter HTTP requests targeting services 
     managed by Traffic Director in a service mesh. They filter requests before the request is served from the application.
+
+<a name="nested_ddos_protection_config"></a>The `ddos_protection_config` block supports:
+
+* `ddos_protection` - (Optional) DDOS protection. Supported values include: "STANDARD", "ADVANCED".
 
 <a name="nested_advanced_options_config"></a>The `advanced_options_config` block supports:
 


### PR DESCRIPTION
API: https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies 
 
If this PR is for Terraform, I acknowledge that I have:
 
* [x]  Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
* [x]  [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
* [x]  Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
* [x]  [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
* [x]  Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
 
**Release Note Template for Downstream PRs (will be copied)**
 
```release-note:enhancement
compute: Added new Cloud Armor Network type and add ddosProtectionConfig for `google_compute_security_policy` to support Cloud Armor (beta)
```
