### PR TITLE
Change the type of internal_ips and external_ips to Set instead of List.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -327,7 +327,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 			<% unless version == "ga" -%>
 			"stateful_internal_ip": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: `External IPs considered stateful by the instance group. `,
 				Elem: &schema.Resource{
@@ -348,7 +348,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				},
 			},
 			"stateful_external_ip": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: `External IPs considered stateful by the instance group. `,
 				Elem: &schema.Resource{
@@ -1035,9 +1035,9 @@ func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
 	<% unless version == "ga" -%>
 	if d.HasChange("stateful_internal_ip") {
 		oldInternalIps, newInternalIps := d.GetChange("stateful_internal_ip")
-		preservedState.InternalIPs = expandStatefulIps(newInternalIps.([]interface{}))
+		preservedState.InternalIPs = expandStatefulIps(newInternalIps.(*schema.Set).List())
 		// Remove Internal Ips
-		for _, raw := range oldInternalIps.([]interface{}) {
+		for _, raw := range oldInternalIps.(*schema.Set).List() {
 			data := raw.(map[string]interface{})
 			networkIp := data["interface_name"].(string)
 			if _, exist := preservedState.InternalIPs[networkIp]; !exist {
@@ -1045,14 +1045,12 @@ func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
 			}
 		}
 		preservedState.ForceSendFields = append(preservedState.ForceSendFields, "InternalIPs")
-		
-
 	}
 	if d.HasChange("stateful_external_ip") {
 		oldExternalIps, newExternalIps := d.GetChange("stateful_external_ip")
-		preservedState.ExternalIPs = expandStatefulIps(newExternalIps.([]interface{}))
+		preservedState.ExternalIPs = expandStatefulIps(newExternalIps.(*schema.Set).List())
 		// Remove External Ips
-		for _, raw := range oldExternalIps.([]interface{}) {
+		for _, raw := range oldExternalIps.(*schema.Set).List() {
 			data := raw.(map[string]interface{})
 			networkIp := data["interface_name"].(string)
 			if _, exist := preservedState.ExternalIPs[networkIp]; !exist {
@@ -1060,9 +1058,7 @@ func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
 			}
 		}
 		preservedState.ForceSendFields = append(preservedState.ForceSendFields, "ExternalIPs")
-		
 	}
-
 	<% end -%>
 	statefulPolicy := &compute.StatefulPolicy{PreservedState: preservedState}
 	statefulPolicy.ForceSendFields = append(statefulPolicy.ForceSendFields, "PreservedState")

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -360,7 +360,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			<% end -%>
 			<% unless version == "ga" -%>
 			"stateful_internal_ip": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: `External IPs considered stateful by the instance group. `,
 				Elem: &schema.Resource{
@@ -381,7 +381,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 				},
 			},
 			"stateful_external_ip": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: `External IPs considered stateful by the instance group. `,
 				Elem: &schema.Resource{


### PR DESCRIPTION
Previous bevahiour was causing flaking tests, as List enforces an order, whereas MIG API does not. 

fixes https://github.com/hashicorp/terraform-provider-google/issues/13430


If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


```release-bug
compute: Fixed problem with ordering in stateful tests of InstanceGroupManager and RegionInstanceGroupManager
```
