### PR TITLE
fix sending disableConnectionDrainOnFailover

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -568,6 +568,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       failoverPolicy.disableConnectionDrainOnFailover: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       failoverPolicy.dropTrafficIfUnhealthy: !ruby/object:Overrides::Terraform::PropertyOverride
+        send_empty_value: true
         default_from_api: true
       connectionTrackingPolicy.idleTimeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -566,9 +566,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       logConfig.enable: !ruby/object:Overrides::Terraform::PropertyOverride
         send_empty_value: true
       failoverPolicy.disableConnectionDrainOnFailover: !ruby/object:Overrides::Terraform::PropertyOverride
-        send_empty_value: true
+        default_from_api: true
       failoverPolicy.dropTrafficIfUnhealthy: !ruby/object:Overrides::Terraform::PropertyOverride
-        send_empty_value: true
+        default_from_api: true
       connectionTrackingPolicy.idleTimeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
   RegionInstanceGroupManager: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -260,7 +260,7 @@ func TestAccComputeRegionBackendService_withBackendAndIAP(t *testing.T) {
 	})
 }
 
-func TestAccComputeRegionBackendService_UDPFailOverPolicy(t *testing.T) {
+func TestAccComputeRegionBackendService_UDPFailOverPolicyUpdate(t *testing.T) {
 	t.Parallel()
 
 	serviceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -272,7 +272,23 @@ func TestAccComputeRegionBackendService_UDPFailOverPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRegionBackendService_UDPFailOverPolicy(serviceName, checkName),
+				Config: testAccComputeRegionBackendService_UDPFailOverPolicyHasDrain(serviceName, "TCP", "true", checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_UDPFailOverPolicyHasDrain(serviceName, "TCP", "false", checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_UDPFailOverPolicy(serviceName, "UDP", "false", checkName),
 			},
 			{
 				ResourceName:      "google_compute_region_backend_service.foobar",
@@ -524,16 +540,17 @@ resource "google_compute_health_check" "health_check" {
 }
 <% end -%>
 
-func testAccComputeRegionBackendService_UDPFailOverPolicy(serviceName, checkName string) string {
+func testAccComputeRegionBackendService_UDPFailOverPolicy(serviceName, protocol, failover, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_health_check.zero.self_link]
   region        = "us-central1"
 
-  protocol = "UDP"
+  protocol = "%s"
   failover_policy {
-      drop_traffic_if_unhealthy = true
+      # Disable connection drain on failover cannot be set when the protocol is UDP
+      drop_traffic_if_unhealthy = "%s"
   }
 }
 
@@ -546,8 +563,36 @@ resource "google_compute_health_check" "zero" {
     port = "80"
   }
 }
-`, serviceName, checkName)
+`, serviceName, protocol, failover, checkName)
 }
+
+func testAccComputeRegionBackendService_UDPFailOverPolicyHasDrain(serviceName, protocol, failover, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_health_check.zero.self_link]
+  region        = "us-central1"
+
+  protocol = "%s"
+  failover_policy {
+      # Disable connection drain on failover cannot be set when the protocol is UDP
+      drop_traffic_if_unhealthy = "%s"
+      disable_connection_drain_on_failover = "%s"
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+`, serviceName, protocol, failover, failover, checkName)
+}
+
 
 func testAccComputeRegionBackendService_basic(serviceName, checkName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -260,6 +260,29 @@ func TestAccComputeRegionBackendService_withBackendAndIAP(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionBackendService_UDPFailOverPolicy(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_UDPFailOverPolicy(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 <% unless version == 'ga' -%>
 func TestAccComputeRegionBackendService_subsettingUpdate(t *testing.T) {
 	t.Parallel()
@@ -500,6 +523,31 @@ resource "google_compute_health_check" "health_check" {
 `, serviceName, igName, instanceName, checkName)
 }
 <% end -%>
+
+func testAccComputeRegionBackendService_UDPFailOverPolicy(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_health_check.zero.self_link]
+  region        = "us-central1"
+
+  protocol = "UDP"
+  failover_policy {
+      drop_traffic_if_unhealthy = true
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+`, serviceName, checkName)
+}
 
 func testAccComputeRegionBackendService_basic(serviceName, checkName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13529


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed the error of invalid value for field `resource.failoverPolicy` when UDP is selected on `google_compute_region_backend_service`
```
