### PR TITLE
Remove compute disk timeouts test

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -4,7 +4,6 @@ package google
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -325,24 +325,6 @@ func TestAccComputeDisk_imageDiffSuppressPublicVendorsFamilyNames(t *testing.T) 
 	}
 }
 
-func TestAccComputeDisk_timeout(t *testing.T) {
-	// Vcr speeds up test, so it doesn't time out
-	skipIfVcr(t)
-	t.Parallel()
-
-	diskName := fmt.Sprintf("tf-test-disk-%d", randInt(t))
-	vcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config:      testAccComputeDisk_timeout(diskName),
-				ExpectError: regexp.MustCompile("timeout"),
-			},
-		},
-	})
-}
-
 func TestAccComputeDisk_update(t *testing.T) {
 	t.Parallel()
 
@@ -711,26 +693,6 @@ resource "google_compute_disk" "foobar" {
   zone  = "us-central1-a"
   labels = {
     my-label = "my-label-value"
-  }
-}
-`, diskName)
-}
-
-func testAccComputeDisk_timeout(diskName string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-11"
-  project = "debian-cloud"
-}
-
-resource "google_compute_disk" "foobar" {
-  name  = "%s"
-  image = data.google_compute_image.my_image.self_link
-  type  = "pd-ssd"
-  zone  = "us-central1-a"
-
-  timeouts {
-    create = ".5s"
   }
 }
 `, diskName)


### PR DESCRIPTION
Removing this test... it doesn't make sense to have this in place as its testing a [terraform native feature](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts). We do not test this feature for other resources.

closes https://github.com/hashicorp/terraform-provider-google/issues/12996
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
