### PR TITLE
Update bucket names used in tests to be shorter

### DIFF
--- a/mmv1/templates/terraform/examples/vertex_ai_index.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index.tf.erb
@@ -1,5 +1,5 @@
 resource "google_storage_bucket" "bucket" {
-  name     = "<%= ctx[:test_env_vars]['project'] %>-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  name     = "<%= ctx[:vars]['bucket_name'] %>"
   location = "us-central1"
   uniform_bucket_level_access = true
 }

--- a/mmv1/templates/terraform/examples/vertex_ai_index_streaming.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_streaming.tf.erb
@@ -1,5 +1,5 @@
 resource "google_storage_bucket" "bucket" {
-  name     = "<%= ctx[:test_env_vars]['project'] %>-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  name     = "<%= ctx[:vars]['bucket_name'] %>"
   location = "us-central1"
   uniform_bucket_level_access = true
 }

--- a/mmv1/third_party/terraform/tests/resource_vertex_ai_index_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vertex_ai_index_test.go
@@ -47,7 +47,7 @@ func TestAccVertexAIIndex_updated(t *testing.T) {
 func testAccVertexAIIndex_basic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_storage_bucket" "bucket" {
-  name     = "tf-test-%{project}-vertex-ai-index-test%{random_suffix}"  # Every bucket name must be globally unique
+  name     = "tf-test-%{random_suffix}"
   location = "us-central1"
   uniform_bucket_level_access = true
 }
@@ -101,7 +101,7 @@ resource "google_vertex_ai_index" "index" {
 func testAccVertexAIIndex_updated(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_storage_bucket" "bucket" {
-  name     = "tf-test-%{project}-vertex-ai-index-test%{random_suffix}"  # Every bucket name must be globally unique
+  name     = "tf-test-%{random_suffix}"
   location = "us-central1"
   uniform_bucket_level_access = true
 }


### PR DESCRIPTION
The names that were being used for these buckets included the project name, which is longer for our new GA test project. With the slightly longer project name, this caused the bucket name to exceed the limit of 63 characters.

The fix here simply shortens the bucket names. Since they use random suffixes, we don't need to include the project and other characters in order to ensure their uniqueness.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
