### PR TITLE
Move billing tests that require permissions beyond Billing User to master billing account

### DIFF
--- a/mmv1/products/billingbudget/terraform.yaml
+++ b/mmv1/products/billingbudget/terraform.yaml
@@ -33,21 +33,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           display_name: 'Example Billing Budget'
         test_env_vars:
-          billing_acct: :BILLING_ACCT
+          billing_acct: :MASTER_BILLING_ACCT
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_lastperiod'
         primary_resource_id: 'budget'
         vars:
           display_name: 'Example Billing Budget'
         test_env_vars:
-          billing_acct: :BILLING_ACCT
+          billing_acct: :MASTER_BILLING_ACCT
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_filter'
         primary_resource_id: 'budget'
         vars:
           display_name: 'Example Billing Budget'
         test_env_vars:
-          billing_acct: :BILLING_ACCT
+          billing_acct: :MASTER_BILLING_ACCT
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_notify'
         primary_resource_id: 'budget'
@@ -55,14 +55,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           budget_name: 'Example Billing Budget'
           channel_name: 'Example Notification Channel'
         test_env_vars:
-          billing_acct: :BILLING_ACCT
+          billing_acct: :MASTER_BILLING_ACCT
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_customperiod'
         primary_resource_id: 'budget'
         vars:
           display_name: 'Example Billing Budget'
         test_env_vars:
-          billing_acct: :BILLING_ACCT
+          billing_acct: :MASTER_BILLING_ACCT
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_optional'
         primary_resource_id: 'budget'
@@ -71,7 +71,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           display_name: 'Example Billing Budget'
           topic_name: "example-topic"
         test_env_vars:
-          billing_acct: :BILLING_ACCT          
+          billing_acct: :MASTER_BILLING_ACCT          
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -63,6 +63,7 @@ module Provider
       #  - :ORG_ID
       #  - :ORG_TARGET
       #  - :BILLING_ACCT
+      #  - :MASTER_BILLING_ACCT
       #  - :SERVICE_ACCT
       #  - :CUST_ID
       #  - :IDENTITY_USER
@@ -158,6 +159,7 @@ module Provider
           ORG_DOMAIN: 'example.com',
           ORG_TARGET: '123456789',
           BILLING_ACCT: '000000-0000000-0000000-000000',
+          MASTER_BILLING_ACCT: '000000-0000000-0000000-000000',
           SERVICE_ACCT: 'emailAddress:my@service-account.com',
           CUST_ID: 'A01b123xz',
           IDENTITY_USER: 'cloud_identity_user'

--- a/mmv1/templates/terraform/env_var_context.go.erb
+++ b/mmv1/templates/terraform/env_var_context.go.erb
@@ -11,6 +11,8 @@
 		"<%= var_name -%>": getTestOrgTargetFromEnv(t),
 	<% elsif var_type == :BILLING_ACCT -%>
 		"<%= var_name -%>": getTestBillingAccountFromEnv(t),
+	<% elsif var_type == :MASTER_BILLING_ACCT -%>
+		"<%= var_name -%>": getTestMasterBillingAccountFromEnv(t),
 	<% elsif var_type == :SERVICE_ACCT -%>
 		"<%= var_name -%>": getTestServiceAccountFromEnv(t),
 	<% elsif var_type == :PROJECT_NAME -%>

--- a/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
@@ -11,7 +11,7 @@ func TestAccBillingBudget_billingBudgetCurrencycode(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"billing_acct":  getTestBillingAccountFromEnv(t),
+		"billing_acct":  getTestMasterBillingAccountFromEnv(t),
 		"random_suffix": randString(t, 10),
 	}
 
@@ -69,7 +69,7 @@ func TestAccBillingBudget_billingBudgetUpdate(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"billing_acct":  getTestBillingAccountFromEnv(t),
+		"billing_acct":  getTestMasterBillingAccountFromEnv(t),
 		"random_suffix": randString(t, 10),
 	}
 
@@ -542,7 +542,7 @@ func TestAccBillingBudget_budgetFilterProjectsOrdering(t *testing.T) {
 
 	context := map[string]interface{}{
 		"org":             getTestOrgFromEnv(t),
-		"billing_acct":    getTestBillingAccountFromEnv(t),
+		"billing_acct":    getTestMasterBillingAccountFromEnv(t),
 		"random_suffix_1": randString(t, 10),
 		"random_suffix_2": randString(t, 10),
 	}

--- a/mmv1/third_party/terraform/tests/resource_google_billing_account_iam_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_billing_account_iam_test.go
@@ -15,7 +15,7 @@ func TestAccBillingAccountIam(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()
 
-	billing := getTestBillingAccountFromEnv(t)
+	billing := getTestMasterBillingAccountFromEnv(t)
 	account := fmt.Sprintf("tf-test-%d", randInt(t))
 	role := "roles/billing.viewer"
 	vcrTest(t, resource.TestCase{


### PR DESCRIPTION
This is being done as a result of the upcoming changes to our billing setup. We intend to have the primary, chargeable billing account only give limited permissions to our test runner, so to perform tests that require a higher level of permission (like making changes), we will need to use a separate billing account that does not get charged.

The best option would be to repurpose the master billing account for these tests, so we are attempting that with this change, and the tests will verify if they can succeed with this configuration.

Related tests that we hope will succeed with the master billing account:
- TestAccBillingBudget_billingBudgetBasicExample
- TestAccBillingBudget_billingBudgetLastperiodExample
- TestAccBillingBudget_billingBudgetFilterExample
- TestAccBillingBudget_billingBudgetNotifyExample
- TestAccBillingBudget_billingBudgetCustomperiodExample
- TestAccBillingBudget_billingBudgetCurrencycode
- TestAccBillingBudget_billingBudgetOptionalExample
- TestAccBillingBudget_billingBudgetUpdate
- TestAccBillingBudget_budgetFilterProjectsOrdering
- TestAccBillingAccountIam
- TestAccLoggingBillingAccountSink_updateBigquerySink (not included here because it currently has an unrelated error)

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
