### PR TITLE
Move more billing tests that require permissions beyond Billing User to master billing account

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_billing_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_billing_account_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceGoogleBillingAccount_byFullName(t *testing.T) {
-	billingId := getTestBillingAccountFromEnv(t)
+	billingId := getTestMasterBillingAccountFromEnv(t)
 	name := "billingAccounts/" + billingId
 
 	vcrTest(t, resource.TestCase{
@@ -29,7 +29,7 @@ func TestAccDataSourceGoogleBillingAccount_byFullName(t *testing.T) {
 }
 
 func TestAccDataSourceGoogleBillingAccount_byShortName(t *testing.T) {
-	billingId := getTestBillingAccountFromEnv(t)
+	billingId := getTestMasterBillingAccountFromEnv(t)
 	name := "billingAccounts/" + billingId
 
 	vcrTest(t, resource.TestCase{
@@ -49,7 +49,7 @@ func TestAccDataSourceGoogleBillingAccount_byShortName(t *testing.T) {
 }
 
 func TestAccDataSourceGoogleBillingAccount_byFullNameClosed(t *testing.T) {
-	billingId := getTestBillingAccountFromEnv(t)
+	billingId := getTestMasterBillingAccountFromEnv(t)
 	name := "billingAccounts/" + billingId
 
 	vcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_project_test.go
@@ -123,6 +123,8 @@ func TestAccProject_create(t *testing.T) {
 func TestAccProject_billing(t *testing.T) {
 	t.Parallel()
 	org := getTestOrgFromEnv(t)
+	// This is a second billing account that can be charged, which is used only in this test to
+	// verify that a project can update its billing account.
 	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT_2")
 	billingId2 := os.Getenv("GOOGLE_BILLING_ACCOUNT_2")
 	billingId := getTestBillingAccountFromEnv(t)

--- a/mmv1/third_party/terraform/tests/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_bucket_config_test.go
@@ -131,7 +131,7 @@ func TestAccLoggingBucketConfigBillingAccount_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix":        randString(t, 10),
-		"billing_account_name": "billingAccounts/" + getTestBillingAccountFromEnv(t),
+		"billing_account_name": "billingAccounts/" + getTestMasterBillingAccountFromEnv(t),
 		"org_id":               getTestOrgFromEnv(t),
 	}
 

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -104,6 +104,8 @@ var orgTargetEnvVars = []string{
 	"GOOGLE_ORG_2",
 }
 
+// This is the billing account that will be charged for the infrastructure used during testing. For
+// that reason, it is also the billing account used for creating new projects.
 var billingAccountEnvVars = []string{
 	"GOOGLE_BILLING_ACCOUNT",
 }
@@ -118,6 +120,8 @@ type VcrSource struct {
 
 var sources map[string]VcrSource
 
+// This is the billing account that will be modified to test billing-related functionality. It is
+// expected to have more permissions granted to the test user and support subaccounts.
 var masterBillingAccountEnvVars = []string{
 	"GOOGLE_MASTER_BILLING_ACCOUNT",
 }
@@ -838,11 +842,15 @@ func getTestOrgTargetFromEnv(t *testing.T) string {
 	return MultiEnvSearch(orgTargetEnvVars)
 }
 
+// This is the billing account that will be charged for the infrastructure used during testing. For
+// that reason, it is also the billing account used for creating new projects.
 func getTestBillingAccountFromEnv(t *testing.T) string {
 	skipIfEnvNotSet(t, billingAccountEnvVars...)
 	return MultiEnvSearch(billingAccountEnvVars)
 }
 
+// This is the billing account that will be modified to test billing-related functionality. It is
+// expected to have more permissions granted to the test user and support subaccounts.
 func getTestMasterBillingAccountFromEnv(t *testing.T) string {
 	skipIfEnvNotSet(t, masterBillingAccountEnvVars...)
 	return MultiEnvSearch(masterBillingAccountEnvVars)


### PR DESCRIPTION
These were missed in https://github.com/GoogleCloudPlatform/magic-modules/pull/7263 and https://github.com/GoogleCloudPlatform/magic-modules/pull/7337. In short, the tests fail with a billing account that only has Billing User permissions, so we need to move them to using the "master" account. Hopefully this is the last set of these changes.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
