### PR TITLE
Added support for workload-vulnerability-scanning and workload-config-audit

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1025,6 +1025,40 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+<% unless version == 'ga' -%>
+			"protect_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems: 	 1,
+				Description: `The notification config for sending cluster upgrade notifications`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"workload_config": {
+							Type:        schema.TypeList,
+							Required:    true,
+							MaxItems:    1,
+							Description: `WorkloadConfig defines the flags to enable or disable the workload configurations for the cluster.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"audit_mode": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `Mode defines how to audit the workload configs. Accepted values are MODE_UNSPECIFIED, DISABLED, BASIC.`,
+									},
+								},
+							},
+						},
+						"workload_vulnerability_mode": {
+										Type:             schema.TypeString,
+										Required:         true,
+										Description: `WorkloadVulnerabilityMode defines mode to perform vulnerability scanning. Accepted values are WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED, DISABLED, BASIC.`,
+									},
+					},
+				},
+			},
+<% end -%>
+
 
 			"monitoring_config": {
 				Type:        schema.TypeList,
@@ -1978,6 +2012,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		ResourceLabels: expandStringMap(d, "resource_labels"),
 <% unless version == 'ga' -%>
 		NodePoolAutoConfig: expandNodePoolAutoConfig(d.Get("node_pool_auto_config")),
+		ProtectConfig: expandProtectConfig(d.Get("protect_config")),
 <% end -%>
 		CostManagementConfig: expandCostManagementConfig(d.Get("cost_management_config")),
 	}
@@ -2515,6 +2550,12 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
         if err := d.Set("node_pool_defaults", flattenNodePoolDefaults(cluster.NodePoolDefaults)); err != nil {
                 return err
         }
+
+<% unless version == 'ga' -%>
+	if err := d.Set("protect_config", flattenProtectConfig(cluster.ProtectConfig)); err != nil {
+		return err
+	}
+<% end -%>
 
 	return nil
 }
@@ -3636,6 +3677,22 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+<% unless version == 'ga' -%>
+	if d.HasChange("protect_config") {
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredProtectConfig: expandProtectConfig(d.Get("protect_config")),
+			},
+		}
+		updateF := updateFunc(req, "updating GKE cluster master protect_config")
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s Protect Config has been updated to %#v", d.Id(), req.Update.DesiredProtectConfig)
+	}
+<% end -%>
+
 	return resourceContainerClusterRead(d, meta)
 }
 
@@ -4201,6 +4258,57 @@ func expandAuthenticatorGroupsConfig(configured interface{}) *container.Authenti
 	return result
 }
 
+<% unless version == 'ga' -%>
+func expandProtectConfig(configured interface{}) *container.ProtectConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return &container.ProtectConfig{}
+	}
+
+	pc := &container.ProtectConfig{}
+	protectConfig := l[0].(map[string]interface{})
+	pc.WorkloadConfig = expandProtectConfigWorkloadConfig(protectConfig["workload_config"])
+	if v, ok := protectConfig["workload_vulnerability_mode"]; ok {
+		pc.WorkloadVulnerabilityMode = v.(string)
+	}
+	return pc
+}
+
+func expandProtectConfigWorkloadConfig(configured interface{}) *container.WorkloadConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return &container.WorkloadConfig{}
+	}
+	workloadConfig := l[0].(map[string]interface{})
+	return &container.WorkloadConfig{
+				AuditMode: workloadConfig["audit_mode"].(string),
+			}
+}
+
+func flattenProtectConfig(pc *container.ProtectConfig) []map[string]interface{} {
+	if pc == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+
+	result["workload_config"] = flattenProtectConfigWorkloadConfig(pc.WorkloadConfig)
+	result["workload_vulnerability_mode"] = pc.WorkloadVulnerabilityMode
+
+	return []map[string]interface{}{result}
+}
+
+func flattenProtectConfigWorkloadConfig(wc *container.WorkloadConfig) []map[string]interface{} {
+	if wc == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	result["audit_mode"] = wc.AuditMode
+
+	return []map[string]interface{}{result}
+}
+<% end -%>
 
 func expandNotificationConfig(configured interface{}) *container.NotificationConfig {
 	l := configured.([]interface{})

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1036,14 +1036,14 @@ func resourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"workload_config": {
 							Type:        schema.TypeList,
-							Required:    true,
+							Optional:    true,
 							MaxItems:    1,
 							Description: `WorkloadConfig defines the flags to enable or disable the workload configurations for the cluster.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"audit_mode": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
 										Description: `Mode defines how to audit the workload configs. Accepted values are MODE_UNSPECIFIED, DISABLED, BASIC.`,
 									},
 								},
@@ -1051,7 +1051,7 @@ func resourceContainerCluster() *schema.Resource {
 						},
 						"workload_vulnerability_mode": {
 										Type:             schema.TypeString,
-										Required:         true,
+										Optional:         true,
 										Description: `WorkloadVulnerabilityMode defines mode to perform vulnerability scanning. Accepted values are WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED, DISABLED, BASIC.`,
 									},
 					},
@@ -4262,7 +4262,7 @@ func expandAuthenticatorGroupsConfig(configured interface{}) *container.Authenti
 func expandProtectConfig(configured interface{}) *container.ProtectConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
-		return &container.ProtectConfig{}
+		return nil
 	}
 
 	pc := &container.ProtectConfig{}
@@ -4277,7 +4277,7 @@ func expandProtectConfig(configured interface{}) *container.ProtectConfig {
 func expandProtectConfigWorkloadConfig(configured interface{}) *container.WorkloadConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
-		return &container.WorkloadConfig{}
+		return nil
 	}
 	workloadConfig := l[0].(map[string]interface{})
 	return &container.WorkloadConfig{

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3500,6 +3500,38 @@ func TestAccContainerCluster_withTPUConfig(t *testing.T) {
 		},
 	})
 }
+
+func TestAccContainerCluster_withProtectConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withProtectConfig(clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_withProtectConfigUpdated(clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
 <% end -%>
 
 func testAccContainerCluster_masterAuthorizedNetworksDisabled(t *testing.T, resource_name string) resource.TestCheckFunc {
@@ -7317,6 +7349,43 @@ resource "google_container_cluster" "primary" {
   }
 }`, cluster, project, project)
 }
+
+<% unless version == 'ga' -%>
+func testAccContainerCluster_withProtectConfig(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  protect_config {
+	workload_config {
+		audit_mode = "BASIC"
+	}
+	workload_vulnerability_mode = "BASIC"
+  }
+}
+`, name)
+}
+
+func testAccContainerCluster_withProtectConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  protect_config {
+	workload_config {
+		audit_mode = "DISABLED"
+	}
+	workload_vulnerability_mode = "DISABLED"
+  }
+}
+`, name)
+}
+<% end -%>
+
 
 <% unless version == 'ga' -%>
 func TestValidateNodePoolAutoConfig(t *testing.T) {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -357,6 +357,9 @@ subnetwork in which the cluster's instances are launched.
 * `gateway_api_config` - (Optional)
   Configuration for [GKE Gateway API controller](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api). Structure is [documented below](#nested_gateway_api_config).
 
+* `protect_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  Enable/Disable Protect API features for the cluster. Structure is [documented below](#nested_protect_config).
+
 <a name="nested_default_snat_status"></a>The `default_snat_status` block supports
 
 *  `disabled` - (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic
@@ -1140,6 +1143,25 @@ and all pods running on the nodes. Specified as a map from the key, such as
 <a name="nested_gateway_api_config"></a>The `gateway_api_config` block supports:
 
 * `channel` - (Required) Which Gateway Api channel should be used. `CHANNEL_DISABLED` or `CHANNEL_STANDARD`.
+
+<a name="nested_protect_config"></a>The `protect_config` block supports:
+
+* `workload_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) WorkloadConfig defines which actions are enabled for a cluster's workload configurations. Structure is [documented below](#nested_workload_config)
+
+* `workload_vulnerability_mode` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED, DISABLED, BASIC.
+
+<a name="nested_workload_config"></a>The `protect_config.workload_config` block supports:
+
+* `auditMode` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) WorkloadConfig defines the flags to enable or disable the workload configurations for the cluster. Accepted values are MODE_UNSPECIFIED, DISABLED, BASIC.
+
+```hcl
+protect_config {
+	workload_config {
+		audit_mode = "BASIC"
+	}
+	workload_vulnerability_mode = "BASIC"
+}
+```
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added support for workload-vulnerability-scanning and workload-config-audit
Fixes https://github.com/hashicorp/terraform-provider-google/issues/12778


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added field `protect_config` to `google_container_cluster` (beta)
```
