### PR TITLE
Change zone of TPU node to get less OOM* messages

### DIFF
--- a/mmv1/templates/terraform/examples/tpu_node_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_basic.tf.erb
@@ -9,7 +9,7 @@ data "google_tpu_tensorflow_versions" "available" {
 
 resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["node_name"] %>"
-  zone = "us-central1-b"
+  zone = "us-central1-c"
 
   accelerator_type   = "v3-8"
   tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[0]

--- a/mmv1/templates/terraform/examples/tpu_node_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_basic.tf.erb
@@ -11,7 +11,7 @@ resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["node_name"] %>"
   zone = "us-central1-c"
 
-  accelerator_type   = "v3-8"
+  accelerator_type   = "v2-8"
   tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[0]
   cidr_block         = "10.2.0.0/29"
 }

--- a/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
@@ -11,7 +11,7 @@ resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["node_name"] %>"
   zone = "us-central1-c"
 
-  accelerator_type = "v3-8"
+  accelerator_type = "v2-8"
 
   tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[0]
 

--- a/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
@@ -9,7 +9,7 @@ data "google_tpu_tensorflow_versions" "available" {
 
 resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["node_name"] %>"
-  zone = "us-central1-b"
+  zone = "us-central1-c"
 
   accelerator_type = "v3-8"
 

--- a/mmv1/third_party/terraform/tests/resource_tpu_node_test.go
+++ b/mmv1/third_party/terraform/tests/resource_tpu_node_test.go
@@ -47,7 +47,7 @@ data "google_tpu_tensorflow_versions" "available" {
 
 resource "google_tpu_node" "tpu" {
   name = "%s"
-  zone = "us-central1-b"
+  zone = "us-central1-c"
 
   accelerator_type   = "v3-8"
   tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[%d]

--- a/mmv1/third_party/terraform/tests/resource_tpu_node_test.go
+++ b/mmv1/third_party/terraform/tests/resource_tpu_node_test.go
@@ -49,7 +49,7 @@ resource "google_tpu_node" "tpu" {
   name = "%s"
   zone = "us-central1-c"
 
-  accelerator_type   = "v3-8"
+  accelerator_type   = "v2-8"
   tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[%d]
 }
 `, nodeId, versionIdx)


### PR DESCRIPTION
Trying to fix consistent failures on `TestAccTPUNode_*` tests. 


While there is nothing /wrong/ with the test per-say this zone consistently runes out of units. Swapping to another zone to see if it alleviates the problem.

```
Error: Error waiting to create Node: Error waiting for Creating Node: Error code 8, message: There is no more capacity in the zone "us-central1-b"; you can try in another zone where Cloud TPU Nodes are offered (see https://cloud.google.com/tpu/docs/regions)
```

closes https://github.com/hashicorp/terraform-provider-google/issues/10222

*oom: https://www.urbandictionary.com/define.php?term=oom
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
