### PR TITLE
Stop acc test using authoritative IAM on shared KMS resources

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_eventarc_channel_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_eventarc_channel_test.go.erb
@@ -111,13 +111,11 @@ data "google_kms_crypto_key" "key1" {
 }
 
   
-resource "google_kms_crypto_key_iam_binding" "key1_binding" {
+resource "google_kms_crypto_key_iam_member" "key1_member" {
 	crypto_key_id = data.google_kms_crypto_key.key1.id
 	role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-	members = [
-	"serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-	]
+	member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_channel" "primary" {
@@ -125,7 +123,7 @@ resource "google_eventarc_channel" "primary" {
 	name     = "tf-test-name%{random_suffix}"
 	crypto_key_name =  data.google_kms_crypto_key.key1.id
 	third_party_provider = "projects/${data.google_project.test_project.project_id}/locations/%{region}/providers/datadog"
-	depends_on = [google_kms_crypto_key_iam_binding.key1_binding]
+	depends_on = [google_kms_crypto_key_iam_member.key1_member]
 }
 `, context)
 }
@@ -146,13 +144,11 @@ data "google_kms_crypto_key" "key2" {
 	key_ring = data.google_kms_key_ring.test_key_ring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "key2_binding" {
+resource "google_kms_crypto_key_iam_member" "key2_member" {
 	crypto_key_id = data.google_kms_crypto_key.key2.id
 	role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 	
-	members = [
-	"serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-	]
+	member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_channel" "primary" {
@@ -160,7 +156,7 @@ resource "google_eventarc_channel" "primary" {
 	name     = "tf-test-name%{random_suffix}"
 	crypto_key_name= data.google_kms_crypto_key.key2.id
 	third_party_provider = "projects/${data.google_project.test_project.project_id}/locations/%{region}/providers/datadog"
-	depends_on = [google_kms_crypto_key_iam_binding.key2_binding]
+	depends_on = [google_kms_crypto_key_iam_member.key2_member]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_eventarc_google_channel_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_eventarc_google_channel_config_test.go.erb
@@ -105,20 +105,18 @@ data "google_kms_crypto_key" "key1" {
 	key_ring = data.google_kms_key_ring.test_key_ring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "key1_binding" {
+resource "google_kms_crypto_key_iam_member" "key1_member" {
 	crypto_key_id = data.google_kms_crypto_key.key1.id
 	role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-	members = [
-	"serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-	]
+	member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_google_channel_config" "primary" {
 	location = "%{region}"
 	name     = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
 	crypto_key_name =  data.google_kms_crypto_key.key1.id
-	depends_on =[google_kms_crypto_key_iam_binding.key1_binding]
+	depends_on =[google_kms_crypto_key_iam_member.key1_member]
 }
 	`, context)
 }
@@ -139,20 +137,18 @@ data "google_kms_crypto_key" "key2" {
 	key_ring = data.google_kms_key_ring.test_key_ring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "key2_binding" {
+resource "google_kms_crypto_key_iam_member" "key2_member" {
 	crypto_key_id = data.google_kms_crypto_key.key2.id
 	role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-	members = [
-	"serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-	]
+	member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_google_channel_config" "primary" {
 	location = "%{region}"
 	name     = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
 	crypto_key_name =  data.google_kms_crypto_key.key2.id
-	depends_on =[google_kms_crypto_key_iam_binding.key2_binding]
+	depends_on =[google_kms_crypto_key_iam_member.key2_member]
 }
 	`, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_eventarc_trigger_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_eventarc_trigger_test.go.erb
@@ -65,13 +65,11 @@ data "google_kms_crypto_key" "key1" {
 }
 
 
-resource "google_kms_crypto_key_iam_binding" "key1_binding" {
+resource "google_kms_crypto_key_iam_member" "key1_member" {
 	crypto_key_id = data.google_kms_crypto_key.key1.id
 	role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-	members = [
-	"serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-	]
+	member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_channel" "test_channel" {
@@ -79,7 +77,7 @@ resource "google_eventarc_channel" "test_channel" {
 	name     = "tf-test-channel%{random_suffix}"
 	crypto_key_name =  data.google_kms_crypto_key.key1.id
 	third_party_provider = "projects/${data.google_project.test_project.project_id}/locations/%{region}/providers/datadog"
-	depends_on = [google_kms_crypto_key_iam_binding.key1_binding]
+	depends_on = [google_kms_crypto_key_iam_member.key1_member]
 }
 
 resource "google_cloud_run_service" "default" {

--- a/tpgtools/overrides/eventarc/samples/channel/basic.tf.tmpl
+++ b/tpgtools/overrides/eventarc/samples/channel/basic.tf.tmpl
@@ -12,13 +12,11 @@ data "google_kms_crypto_key" "key" {
 	key_ring = data.google_kms_key_ring.test_key_ring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "key1_binding" {
+resource "google_kms_crypto_key_iam_member" "key1_member" {
     crypto_key_id = data.google_kms_crypto_key.key1.id
     role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   
-    members = [
-    "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-    ]
+    member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_channel" "primary" {
@@ -27,5 +25,5 @@ resource "google_eventarc_channel" "primary" {
   project  = "${data.google_project.test_project.project_id}"
   crypto_key_name =  "${data.google_kms_crypto_key.key1.id}"
   third_party_provider = "projects/${data.google_project.test_project.project_id}/locations/{{region}}/providers/datadog"
-  depends_on = [google_kms_crypto_key_iam_binding.key1_binding]
+  depends_on = [google_kms_crypto_key_iam_member.key1_member]
 }

--- a/tpgtools/overrides/eventarc/samples/googlechannelconfig/basic.tf.tmpl
+++ b/tpgtools/overrides/eventarc/samples/googlechannelconfig/basic.tf.tmpl
@@ -12,13 +12,11 @@ data "google_kms_crypto_key" "key" {
 	key_ring = data.google_kms_key_ring.test_key_ring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "key1_binding" {
+resource "google_kms_crypto_key_iam_member" "key1_member" {
     crypto_key_id = data.google_kms_crypto_key.key1.id
     role      = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-    members = [
-    "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com",
-    ]
+    member = "serviceAccount:service-${data.google_project.test_project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_eventarc_google_channel_config" "primary" {
@@ -26,5 +24,5 @@ resource "google_eventarc_google_channel_config" "primary" {
   name     = "{{channel}}"
   project  = "${data.google_project.test_project.project_id}"
   crypto_key_name =  "${data.google_kms_crypto_key.key1.id}"
-  depends_on = [google_kms_crypto_key_iam_binding.key1_binding]
+  depends_on = [google_kms_crypto_key_iam_member.key1_member]
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR changes some Event Arc acceptance tests so they stop using an authoritative IAM binding on shared KMS resources.

I realised this was potentially a problem when I saw this test failing, [`TestAccEventarcTrigger_channel` test in TPG night build](https://ci-oss.hashicorp.engineering/test/-4508774451323501918?currentProjectId=GoogleCloudBeta&branch=%3Cdefault%3E&expandedTest=id%3A27380%2Cbuild%3A%28id%3A372030%29), which made me look at the tests. I realised that the test uses an authoritative IAM binding on shared KMS resources and this **could mean that tests interfere with each other**.

After this change, it'll match other acceptance tests that use bootstrapped KMS resources via data sources, e.g [here in testAccComputeInstanceTemplate_sourceSnapshotEncryptionKey](https://github.com/hashicorp/magic-modules/blob/62a62f251ee61797c7665a8c431942948f69c4ae/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb#L3047-L3069)

This test used to use authoritative bindings on `tf-bootstrap-key1` and `tf-bootstrap-key2`.

Other test failures that may be resolved by this fix:

- https://github.com/hashicorp/terraform-provider-google/issues/12908
    - mentions `tf-bootstrap-key2`
- https://github.com/hashicorp/terraform-provider-google/issues/13268
    - mentions `tf-bootstrap-key1`


___

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
