### PR TITLE
enhancement: Promote Firestore database resource to GA

### DIFF
--- a/mmv1/products/firestore/api.yaml
+++ b/mmv1/products/firestore/api.yaml
@@ -29,7 +29,6 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Database'
-    min_version: beta
     base_url: 'projects/{{project}}/databases'
     create_url: 'projects/{{project}}/databases?databaseId={{name}}'
     update_verb: :PATCH

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -1,6 +1,4 @@
 resource "google_project" "project" {
-  provider = "google-beta"
-
   project_id = "tf-test%{random_suffix}"
   name       = "tf-test%{random_suffix}"
   org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
@@ -13,8 +11,6 @@ resource "time_sleep" "wait_60_seconds" {
 }
 
 resource "google_project_service" "firestore" {
-  provider = "google-beta"
-
   project = google_project.project.project_id
   service = "firestore.googleapis.com"
 
@@ -23,8 +19,6 @@ resource "google_project_service" "firestore" {
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
-
   project                     = google_project.project.project_id
   name                        = "(default)"
   location_id                 = "nam5"

--- a/mmv1/templates/terraform/examples/firestore_database_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_datastore_mode.tf.erb
@@ -1,6 +1,4 @@
 resource "google_project" "project" {
-  provider = "google-beta"
-
   project_id = "tf-test%{random_suffix}"
   name       = "tf-test%{random_suffix}"
   org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
@@ -13,8 +11,6 @@ resource "time_sleep" "wait_60_seconds" {
 }
 
 resource "google_project_service" "firestore" {
-  provider = "google-beta"
-
   project = google_project.project.project_id
   service = "firestore.googleapis.com"
 
@@ -23,8 +19,6 @@ resource "google_project_service" "firestore" {
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
-
   project = google_project.project.project_id
 
   name = "(default)"

--- a/mmv1/third_party/terraform/tests/resource_firestore_database_update_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firestore_database_update_test.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
-
 import (
 	"fmt"
 	"testing"
@@ -79,4 +77,3 @@ resource "google_firestore_database" "default" {
 }
 `, randomSuffix, randomSuffix, orgId, concurrencyMode)
 }
-<% end -%>


### PR DESCRIPTION
Promotes Firestore (default) database support to GA

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- []  [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: Promote `google_firestore_database` to GA
```
