### PR TITLE
Added github enterprise docs examples to google_cloudbuildv2_connection and repository resources

### DIFF
--- a/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
@@ -1,70 +1,70 @@
 resource "google_secret_manager_secret" "private-key-secret" {
-    provider = google-beta
-    secret_id = "ghe-pk-secret"
+  provider = google-beta
+  secret_id = "ghe-pk-secret"
 
-    replication {
-        automatic = true
-    }
+  replication {
+    automatic = true
+  }
 }
 
 resource "google_secret_manager_secret_version" "private-key-secret-version" {
-    provider = google-beta
-    secret = google_secret_manager_secret.private-key-secret.id
-    secret_data = file("private-key.pem")
+  provider = google-beta
+  secret = google_secret_manager_secret.private-key-secret.id
+  secret_data = file("private-key.pem")
 }
 
 resource "google_secret_manager_secret" "webhook-secret-secret" {
-    provider = google-beta
-    secret_id = "github-token-secret"
+  provider = google-beta
+  secret_id = "github-token-secret"
 
-    replication {
-        automatic = true
-    }
+  replication {
+    automatic = true
+  }
 }
 
 resource "google_secret_manager_secret_version" "webhook-secret-secret-version" {
-    provider = google-beta
-    secret = google_secret_manager_secret.webhook-secret-secret.id
-    secret_data = "<webhook-secret-data>"
+  provider = google-beta
+  secret = google_secret_manager_secret.webhook-secret-secret.id
+  secret_data = "<webhook-secret-data>"
 }
 
 data "google_iam_policy" "p4sa-secretAccessor" {
-    provider = google-beta
-    binding {
-        role = "roles/secretmanager.secretAccessor"
-        // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
-        members = ["serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
-    }
+  provider = google-beta
+  binding {
+    role = "roles/secretmanager.secretAccessor"
+    // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
+    members = ["serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
+  }
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-pk" {
-    provider = google-beta
-    secret_id = google_secret_manager_secret.private-key-secret.secret_id
-    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+  provider = google-beta
+  secret_id = google_secret_manager_secret.private-key-secret.secret_id
+  policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-whs" {
-    provider = google-beta
-    secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
-    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+  provider = google-beta
+  secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
+  policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_cloudbuildv2_connection" "my-connection" {
-    provider = google-beta
-    location = "us-central1"
-    name = "my-terraform-ghe-connection"
+  provider = google-beta
+  location = "us-central1"
+  name = "my-terraform-ghe-connection"
 
-    github_enterprise_config {
-        host_uri = "https://ghe.com"
-        private_key_secret_version = google_secret_manager_secret_version.private-key-secret-version.id
-        webhook_secret_secret_version = google_secret_manager_secret_version.webhook-secret-secret-version.id
-        app_id = 200
-        app_slug = "gcb-app"
-        app_installation_id = 300
-    }
+  github_enterprise_config {
+    host_uri = "https://ghe.com"
+    private_key_secret_version = google_secret_manager_secret_version.private-key-secret-version.id
+    webhook_secret_secret_version = google_secret_manager_secret_version.webhook-secret-secret-version.id
+    app_id = 200
+    app_slug = "gcb-app"
+    app_installation_id = 300
+  }
 
-    depends_on = [
-        google_secret_manager_secret_iam_policy.policy-pk,
-        google_secret_manager_secret_iam_policy.policy-whs
-    ]
+  depends_on = [
+    google_secret_manager_secret_iam_policy.policy-pk,
+    google_secret_manager_secret_iam_policy.policy-whs
+  ]
 }

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
@@ -1,0 +1,70 @@
+resource "google_secret_manager_secret" "private-key-secret" {
+    provider = google-beta
+    secret_id = "ghe-pk-secret"
+
+    replication {
+        automatic = true
+    }
+}
+
+resource "google_secret_manager_secret_version" "private-key-secret-version" {
+    provider = google-beta
+    secret = google_secret_manager_secret.private-key-secret.id
+    secret_data = file("private-key.pem")
+}
+
+resource "google_secret_manager_secret" "webhook-secret-secret" {
+    provider = google-beta
+    secret_id = "github-token-secret"
+
+    replication {
+        automatic = true
+    }
+}
+
+resource "google_secret_manager_secret_version" "webhook-secret-secret-version" {
+    provider = google-beta
+    secret = google_secret_manager_secret.webhook-secret-secret.id
+    secret_data = "<webhook-secret-data>"
+}
+
+data "google_iam_policy" "p4sa-secretAccessor" {
+    provider = google-beta
+    binding {
+        role = "roles/secretmanager.secretAccessor"
+        // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
+        members = ["serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
+    }
+}
+
+resource "google_secret_manager_secret_iam_policy" "policy-pk" {
+    provider = google-beta
+    secret_id = google_secret_manager_secret.private-key-secret.secret_id
+    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+}
+
+resource "google_secret_manager_secret_iam_policy" "policy-whs" {
+    provider = google-beta
+    secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
+    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+}
+
+resource "google_cloudbuildv2_connection" "my-connection" {
+    provider = google-beta
+    location = "us-central1"
+    name = "my-terraform-ghe-connection"
+
+    github_enterprise_config {
+        host_uri = "https://ghe.com"
+        private_key_secret_version = google_secret_manager_secret_version.private-key-secret-version.id
+        webhook_secret_secret_version = google_secret_manager_secret_version.webhook-secret-secret-version.id
+        app_id = 200
+        app_slug = "gcb-app"
+        app_installation_id = 300
+    }
+
+    depends_on = [
+        google_secret_manager_secret_iam_policy.policy-pk,
+        google_secret_manager_secret_iam_policy.policy-whs
+    ]
+}

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/meta.yaml
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/meta.yaml
@@ -4,6 +4,7 @@ test_hide:
 # resources (github repos and credentials).
 - github.yaml
 - github.tf.tmpl
+- ghe.tf.tmpl
 doc_hide:
 # These tests depend on secrets stored in a separate project, so we prefer not
 # to show them in the docs.

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
@@ -1,0 +1,78 @@
+resource "google_secret_manager_secret" "private-key-secret" {
+    provider = google-beta
+    secret_id = "ghe-pk-secret"
+
+    replication {
+        automatic = true
+    }
+}
+
+resource "google_secret_manager_secret_version" "private-key-secret-version" {
+    provider = google-beta
+    secret = google_secret_manager_secret.private-key-secret.id
+    secret_data = file("private-key.pem")
+}
+
+resource "google_secret_manager_secret" "webhook-secret-secret" {
+    provider = google-beta
+    secret_id = "github-token-secret"
+
+    replication {
+        automatic = true
+    }
+}
+
+resource "google_secret_manager_secret_version" "webhook-secret-secret-version" {
+    provider = google-beta
+    secret = google_secret_manager_secret.webhook-secret-secret.id
+    secret_data = "<webhook-secret-data>"
+}
+
+data "google_iam_policy" "p4sa-secretAccessor" {
+    provider = google-beta
+    binding {
+        role = "roles/secretmanager.secretAccessor"
+        // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
+        members = ["serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
+    }
+}
+
+resource "google_secret_manager_secret_iam_policy" "policy-pk" {
+    provider = google-beta
+    secret_id = google_secret_manager_secret.private-key-secret.secret_id
+    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+}
+
+resource "google_secret_manager_secret_iam_policy" "policy-whs" {
+    provider = google-beta
+    secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
+    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+}
+
+resource "google_cloudbuildv2_connection" "my-connection" {
+    provider = google-beta
+    location = "us-central1"
+    name = "my-terraform-ghe-connection"
+
+    github_enterprise_config {
+        host_uri = "https://ghe.com"
+        private_key_secret_version = google_secret_manager_secret_version.private-key-secret-version.id
+        webhook_secret_secret_version = google_secret_manager_secret_version.webhook-secret-secret-version.id
+        app_id = 200
+        app_slug = "gcb-app"
+        app_installation_id = 300
+    }
+
+    depends_on = [
+        google_secret_manager_secret_iam_policy.policy-pk,
+        google_secret_manager_secret_iam_policy.policy-whs
+    ]
+}
+
+resource "google_cloudbuildv2_repository" "my-repository" {
+    provider = google-beta
+    name = "my-terraform-ghe-repo"
+    location = "us-central1"
+    parent_connection = google_cloudbuildv2_connection.my-connection.id
+    remote_uri = "https://ghe.com/hashicorp/terraform-provider-google.git"
+}

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
@@ -1,78 +1,78 @@
 resource "google_secret_manager_secret" "private-key-secret" {
-    provider = google-beta
-    secret_id = "ghe-pk-secret"
+  provider = google-beta
+  secret_id = "ghe-pk-secret"
 
-    replication {
-        automatic = true
-    }
+  replication {
+    automatic = true
+  }
 }
 
 resource "google_secret_manager_secret_version" "private-key-secret-version" {
-    provider = google-beta
-    secret = google_secret_manager_secret.private-key-secret.id
-    secret_data = file("private-key.pem")
+  provider = google-beta
+  secret = google_secret_manager_secret.private-key-secret.id
+  secret_data = file("private-key.pem")
 }
 
 resource "google_secret_manager_secret" "webhook-secret-secret" {
-    provider = google-beta
-    secret_id = "github-token-secret"
+  provider = google-beta
+  secret_id = "github-token-secret"
 
-    replication {
-        automatic = true
-    }
+  replication {
+    automatic = true
+  }
 }
 
 resource "google_secret_manager_secret_version" "webhook-secret-secret-version" {
-    provider = google-beta
-    secret = google_secret_manager_secret.webhook-secret-secret.id
-    secret_data = "<webhook-secret-data>"
+  provider = google-beta
+  secret = google_secret_manager_secret.webhook-secret-secret.id
+  secret_data = "<webhook-secret-data>"
 }
 
 data "google_iam_policy" "p4sa-secretAccessor" {
-    provider = google-beta
-    binding {
-        role = "roles/secretmanager.secretAccessor"
-        // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
-        members = ["serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
-    }
+  provider = google-beta
+  binding {
+    role = "roles/secretmanager.secretAccessor"
+    // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
+    members = ["serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
+  }
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-pk" {
-    provider = google-beta
-    secret_id = google_secret_manager_secret.private-key-secret.secret_id
-    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+  provider = google-beta
+  secret_id = google_secret_manager_secret.private-key-secret.secret_id
+  policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-whs" {
-    provider = google-beta
-    secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
-    policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
+  provider = google-beta
+  secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
+  policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_cloudbuildv2_connection" "my-connection" {
-    provider = google-beta
-    location = "us-central1"
-    name = "my-terraform-ghe-connection"
+  provider = google-beta
+  location = "us-central1"
+  name = "my-terraform-ghe-connection"
 
-    github_enterprise_config {
-        host_uri = "https://ghe.com"
-        private_key_secret_version = google_secret_manager_secret_version.private-key-secret-version.id
-        webhook_secret_secret_version = google_secret_manager_secret_version.webhook-secret-secret-version.id
-        app_id = 200
-        app_slug = "gcb-app"
-        app_installation_id = 300
-    }
+  github_enterprise_config {
+    host_uri = "https://ghe.com"
+    private_key_secret_version = google_secret_manager_secret_version.private-key-secret-version.id
+    webhook_secret_secret_version = google_secret_manager_secret_version.webhook-secret-secret-version.id
+    app_id = 200
+    app_slug = "gcb-app"
+    app_installation_id = 300
+  }
 
-    depends_on = [
-        google_secret_manager_secret_iam_policy.policy-pk,
-        google_secret_manager_secret_iam_policy.policy-whs
-    ]
+  depends_on = [
+    google_secret_manager_secret_iam_policy.policy-pk,
+    google_secret_manager_secret_iam_policy.policy-whs
+  ]
 }
 
 resource "google_cloudbuildv2_repository" "my-repository" {
-    provider = google-beta
-    name = "my-terraform-ghe-repo"
-    location = "us-central1"
-    parent_connection = google_cloudbuildv2_connection.my-connection.id
-    remote_uri = "https://ghe.com/hashicorp/terraform-provider-google.git"
+  provider = google-beta
+  name = "my-terraform-ghe-repo"
+  location = "us-central1"
+  parent_connection = google_cloudbuildv2_connection.my-connection.id
+  remote_uri = "https://ghe.com/hashicorp/terraform-provider-google.git"
 }

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/meta.yaml
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/meta.yaml
@@ -4,6 +4,7 @@ test_hide:
 # resources (github repos and credentials).
 - github.yaml
 - github.tf.tmpl
+- ghe.tf.tmpl
 doc_hide:
 # These tests depend on secrets stored in a separate project, so we prefer not
 # to show them in the docs.


### PR DESCRIPTION

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added github enterprise docs examples to google_cloudbuildv2_connection and repository resources.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuildv2: Added github enterprise docs examples to `google_cloudbuildv2_connection` and `google_cloudbuildv2_resources`
```
