### PR TITLE
Add ability to create `.copywrite.hcl` file in downstreams

### DIFF
--- a/mmv1/provider/terraform/common~compile.yaml
+++ b/mmv1/provider/terraform/common~compile.yaml
@@ -49,3 +49,4 @@
 '.goreleaser.yml': 'third_party/terraform/.goreleaser.yml.erb'
 'terraform-registry-manifest.json': 'third_party/terraform/terraform-registry-manifest.json.erb'
 '.release/release-metadata.hcl': 'third_party/terraform/release-metadata.hcl.erb'
+'.copywrite.hcl': 'third_party/terraform/.copywrite.hcl.erb'

--- a/mmv1/third_party/terraform/.copywrite.hcl.erb
+++ b/mmv1/third_party/terraform/.copywrite.hcl.erb
@@ -19,4 +19,8 @@ project {
     ".golangci.yml",
     ".goreleaser.yml",
   ]
+
+  # (OPTIONAL) Links to an upstream repo for determining repo relationships
+  # This is for special cases and should not normally be set.
+  upstream = "GoogleCloudPlatform/magic-modules"
 }

--- a/mmv1/third_party/terraform/.copywrite.hcl.erb
+++ b/mmv1/third_party/terraform/.copywrite.hcl.erb
@@ -1,0 +1,22 @@
+<% autogen_exception -%>
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2017
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    # Some ignores here are not strictly needed, but protects us if we change the types of files we put in those folders
+    # See here for file extensions altered by copywrite CLI (all other extensions are ignored)
+    # Ignores below might not have an https://github.com/hashicorp/copywrite/blob/4af928579f5aa8f1dece9de1bb3098218903053d/addlicense/main.go#L357-L394
+    ".release/**",
+    ".changelog/**",
+    "examples/**",
+    "META.d/*.yml",
+    ".golangci.yml",
+    ".goreleaser.yaml",
+  ]
+}

--- a/mmv1/third_party/terraform/.copywrite.hcl.erb
+++ b/mmv1/third_party/terraform/.copywrite.hcl.erb
@@ -11,7 +11,7 @@ project {
   header_ignore = [
     # Some ignores here are not strictly needed, but protects us if we change the types of files we put in those folders
     # See here for file extensions altered by copywrite CLI (all other extensions are ignored)
-    # Ignores below might not have an https://github.com/hashicorp/copywrite/blob/4af928579f5aa8f1dece9de1bb3098218903053d/addlicense/main.go#L357-L394
+    # https://github.com/hashicorp/copywrite/blob/4af928579f5aa8f1dece9de1bb3098218903053d/addlicense/main.go#L357-L394
     ".release/**",
     ".changelog/**",
     "examples/**",

--- a/mmv1/third_party/terraform/.copywrite.hcl.erb
+++ b/mmv1/third_party/terraform/.copywrite.hcl.erb
@@ -17,6 +17,6 @@ project {
     "examples/**",
     "META.d/*.yml",
     ".golangci.yml",
-    ".goreleaser.yaml",
+    ".goreleaser.yml",
   ]
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

**Context:**

HashiCorp has a tool called [copywrite](https://github.com/hashicorp/copywrite) that adds licenses and copyright headers to files in public HashiCorp repos. There's also automation where PRs will be opened against repos that have any of that info missing, e.g.:
- https://github.com/hashicorp/terraform-provider-google/pull/13624
- https://github.com/hashicorp/terraform-provider-google-beta/pull/5155

**This PR:**

This PR adds a config file that influences the behaviour of this automation/actions of the [copywrite CLI](https://github.com/hashicorp/copywrite).

By defining a .copywrite.hcl file in Magic Modules we can ensure the downstream google and google-beta repos have the same config in place.

The intention of this PR is to settling on which files we want excluded from copyright headers being added to.
In a future PR(s) we can add automation to make sure adding the headers is part of the process for generating the downstream.


---
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] ~~Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).~~
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~
- [x] ~~[Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.~~
- [x] ~~[Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
