### PR TITLE
Fix DataFusion instance versions used in tests

### DIFF
--- a/mmv1/templates/terraform/examples/data_fusion_instance_event.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_event.tf.erb
@@ -2,7 +2,6 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
   name    = "<%= ctx[:vars]["instance_name"] %>"
   region  = "us-central1"
   type    = "BASIC"
-  version = "6.7.0"
 
   event_publish_config {
     enabled = true

--- a/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_full.tf.erb
@@ -7,7 +7,6 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
   enable_stackdriver_logging    = true
   enable_stackdriver_monitoring = true
   private_instance              = true
-  version                       = "6.6.0"
   dataproc_service_account      = data.google_app_engine_default_service_account.default.email
 
   labels = {

--- a/mmv1/third_party/terraform/tests/resource_data_fusion_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_fusion_instance_test.go
@@ -42,7 +42,8 @@ resource "google_data_fusion_instance" "foobar" {
   name   = "%s"
   region = "us-central1"
   type   = "BASIC"
-  version = "6.1.1"
+  # See supported versions here https://cloud.google.com/data-fusion/docs/support/version-support-policy
+  version = "6.7.0"
   # Mark for testing to avoid service networking connection usage that is not cleaned up
   options = {
   	prober_test_run = "true"
@@ -64,7 +65,7 @@ resource "google_data_fusion_instance" "foobar" {
     label1 = "value1"
     label2 = "value2"
   }
-  version = "6.2.0"
+  version = "6.8.0"
   # Mark for testing to avoid service networking connection usage that is not cleaned up
   options = {
   	prober_test_run = "true"


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/11822

Per https://cloud.google.com/data-fusion/docs/support/version-support-policy, some of the versions we were using for these tests have been deprecated.

For the tests that do not explicitly deal with the version, I've removed it to prevent this from happening in the future. For the `_update` test, we do want to test upgrading the version, so I've chosen the latest version I could (6.7.0).

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
