### PR TITLE
Mention Jumbo Frames for VPC MTU

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8290,8 +8290,11 @@ objects:
       - !ruby/object:Api::Type::Integer
         name: 'mtu'
         description: |
-          Maximum Transmission Unit in bytes. The minimum value for this field is 1460
-          and the maximum value is 1500 bytes.
+          Maximum Transmission Unit in bytes. The default value is 1460 bytes. 
+          The minimum value for this field is 1300 and the maximum value is 8896 bytes (jumbo frames).
+          Note that packets larger than 1500 bytes (standard Ethernet) can be subject to TCP-MSS clamping or dropped
+          with an ICMP `Fragmentation-Needed` message if the packets are routed to the Internet or other VPCs 
+          with varying MTUs.
         input: true
       - !ruby/object:Api::Type::Boolean
         name: 'enableUlaInternalIpv6'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adjust description for VPC MTU to mention jumbo frames.
Currently, the field says the maximum is 1500 bytes which is not correct, but it's also not enforced. You can set it to 8896 bytes for jumbo frames and it will work, just the description says it's wrong.

The idea with this change is to convey the most important bits of information from here: https://cloud.google.com/vpc/docs/mtu

Since there's various cases to be covered I don't know what would be the best way to convey this in a short description, but here's my shot on that.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). -> Very small change.
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests. -> No, first the link is broken, second that version of Ruby is too ancient to build properly. It's just a description change anyway, maybe a linter check would be nice but I can't get it working without Ruby. Or maybe I am just doing wrong, idk but it's just a description change.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). -> There's no new field.
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). -> Cannot run.
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed wrong maximum limit description for possible VPC MTUs
```
