### PR TITLE
feat(google_container_node_pool): support `node_config.kubelet_config.pod_pids_limit`

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -402,10 +402,12 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "100us", true),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "100us", true, 2048),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.cpu_cfs_quota", "true"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
+						"node_config.0.kubelet_config.0.pod_pids_limit", "2048"),
 				),
 			},
 			{
@@ -414,7 +416,7 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "", "", false),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "", "", false, 1024),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.cpu_cfs_quota", "false"),
@@ -443,7 +445,7 @@ func TestAccContainerNodePool_withInvalidKubeletCpuManagerPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "100us", true),
+				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "100us", true, 1024),
 				ExpectError: regexp.MustCompile(`.*to be one of \[static none \].*`),
 			},
 		},
@@ -2222,7 +2224,7 @@ resource "google_container_node_pool" "with_sandbox_config" {
 }
 <% end -%>
 
-func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, period string, quota bool) string {
+func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, period string, quota bool, podPidsLimit int) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -2248,6 +2250,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
       cpu_manager_policy   = %q
       cpu_cfs_quota        = %v
       cpu_cfs_quota_period = %q
+			pod_pids_limit			 = %d
     }
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
@@ -2255,7 +2258,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
     ]
   }
 }
-`, cluster, np, policy, quota, period)
+`, cluster, np, policy, quota, period, podPidsLimit)
 }
 
 func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, maxBacklog, soMaxConn int, tcpMem string, twReuse int) string {

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -2250,7 +2250,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
       cpu_manager_policy   = %q
       cpu_cfs_quota        = %v
       cpu_cfs_quota_period = %q
-			pod_pids_limit			 = %d
+      pod_pids_limit			 = %d
     }
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -456,6 +456,11 @@ func schemaNodeConfig() *schema.Schema {
 								Optional: true,
 								Description: `Set the CPU CFS quota period value 'cpu.cfs_period_us'.`,
 							},
+							"pod_pids_limit": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: `Controls the maximum number of processes allowed to run in a pod.`,
+							},
 						},
 					},
 				},
@@ -770,6 +775,9 @@ func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 	}
 	if cpuCfsQuotaPeriod, ok := cfg["cpu_cfs_quota_period"]; ok {
 		kConfig.CpuCfsQuotaPeriod = cpuCfsQuotaPeriod.(string)
+	}
+	if podPidsLimit, ok := cfg["pod_pids_limit"]; ok {
+		kConfig.PodPidsLimit = podPidsLimit.(int64)
 	}
 	return kConfig
 }
@@ -1101,6 +1109,7 @@ func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface
 			"cpu_cfs_quota":        c.CpuCfsQuota,
 			"cpu_cfs_quota_period": c.CpuCfsQuotaPeriod,
 			"cpu_manager_policy":   c.CpuManagerPolicy,
+			"pod_pids_limit":       c.PodPidsLimit,
 		})
 	}
 	return result

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -777,7 +777,7 @@ func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 		kConfig.CpuCfsQuotaPeriod = cpuCfsQuotaPeriod.(string)
 	}
 	if podPidsLimit, ok := cfg["pod_pids_limit"]; ok {
-		kConfig.PodPidsLimit = podPidsLimit.(int64)
+		kConfig.PodPidsLimit = int64(podPidsLimit.(int))
 	}
 	return kConfig
 }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -851,6 +851,7 @@ kubelet_config {
   cpu_manager_policy   = "static"
   cpu_cfs_quota        = true
   cpu_cfs_quota_period = "100us"
+  pod_pids_limit       = 1024
 }
 ```
 
@@ -1115,6 +1116,8 @@ such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
 value and accepts an invalid `default` value instead. While this remains true,
 not specifying the `kubelet_config` block should be the equivalent of specifying
 `none`.
+
+* `pod_pids_limit` - (Optional) Controls the maximum number of processes allowed to run in a pod. The value must be greater than or equal to 1024 and less than 4194304.
 
 <a name="nested_linux_node_config"></a>The `linux_node_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for setting the [Pod PIDs limit on the Kubelet](https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/create#--system-config-from-file:~:text=e.g.%2C%20%27100ms%27)-,podPidsLimit,-integer%20(The%20value).



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
feat(google_container_node_pool): support `node_config.kubelet_config.pod_pids_limit`
```
