### PR TITLE
Fix buggy IAM import tests previously excluded using `skip_import_test`

### DIFF
--- a/mmv1/products/apigateway/terraform.yaml
+++ b/mmv1/products/apigateway/terraform.yaml
@@ -16,7 +16,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Api: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
-      skip_import_test: true
       allowed_iam_role: 'roles/apigateway.viewer'
       method_name_separator: ':'
       parent_resource_attribute: 'api'
@@ -27,15 +26,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: beta
         name: "apigateway_api_basic"
         primary_resource_id: "api"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-api%s\", context[\"random_suffix\"])"
         vars:
-          name: "api"
+          api_id: "my-api"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta
         name: "apigateway_api_full"
         primary_resource_id: "api"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-api%s\", context[\"random_suffix\"])"
         vars:
-          name: "api"
+          api_id: "my-api"
     properties:
       displayName: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
@@ -60,23 +61,27 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: beta
         name: "apigateway_api_config_basic"
         primary_resource_id: "api_cfg"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-api%s\", context[\"random_suffix\"]), fmt.Sprintf(\"tf-test-my-config%s\", context[\"random_suffix\"])" # Need to pass 2 ids into a Sprintf - parent resource id also needed to identify primary resource
         vars:
-          name: "api-cfg"
-          config: "cfg"
+          api_id: "my-api"
+          config_d: "my-config"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta
         name: "apigateway_api_config_full"
         primary_resource_id: "api_cfg"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-api%s\", context[\"random_suffix\"])"
         vars:
-          name: "api-cfg"
+          api_id: "my-api"
+          config_id: "my-config"
       - !ruby/object:Provider::Terraform::Examples
         min_version: beta
         name: "apigateway_api_config_grpc"
         primary_resource_id: "api_cfg"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-api%s\", context[\"random_suffix\"])"
         vars:
-          name: "api-cfg"
-          config: "cfg"
+          api_id: "my-api"
+          config_id: "my-config"
         ignore_read_extra:
           - "grpc_services.0.file_descriptor_set"
       - !ruby/object:Provider::Terraform::Examples
@@ -84,9 +89,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: beta
         name: "apigateway_api_config_grpc_full"
         primary_resource_id: "api_cfg"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-config%s\", context[\"random_suffix\"])"
         vars:
-          name: "api-cfg"
-          config: "cfg"
+          api_id: "my-api"
+          config_id: "my-config"
     properties:
       openapiDocuments.document.contents: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
@@ -124,16 +130,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: beta
         name: "apigateway_gateway_basic"
         primary_resource_id: "api_gw"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-gateway%s\", context[\"random_suffix\"])"
         vars:
-          name: "api-gw"
-          config: "config"
+          api_id: "my-api"
+          config_id: "my-config"
+          gateway_id: "my-gateway"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta
         name: "apigateway_gateway_full"
         primary_resource_id: "api_gw"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-gateway%s\", context[\"random_suffix\"])"
         vars:
-          name: "api-gw"
+          api_id: "my-api"
+          config_id: "my-config"
+          gateway_id: "my-gateway"
     properties:
       apiConfig: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: compareResourceNames

--- a/mmv1/products/apigateway/terraform.yaml
+++ b/mmv1/products/apigateway/terraform.yaml
@@ -49,7 +49,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
          specified prefix. If this and api_config_id are unspecified, a random value is chosen for the name.
     autogen_async: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
-      skip_import_test: true
       allowed_iam_role: 'roles/apigateway.viewer'
       parent_resource_attribute: api_config
       base_url: projects/{{project}}/locations/global/apis/{{api}}/configs/{{api_config}}
@@ -119,7 +118,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Gateway: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
-      skip_import_test: true
       allowed_iam_role: 'roles/apigateway.viewer'
       method_name_separator: ':'
       parent_resource_attribute: 'gateway'

--- a/mmv1/products/apigateway/terraform.yaml
+++ b/mmv1/products/apigateway/terraform.yaml
@@ -64,7 +64,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_name: "fmt.Sprintf(\"tf-test-my-api%s\", context[\"random_suffix\"]), fmt.Sprintf(\"tf-test-my-config%s\", context[\"random_suffix\"])" # Need to pass 2 ids into a Sprintf - parent resource id also needed to identify primary resource
         vars:
           api_id: "my-api"
-          config_d: "my-config"
+          config_id: "my-config"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta

--- a/mmv1/products/apigateway/terraform.yaml
+++ b/mmv1/products/apigateway/terraform.yaml
@@ -49,6 +49,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
          specified prefix. If this and api_config_id are unspecified, a random value is chosen for the name.
     autogen_async: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
+      skip_import_test: true
       allowed_iam_role: 'roles/apigateway.viewer'
       parent_resource_attribute: api_config
       base_url: projects/{{project}}/locations/global/apis/{{api}}/configs/{{api_config}}
@@ -118,6 +119,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Gateway: !ruby/object:Overrides::Terraform::ResourceOverride
     autogen_async: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
+      skip_import_test: true
       allowed_iam_role: 'roles/apigateway.viewer'
       method_name_separator: ':'
       parent_resource_attribute: 'gateway'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1499,7 +1499,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       machineImageEncryptionKey.kmsKeyName: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: compareCryptoKeyVersions
     iam_policy: !ruby/object:Api::Resource::IamPolicy
-      skip_import_test: true
       allowed_iam_role: 'roles/compute.admin'
       parent_resource_attribute: 'machine_image'
       iam_conditions_request_type: :QUERY_PARAM
@@ -1507,15 +1506,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "machine_image_basic"
         primary_resource_id: "image"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-image%s\", context[\"random_suffix\"])"
         vars:
-          vm_name: "vm"
-          image_name: "image"
+          vm_name: "my-vm"
+          image_name: "my-image"
       - !ruby/object:Provider::Terraform::Examples
         name: "compute_machine_image_kms"
         primary_resource_id: "image"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-image%s\", context[\"random_suffix\"])"
         vars:
-          vm_name: "vm"
-          image_name: "image"
+          vm_name: "my-vm"
+          image_name: "my-image"
           key_name: "key"
           keyring_name: "keyring"
 

--- a/mmv1/products/metastore/terraform.yaml
+++ b/mmv1/products/metastore/terraform.yaml
@@ -98,12 +98,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: beta
         primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
         vars:
-          metastore_federation_name: "fed-1"
+          federation_id: "metastore-fed"
+          service_id:    "metastore-service"
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_federation_bigquery"
         skip_test: true  # https://github.com/hashicorp/terraform-provider-google/issues/13710
         primary_resource_id: "default"
         min_version: beta
-        primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed-bq%s", context["random_suffix"])'
+        primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
         vars:
-          metastore_federation_name: "fed-2"          
+          federation_id: "metastore-fed"
+          service_id:    "metastore-service"

--- a/mmv1/templates/terraform/examples/apigateway_api_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_basic.tf.erb
@@ -1,4 +1,4 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }

--- a/mmv1/templates/terraform/examples/apigateway_api_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_config_basic.tf.erb
@@ -1,12 +1,12 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }
 
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["config"] %>"
+  api_config_id = "<%= ctx[:vars]['config_id'] %>"
 
   openapi_documents {
     document {

--- a/mmv1/templates/terraform/examples/apigateway_api_config_full.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_config_full.tf.erb
@@ -1,12 +1,12 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }
 
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["name"] %>"
+  api_config_id = "<%= ctx[:vars]['config_id'] %>"
   display_name = "MM Dev API Config"
   labels = {
     environment = "dev"

--- a/mmv1/templates/terraform/examples/apigateway_api_config_grpc.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_config_grpc.tf.erb
@@ -1,12 +1,12 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }
 
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["config"] %>"
+  api_config_id = "<%= ctx[:vars]['config_id'] %>"
 
   grpc_services {
     file_descriptor_set {

--- a/mmv1/templates/terraform/examples/apigateway_api_config_grpc_full.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_config_grpc_full.tf.erb
@@ -1,12 +1,12 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }
 
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["config"] %>"
+  api_config_id = "<%= ctx[:vars]['config_id'] %>"
 
   grpc_services {
     file_descriptor_set {

--- a/mmv1/templates/terraform/examples/apigateway_api_full.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_full.tf.erb
@@ -1,6 +1,6 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
   display_name = "MM Dev API"
   labels = {
     environment = "dev"

--- a/mmv1/templates/terraform/examples/apigateway_gateway_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_gateway_basic.tf.erb
@@ -1,12 +1,12 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }
 
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["config"] %>"
+  api_config_id = "<%= ctx[:vars]['config_id'] %>"
 
   openapi_documents {
     document {
@@ -22,5 +22,5 @@ resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
 resource "google_api_gateway_gateway" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api_config = google_api_gateway_api_config.<%= ctx[:primary_resource_id] %>.id
-  gateway_id = "<%= ctx[:vars]["name"] %>"
+  gateway_id = "<%= ctx[:vars]['gateway_id'] %>"
 }

--- a/mmv1/templates/terraform/examples/apigateway_gateway_full.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_gateway_full.tf.erb
@@ -1,12 +1,12 @@
 resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  api_id = "<%= ctx[:vars]["name"] %>"
+  api_id = "<%= ctx[:vars]['api_id'] %>"
 }
 
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["name"] %>"
+  api_config_id = "<%= ctx[:vars]['config_id'] %>"
 
   openapi_documents {
     document {
@@ -20,7 +20,7 @@ resource "google_api_gateway_gateway" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   region     = "us-central1"
   api_config = google_api_gateway_api_config.<%= ctx[:primary_resource_id] %>.id
-  gateway_id = "<%= ctx[:vars]["name"] %>"
+  gateway_id = "<%= ctx[:vars]['gateway_id'] %>"
   display_name = "MM Dev API Gateway"
   labels = {
     environment = "dev"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Relates to https://github.com/hashicorp/terraform-provider-google/issues/12610

This PR:
- is linked to this previous PR, which introduced ignoring of import steps in acc tests for IAM resources : https://github.com/GoogleCloudPlatform/magic-modules/pull/7185
- removes `skip_import_test` from some resources so that the IAM acceptance tests include import steps
- fixes the yaml to allow those import steps to pass
- leaves some tests with skipped import steps, due to the import identifier needing to include an id that's made by the API at create time (we don't have sufficient prior knowledge when configuring the test)

----

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
