### PR TITLE
Fix TestAccBigQueryDatasetAccess_authorizedRoutine and add note about usage

### DIFF
--- a/mmv1/products/bigquery/api.yaml
+++ b/mmv1/products/bigquery/api.yaml
@@ -311,6 +311,7 @@ objects:
       ~> **Note:** If this resource is used alongside a `google_bigquery_dataset` resource, the
       dataset resource must either have no defined `access` blocks or a `lifecycle` block with
       `ignore_changes = [access]` so they don't fight over which accesses should be on the dataset.
+      Additionally, both resource cannot be modified in the same apply.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Controlling access to datasets': 'https://cloud.google.com/bigquery/docs/dataset-access-controls'

--- a/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -421,7 +421,6 @@ resource "google_bigquery_routine" "public" {
 
 resource "google_bigquery_dataset" "private" {
   dataset_id  = "%{private_dataset}"
-  description = "This dataset is private"
 }
 
 resource "google_bigquery_dataset_access" "authorized_routine" {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13023

There is more detail on the test failure ticket, but basically a couple of things happening with this change:
- https://github.com/hashicorp/terraform-provider-google/issues/13779 was created to capture the underlying issue, to see if we want to prioritize or fix
- Removing the `description` in our test gets around the underlying issue and allows the test to pass
- The documentation note mentions the underlying issue as a usage limitation

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
