### PR TITLE
Fix YAML.load_file in ruby 3.2

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -137,6 +137,8 @@ start_time = Time.now
 Google::LOGGER.info "Generating MM output to '#{output_path}'"
 Google::LOGGER.info "Using #{version} version"
 
+allowed_classes = Google::YamlValidator::allowed_classes
+
 # products_for_version entries are a hash of product definitions (:definitions)
 # and provider config (:overrides) for the product
 products_for_version = []
@@ -163,18 +165,18 @@ all_product_files.each do |product_name|
 
   if File.exist?(api_override_path)
     result = if File.exist?(api_yaml_path)
-               YAML.load_file(api_yaml_path).merge(YAML.load_file(api_override_path))
+               YAML.load_file(api_yaml_path, permitted_classes: allowed_classes).merge(YAML.load_file(api_override_path, permitted_classes: allowed_classes))
              else
-               YAML.load_file(api_override_path)
+               YAML.load_file(api_override_path, permitted_classes: allowed_classes)
              end
     product_yaml = result.to_yaml
   elsif File.exist?(api_yaml_path)
     product_yaml = File.read(api_yaml_path)
   elsif File.exist?(product_override_path)
     result = if File.exist?(product_yaml_path)
-               YAML.load_file(product_yaml_path).merge(YAML.load_file(product_override_path))
+               YAML.load_file(product_yaml_pat, permitted_classes: allowed_classesh).merge(YAML.load_file(product_override_path, permitted_classes: allowed_classes))
              else
-               YAML.load_file(product_override_path)
+               YAML.load_file(product_override_path, permitted_classes: allowed_classes)
              end
     product_yaml = result.to_yaml
   elsif File.exist?(product_yaml_path)

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -137,7 +137,7 @@ start_time = Time.now
 Google::LOGGER.info "Generating MM output to '#{output_path}'"
 Google::LOGGER.info "Using #{version} version"
 
-allowed_classes = Google::YamlValidator::allowed_classes
+allowed_classes = Google::YamlValidator.allowed_classes
 
 # products_for_version entries are a hash of product definitions (:definitions)
 # and provider config (:overrides) for the product
@@ -165,7 +165,8 @@ all_product_files.each do |product_name|
 
   if File.exist?(api_override_path)
     result = if File.exist?(api_yaml_path)
-               YAML.load_file(api_yaml_path, permitted_classes: allowed_classes).merge(YAML.load_file(api_override_path, permitted_classes: allowed_classes))
+               YAML.load_file(api_yaml_path, permitted_classes: allowed_classes) \
+                   .merge(YAML.load_file(api_override_path, permitted_classes: allowed_classes))
              else
                YAML.load_file(api_override_path, permitted_classes: allowed_classes)
              end
@@ -174,7 +175,8 @@ all_product_files.each do |product_name|
     product_yaml = File.read(api_yaml_path)
   elsif File.exist?(product_override_path)
     result = if File.exist?(product_yaml_path)
-               YAML.load_file(product_yaml_pat, permitted_classes: allowed_classes).merge(YAML.load_file(product_override_path, permitted_classes: allowed_classes))
+               YAML.load_file(product_yaml_pat, permitted_classes: allowed_classes) \
+                   .merge(YAML.load_file(product_override_path, permitted_classes: allowed_classes))
              else
                YAML.load_file(product_override_path, permitted_classes: allowed_classes)
              end

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -174,7 +174,7 @@ all_product_files.each do |product_name|
     product_yaml = File.read(api_yaml_path)
   elsif File.exist?(product_override_path)
     result = if File.exist?(product_yaml_path)
-               YAML.load_file(product_yaml_pat, permitted_classes: allowed_classesh).merge(YAML.load_file(product_override_path, permitted_classes: allowed_classes))
+               YAML.load_file(product_yaml_pat, permitted_classes: allowed_classes).merge(YAML.load_file(product_override_path, permitted_classes: allowed_classes))
              else
                YAML.load_file(product_override_path, permitted_classes: allowed_classes)
              end


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

New ruby upgrade comes with psych 4.0 which had breaking changes in load_file. Reusing existing safe_load logic for this fixes the introduced error


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
