### PR TITLE
Fix caps in spanner resource schema accesses

### DIFF
--- a/mmv1/templates/terraform/pre_update/spanner_database.go.erb
+++ b/mmv1/templates/terraform/pre_update/spanner_database.go.erb
@@ -19,7 +19,7 @@ if len(obj["statements"].([]string)) == 0 {
 	return resourceSpannerDatabaseRead(d, meta)
 }
 
-if resourceSpannerDBVirtualUpdate(d, resourceSpannerInstance().Schema) {
+if resourceSpannerDBVirtualUpdate(d, ResourceSpannerInstance().Schema) {
     if d.Get("deletion_protection") != nil {
         if err := d.Set("deletion_protection", d.Get("deletion_protection")); err != nil {
             return fmt.Errorf("Error reading Instance: %s", err)

--- a/mmv1/templates/terraform/pre_update/spanner_database.go.erb
+++ b/mmv1/templates/terraform/pre_update/spanner_database.go.erb
@@ -19,7 +19,7 @@ if len(obj["statements"].([]string)) == 0 {
 	return resourceSpannerDatabaseRead(d, meta)
 }
 
-if resourceSpannerDBVirtualUpdate(d, ResourceSpannerInstance().Schema) {
+if resourceSpannerDBVirtualUpdate(d, ResourceSpannerDatabase().Schema) {
     if d.Get("deletion_protection") != nil {
         if err := d.Set("deletion_protection", d.Get("deletion_protection")); err != nil {
             return fmt.Errorf("Error reading Instance: %s", err)

--- a/mmv1/templates/terraform/pre_update/spanner_instance.go.erb
+++ b/mmv1/templates/terraform/pre_update/spanner_instance.go.erb
@@ -1,4 +1,4 @@
-if resourceSpannerInstanceVirtualUpdate(d, resourceSpannerInstance().Schema) {
+if resourceSpannerInstanceVirtualUpdate(d, ResourceSpannerInstance().Schema) {
     if d.Get("force_destroy") != nil {
         if err := d.Set("force_destroy", d.Get("force_destroy")); err != nil {
             return fmt.Errorf("Error reading Instance: %s", err)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Should fix the broken build from a cross-merge between https://github.com/GoogleCloudPlatform/magic-modules/pull/7318 and https://github.com/GoogleCloudPlatform/magic-modules/pull/7324


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
