### PR TITLE
Marked DataprocMetastoreService tests for skipping

### DIFF
--- a/mmv1/products/metastore/terraform.yaml
+++ b/mmv1/products/metastore/terraform.yaml
@@ -43,6 +43,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "dataproc_metastore_service_endpoint"
         min_version: beta
         skip_docs: true
+        skip_test: true  # https://github.com/hashicorp/terraform-provider-google/issues/13710
         primary_resource_id: "endpoint"
         vars:
           metastore_service_name: "metastore-endpoint"
@@ -92,6 +93,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_federation_basic"
+        skip_test: true  # https://github.com/hashicorp/terraform-provider-google/issues/13710
         primary_resource_id: "default"
         min_version: beta
         primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
@@ -99,6 +101,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           metastore_federation_name: "fed-1"
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_metastore_federation_bigquery"
+        skip_test: true  # https://github.com/hashicorp/terraform-provider-google/issues/13710
         primary_resource_id: "default"
         min_version: beta
         primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed-bq%s", context["random_suffix"])'

--- a/mmv1/third_party/terraform/tests/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_metastore_service_test.go.erb
@@ -54,6 +54,7 @@ resource "google_dataproc_metastore_service" "my_metastore" {
 }
 
 func TestAccDataprocMetastoreService_PrivateServiceConnect(t *testing.T) {
+	t.Skip("Skipping due to https://github.com/hashicorp/terraform-provider-google/issues/13710")
 	t.Parallel()
 
 	context := map[string]interface{}{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Dataproc Metastore Service-related tests started failing due to what looks like a server-side change. https://github.com/hashicorp/terraform-provider-google/issues/13710 Marking for skipping.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
