### PR TITLE
docs: update google_api_gateway_api_config_basic

### DIFF
--- a/mmv1/products/apigateway/terraform.yaml
+++ b/mmv1/products/apigateway/terraform.yaml
@@ -60,7 +60,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "api_cfg"
         vars:
           name: "api-cfg"
-          config: "cfg"
+          config_prefix: "cfg-"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta

--- a/mmv1/templates/terraform/examples/apigateway_api_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigateway_api_config_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id = "<%= ctx[:vars]["config"] %>"
+  api_config_id_prefix = "<%= ctx[:vars]["config_prefix"] %>"
 
   openapi_documents {
     document {


### PR DESCRIPTION
This PR updates the documentation of [google_api_gateway_api_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/api_gateway_api_config) to reflect its most common use case.

In its current version it leads to issues on any change due to this object requiring a `create_before_destroy` lifecycle. When using this option the argument `api_config_id_prefix` should be used instead of a fixed `api_config_id`. This is also described within the documentation of the [lifecycle argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle).

The result should look somewhat like in this [PR](https://github.com/hashicorp/terraform-provider-google/pull/13680).


If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
