### PR TITLE
Fix FirebaseApp sweepers

### DIFF
--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -53,7 +53,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           org_id: :ORG_ID
         test_vars_overrides:
-          display_name: "tf-test Display Name Basic"
+          display_name: '"tf-test Display Name Basic"'
         ignore_read_extra:
           - project
           - deletion_policy
@@ -85,7 +85,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project_id: :PROJECT_NAME
         test_vars_overrides:
           package_name: '"android.package.app" + randString(t, 4)'
-          display_name: "tf-test Display Name Basic"
+          display_name: '"tf-test Display Name Basic"'
         ignore_read_extra:
           - project
           - deletion_policy
@@ -117,7 +117,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
           project_id: :PROJECT_NAME
         test_vars_overrides:
-          display_name: "tf-test Display Name Basic"
+          display_name: '"tf-test Display Name Basic"'
       - !ruby/object:Provider::Terraform::Examples
         name: "firebase_apple_app_full"
         min_version: "beta"
@@ -133,7 +133,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_vars_overrides:
           app_store_id: "12345"
           team_id: "9987654321"
-          display_name: "tf-test Display Name Full"
+          display_name: '"tf-test Display Name Full"'
         ignore_read_extra:
           - project
           - deletion_policy

--- a/mmv1/products/firebase/terraform.yaml
+++ b/mmv1/products/firebase/terraform.yaml
@@ -52,6 +52,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           bucket_name: "fb-webapp-"
         test_env_vars:
           org_id: :ORG_ID
+        test_vars_overrides:
+          display_name: "tf-test Display Name Basic"
         ignore_read_extra:
           - project
           - deletion_policy
@@ -83,6 +85,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project_id: :PROJECT_NAME
         test_vars_overrides:
           package_name: '"android.package.app" + randString(t, 4)'
+          display_name: "tf-test Display Name Basic"
         ignore_read_extra:
           - project
           - deletion_policy
@@ -113,6 +116,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           org_id: :ORG_ID
           project_id: :PROJECT_NAME
+        test_vars_overrides:
+          display_name: "tf-test Display Name Basic"
       - !ruby/object:Provider::Terraform::Examples
         name: "firebase_apple_app_full"
         min_version: "beta"
@@ -128,6 +133,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_vars_overrides:
           app_store_id: "12345"
           team_id: "9987654321"
+          display_name: "tf-test Display Name Full"
         ignore_read_extra:
           - project
           - deletion_policy

--- a/mmv1/products/firebasehosting/terraform.yaml
+++ b/mmv1/products/firebasehosting/terraform.yaml
@@ -30,8 +30,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "full"
         vars:
           site_id: site-with-app
+          display_name: "Test web app for Firebase Hosting"
         test_env_vars:
           project_id: :PROJECT_NAME
+        test_vars_overrides:
+          display_name: "tf-test Test web app for Firebase Hosting"
   Channel: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ['sites/{{site_id}}/channels/{{channel_id}}']
     properties:

--- a/mmv1/products/firebasehosting/terraform.yaml
+++ b/mmv1/products/firebasehosting/terraform.yaml
@@ -34,7 +34,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project_id: :PROJECT_NAME
         test_vars_overrides:
-          display_name: "tf-test Test web app for Firebase Hosting"
+          display_name: '"tf-test Test web app for Firebase Hosting"'
   Channel: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ['sites/{{site_id}}/channels/{{channel_id}}']
     properties:

--- a/mmv1/templates/terraform/examples/firebasehosting_site_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebasehosting_site_full.tf.erb
@@ -1,7 +1,7 @@
 resource "google_firebase_web_app" "default" {
   provider = google-beta
   project  = "<%= ctx[:test_env_vars]['project_id'] %>"
-  display_name = "Test web app for Firebase Hosting"
+  display_name = "<%= ctx[:vars]['display_name'] %>"
   deletion_policy = "DELETE"
 }
 

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_android_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_android_app_test.go.erb
@@ -13,7 +13,7 @@ func TestAccDataSourceGoogleFirebaseAndroidApp(t *testing.T) {
 	context := map[string]interface{}{
 		"project_id":   getTestProjectFromEnv(),
 		"package_name": "android.package.app" + randString(t, 4),
-		"display_name": "Display Name AndroidApp DataSource",
+		"display_name": "tf-test Display Name AndroidApp DataSource",
 	}
 
 	resourceName := "data.google_firebase_android_app.my_app"

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_config_test.go.erb
@@ -15,7 +15,7 @@ func TestAccDataSourceGoogleFirebaseAppleAppConfig(t *testing.T) {
 	context := map[string]interface{}{
 		"project_id":   getTestProjectFromEnv(),
 		"bundle_id":    "apple.app." + randString(t, 5),
-		"display_name": "Display Name AppleAppConfig DataSource",
+		"display_name": "tf-test Display Name AppleAppConfig DataSource",
 		"app_store_id": 12345,
 		"team_id":      1234567890,
 	}

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_test.go.erb
@@ -13,7 +13,7 @@ func TestAccDataSourceGoogleFirebaseAppleApp(t *testing.T) {
 	context := map[string]interface{}{
 		"project_id":   getTestProjectFromEnv(),
 		"bundle_id":    "apple.app." + randString(t, 5),
-		"display_name": "Display Name AppleApp DataSource",
+		"display_name": "tf-test Display Name AppleApp DataSource",
 		"app_store_id": 12345,
 		"team_id":      1234567890,
 	}

--- a/mmv1/third_party/terraform/tests/resource_firebase_android_app_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firebase_android_app_sweeper_test.go
@@ -66,7 +66,7 @@ func testSweepFirebaseAndroidApp(region string) error {
 		return nil
 	}
 
-	resourceList, ok := res["androidApps"]
+	resourceList, ok := res["apps"]
 	if !ok {
 		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
 		return nil
@@ -79,14 +79,14 @@ func testSweepFirebaseAndroidApp(region string) error {
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
-		if obj["name"] == nil {
+		if obj["displayName"] == nil {
 			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
 			return nil
 		}
 
 		name := GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
-		if !isSweepableTestResource(name) {
+		if !isSweepableTestResource(obj["displayName"].(string)) {
 			nonPrefixCount++
 			continue
 		}
@@ -103,7 +103,7 @@ func testSweepFirebaseAndroidApp(region string) error {
 		body["immediate"] = true
 
 		// Don't wait on operations as we may have a lot to delete
-		_, err = sendRequest(config, "DELETE", config.Project, deleteUrl, config.userAgent, body)
+		_, err = sendRequest(config, "POST", config.Project, deleteUrl, config.userAgent, body)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
 		} else {

--- a/mmv1/third_party/terraform/tests/resource_firebase_android_app_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firebase_android_app_sweeper_test.go
@@ -8,6 +8,7 @@ package google
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -84,20 +85,14 @@ func testSweepFirebaseAndroidApp(region string) error {
 			return nil
 		}
 
-		name := GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
 		if !isSweepableTestResource(obj["displayName"].(string)) {
 			nonPrefixCount++
 			continue
 		}
 
-		deleteTemplate := "https://firebase.googleapis.com/v1beta1/{{name}}:remove"
-		deleteUrl, err := replaceVars(d, config, deleteTemplate)
-		if err != nil {
-			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-			return nil
-		}
-		deleteUrl = deleteUrl + name
+		name := obj["name"].(string)
+		deleteUrl := fmt.Sprintf("https://firebase.googleapis.com/v1beta1/%s:remove", name)
 
 		body := make(map[string]interface{})
 		body["immediate"] = true

--- a/mmv1/third_party/terraform/tests/resource_firebase_android_app_update_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_android_app_update_test.go.erb
@@ -14,7 +14,7 @@ func TestAccFirebaseAndroidApp_update(t *testing.T) {
                 "project_id": getTestProjectFromEnv(),
                 "package_name":  "android.package.app" + randString(t, 4),
                 "random_suffix": randString(t, 10),
-		"display_name":  "Display Name N",
+		"display_name":  "tf-test Display Name N",
 	}
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/mmv1/third_party/terraform/tests/resource_firebase_apple_app_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firebase_apple_app_sweeper_test.go
@@ -66,7 +66,7 @@ func testSweepFirebaseAppleApp(region string) error {
 		return nil
 	}
 
-	resourceList, ok := res["appleApps"]
+	resourceList, ok := res["apps"]
 	if !ok {
 		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
 		return nil
@@ -79,14 +79,14 @@ func testSweepFirebaseAppleApp(region string) error {
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
-		if obj["name"] == nil {
+		if obj["displayName"] == nil {
 			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
 			return nil
 		}
 
 		name := GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
-		if !isSweepableTestResource(name) {
+		if !isSweepableTestResource(obj["displayName"].(string)) {
 			nonPrefixCount++
 			continue
 		}
@@ -103,7 +103,7 @@ func testSweepFirebaseAppleApp(region string) error {
 		body["immediate"] = true
 
 		// Don't wait on operations as we may have a lot to delete
-		_, err = sendRequest(config, "DELETE", config.Project, deleteUrl, config.userAgent, body)
+		_, err = sendRequest(config, "POST", config.Project, deleteUrl, config.userAgent, body)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
 		} else {

--- a/mmv1/third_party/terraform/tests/resource_firebase_apple_app_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firebase_apple_app_sweeper_test.go
@@ -8,6 +8,7 @@ package google
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -84,20 +85,14 @@ func testSweepFirebaseAppleApp(region string) error {
 			return nil
 		}
 
-		name := GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
 		if !isSweepableTestResource(obj["displayName"].(string)) {
 			nonPrefixCount++
 			continue
 		}
 
-		deleteTemplate := "https://firebase.googleapis.com/v1beta1/projects/{{project}}/iosApps/{{app_id}}:remove"
-		deleteUrl, err := replaceVars(d, config, deleteTemplate)
-		if err != nil {
-			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-			return nil
-		}
-		deleteUrl = deleteUrl + name
+		name := obj["name"].(string)
+		deleteUrl := fmt.Sprintf("https://firebase.googleapis.com/v1beta1/%s:remove", name)
 
 		body := make(map[string]interface{})
 		body["immediate"] = true

--- a/mmv1/third_party/terraform/tests/resource_firebase_apple_app_update_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_apple_app_update_test.go.erb
@@ -14,7 +14,7 @@ func TestAccFirebaseAppleApp_update(t *testing.T) {
                 "project_id": getTestProjectFromEnv(),
                 "bundle_id":  "apple.app.12345",
                 "random_suffix": randString(t, 10),
-                "display_name":  "Display Name N",
+                "display_name":  "tf-test Display Name N",
 	}
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/mmv1/third_party/terraform/tests/resource_firebase_hosting_site_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_hosting_site_test.go.erb
@@ -49,7 +49,7 @@ func testAccFirebaseHostingSite_firebasehostingSiteBeforeUpdate(context map[stri
 resource "google_firebase_web_app" "before" {
   provider = google-beta
   project  = "%{project_id}"
-  display_name = "Test web app before for Firebase Hosting"
+  display_name = "tf-test Test web app before for Firebase Hosting"
   deletion_policy = "DELETE"
 }
 
@@ -67,7 +67,7 @@ func testAccFirebaseHostingSite_firebasehostingSiteAfterUpdate(context map[strin
 resource "google_firebase_web_app" "after" {
   provider = google-beta
   project  = "%{project_id}"
-  display_name = "Test web app after for Firebase Hosting"
+  display_name = "tf-test Test web app after for Firebase Hosting"
   deletion_policy = "DELETE"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_firebase_web_app_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firebase_web_app_sweeper_test.go
@@ -66,7 +66,7 @@ func testSweepFirebaseWebApp(region string) error {
 		return nil
 	}
 
-	resourceList, ok := res["webApps"]
+	resourceList, ok := res["apps"]
 	if !ok {
 		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
 		return nil
@@ -79,14 +79,14 @@ func testSweepFirebaseWebApp(region string) error {
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
-		if obj["name"] == nil {
+		if obj["displayName"] == nil {
 			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
 			return nil
 		}
 
 		name := GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
-		if !isSweepableTestResource(name) {
+		if !isSweepableTestResource(obj["displayName"].(string)) {
 			nonPrefixCount++
 			continue
 		}

--- a/mmv1/third_party/terraform/tests/resource_firebase_web_app_sweeper_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firebase_web_app_sweeper_test.go
@@ -8,6 +8,7 @@ package google
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -84,20 +85,14 @@ func testSweepFirebaseWebApp(region string) error {
 			return nil
 		}
 
-		name := GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
 		if !isSweepableTestResource(obj["displayName"].(string)) {
 			nonPrefixCount++
 			continue
 		}
 
-		deleteTemplate := "https://firebase.googleapis.com/v1beta1/{{name}}:remove"
-		deleteUrl, err := replaceVars(d, config, deleteTemplate)
-		if err != nil {
-			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-			return nil
-		}
-		deleteUrl = deleteUrl + name
+		name := obj["name"].(string)
+		deleteUrl := fmt.Sprintf("https://firebase.googleapis.com/v1beta1/%s:remove", name)
 
 		body := make(map[string]interface{})
 		body["immediate"] = true

--- a/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
@@ -17,7 +17,7 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 	context := map[string]interface{}{
 		"org_id":        getTestOrgFromEnv(t),
 		"random_suffix": randString(t, 10),
-		"display_name":  "Display Name N",
+		"display_name":  "tf-test Display Name N",
 	}
 
 	vcrTest(t, resource.TestCase{
@@ -79,7 +79,7 @@ func TestAccFirebaseWebApp_firebaseWebAppSkipDelete(t *testing.T) {
 	context := map[string]interface{}{
 		"project_id": getTestProjectFromEnv(),
 		"random_suffix": randString(t, 10),
-		"display_name":  "Display Name N",
+		"display_name":  "tf-test Display Name N",
 	}
 
 	vcrTest(t, resource.TestCase{


### PR DESCRIPTION
These sweepers have been reporting that there are no sweepable resources, but there are resources accumulating and they have hit the limit. This makes a few changes to get the sweeper working as intended:

(One of the API specs for reference https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects.iosApps)
- Fix the field used from the list response to `apps`
- Fix the `remove` request to use POST
- Fix the sweeper sweepable field to be `displayName` instead of `name`, because name is server-generated
- Fix the `displayName`s used for FirebaseApp tests to include sweepable prefixes

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
