### PR TITLE
Move logging-related billing tests to master billing account

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_logging_billing_account_exclusion_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_billing_account_exclusion_test.go
@@ -31,7 +31,7 @@ func TestAccLoggingBillingAccountExclusion(t *testing.T) {
 }
 
 func testAccLoggingBillingAccountExclusion_basic(t *testing.T) {
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 	exclusionName := "tf-test-exclusion-" + randString(t, 10)
 	description := "Description " + randString(t, 10)
 
@@ -53,7 +53,7 @@ func testAccLoggingBillingAccountExclusion_basic(t *testing.T) {
 }
 
 func testAccLoggingBillingAccountExclusion_update(t *testing.T) {
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 	exclusionName := "tf-test-exclusion-" + randString(t, 10)
 	descriptionBefore := "Basic BillingAccount Logging Exclusion" + randString(t, 10)
 	descriptionAfter := "Updated Basic BillingAccount Logging Exclusion" + randString(t, 10)
@@ -84,7 +84,7 @@ func testAccLoggingBillingAccountExclusion_update(t *testing.T) {
 }
 
 func testAccLoggingBillingAccountExclusion_multiple(t *testing.T) {
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/mmv1/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -14,7 +14,7 @@ func TestAccLoggingBillingAccountSink_basic(t *testing.T) {
 
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	var sink logging.LogSink
 
@@ -44,7 +44,7 @@ func TestAccLoggingBillingAccountSink_update(t *testing.T) {
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
 	updatedBucketName := "tf-test-sink-bucket-" + randString(t, 10)
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	var sinkBefore, sinkAfter logging.LogSink
 
@@ -88,7 +88,7 @@ func TestAccLoggingBillingAccountSink_described(t *testing.T) {
 
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -111,7 +111,7 @@ func TestAccLoggingBillingAccountSink_disabled(t *testing.T) {
 
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -134,7 +134,7 @@ func TestAccLoggingBillingAccountSink_updateBigquerySink(t *testing.T) {
 
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bqDatasetID := "tf_test_sink_" + randString(t, 10)
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -166,7 +166,7 @@ func TestAccLoggingBillingAccountSink_heredoc(t *testing.T) {
 
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
-	billingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestMasterBillingAccountFromEnv(t)
 
 	var sink logging.LogSink
 


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/7263

For these logging-related billing tests, the user needs to have permissions beyond Billing User, so we will attempt to use the master billing account instead.

`logging.sinks.create`:
- TestAccLoggingBillingAccountSink_basic
- TestAccLoggingBillingAccountSink_update
- TestAccLoggingBillingAccountSink_described
- TestAccLoggingBillingAccountSink_disabled
- TestAccLoggingBillingAccountSink_updateBigquerySink
- TestAccLoggingBillingAccountSink_heredoc

`logging.exclusions.create`:
- TestAccLoggingBillingAccountExclusion

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
