### PR TITLE
feat: Add support for deletion_policy on shared vpc service project

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go.erb
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/googleapi"
 
 <% if version == "ga" -%>
@@ -22,6 +23,7 @@ func resourceComputeSharedVpcServiceProject() *schema.Resource {
 		Create: resourceComputeSharedVpcServiceProjectCreate,
 		Read:   resourceComputeSharedVpcServiceProjectRead,
 		Delete: resourceComputeSharedVpcServiceProjectDelete,
+		Update: resourceComputeSharedVpcServiceProjectUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -43,6 +45,14 @@ func resourceComputeSharedVpcServiceProject() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The ID of the project that will serve as a Shared VPC service project.`,
+			},
+			"deletion_policy": {
+				Type:   schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Description: `The deletion policy for the shared VPC service. Setting ABANDON allows the resource
+				to be abandoned rather than deleted. Possible values are: "ABANDON".`,
+				ValidateFunc: validation.StringInSlice([]string{"ABANDON", ""}, false),
 			},
 		},
 		UseJSONNumber: true,
@@ -121,6 +131,12 @@ func resourceComputeSharedVpcServiceProjectDelete(d *schema.ResourceData, meta i
 	config := meta.(*Config)
 	hostProject := d.Get("host_project").(string)
 	serviceProject := d.Get("service_project").(string)
+	
+	if d.Get("deletion_policy").(string) == "ABANDON" {
+		log.Printf("[WARN] Shared VPC service project %q deletion_policy is set to 'ABANDON', skip disabling shared VPC service project", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err := disableXpnResource(d, config, hostProject, serviceProject); err != nil {
 		// Don't fail if the service project is already disabled.
@@ -162,4 +178,10 @@ func isDisabledXpnResourceError(err error) bool {
 		}
 	}
 	return false
+}
+
+func resourceComputeSharedVpcServiceProjectUpdate(d *schema.ResourceData, meta interface{}) error{
+	// This update method is no-op because the only updatable fields
+	// are state/config-only, i.e. they aren't sent in requests to the API.
+	return nil
 }

--- a/mmv1/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go.erb
@@ -132,7 +132,7 @@ func resourceComputeSharedVpcServiceProjectDelete(d *schema.ResourceData, meta i
 	hostProject := d.Get("host_project").(string)
 	serviceProject := d.Get("service_project").(string)
 	
-	if d.Get("deletion_policy").(string) == "ABANDON" {
+	if deletionPolicy := d.Get("deletion_policy"); deletionPolicy == "ABANDON" {
 		log.Printf("[WARN] Shared VPC service project %q deletion_policy is set to 'ABANDON', skip disabling shared VPC service project", d.Id())
 		d.SetId("")
 		return nil

--- a/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
@@ -48,6 +48,20 @@ func TestAccComputeSharedVpc_basic(t *testing.T) {
 					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, false),
 				),
 			},
+			{
+				Config: testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicy(hostProject, serviceProject, org, billingId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSharedVpcHostProject(t, hostProject, true),
+					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, true),
+				),
+			},
+			{
+				Config: testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicyDeleted(hostProject, serviceProject, org, billingId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSharedVpcHostProject(t, hostProject, false),
+					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, false),
+				),
+			},
 		},
 	})
 }
@@ -159,5 +173,83 @@ resource "google_project_service" "service" {
   project = google_project.service.project_id
   service = "compute.googleapis.com"
 }
+`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
+}
+
+
+func testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicy(hostProject, serviceProject, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "host" {
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project" "service" {
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "host" {
+  project = google_project.host.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "service" {
+  project = google_project.service.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_shared_vpc_host_project" "host" {
+  project    = google_project.host.project_id
+  depends_on = [google_project_service.host]
+}
+
+resource "google_compute_shared_vpc_service_project" "service" {
+  host_project    = google_project.host.project_id
+  service_project = google_project.service.project_id
+  deletion_policy = "ABANDON"
+  depends_on = [
+    google_compute_shared_vpc_host_project.host,
+    google_project_service.service,
+  ]
+}
+`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
+}
+
+func testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicyDeleted(hostProject, serviceProject, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "host" {
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project" "service" {
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "host" {
+  project = google_project.host.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "service" {
+  project = google_project.service.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_shared_vpc_host_project" "host" {
+  project    = google_project.host.project_id
+  depends_on = [google_project_service.host]
+}
+
 `, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
@@ -63,7 +63,7 @@ func TestAccComputeSharedVpc_basic(t *testing.T) {
 					testAccCheckComputeSharedVpcHostProject(t, hostProject, false),
 					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, false),
 				),
-			}
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
@@ -22,6 +22,22 @@ func TestAccComputeSharedVpc_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
+			//Create resources with the deletion_policy flag
+			{
+				Config: testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicy(hostProject, serviceProject, org, billingId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSharedVpcHostProject(t, hostProject, true),
+					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, true),
+				),
+			},
+			// Test that resource haven't been deleted after resource has been removed
+			{
+				Config: testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicyDeleted(hostProject, serviceProject, org, billingId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSharedVpcHostProject(t, hostProject, true),
+					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, true),
+				),
+			},
 			{
 				Config: testAccComputeSharedVpc_basic(hostProject, serviceProject, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
@@ -47,21 +63,7 @@ func TestAccComputeSharedVpc_basic(t *testing.T) {
 					testAccCheckComputeSharedVpcHostProject(t, hostProject, false),
 					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, false),
 				),
-			},
-			{
-				Config: testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicy(hostProject, serviceProject, org, billingId),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeSharedVpcHostProject(t, hostProject, true),
-					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, true),
-				),
-			},
-			{
-				Config: testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicyDeleted(hostProject, serviceProject, org, billingId),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeSharedVpcHostProject(t, hostProject, false),
-					testAccCheckComputeSharedVpcServiceProject(t, hostProject, serviceProject, false),
-				),
-			},
+			}
 		},
 	})
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_shared_vpc_test.go
@@ -178,7 +178,6 @@ resource "google_project_service" "service" {
 `, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
 }
 
-
 func testAccComputeSharedVpc_SharedVPCServiceProjectWithDeletionPolicy(hostProject, serviceProject, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "host" {


### PR DESCRIPTION
Signed-off-by: NexusNull <p.wellershaus@gmail.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
part of: https://github.com/hashicorp/terraform-provider-google/issues/13699


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement


Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `deletion_policy` to resource `google_compute_shared_vpc_service_project`
```
