### PR TITLE
Cloud identity, fix import perma diff problem

### DIFF
--- a/mmv1/products/cloudidentity/terraform.yaml
+++ b/mmv1/products/cloudidentity/terraform.yaml
@@ -42,7 +42,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           cust_id: :CUST_ID
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/set_computed_name.erb
-      custom_import: templates/terraform/custom_import/set_id_name_with_slashes.go.erb
+      custom_import: templates/terraform/custom_import/cloud_identity_group_import.go.erb
   GroupMembership: !ruby/object:Overrides::Terraform::ResourceOverride
     read_error_transform: "transformCloudIdentityGroupMembershipReadError"
     docs: !ruby/object:Provider::Terraform::Docs

--- a/mmv1/templates/terraform/custom_import/cloud_identity_group_import.go.erb
+++ b/mmv1/templates/terraform/custom_import/cloud_identity_group_import.go.erb
@@ -1,0 +1,18 @@
+config := meta.(*Config)
+
+// current import_formats can't import fields with forward slashes in their value
+if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+name := d.Get("name").(string)
+
+if d.Get("initial_group_config") == nil {
+    d.Set("initial_group_config", "EMPTY")
+}
+
+if err := d.Set("name", name); err != nil {
+	return nil, fmt.Errorf("Error setting name: %s", err)
+}
+d.SetId(name)
+return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/hashicorp/terraform-provider-google/issues/13515

Bug description included in the link above.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudidentity: fixed an issue on `group` field when users make an import.
```
