### PR TITLE
Remove artifact repository beta URL, fixup handwritten tests

### DIFF
--- a/mmv1/products/artifactregistry/product.yaml
+++ b/mmv1/products/artifactregistry/product.yaml
@@ -18,9 +18,6 @@ scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:
   - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://artifactregistry.googleapis.com/v1beta2/
-  - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://artifactregistry.googleapis.com/v1/    
 apis_required:

--- a/mmv1/third_party/terraform/tests/resource_artifact_registry_repository_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_artifact_registry_repository_test.go.erb
@@ -155,7 +155,7 @@ func testAccArtifactRegistryRepository_kfp(repositoryID string) string {
 resource "google_artifact_registry_repository" "test" {
   repository_id = "%s"
   location = "us-central1"
-  description = "my-kfp-repository""
+  description = "my-kfp-repository"
   format = "KFP"
 }
 `, repositoryID)

--- a/mmv1/third_party/terraform/tests/resource_artifact_registry_repository_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_artifact_registry_repository_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -16,7 +15,7 @@ func TestAccArtifactRegistryRepository_update(t *testing.T) {
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckArtifactRegistryRepositoryDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -39,18 +38,18 @@ func TestAccArtifactRegistryRepository_update(t *testing.T) {
 	})
 }
 
-func TestAccArtifactRegistryRepository_create_mvn_snapshot(t *testing.T) {
+func TestAccArtifactRegistryRepository_createMvnSnapshot(t *testing.T) {
 	t.Parallel()
 
 	repositoryID := fmt.Sprintf("tf-test-%d", randInt(t))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckArtifactRegistryRepositoryDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArtifactRegistryRepository_create(repositoryID, "SNAPSHOT"),
+				Config: testAccArtifactRegistryRepository_createMvnWithVersionPolicy(repositoryID, "SNAPSHOT"),
 			},
 			{
 				ResourceName:      "google_artifact_registry_repository.test",
@@ -61,18 +60,40 @@ func TestAccArtifactRegistryRepository_create_mvn_snapshot(t *testing.T) {
 	})
 }
 
-func TestAccArtifactRegistryRepository_create_mvn_release(t *testing.T) {
+func TestAccArtifactRegistryRepository_createMvnRelease(t *testing.T) {
 	t.Parallel()
 
 	repositoryID := fmt.Sprintf("tf-test-%d", randInt(t))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckArtifactRegistryRepositoryDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArtifactRegistryRepository_create(repositoryID, "RELEASE"),
+				Config: testAccArtifactRegistryRepository_createMvnWithVersionPolicy(repositoryID, "RELEASE"),
+			},
+			{
+				ResourceName:      "google_artifact_registry_repository.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccArtifactRegistryRepository_kfp(t *testing.T) {
+	t.Parallel()
+
+	repositoryID := fmt.Sprintf("tf-test-%d", randInt(t))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckArtifactRegistryRepositoryDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArtifactRegistryRepository_kfp(repositoryID),
 			},
 			{
 				ResourceName:      "google_artifact_registry_repository.test",
@@ -86,8 +107,6 @@ func TestAccArtifactRegistryRepository_create_mvn_release(t *testing.T) {
 func testAccArtifactRegistryRepository_update(repositoryID string) string {
 	return fmt.Sprintf(`
 resource "google_artifact_registry_repository" "test" {
-  provider = google-beta
-
   repository_id = "%s"
   location = "us-central1"
   description = "pre-update"
@@ -104,8 +123,6 @@ resource "google_artifact_registry_repository" "test" {
 func testAccArtifactRegistryRepository_update2(repositoryID string) string {
 	return fmt.Sprintf(`
 resource "google_artifact_registry_repository" "test" {
-  provider = google-beta
-
   repository_id = "%s"
   location = "us-central1"
   description = "post-update"
@@ -119,11 +136,9 @@ resource "google_artifact_registry_repository" "test" {
 `, repositoryID)
 }
 
-func testAccArtifactRegistryRepository_create(repositoryID string, versionPolicy string) string {
+func testAccArtifactRegistryRepository_createMvnWithVersionPolicy(repositoryID string, versionPolicy string) string {
 	return fmt.Sprintf(`
 resource "google_artifact_registry_repository" "test" {
-  provider = google-beta
-
   repository_id = "%s"
   location = "us-central1"
   description = "post-update"
@@ -134,4 +149,14 @@ resource "google_artifact_registry_repository" "test" {
 }
 `, repositoryID, versionPolicy)
 }
-<% end -%>
+
+func testAccArtifactRegistryRepository_kfp(repositoryID string) string {
+	return fmt.Sprintf(`
+resource "google_artifact_registry_repository" "test" {
+  repository_id = "%s"
+  location = "us-central1"
+  description = "my-kfp-repository""
+  format = "KFP"
+}
+`, repositoryID)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes b/270298939

Seems like this service declined to update its beta API, meaning the invariant that beta APIs are a superset of GAs is broken. The test configuration here succeeds on the GA provider but fails on the beta one:

```
│ Error: Error creating Repository: googleapi: Error 400: Invalid value at 'repository.format' (type.googleapis.com/google.devtools.artifactregistry.v1beta2.Repository.Format), "KFP"
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.BadRequest",
│     "fieldViolations": [
│       {
│         "description": "Invalid value at 'repository.format' (type.googleapis.com/google.devtools.artifactregistry.v1beta2.Repository.Format), \"KFP\"",
│         "field": "repository.format"
│       }
│     ]
│   }
│ ]
│
│   on main.tf line 1, in resource "google_artifact_registry_repository" "my-repo":
│    1: resource "google_artifact_registry_repository" "my-repo" {
```

Also rename some tests to match standard format, un-guard the handwritten test file.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
artifactregistry: fixed an issue where `google-beta` used an outdated beta API rather than the GA service API. New format values like "KFP" will now be accepted by both providers.
```
