### PR TITLE
Add support for binauthz policy

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -782,9 +782,14 @@ func ResourceContainerCluster() *schema.Resource {
                                                 "evaluation_mode": {
                                                         Type:          schema.TypeString,
                                                         Optional:      true,
-                                                        ValidateFunc:  validation.StringInSlice([]string{"DISABLED", "PROJECT_SINGLETON_POLICY_ENFORCE"}, false),
+                                                        ValidateFunc:  validation.StringInSlice([]string{"DISABLED", "PROJECT_SINGLETON_POLICY_ENFORCE", "MONITORING", "MONITORING_AND_PROJECT_SINGLETON_POLICY_ENFORCE"}, false),
                                                         Description:   "Mode of operation for Binary Authorization policy evaluation.",
                                                         ConflictsWith: []string{"binary_authorization.0.enabled"},
+                                                },
+                                                "policy": {
+                                                        Type:          schema.TypeString,
+                                                        Optional:      true,
+                                                        Description:   "The relative resource name of the binauthz platform policy to audit and/or enforce against. GKE platform policies have the following format: `projects/{project_number}/platforms/gke/policies/{policy_id}`. Can only be set if `evaluation_mode` is set to `MONITORING` or `MONITORING_AND_PROJECT_SINGLETON_POLICY_ENFORCE`.",
                                                 },
                                         },
                                 },
@@ -4255,6 +4260,7 @@ func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *con
 	return &container.BinaryAuthorization{
                 Enabled:        config["enabled"].(bool),
                 EvaluationMode: config["evaluation_mode"].(string),
+                Policy:         config["policy"].(string),
 	}
 }
 
@@ -4748,6 +4754,7 @@ func flattenBinaryAuthorization(c *container.BinaryAuthorization) []map[string]i
 		result = append(result, map[string]interface{}{
                         "enabled":         c.Enabled,
 			"evaluation_mode": c.EvaluationMode,
+                        "policy":          c.Policy,
 		})
         }
 	return result

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2895,6 +2895,65 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeClassic(t *tes
 	})
 }
 
+func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicyAutopilot(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicy(clusterName, true, "MONITORING"),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode_and_policy",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+			},
+			{
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicy(clusterName, true, "MONITORING_AND_PROJECT_SINGLETON_POLICY_ENFORCE"),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode_and_policy",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+                        }
+		},
+	})
+}
+
+func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicyClassic(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicy(clusterName, false, "MONITORING"),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode_and_policy",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+			},
+			{
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicy(clusterName, false, "MONITORING_AND_PROJECT_SINGLETON_POLICY_ENFORCE"),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode_and_policy",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+			},
+		},
+	})
+}
 func TestAccContainerCluster_withFlexiblePodCIDR(t *testing.T) {
 	t.Parallel()
 
@@ -6576,6 +6635,24 @@ resource "google_container_cluster" "with_binary_authorization_evaluation_mode" 
 
   binary_authorization {
     evaluation_mode = "%s"
+  }
+}
+`, clusterName, autopilot_enabled, evaluation_mode)
+}
+
+func testAccContainerCluster_withBinaryAuthorizationEvaluationModeAndPolicy(clusterName string, autopilot_enabled bool, evaluation_mode string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_binary_authorization_evaluation_mode_and_policy" {
+  name               = "%s"
+  location           = "us-central1"
+  initial_node_count = 1
+  ip_allocation_policy {
+  }
+  enable_autopilot = %v
+
+  binary_authorization {
+    evaluation_mode = "%s"
+    policy          = "projects/test-project/platforms/gke/policies/test-policy"
   }
 }
 `, clusterName, autopilot_enabled, evaluation_mode)

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -432,9 +432,14 @@ addons_config {
 
 * `enabled` - (DEPRECATED) Enable Binary Authorization for this cluster. Deprecated in favor of `evaluation_mode`.
 
-* `evaluation_mode` - (Optional) Mode of operation for Binary Authorization policy evaluation. Valid values are `DISABLED`
-  and `PROJECT_SINGLETON_POLICY_ENFORCE`. `PROJECT_SINGLETON_POLICY_ENFORCE` is functionally equivalent to the
-  deprecated `enable_binary_authorization` parameter being set to `true`.
+* `evaluation_mode` - (Optional) Mode of operation for Binary Authorization policy evaluation. Valid values are `DISABLED`,
+  `PROJECT_SINGLETON_POLICY_ENFORCE`, `MONITORING` and `MONITORING_AND_PROJECT_SINGLETON_POLICY_ENFORCE`.
+  `PROJECT_SINGLETON_POLICY_ENFORCE` is functionally equivalent to the deprecated `enable_binary_authorization` parameter
+  being set to `true`.
+
+* `policy` - (Optional) The relative resource name of the binauthz platform policy to audit and/or enforce against.
+  GKE platform policies have the following format: `projects/{project_number}/platforms/gke/policies/{policy_id}`.
+  Can only be set if `evaluation_mode` is set to `MONITORING` or `MONITORING_AND_PROJECT_SINGLETON_POLICY_ENFORCE`.
 
 <a name="nested_service_external_ips_config"></a>The `service_external_ips_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added `binauthz_policy` field to `resource_container_cluster`.
```
