### PR TITLE
remove hardcoded permissions on cryptoKeyEncrypterDecrypter

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1355,9 +1355,7 @@ resource "google_kms_crypto_key_iam_member" "iam" {
   member  = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
 }
 resource "google_composer_environment" "test" {
-  depends_on = [google_project_iam_member.kms-project-binding1, google_project_iam_member.kms-project-binding2,
-  google_project_iam_member.kms-project-binding3, google_project_iam_member.kms-project-binding4,
-  google_project_iam_member.kms-project-binding5, google_kms_crypto_key_iam_member.iam]
+  depends_on = [google_kms_crypto_key_iam_member.iam]
   name   = "%s"
   region = "us-central1"
   config {

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1349,32 +1349,6 @@ data "google_project" "project" {
   project_id = "%s"
 }
 
-
-resource "google_project_iam_member" "kms-project-binding1" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@cloudcomposer-accounts.iam.gserviceaccount.com"
-}
-resource "google_project_iam_member" "kms-project-binding2" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@compute-system.iam.gserviceaccount.com"
-}
-resource "google_project_iam_member" "kms-project-binding3" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-resource "google_project_iam_member" "kms-project-binding4" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
-}
-resource "google_project_iam_member" "kms-project-binding5" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
 resource "google_kms_crypto_key_iam_member" "iam" {
   crypto_key_id = "%s"
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"

--- a/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -93,10 +93,6 @@ resource "google_pubsub_topic" "foo" {
 
 func testAccPubsubTopic_cmek(pid, topicName, kmsKey string) string {
 	return fmt.Sprintf(`
-data "google_project" "project" {
-  project_id = "%s"
-}
-
 resource "google_pubsub_topic" "topic" {
   name         = "%s"
   kms_key_name = "%s"

--- a/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -97,12 +97,6 @@ data "google_project" "project" {
   project_id = "%s"
 }
 
-resource "google_project_iam_member" "kms-project-binding" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-
 resource "google_pubsub_topic" "topic" {
   name         = "%s"
   project      = google_project_iam_member.kms-project-binding.project

--- a/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -99,7 +99,6 @@ data "google_project" "project" {
 
 resource "google_pubsub_topic" "topic" {
   name         = "%s"
-  project      = google_project_iam_member.kms-project-binding.project
   kms_key_name = "%s"
 }
 `, pid, topicName, kmsKey)

--- a/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -90,7 +90,7 @@ resource "google_pubsub_topic" "foo" {
 `, topic, key, value, region)
 }
 
-func testAccPubsubTopic_cmek(pid, topicName, kmsKey string) string {
+func testAccPubsubTopic_cmek(topicName, kmsKey string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "topic" {
   name         = "%s"

--- a/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -43,7 +43,6 @@ func TestAccPubsubTopic_cmek(t *testing.T) {
 	t.Parallel()
 
 	kms := BootstrapKMSKey(t)
-	pid := getTestProjectFromEnv()
 	topicName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
@@ -52,7 +51,7 @@ func TestAccPubsubTopic_cmek(t *testing.T) {
 		CheckDestroy: testAccCheckPubsubTopicDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPubsubTopic_cmek(pid, topicName, kms.CryptoKey.Name),
+				Config: testAccPubsubTopic_cmek(topicName, kms.CryptoKey.Name),
 			},
 			{
 				ResourceName:      "google_pubsub_topic.topic",
@@ -97,5 +96,5 @@ resource "google_pubsub_topic" "topic" {
   name         = "%s"
   kms_key_name = "%s"
 }
-`, pid, topicName, kmsKey)
+`, topicName, kmsKey)
 }


### PR DESCRIPTION
This configuration will cause the permission to get deleted even if in use for other tests. Lets remove these hard coded permissions and then fix any failing tests by enabling them in pantheon UI on a per instance basis.

helps with https://github.com/hashicorp/terraform-provider-google/issues/12908
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
