### PR TITLE
Add stateful_ips to region_per_instance_config and per_instance_config

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -9750,6 +9750,70 @@ objects:
                     - :NEVER
                     - :ON_PERMANENT_INSTANCE_DELETION
                   default_value: :NEVER
+          - !ruby/object:Api::Type::Map
+            name: 'internalIp'
+            api_name: internalIPs
+            min_version: beta
+            key_name: "interface_name"
+            description: |
+              Preserved internal IPs defined for this instance. This map is keyed with the name of the network interface.
+            value_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: autoDelete
+                  description: |
+                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
+                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
+                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
+                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
+                    deleted from the instance group.
+                  values:
+                    - :NEVER
+                    - :ON_PERMANENT_INSTANCE_DELETION
+                  default_value: :NEVER
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'ipAddress'
+                  description: |
+                    Ip address representation
+                  properties:
+                    - !ruby/object:Api::Type::ResourceRef
+                      name: 'address'
+                      resource: 'Address'
+                      imports: 'selfLink'
+                      description: |
+                        The URL of the reservation for this IP address.
+          - !ruby/object:Api::Type::Map
+            name: 'externalIp'
+            min_version: beta
+            api_name: externalIPs
+            key_name: "interface_name"
+            description: |
+              Preserved external IPs defined for this instance. This map is keyed with the name of the network interface.
+            value_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: autoDelete
+                  description: |
+                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
+                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
+                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
+                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
+                    deleted from the instance group.
+                  values:
+                    - :NEVER
+                    - :ON_PERMANENT_INSTANCE_DELETION
+                  default_value: :NEVER
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'ipAddress'
+                  description: |
+                    Ip address representation
+                  properties:
+                    - !ruby/object:Api::Type::ResourceRef
+                      name: 'address'
+                      resource: 'Address'
+                      imports: 'selfLink'
+                      description: |
+                        The URL of the reservation for this IP address.
   - !ruby/object:Api::Resource
     name: 'RegionPerInstanceConfig'
     base_url:  'projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}'
@@ -9865,6 +9929,70 @@ objects:
                     - :NEVER
                     - :ON_PERMANENT_INSTANCE_DELETION
                   default_value: :NEVER
+          - !ruby/object:Api::Type::Map
+            name: 'internalIp'
+            api_name: internalIPs
+            min_version: beta
+            key_name: "interface_name"
+            description: |
+              Preserved internal IPs defined for this instance. This map is keyed with the name of the network interface.
+            value_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: autoDelete
+                  description: |
+                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
+                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
+                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
+                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
+                    deleted from the instance group.
+                  values:
+                    - :NEVER
+                    - :ON_PERMANENT_INSTANCE_DELETION
+                  default_value: :NEVER
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'ipAddress'
+                  description: |
+                    Ip address representation
+                  properties:
+                    - !ruby/object:Api::Type::ResourceRef
+                      name: 'address'
+                      resource: 'Address'
+                      imports: 'selfLink'
+                      description: |
+                        The URL of the reservation for this IP address.
+          - !ruby/object:Api::Type::Map
+            name: 'externalIp'
+            min_version: beta
+            api_name: externalIPs
+            key_name: "interface_name"
+            description: |
+              Preserved external IPs defined for this instance. This map is keyed with the name of the network interface.
+            value_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: autoDelete
+                  description: |
+                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
+                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
+                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
+                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
+                    deleted from the instance group.
+                  values:
+                    - :NEVER
+                    - :ON_PERMANENT_INSTANCE_DELETION
+                  default_value: :NEVER
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'ipAddress'
+                  description: |
+                    Ip address representation
+                  properties:
+                    - !ruby/object:Api::Type::ResourceRef
+                      name: 'address'
+                      resource: 'Address'
+                      imports: 'selfLink'
+                      description: |
+                        The URL of the reservation for this IP address.
   - !ruby/object:Api::Resource
     name: 'ProjectInfo'
     base_url: projects

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -9762,11 +9762,7 @@ objects:
                 - !ruby/object:Api::Type::Enum
                   name: autoDelete
                   description: |
-                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
-                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
-                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
-                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
-                    deleted from the instance group.
+                    These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
                   values:
                     - :NEVER
                     - :ON_PERMANENT_INSTANCE_DELETION
@@ -9794,11 +9790,7 @@ objects:
                 - !ruby/object:Api::Type::Enum
                   name: autoDelete
                   description: |
-                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
-                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
-                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
-                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
-                    deleted from the instance group.
+                    These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
                   values:
                     - :NEVER
                     - :ON_PERMANENT_INSTANCE_DELETION
@@ -9941,11 +9933,7 @@ objects:
                 - !ruby/object:Api::Type::Enum
                   name: autoDelete
                   description: |
-                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
-                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
-                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
-                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
-                    deleted from the instance group.
+                    These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
                   values:
                     - :NEVER
                     - :ON_PERMANENT_INSTANCE_DELETION
@@ -9973,11 +9961,7 @@ objects:
                 - !ruby/object:Api::Type::Enum
                   name: autoDelete
                   description: |
-                    A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
-                    The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
-                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
-                    `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
-                    deleted from the instance group.
+                    These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
                   values:
                     - :NEVER
                     - :ON_PERMANENT_INSTANCE_DELETION

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1961,10 +1961,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
         custom_flatten: templates/terraform/custom_flatten/preserved_state_disks.go.erb
         custom_expand: templates/terraform/custom_expand/preserved_state_disks.go.erb
-      preservedState.internalIp: !ruby/object:Overrides::Terraform::PropertyOverride
-        is_set: true
-      preservedState.externalIp: !ruby/object:Overrides::Terraform::PropertyOverride
-        is_set: true
     virtual_fields:
       - !ruby/object:Api::Type::Enum
         name: 'minimal_action'
@@ -2036,10 +2032,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
         custom_flatten: templates/terraform/custom_flatten/preserved_state_disks.go.erb
         custom_expand: templates/terraform/custom_expand/preserved_state_disks.go.erb
-      preservedState.internalIp: !ruby/object:Overrides::Terraform::PropertyOverride
-        is_set: true
-      preservedState.externalIp: !ruby/object:Overrides::Terraform::PropertyOverride
-        is_set: true
     virtual_fields:
       - !ruby/object:Api::Type::Enum
         name: 'minimal_action'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1961,6 +1961,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
         custom_flatten: templates/terraform/custom_flatten/preserved_state_disks.go.erb
         custom_expand: templates/terraform/custom_expand/preserved_state_disks.go.erb
+      preservedState.internalIp: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+      preservedState.externalIp: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     virtual_fields:
       - !ruby/object:Api::Type::Enum
         name: 'minimal_action'
@@ -2032,6 +2036,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
         custom_flatten: templates/terraform/custom_flatten/preserved_state_disks.go.erb
         custom_expand: templates/terraform/custom_expand/preserved_state_disks.go.erb
+      preservedState.internalIp: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+      preservedState.externalIp: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     virtual_fields:
       - !ruby/object:Api::Type::Enum
         name: 'minimal_action'

--- a/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -339,149 +339,149 @@ resource "google_compute_instance_group_manager" "igm" {
 func testAccComputePerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "%{network}"
+  name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "%{subnetwork}"
-	ip_cidr_range = "10.0.0.0/16"
-	region        = "us-central1"
-	network       = google_compute_network.default.id
+  name          = "%{subnetwork}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
 }
 	
 resource "google_compute_address" "static_internal_ip" {
-	name         = "%{address1}"
-	address_type = "INTERNAL"
+  name         = "%{address1}"
+  address_type = "INTERNAL"
 }
 	
 resource "google_compute_address" "static_external_ip" {
-	name         = "%{address2}"
-	address_type = "EXTERNAL"
+  name         = "%{address2}"
+  address_type = "EXTERNAL"
 }
 	  
 resource "google_compute_per_instance_config" "default" {
-	instance_group_manager = google_compute_instance_group_manager.igm.name
-	name = "%{config_name}"
-	remove_instance_state_on_destroy = true
-	preserved_state {
-		metadata = {
-			asdf = "asdf"
-		}
-		disk {
-			device_name = "my-stateful-disk1"
-			source      = google_compute_disk.disk.id
-		}
+  instance_group_manager = google_compute_instance_group_manager.igm.name
+  name = "%{config_name}"
+  remove_instance_state_on_destroy = true
+  preserved_state {
+    metadata = {
+      asdf = "asdf"
+    }
+    disk {
+      device_name = "my-stateful-disk1"
+      source      = google_compute_disk.disk.id
+    }
 
-		disk {
-			device_name = "my-stateful-disk2"
-			source      = google_compute_disk.disk1.id
-		}
-		internal_ip {
-			ip_address {
-				address = google_compute_address.static_internal_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-		external_ip {
-			ip_address {
-				address = google_compute_address.static_external_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-	}
+    disk {
+      device_name = "my-stateful-disk2"
+      source      = google_compute_disk.disk1.id
+    }
+    internal_ip {
+      ip_address {
+        address = google_compute_address.static_internal_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+    external_ip {
+      ip_address {
+        address = google_compute_address.static_external_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+  }
 }
 
 resource "google_compute_disk" "disk" {
-	name  = "test-disk-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = google_compute_instance_group_manager.igm.zone
-	image = "debian-8-jessie-v20170523"
-	physical_block_size_bytes = 4096
-  }
+  name  = "test-disk-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = google_compute_instance_group_manager.igm.zone
+  image = "debian-8-jessie-v20170523"
+  physical_block_size_bytes = 4096
+}
   
 resource "google_compute_disk" "disk1" {
-	name  = "test-disk2-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = google_compute_instance_group_manager.igm.zone
-	image = "debian-cloud/debian-11"
-	physical_block_size_bytes = 4096
-  }
+  name  = "test-disk2-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = google_compute_instance_group_manager.igm.zone
+  image = "debian-cloud/debian-11"
+  physical_block_size_bytes = 4096
+}
 `, context) + testAccComputePerInstanceConfig_igm(context)
 }
 
 func testAccComputePerInstanceConfig_statefulIpsUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "%{network}"
+  name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "%{subnetwork}"
-	ip_cidr_range = "10.0.0.0/16"
-	region        = "us-central1"
-	network       = google_compute_network.default.id
+  name          = "%{subnetwork}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
 }
 	
 resource "google_compute_address" "static_internal_ip" {
-	name         = "%{address1}"
-	address_type = "INTERNAL"
+  name         = "%{address1}"
+  address_type = "INTERNAL"
 }
-
+	
 resource "google_compute_address" "static_external_ip" {
-	name         = "%{address2}"
-	address_type = "EXTERNAL"
+  name         = "%{address2}"
+  address_type = "EXTERNAL"
 }
-		  
+	  
 resource "google_compute_per_instance_config" "default" {
-	instance_group_manager = google_compute_instance_group_manager.igm.name
-	name = "%{config_name}"
-	remove_instance_state_on_destroy = true
-	preserved_state {
-		metadata = {
-			asdf = "asdf"
-		}
-		disk {
-			device_name = "my-stateful-disk1"
-			source      = google_compute_disk.disk.id
-		}
+  instance_group_manager = google_compute_instance_group_manager.igm.name
+  name = "%{config_name}"
+  remove_instance_state_on_destroy = true
+  preserved_state {
+    metadata = {
+      asdf = "asdf"
+    }
+    disk {
+      device_name = "my-stateful-disk1"
+      source      = google_compute_disk.disk.id
+    }
 
-		disk {
-			device_name = "my-stateful-disk2"
-			source      = google_compute_disk.disk1.id
-		}
-		internal_ip {
-			ip_address {
-				address = google_compute_address.static_internal_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-		external_ip {
-			ip_address {
-				address = google_compute_address.static_external_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-	}
+    disk {
+      device_name = "my-stateful-disk2"
+      source      = google_compute_disk.disk1.id
+    }
+    internal_ip {
+      ip_address {
+        address = google_compute_address.static_internal_ip.self_link
+      }
+      auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
+      interface_name = "nic0"
+    }
+    external_ip {
+      ip_address {
+        address = google_compute_address.static_external_ip.self_link
+      }
+      auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
+      interface_name = "nic0"
+    }
+  }
 }
 
 resource "google_compute_disk" "disk" {
-	name  = "test-disk-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = google_compute_instance_group_manager.igm.zone
-	image = "debian-8-jessie-v20170523"
-	physical_block_size_bytes = 4096
+  name  = "test-disk-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = google_compute_instance_group_manager.igm.zone
+  image = "debian-8-jessie-v20170523"
+  physical_block_size_bytes = 4096
 }
   
 resource "google_compute_disk" "disk1" {
-	name  = "test-disk2-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = google_compute_instance_group_manager.igm.zone
-	image = "debian-cloud/debian-11"
-	physical_block_size_bytes = 4096
+  name  = "test-disk2-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = google_compute_instance_group_manager.igm.zone
+  image = "debian-cloud/debian-11"
+  physical_block_size_bytes = 4096
 }
 `, context) + testAccComputePerInstanceConfig_igm(context)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -125,6 +125,44 @@ func TestAccComputePerInstanceConfig_update(t *testing.T) {
 	})
 }
 
+func TestAccComputePerInstanceConfig_statefulIps(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"igm_name":      fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
+		"network":       fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create one config
+				Config: testAccComputePerInstanceConfig_statefulIpsBasic(context),
+			},
+			{
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy", "zone"},
+			},
+			{
+				// Update an existing config
+				Config: testAccComputePerInstanceConfig_statefulIpsUpdate(context),
+			},
+			{
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy", "zone"},
+			},
+		},
+	})
+}
+
 func testAccComputePerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_per_instance_config" "default" {
@@ -293,6 +331,156 @@ resource "google_compute_instance_group_manager" "igm" {
   base_instance_name = "tf-test-igm-no-tp"
 }
 `, context)
+}
+
+func testAccComputePerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+	name = "my-network"
+}
+
+resource "google_compute_subnetwork" "default" {
+	name          = "my-subnet"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.default.id
+}
+	
+resource "google_compute_address" "static_internal_ip" {
+	name         = "instance-1-address"
+	address_type = "INTERNAL"
+}
+	
+resource "google_compute_address" "static_external_ip" {
+	name         = "instance-3-address"
+	address_type = "EXTERNAL"
+}
+	  
+resource "google_compute_per_instance_config" "default" {
+	instance_group_manager = google_compute_instance_group_manager.igm.name
+	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "asdf"
+		}
+		disk {
+			device_name = "my-stateful-disk1"
+			source      = google_compute_disk.disk.id
+		}
+
+		disk {
+			device_name = "my-stateful-disk2"
+			source      = google_compute_disk.disk1.id
+		}
+		internal_ip {
+			ip_address {
+				address = google_compute_address.static_internal_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+		external_ip {
+			ip_address {
+				address = google_compute_address.static_external_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+	}
+}
+
+resource "google_compute_disk" "disk" {
+	name  = "test-disk-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = google_compute_instance_group_manager.igm.zone
+	image = "debian-8-jessie-v20170523"
+	physical_block_size_bytes = 4096
+  }
+  
+resource "google_compute_disk" "disk1" {
+	name  = "test-disk2-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = google_compute_instance_group_manager.igm.zone
+	image = "debian-cloud/debian-11"
+	physical_block_size_bytes = 4096
+  }
+`, context) + testAccComputePerInstanceConfig_igm(context)
+}
+
+func testAccComputePerInstanceConfig_statefulIpsUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+	name = "my-network"
+}
+
+resource "google_compute_subnetwork" "default" {
+	name          = "my-subnet"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.default.id
+}
+	
+resource "google_compute_address" "static_internal_ip" {
+	name         = "instance-1-address"
+	address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "static_external_ip" {
+	name         = "instance-3-address"
+	address_type = "EXTERNAL"
+}
+		  
+resource "google_compute_per_instance_config" "default" {
+	instance_group_manager = google_compute_instance_group_manager.igm.name
+	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "asdf"
+		}
+		disk {
+			device_name = "my-stateful-disk1"
+			source      = google_compute_disk.disk.id
+		}
+
+		disk {
+			device_name = "my-stateful-disk2"
+			source      = google_compute_disk.disk1.id
+		}
+		internal_ip {
+			ip_address {
+				address = google_compute_address.static_internal_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+		external_ip {
+			ip_address {
+				address = google_compute_address.static_external_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+	}
+}
+
+resource "google_compute_disk" "disk" {
+	name  = "test-disk-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = google_compute_instance_group_manager.igm.zone
+	image = "debian-8-jessie-v20170523"
+	physical_block_size_bytes = 4096
+}
+  
+resource "google_compute_disk" "disk1" {
+	name  = "test-disk2-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = google_compute_instance_group_manager.igm.zone
+	image = "debian-cloud/debian-11"
+	physical_block_size_bytes = 4096
+}
+`, context) + testAccComputePerInstanceConfig_igm(context)
 }
 
 // Checks that the per instance config with the given name was destroyed

--- a/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -133,6 +133,9 @@ func TestAccComputePerInstanceConfig_statefulIps(t *testing.T) {
 		"igm_name":      fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
 		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
 		"network":       fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"subnetwork":    fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"address1":      fmt.Sprintf("tf-test-igm-address%s", randString(t, 10)),
+		"address2":      fmt.Sprintf("tf-test-igm-address%s", randString(t, 10)),
 	}
 
 	vcrTest(t, resource.TestCase{
@@ -336,23 +339,23 @@ resource "google_compute_instance_group_manager" "igm" {
 func testAccComputePerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "my-network"
+	name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "my-subnet"
+	name          = "%{subnetwork}"
 	ip_cidr_range = "10.0.0.0/16"
 	region        = "us-central1"
 	network       = google_compute_network.default.id
 }
 	
 resource "google_compute_address" "static_internal_ip" {
-	name         = "instance-1-address"
+	name         = "%{address1}"
 	address_type = "INTERNAL"
 }
 	
 resource "google_compute_address" "static_external_ip" {
-	name         = "instance-3-address"
+	name         = "%{address2}"
 	address_type = "EXTERNAL"
 }
 	  
@@ -411,23 +414,23 @@ resource "google_compute_disk" "disk1" {
 func testAccComputePerInstanceConfig_statefulIpsUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "my-network"
+	name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "my-subnet"
+	name          = "%{subnetwork}"
 	ip_cidr_range = "10.0.0.0/16"
 	region        = "us-central1"
 	network       = google_compute_network.default.id
 }
 	
 resource "google_compute_address" "static_internal_ip" {
-	name         = "instance-1-address"
+	name         = "%{address1}"
 	address_type = "INTERNAL"
 }
 
 resource "google_compute_address" "static_external_ip" {
-	name         = "instance-3-address"
+	name         = "%{address2}"
 	address_type = "EXTERNAL"
 }
 		  

--- a/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -130,9 +130,12 @@ func TestAccComputeRegionPerInstanceConfig_statefulIps(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": randString(t, 10),
-		"rigm_name":     fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"rigm_name":     fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
 		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
-		"network":       fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"network":       fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
+		"subnetwork":    fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
+		"address1":      fmt.Sprintf("tf-test-rigm-address%s", randString(t, 10)),
+		"address2":      fmt.Sprintf("tf-test-rigm-address%s", randString(t, 10)),
 	}
 
 	vcrTest(t, resource.TestCase{
@@ -344,23 +347,23 @@ resource "google_compute_region_instance_group_manager" "rigm" {
 func testAccComputeRegionPerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "my-network"
+	name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "my-subnet"
+	name          = "%{subnetwork}"
 	ip_cidr_range = "10.0.0.0/16"
 	region        = "us-central1"
 	network       = google_compute_network.default.id
 }
 	
 resource "google_compute_address" "static_internal_ip" {
-	name         = "instance-1-address"
+	name         = "%{address1}"
 	address_type = "INTERNAL"
 }
 	
 resource "google_compute_address" "static_external_ip" {
-	name         = "instance-3-address"
+	name         = "%{address2}"
 	address_type = "EXTERNAL"
 }
 	  
@@ -420,23 +423,23 @@ resource "google_compute_disk" "disk1" {
 func testAccComputeRegionPerInstanceConfig_statefulIpsUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "my-network"
+	name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "my-subnet"
+	name          = "%{subnetwork}"
 	ip_cidr_range = "10.0.0.0/16"
 	region        = "us-central1"
 	network       = google_compute_network.default.id
 }
 	
 resource "google_compute_address" "static_internal_ip" {
-	name         = "instance-1-address"
+	name         = "%{address1}"
 	address_type = "INTERNAL"
 }
 
 resource "google_compute_address" "static_external_ip" {
-	name         = "instance-3-address"
+	name         = "%{address2}"
 	address_type = "EXTERNAL"
 }
 		  

--- a/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -347,151 +347,151 @@ resource "google_compute_region_instance_group_manager" "rigm" {
 func testAccComputeRegionPerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "%{network}"
+  name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "%{subnetwork}"
-	ip_cidr_range = "10.0.0.0/16"
-	region        = "us-central1"
-	network       = google_compute_network.default.id
+  name          = "%{subnetwork}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
 }
-	
-resource "google_compute_address" "static_internal_ip" {
-	name         = "%{address1}"
-	address_type = "INTERNAL"
-}
-	
-resource "google_compute_address" "static_external_ip" {
-	name         = "%{address2}"
-	address_type = "EXTERNAL"
-}
-	  
-resource "google_compute_region_per_instance_config" "default" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
-	name = "%{config_name}"
-	remove_instance_state_on_destroy = true
-	preserved_state {
-		metadata = {
-			asdf = "asdf"
-		}
-		disk {
-			device_name = "my-stateful-disk1"
-			source      = google_compute_disk.disk.id
-		}
 
-		disk {
-			device_name = "my-stateful-disk2"
-			source      = google_compute_disk.disk1.id
-		}
-		internal_ip {
-			ip_address {
-				address = google_compute_address.static_internal_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-		external_ip {
-			ip_address {
-				address = google_compute_address.static_external_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-	}
+resource "google_compute_address" "static_internal_ip" {
+  name         = "%{address1}"
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "static_external_ip" {
+  name         = "%{address2}"
+  address_type = "EXTERNAL"
+}
+
+resource "google_compute_region_per_instance_config" "default" {
+  region = google_compute_region_instance_group_manager.rigm.region
+  region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+  name = "%{config_name}"
+  remove_instance_state_on_destroy = true
+  preserved_state {
+    metadata = {
+      asdf = "asdf"
+    }
+    disk {
+      device_name = "my-stateful-disk1"
+      source      = google_compute_disk.disk.id
+    }
+
+    disk {
+      device_name = "my-stateful-disk2"
+      source      = google_compute_disk.disk1.id
+    }
+    internal_ip {
+      ip_address {
+	    address = google_compute_address.static_internal_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+    external_ip {
+      ip_address {
+        address = google_compute_address.static_external_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+  }
 }
 
 resource "google_compute_disk" "disk" {
-	name  = "test-disk-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = "us-central1-c"
-	image = "debian-8-jessie-v20170523"
-	physical_block_size_bytes = 4096
-  }
-  
+  name  = "test-disk-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+  image = "debian-8-jessie-v20170523"
+  physical_block_size_bytes = 4096
+}
+
 resource "google_compute_disk" "disk1" {
-	name  = "test-disk2-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = "us-central1-c"
-	image = "debian-cloud/debian-11"
-	physical_block_size_bytes = 4096
-  }
+  name  = "test-disk2-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+  image = "debian-cloud/debian-11"
+  physical_block_size_bytes = 4096
+}
 `, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }
 
 func testAccComputeRegionPerInstanceConfig_statefulIpsUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_network" "default" {
-	name = "%{network}"
+  name = "%{network}"
 }
 
 resource "google_compute_subnetwork" "default" {
-	name          = "%{subnetwork}"
-	ip_cidr_range = "10.0.0.0/16"
-	region        = "us-central1"
-	network       = google_compute_network.default.id
+  name          = "%{subnetwork}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
 }
-	
+
 resource "google_compute_address" "static_internal_ip" {
-	name         = "%{address1}"
-	address_type = "INTERNAL"
+  name         = "%{address1}"
+  address_type = "INTERNAL"
 }
 
 resource "google_compute_address" "static_external_ip" {
-	name         = "%{address2}"
-	address_type = "EXTERNAL"
+  name         = "%{address2}"
+  address_type = "EXTERNAL"
 }
-		  
-resource "google_compute_region_per_instance_config" "default" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
-	name = "%{config_name}"
-	remove_instance_state_on_destroy = true
-	preserved_state {
-		metadata = {
-			asdf = "asdf"
-		}
-		disk {
-			device_name = "my-stateful-disk1"
-			source      = google_compute_disk.disk.id
-		}
 
-		disk {
-			device_name = "my-stateful-disk2"
-			source      = google_compute_disk.disk1.id
-		}
-		internal_ip {
-			ip_address {
-				address = google_compute_address.static_internal_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-		external_ip {
-			ip_address {
-				address = google_compute_address.static_external_ip.self_link
-			}
-			auto_delete    = "NEVER"
-			interface_name = "nic0"
-		}
-	}
+resource "google_compute_region_per_instance_config" "default" {
+  region = google_compute_region_instance_group_manager.rigm.region
+  region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+  name = "%{config_name}"
+  remove_instance_state_on_destroy = true
+  preserved_state {
+    metadata = {
+      asdf = "asdf"
+    }
+    disk {
+      device_name = "my-stateful-disk1"
+      source      = google_compute_disk.disk.id
+    }
+
+    disk {
+      device_name = "my-stateful-disk2"
+      source      = google_compute_disk.disk1.id
+    }
+    internal_ip {
+      ip_address {
+	    address = google_compute_address.static_internal_ip.self_link
+      }
+      auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
+      interface_name = "nic0"
+    }
+    external_ip {
+      ip_address {
+        address = google_compute_address.static_external_ip.self_link
+      }
+      auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
+      interface_name = "nic0"
+    }
+  }
 }
 
 resource "google_compute_disk" "disk" {
-	name  = "test-disk-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = "us-central1-c"
-	image = "debian-8-jessie-v20170523"
-	physical_block_size_bytes = 4096
+  name  = "test-disk-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+  image = "debian-8-jessie-v20170523"
+  physical_block_size_bytes = 4096
 }
-  
+
 resource "google_compute_disk" "disk1" {
-	name  = "test-disk2-%{random_suffix}"
-	type  = "pd-ssd"
-	zone  = "us-central1-c"
-	image = "debian-cloud/debian-11"
-	physical_block_size_bytes = 4096
+  name  = "test-disk2-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+  image = "debian-cloud/debian-11"
+  physical_block_size_bytes = 4096
 }
 `, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -125,6 +125,44 @@ func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionPerInstanceConfig_statefulIps(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"rigm_name":     fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
+		"network":       fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create one config
+				Config: testAccComputeRegionPerInstanceConfig_statefulIpsBasic(context),
+			},
+			{
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy", "region"},
+			},
+			{
+				// Update an existing config
+				Config: testAccComputeRegionPerInstanceConfig_statefulIpsUpdate(context),
+			},
+			{
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy", "region"},
+			},
+		},
+	})
+}
+
 func testAccComputeRegionPerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_region_per_instance_config" "default" {
@@ -301,6 +339,158 @@ resource "google_compute_region_instance_group_manager" "rigm" {
   }
 }
 `, context)
+}
+
+func testAccComputeRegionPerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+	name = "my-network"
+}
+
+resource "google_compute_subnetwork" "default" {
+	name          = "my-subnet"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.default.id
+}
+	
+resource "google_compute_address" "static_internal_ip" {
+	name         = "instance-1-address"
+	address_type = "INTERNAL"
+}
+	
+resource "google_compute_address" "static_external_ip" {
+	name         = "instance-3-address"
+	address_type = "EXTERNAL"
+}
+	  
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "asdf"
+		}
+		disk {
+			device_name = "my-stateful-disk1"
+			source      = google_compute_disk.disk.id
+		}
+
+		disk {
+			device_name = "my-stateful-disk2"
+			source      = google_compute_disk.disk1.id
+		}
+		internal_ip {
+			ip_address {
+				address = google_compute_address.static_internal_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+		external_ip {
+			ip_address {
+				address = google_compute_address.static_external_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+	}
+}
+
+resource "google_compute_disk" "disk" {
+	name  = "test-disk-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = "us-central1-c"
+	image = "debian-8-jessie-v20170523"
+	physical_block_size_bytes = 4096
+  }
+  
+resource "google_compute_disk" "disk1" {
+	name  = "test-disk2-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = "us-central1-c"
+	image = "debian-cloud/debian-11"
+	physical_block_size_bytes = 4096
+  }
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+}
+
+func testAccComputeRegionPerInstanceConfig_statefulIpsUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+	name = "my-network"
+}
+
+resource "google_compute_subnetwork" "default" {
+	name          = "my-subnet"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.default.id
+}
+	
+resource "google_compute_address" "static_internal_ip" {
+	name         = "instance-1-address"
+	address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "static_external_ip" {
+	name         = "instance-3-address"
+	address_type = "EXTERNAL"
+}
+		  
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "asdf"
+		}
+		disk {
+			device_name = "my-stateful-disk1"
+			source      = google_compute_disk.disk.id
+		}
+
+		disk {
+			device_name = "my-stateful-disk2"
+			source      = google_compute_disk.disk1.id
+		}
+		internal_ip {
+			ip_address {
+				address = google_compute_address.static_internal_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+		external_ip {
+			ip_address {
+				address = google_compute_address.static_external_ip.self_link
+			}
+			auto_delete    = "NEVER"
+			interface_name = "nic0"
+		}
+	}
+}
+
+resource "google_compute_disk" "disk" {
+	name  = "test-disk-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = "us-central1-c"
+	image = "debian-8-jessie-v20170523"
+	physical_block_size_bytes = 4096
+}
+  
+resource "google_compute_disk" "disk1" {
+	name  = "test-disk2-%{random_suffix}"
+	type  = "pd-ssd"
+	zone  = "us-central1-c"
+	image = "debian-cloud/debian-11"
+	physical_block_size_bytes = 4096
+}
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }
 
 // Checks that the per instance config with the given name was destroyed


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add stateful_ips to region_per_instance_config and per_instance_config

https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/createInstances


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `internal_ip` and `external_ip` to `google_compute_per_instance_config` and `google_compute_region_per_instance_config` (beta)
```
