### PR TITLE
Fix kms `externalProtectionLevelOptions` shown as read only and within `attestation`

### DIFF
--- a/mmv1/products/kms/api.yaml
+++ b/mmv1/products/kms/api.yaml
@@ -249,19 +249,19 @@ objects:
                 name: 'googlePartitionCerts'
                 description: |
                   Google partition certificate chain corresponding to the attestation.
-          - !ruby/object:Api::Type::NestedObject
-            name: 'externalProtectionLevelOptions'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'externalProtectionLevelOptions'
+        description: |
+          ExternalProtectionLevelOptions stores a group of additional fields for configuring a CryptoKeyVersion that are specific to the EXTERNAL protection level and EXTERNAL_VPC protection levels.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'externalKeyUri'
             description: |
-              ExternalProtectionLevelOptions stores a group of additional fields for configuring a CryptoKeyVersion that are specific to the EXTERNAL protection level and EXTERNAL_VPC protection levels.
-            properties:
-              - !ruby/object:Api::Type::String
-                name: 'externalKeyUri'
-                description: |
-                  The URI for an external resource that this CryptoKeyVersion represents.
-              - !ruby/object:Api::Type::String
-                name: 'ekmConnectionKeyPath'
-                description: |
-                  The path to the external key material on the EKM when using EkmConnection e.g., "v0/my/key". Set this field instead of externalKeyUri when using an EkmConnection.
+              The URI for an external resource that this CryptoKeyVersion represents.
+          - !ruby/object:Api::Type::String
+            name: 'ekmConnectionKeyPath'
+            description: |
+              The path to the external key material on the EKM when using EkmConnection e.g., "v0/my/key". Set this field instead of externalKeyUri when using an EkmConnection.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides: 
         'Creating a key Version':

--- a/mmv1/products/kms/api.yaml
+++ b/mmv1/products/kms/api.yaml
@@ -249,6 +249,19 @@ objects:
                 name: 'googlePartitionCerts'
                 description: |
                   Google partition certificate chain corresponding to the attestation.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'externalProtectionLevelOptions'
+            description: |
+              ExternalProtectionLevelOptions stores a group of additional fields for configuring a CryptoKeyVersion that are specific to the EXTERNAL protection level and EXTERNAL_VPC protection levels.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'externalKeyUri'
+                description: |
+                  The URI for an external resource that this CryptoKeyVersion represents.
+              - !ruby/object:Api::Type::String
+                name: 'ekmConnectionKeyPath'
+                description: |
+                  The path to the external key material on the EKM when using EkmConnection e.g., "v0/my/key". Set this field instead of externalKeyUri when using an EkmConnection.
       - !ruby/object:Api::Type::NestedObject
         name: 'externalProtectionLevelOptions'
         description: |

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -885,6 +885,10 @@ resource "google_kms_crypto_key" "crypto_key" {
     labels = {
         key = "value"
     }
+    version_template {
+        algorithm        = "EXTERNAL_SYMMETRIC_ENCRYPTION"
+        protection_level = "EXTERNAL"
+    }
     skip_initial_version_creation = true
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
`externalProtectionLevelOptions` is defined within `attestation`, and the whole `attestation` is flagged as output only, which makes it impossible to modify the `externalKeyUri` attribute for example.
However, according to the documentation : https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys.cryptoKeyVersions#CryptoKeyVersion, externalProtectionLevelOptions is on its own, and it's not flagged as output only.

Without this modification, it's not possible to create external keys via terraform.

I was able to use an external key manager (Thales Key Broker for Google Cloud EKM) using this modification. 

This will fix the following issue https://github.com/hashicorp/terraform-provider-google/issues/11500
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: Moved externalProtectionLevelOptions to be on its own and not under attestation in the google_kms_crypto_key_versions resource

```
