### PR TITLE
Update github token to use secret manager

### DIFF
--- a/.ci/gcb-changelog-checker.yml
+++ b/.ci/gcb-changelog-checker.yml
@@ -11,7 +11,7 @@ steps:
   args:
     - $_PR_NUMBER
 
-secrets:
-    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
-      secretEnv:
-          GITHUB_TOKEN: CiQADkR4Nt6nHLI52Kc1W55OwpLdc4vjBfVR0SGQNzm6VSVj9lUSUQBfF82vVhn43A1jNYOv8ScoWgrZONwNrUabHfGjkvl+IZxcii0JlOVUawbscs4OJga0eitNNlagAOruLs6C926X20ZZPqWtH97ui6CKNvxgkQ==
+availableSecrets:
+  secretManager:
+    - versionName: projects/673497134629/secrets/github-magician-token
+      env: GITHUB_TOKEN

--- a/.ci/gcb-changelog-checker.yml
+++ b/.ci/gcb-changelog-checker.yml
@@ -13,5 +13,5 @@ steps:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token
+    - versionName: projects/673497134629/secrets/github-magician-token/latest
       env: GITHUB_TOKEN

--- a/.ci/gcb-changelog-checker.yml
+++ b/.ci/gcb-changelog-checker.yml
@@ -13,5 +13,5 @@ steps:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token/latest
+    - versionName: projects/673497134629/secrets/github-magician-token/versions/latest
       env: GITHUB_TOKEN

--- a/.ci/gcb-community.yml
+++ b/.ci/gcb-community.yml
@@ -13,7 +13,7 @@ timeout: 20000s
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token
+    - versionName: projects/673497134629/secrets/github-magician-token/latest
       env: GITHUB_TOKEN
   inline:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/teamcity-token

--- a/.ci/gcb-community.yml
+++ b/.ci/gcb-community.yml
@@ -13,7 +13,7 @@ timeout: 20000s
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token/latest
+    - versionName: projects/673497134629/secrets/github-magician-token/versions/latest
       env: GITHUB_TOKEN
   inline:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/teamcity-token

--- a/.ci/gcb-community.yml
+++ b/.ci/gcb-community.yml
@@ -11,10 +11,11 @@ steps:
 # Long timeout to enable waiting on VCR test
 timeout: 20000s
 
-secrets:
-    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
-      secretEnv:
-          GITHUB_TOKEN: CiQADkR4Nt6nHLI52Kc1W55OwpLdc4vjBfVR0SGQNzm6VSVj9lUSUQBfF82vVhn43A1jNYOv8ScoWgrZONwNrUabHfGjkvl+IZxcii0JlOVUawbscs4OJga0eitNNlagAOruLs6C926X20ZZPqWtH97ui6CKNvxgkQ==
+availableSecrets:
+  secretManager:
+    - versionName: projects/673497134629/secrets/github-magician-token
+      env: GITHUB_TOKEN
+  inline:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/teamcity-token
-      secretEnv:
+      envMap:
           TEAMCITY_TOKEN: CiQAth83aSgKrb5ASI5XwE+yv62KbNtNG+O9gKXJzoflm65H7fESkwEASc1NF0oM3pHb5cUBAHcXZqFjEJrF4eGowPycUpKDmEncuQQSkm8v+dswSNXTXnX2C/reLpw9uGTw7G+K1kqA0sVrzYG3sTdDf/IcS//uloAerUff2wVIlV5rxV357PMkBl5dGyybnKMybgrXGl+CcW9PDLAwqfELWrr5zTSHy799dAhJZi1Wb5KbImmvvU5Z46g=

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -253,7 +253,7 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token
+    - versionName: projects/673497134629/secrets/github-magician-token/latest
       env: GITHUB_TOKEN
   inline:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/environment-keyring/cryptoKeys/ci-project-key

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -253,7 +253,7 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token/latest
+    - versionName: projects/673497134629/secrets/github-magician-token/versions/latest
       env: GITHUB_TOKEN
   inline:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/environment-keyring/cryptoKeys/ci-project-key

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -251,12 +251,13 @@ timeout: 20000s
 options:
     machineType: 'N1_HIGHCPU_32'
 
-secrets:
-    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
-      secretEnv:
-          GITHUB_TOKEN: CiQADkR4Nt6nHLI52Kc1W55OwpLdc4vjBfVR0SGQNzm6VSVj9lUSUQBfF82vVhn43A1jNYOv8ScoWgrZONwNrUabHfGjkvl+IZxcii0JlOVUawbscs4OJga0eitNNlagAOruLs6C926X20ZZPqWtH97ui6CKNvxgkQ==
+availableSecrets:
+  secretManager:
+    - versionName: projects/673497134629/secrets/github-magician-token
+      env: GITHUB_TOKEN
+  inline:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/environment-keyring/cryptoKeys/ci-project-key
-      secretEnv:
+      envMap:
           GOOGLE_BILLING_ACCOUNT: CiQAis6xrGyvnmGipEEjCQVUzu3o1H4XRJSsp/B8A0IFqwRwnogSPQDOc1nLdG/+VCWpKtYtbEl12+luWkHmOYn/VtkDuMkz3bCj2DNbcuLw2fgvmkha1IjnouGPIah0qLkDmTU=
           GOOGLE_CUST_ID: CiQAis6xrAfbX3gtctcnZnt8n5DDZjercDObUGlyN4CqIpWKu5kSMgDOc1nLhLObfpnlhaUxdZ6Aoo38TBtRXoXAW5W4dbdyP+8ILKjtx1+zVL5WV641NM90
           GOOGLE_FIRESTORE_PROJECT: CiQAis6xrGkbSHeyBpgJg7/DkxNbHgqVJn3iaMYL7ybzkvDUzLESQgDOc1nLn0yUyrqLVfEujlbJEO4HDsk+o+6w608UfOXExJ3v3CTL+DwVwhXqIK/Vbo7UIMUyuP+Lu497BlcDIYyOwQ==

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -150,7 +150,7 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token
+    - versionName: projects/673497134629/secrets/github-magician-token/latest
       env: GITHUB_TOKEN
   inline:
 # This is the ciphertext of the token, encrypted using the above KMS key.

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -150,7 +150,7 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token/latest
+    - versionName: projects/673497134629/secrets/github-magician-token/versions/latest
       env: GITHUB_TOKEN
   inline:
 # This is the ciphertext of the token, encrypted using the above KMS key.

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -147,11 +147,13 @@ timeout: 86400s
 options:
     machineType: 'N1_HIGHCPU_32'
 
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/673497134629/secrets/github-magician-token
+      env: GITHUB_TOKEN
+  inline:
 # This is the ciphertext of the token, encrypted using the above KMS key.
-secrets:
-    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
-      secretEnv:
-          GITHUB_TOKEN: CiQADkR4Nt6nHLI52Kc1W55OwpLdc4vjBfVR0SGQNzm6VSVj9lUSUQBfF82vVhn43A1jNYOv8ScoWgrZONwNrUabHfGjkvl+IZxcii0JlOVUawbscs4OJga0eitNNlagAOruLs6C926X20ZZPqWtH97ui6CKNvxgkQ==
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/environment-keyring/cryptoKeys/ci-project-key
-      secretEnv:
+      envMap:
           GOOGLE_PROJECT: CiQAis6xrDDU4Wcxn5s8Y790IMxTUEe2d3SaYEXUGScHfaLjOw8SPwDOc1nLe6Yz0zzA0mcYTsXaeGSFYu7uQ5+QCtTProJWRv2ITrNwCS3AF/kvMCrHvltx7O1CZnJveutlVpZH3w==


### PR DESCRIPTION
Generated new credentials for magic-modules and changing ingestion format to using secret manager instead of KMS encrypted text.

https://cloud.google.com/build/docs/securing-builds/use-secrets
https://cloud.google.com/build/docs/securing-builds/use-encrypted-credentials
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
