### PR TITLE
Fix patching in stateful disks1

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -1057,18 +1057,38 @@ func expandAutoHealingPolicies(configured []interface{}) []*compute.InstanceGrou
 }
 
 func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
-	preservedState := &compute.StatefulPolicyPreservedState{
-	}
-	stateful_disks := d.Get("stateful_disk").(*schema.Set).List()
-	disks := make(map[string]compute.StatefulPolicyPreservedStateDiskDevice)
-	for _, raw := range stateful_disks {
-		data := raw.(map[string]interface{})
-		disk := compute.StatefulPolicyPreservedStateDiskDevice{
-			AutoDelete: data["delete_rule"].(string),
+
+	preservedState := &compute.StatefulPolicyPreservedState{}
+
+	isRemovingAStatefulDisk := false
+	if d.HasChange("stateful_disk") {
+		oldDisks, newDisks := d.GetChange("stateful_disk")
+		preservedState.Disks = expandStatefulDisks(newDisks.(*schema.Set).List())
+		// Remove Disks
+		for _, raw := range oldDisks.(*schema.Set).List() {
+			data := raw.(map[string]interface{})
+			deviceName := data["device_name"].(string)
+			if _, exist := preservedState.Disks[deviceName]; !exist {
+				isRemovingAStatefulDisk = true
+				preservedState.NullFields = append(preservedState.NullFields, "Disks." + deviceName)
+			}
 		}
-		disks[data["device_name"].(string)] = disk
+		preservedState.ForceSendFields = append(preservedState.ForceSendFields, "Disks")
 	}
-	preservedState.Disks = disks
+	if !isRemovingAStatefulDisk {
+		preservedState := &compute.StatefulPolicyPreservedState{}
+		stateful_disks := d.Get("stateful_disk").(*schema.Set).List()
+		disks := make(map[string]compute.StatefulPolicyPreservedStateDiskDevice)
+		for _, raw := range stateful_disks {
+			data := raw.(map[string]interface{})
+			disk := compute.StatefulPolicyPreservedStateDiskDevice{
+				AutoDelete: data["delete_rule"].(string),
+			}
+			disks[data["device_name"].(string)] = disk
+		}
+		preservedState.Disks = disks
+	}
+
 	<% unless version == "ga" -%>
 	if d.HasChange("stateful_internal_ip") {
 		oldInternalIps, newInternalIps := d.GetChange("stateful_internal_ip")
@@ -1082,9 +1102,8 @@ func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
 			}
 		}
 		preservedState.ForceSendFields = append(preservedState.ForceSendFields, "InternalIPs")
-		
-
 	}
+
 	if d.HasChange("stateful_external_ip") {
 		oldExternalIps, newExternalIps := d.GetChange("stateful_external_ip")
 		preservedState.ExternalIPs = expandStatefulIps(newExternalIps.([]interface{}))
@@ -1097,7 +1116,6 @@ func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
 			}
 		}
 		preservedState.ForceSendFields = append(preservedState.ForceSendFields, "ExternalIPs")
-		
 	}
 
 	<% end -%>
@@ -1105,6 +1123,19 @@ func expandStatefulPolicy(d *schema.ResourceData) *compute.StatefulPolicy {
 	statefulPolicy.ForceSendFields = append(statefulPolicy.ForceSendFields, "PreservedState")
 
 	return statefulPolicy
+}
+
+func expandStatefulDisks(statefulDisk []interface{}) map[string]compute.StatefulPolicyPreservedStateDiskDevice {
+	statefulDisksMap :=	make(map[string]compute.StatefulPolicyPreservedStateDiskDevice)
+
+	for _, raw := range statefulDisk {
+		data := raw.(map[string]interface{})
+		deviceName := compute.StatefulPolicyPreservedStateDiskDevice{
+			AutoDelete: data["delete_rule"].(string),
+		}
+		statefulDisksMap[data["device_name"].(string)] = deviceName
+	}
+	return statefulDisksMap
 }
 
 <% unless version == "ga" -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -1538,6 +1538,10 @@ resource "google_compute_instance_group_manager" "igm-basic" {
     device_name = "my-stateful-disk"
     delete_rule = "NEVER"
   }
+  stateful_disk {
+    device_name = "my-stateful-disk2"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
+  }
 
 <% unless version == "ga" -%>
   stateful_internal_ip {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -1630,10 +1630,6 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   base_instance_name = "tf-test-igm-basic"
   zone               = "us-central1-c"
   target_size        = 2
-  stateful_disk {
-    device_name = "my-stateful-disk"
-    delete_rule = "NEVER"
-  }
 }
 `, network, template, target, igm)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -1567,14 +1567,6 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     max_surge_fixed              = 0
     max_unavailable_fixed        = 6
   }
-  stateful_disk {
-    device_name = "stateful-disk"
-    delete_rule = "NEVER"
-  }
-  stateful_disk {
-    device_name = "stateful-disk2"
-    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
-  }
 }
 `, network, template, igm)
 }


### PR DESCRIPTION
Add possibility to remove Stateful Disks by using Null Values.
resolves https://github.com/hashicorp/terraform-provider-google/issues/10266



If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:bug
compute: added possibility to remove `stateful_disks` in `compute_instance_group_manager` and `compute_region_instance_group_manager`.
```
