### PR TITLE
Upgrade DCL to v1.34

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -5,7 +5,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/bigtable v1.17.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.31.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.34.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -17,6 +17,8 @@ cloud.google.com/go/longrunning v0.3.0/go.mod h1:qth9Y41RRSUE69rDcOn6DdK3HfQfsUI
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.31.0 h1:4Orb9zAllU52CUtZfKu9OWYyDK6neeBt2ye6NKqAfOg=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.31.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.34.0 h1:o7t+hPFv+Ax5O2vxzIH7dEtvlWA7JJOlOd7mWFvMa6s=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.34.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_worker_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_worker_pool_test.go.erb
@@ -151,6 +151,7 @@ resource "google_cloudbuild_worker_pool" "pool" {
 	}
 	network_config {
 		peered_network = google_compute_network.network.id
+		peered_network_ip_range = "/29"
 	}
 	depends_on = [google_service_networking_connection.worker_pool_conn]
 }

--- a/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
@@ -100,6 +100,10 @@ The following arguments are supported:
 * `peered_network` -
   (Required)
   Immutable. The network definition that the workers are peered to. If this section is left empty, the workers will be peered to `WorkerPool.project_id` on the service producer network. Must be in the format `projects/{project}/global/networks/{network}`, where `{project}` is a project number, such as `12345`, and `{network}` is the name of a VPC network in the project. See (https://cloud.google.com/cloud-build/docs/custom-workers/set-up-custom-worker-pool-environment#understanding_the_network_configuration_options)
+
+* `peered_network_ip_range` -
+  (Optional)
+  Immutable. Subnet IP range within the peered network. This is specified in CIDR notation with a slash and the subnet prefix size. You can optionally specify an IP address before the subnet prefix value. e.g. `192.168.0.0/29` would specify an IP range starting at 192.168.0.0 with a prefix size of 29 bits. `/16` would specify a prefix size of 16 bits, with an automatically determined IP within the peered VPC. If unspecified, a value of `/24` will be used.
     
 <a name="nested_worker_config"></a>The `worker_config` block supports:
     

--- a/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
@@ -61,6 +61,7 @@ resource "google_cloudbuild_worker_pool" "pool" {
   }
   network_config {
     peered_network = google_compute_network.network.id
+    peered_network_ip_range = "/29"
   }
   depends_on = [google_service_networking_connection.worker_pool_conn]
 }

--- a/tpgtools/api/clouddeploy/samples/multi.target.json
+++ b/tpgtools/api/clouddeploy/samples/multi.target.json
@@ -1,0 +1,28 @@
+{
+  "name": "{{target}}",
+  "location": "{{region}}",
+  "project": "{{project}}",
+
+  "description": "multi-target description",
+  "annotations": {
+    "my_first_annotation": "example-annotation-1",
+    "my_second_annotation": "example-annotation-2"
+  },
+  "labels": {
+    "my_first_label": "example-label-1",
+    "my_second_label": "example-label-2"
+  },
+  "requireApproval": false,
+  "multiTarget": {
+    "targetIds": [
+      "1",
+      "2"
+    ]
+  },
+  "executionConfigs": [
+    {
+      "usages": ["RENDER", "DEPLOY"],
+      "executionTimeout": "3600s"
+    }
+  ]
+}

--- a/tpgtools/api/clouddeploy/samples/multi_target.yaml
+++ b/tpgtools/api/clouddeploy/samples/multi_target.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: multi_target
+description: tests creating and updating a multi-target
+type: target
+versions:
+- beta
+resource: samples/multi.target.json
+updates:
+- resource: samples/update_multi.target.json
+  dependencies: []
+variables:
+- name: project
+  type: project
+- name: region
+  type: region
+- name: target
+  type: resource_name

--- a/tpgtools/api/clouddeploy/samples/update_multi.target.json
+++ b/tpgtools/api/clouddeploy/samples/update_multi.target.json
@@ -1,0 +1,23 @@
+{
+  "name": "{{target}}",
+  "location": "{{region}}",
+  "project": "{{project}}",
+
+  "description": "updated mutli-target description",
+  "annotations": {
+    "my_second_annotation": "updated-example-annotation-2",
+    "my_third_annotation": "example-annotation-3"
+  },
+  "labels": {
+    "my_second_label": "example-label-2",
+    "my_third_label": "example-label-3"
+  },
+  "requireApproval": true,
+  "multiTarget": {
+    "targetIds": [
+      "1",
+      "2",
+      "3"
+    ]
+  }
+}

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.31.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.33.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/hcl v1.0.0

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.33.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.34.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/hcl v1.0.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -35,8 +35,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.31.0 h1:4Orb9zAllU52CUtZfKu9OWYyDK6neeBt2ye6NKqAfOg=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.31.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.33.0 h1:YnhVkMoBshm4Z6mitwz2Y496PXkIri+i2fhHALZE+pI=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.33.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -37,6 +37,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.33.0 h1:YnhVkMoBshm4Z6mitwz2Y496PXkIri+i2fhHALZE+pI=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.33.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.34.0 h1:o7t+hPFv+Ax5O2vxzIH7dEtvlWA7JJOlOd7mWFvMa6s=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.34.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -21,7 +21,7 @@
   details:
     product: gke_hub
 - type: DEPRECATED
-  field: control_plane
+  field: mesh.control_plane
   details:
     message: >-
       Deprecated in favor of the `management` field

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -20,3 +20,8 @@
 - type: CUSTOM_TERRAFORM_PRODUCT_NAME
   details:
     product: gke_hub
+- type: DEPRECATED
+  field: control_plane
+  details:
+    message: >-
+      Deprecated in favor of the `management` field


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
containerazure: added `azure_services_authentication` to `google_container_azure_cluster`
```

```release-note:deprecation
gkehub: deprecated `mesh.control_plane` in `google_gke_hub_feature_membership`. Use `mesh.management` instead (beta-only)
```

```release-note:enhancement
cloudbuild: added `peered_network_ip_range` field to `google_cloudbuild_worker_pool` resource
```

```release-note:enhancement
clouddeploy: added `multi_target` field to `google_clouddeploy_target` resource (beta-only)
```