### PR TITLE
Allow copyright headers in downstream by adding copywrite CLI to downstream generation

### DIFF
--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -70,4 +70,8 @@ RUN wget https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_
 RUN unzip terraform_0.13.7_linux_amd64.zip && rm terraform_0.13.7_linux_amd64.zip
 RUN mv ./terraform /bin/terraform
 
+RUN wget https://github.com/hashicorp/copywrite/releases/download/v0.16.0/copywrite_0.16.0_linux_x86_64.tar.gz
+RUN tar -xf copywrite_0.16.0_linux_x86_64.tar.gz
+RUN mv ./copywrite /bin/copywrite
+
 ENTRYPOINT ["/generate_downstream.sh"]

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -171,7 +171,14 @@ popd
 pushd $LOCAL_PATH
 
 if [ "$REPO" == "terraform" ]; then
+    # See https://github.com/hashicorp/terraform-provider-google/issues/13864
     make generate
+fi
+
+if [ "$REPO" == "terraform" ] && [ $PR_NUMBER == "7255" ]; then
+    # Add copyright headers using copywrite CLI (see .copywrite.hcl config file)
+    # Only add copyright headers to the TPG and TPGB repos
+    copywrite headers
 fi
 
 git config --local user.name "Modular Magician"
@@ -183,10 +190,8 @@ COMMITTED=true
 git commit --signoff -m "$COMMIT_MESSAGE" || COMMITTED=false
 
 CHANGELOG=false
-COPYRIGHT=false
 if [ "$REPO" == "terraform" ]; then
   CHANGELOG=true
-  COPYRIGHT=true
 fi
 
 PR_NUMBER=$(curl -L -s -H "Authorization: token ${GITHUB_TOKEN}" \
@@ -204,12 +209,6 @@ if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && [ "$CHANGELOG
     git commit --signoff --amend --no-edit
 fi
 
-if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && [ "$COPYRIGHT" == "true" ]; then
-    # Add copyright headers using copywrite CLI
-    copywrite headers --spdx 'MPL-2.0'
-    git add .
-    git commit --signoff --amend --no-edit
-fi
 
 git push $SCRATCH_PATH $BRANCH -f
 

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -209,7 +209,6 @@ if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && [ "$CHANGELOG
     git commit --signoff --amend --no-edit
 fi
 
-
 git push $SCRATCH_PATH $BRANCH -f
 
 if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -183,8 +183,10 @@ COMMITTED=true
 git commit --signoff -m "$COMMIT_MESSAGE" || COMMITTED=false
 
 CHANGELOG=false
+COPYRIGHT=false
 if [ "$REPO" == "terraform" ]; then
   CHANGELOG=true
+  COPYRIGHT=true
 fi
 
 PR_NUMBER=$(curl -L -s -H "Authorization: token ${GITHUB_TOKEN}" \
@@ -199,6 +201,13 @@ if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && [ "$CHANGELOG
         sed -e '/```release-note/,/```/!d' \
         > .changelog/$PR_NUMBER.txt
     git add .changelog
+    git commit --signoff --amend --no-edit
+fi
+
+if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && [ "$COPYRIGHT" == "true" ]; then
+    # Add copyright headers using copywrite CLI
+    copywrite headers --spdx 'MPL-2.0'
+    git add .
     git commit --signoff --amend --no-edit
 fi
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

WIP - I'm not sure about contributing to the CI!


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
