### PR TITLE
Add unit tests for missing test detector and breaking change detector to ci

### DIFF
--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -44,7 +44,7 @@ git checkout origin/$NEW_BRANCH
 popd
 
 ## Breaking change and missing tests unit tests
-./test_tools.sh $MM_LOCAL_PATH $TPG_LOCAL_PATH $COMMIT_SHA $BUILD_ID $((BUILD_STEP + 1)) $PROJECT_ID
+./test_tools.sh $MM_LOCAL_PATH $TPG_LOCAL_PATH $COMMIT_SHA $BUILD_ID $BUILD_STEP $PROJECT_ID
 
 ## Breaking change setup and execution
 TPG_LOCAL_PATH_OLD="${TPG_LOCAL_PATH}old"

--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -43,6 +43,9 @@ fi
 git checkout origin/$NEW_BRANCH
 popd
 
+## Breaking change and missing tests unit tests
+./test_tools.sh $MM_LOCAL_PATH $TPG_LOCAL_PATH $COMMIT_SHA $BUILD_ID $((BUILD_STEP + 1)) $PROJECT_ID
+
 ## Breaking change setup and execution
 TPG_LOCAL_PATH_OLD="${TPG_LOCAL_PATH}old"
 mkdir -p $TPG_LOCAL_PATH_OLD

--- a/.ci/containers/github-differ/test_tools.sh
+++ b/.ci/containers/github-differ/test_tools.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+MM_LOCAL_PATH=$1
+TPG_LOCAL_PATH=$2
+mm_commit_sha=$3
+build_id=$4
+build_step=$5
+project_id=$6
+
+github_username=modular-magician
+
+pushd $MM_LOCAL_PATH/tools/breaking-change-detector
+go test
+exit_code=$?
+popd
+
+
+if [ $exit_code -ne 0 ]; then
+	state="failure"
+else
+	state="success"
+fi
+
+post_body=$( jq -n \
+	--arg context "breaking-change-detector-test" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+	--arg state "${state}" \
+	'{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+build_step=$((build_step + 1))
+
+pushd $MM_LOCAL_PATH/tools/missing-test-detector
+PROVIDER_DIR=$TPG_LOCAL_PATH go test
+exit_code=$?
+popd
+
+
+if [ $exit_code -ne 0 ]; then
+	state="failure"
+else
+	state="success"
+fi
+
+post_body=$( jq -n \
+	--arg context "missing-test-detector-test" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+	--arg state "${state}" \
+	'{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+

--- a/.ci/containers/github-differ/test_tools.sh
+++ b/.ci/containers/github-differ/test_tools.sh
@@ -9,10 +9,12 @@ project_id=$6
 
 github_username=modular-magician
 
+set +e
 pushd $MM_LOCAL_PATH/tools/breaking-change-detector
-go test
+go test ./...
 exit_code=$?
 popd
+set -e
 
 
 if [ $exit_code -ne 0 ]; then
@@ -34,12 +36,12 @@ curl \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
   -d "$post_body"
 
-build_step=$((build_step + 1))
-
+set +e
 pushd $MM_LOCAL_PATH/tools/missing-test-detector
 PROVIDER_DIR=$TPG_LOCAL_PATH go test
 exit_code=$?
 popd
+set -e
 
 
 if [ $exit_code -ne 0 ]; then

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -153,7 +153,7 @@ steps:
       env:
         - BUILD_ID=$BUILD_ID
         - PROJECT_ID=$PROJECT_ID
-        - BUILD_STEP="19" # also includes steps 20 and 21
+        - BUILD_STEP="19"
         - COMMIT_SHA=$COMMIT_SHA
         - PR_NUMBER=$_PR_NUMBER
       args:

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -173,7 +173,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "22"  # Build step
+          - "20"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-validator-tester-integration'
       id: tfv-test-integration-0.12.31
@@ -190,7 +190,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "23"  # Build step
+          - "21"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-validator-tester-integration'
       id: tfv-test-integration-0.13.7
@@ -207,7 +207,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "24"  # Build step
+          - "22"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test
@@ -220,7 +220,7 @@ steps:
           - $BUILD_ID
           - $PROJECT_ID
           - GoogleCloudPlatform/magic-modules
-          - "25"  # Build step
+          - "23"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpg-test
@@ -233,7 +233,7 @@ steps:
           - $BUILD_ID
           - $PROJECT_ID
           - GoogleCloudPlatform/magic-modules
-          - "26"  # Build step
+          - "24"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/gcb-terraform-vcr-tester'
       id: gcb-tpg-vcr-test
@@ -244,7 +244,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "27"  # Build step
+          - "25"  # Build step
 
 # Long timeout to enable waiting on VCR test
 timeout: 20000s

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -153,7 +153,7 @@ steps:
       env:
         - BUILD_ID=$BUILD_ID
         - PROJECT_ID=$PROJECT_ID
-        - BUILD_STEP="19"
+        - BUILD_STEP="19" # also includes steps 20 and 21
         - COMMIT_SHA=$COMMIT_SHA
         - PR_NUMBER=$_PR_NUMBER
       args:
@@ -173,7 +173,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "20"  # Build step
+          - "22"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-validator-tester-integration'
       id: tfv-test-integration-0.12.31
@@ -190,7 +190,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "21"  # Build step
+          - "23"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-validator-tester-integration'
       id: tfv-test-integration-0.13.7
@@ -207,7 +207,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "22"  # Build step
+          - "24"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test
@@ -220,7 +220,7 @@ steps:
           - $BUILD_ID
           - $PROJECT_ID
           - GoogleCloudPlatform/magic-modules
-          - "23"  # Build step
+          - "25"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpg-test
@@ -233,7 +233,7 @@ steps:
           - $BUILD_ID
           - $PROJECT_ID
           - GoogleCloudPlatform/magic-modules
-          - "24"  # Build step
+          - "26"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/gcb-terraform-vcr-tester'
       id: gcb-tpg-vcr-test
@@ -244,7 +244,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "25"  # Build step
+          - "27"  # Build step
 
 # Long timeout to enable waiting on VCR test
 timeout: 20000s

--- a/tools/missing-test-detector/go.mod
+++ b/tools/missing-test-detector/go.mod
@@ -1,6 +1,6 @@
 module github.com/trodge/magic-modules/tools/missing-test-detector
 
-go 1.20
+go 1.18
 
 replace google/provider/old => github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20220901180512-245a877821d3
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
