### PR TITLE
Fix the KCC provider templates

### DIFF
--- a/mmv1/templates/kcc/product/service_mapping.yaml.erb
+++ b/mmv1/templates/kcc/product/service_mapping.yaml.erb
@@ -1,7 +1,7 @@
 <%
 autogen_exception
 -%>
-# Copyright 2023 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,11 +26,15 @@ spec:
   serviceHostName: <%= product.name.downcase %>.googleapis.com
   resources:
 <%
-  product.objects.reject { |r| r.exclude || r.not_in_version?(product.version_obj_or_closest(version)) }.each do |object|
-    if @config.legacy_name.nil?
-     terraform_name = "google_" + (product.name + object.name).underscore
+  product.objects.reject { |r| r.exclude || r.exclude_resource || r.not_in_version?(product.version_obj_or_closest(version)) }.each do |object|
+    if object.legacy_name.nil?
+      if @config.legacy_name.nil?
+        terraform_name = "google_" + (product.name + object.name).underscore
+      else
+        terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+      end
     else
-     terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+      terraform_name = object.legacy_name
     end
 -%>
     - name: <%= terraform_name %>
@@ -40,7 +44,7 @@ spec:
       # idTemplate is an import id fed into the provider, which is (slightly)
       # distinct from a Terraform id.
       # Select the first format, which will generally be the long form.
-      id_template = import_id_formats_from_resource(object)[0]
+      id_template = import_id_formats_from_resource(object)[0].gsub('%', '')
       name = guess_metadata_mapping_name(object)
       has_name = !name.nil?
       has_labels = object.all_user_properties.map(&:name).include?("labels")

--- a/mmv1/templates/kcc/samples/sample.tf.erb
+++ b/mmv1/templates/kcc/samples/sample.tf.erb
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Used `legacy_name` as the TF resource name when it exists. (b/270770142)
* Excluded resources with `exclude_resource: true` configured as they are dummy resource configuration used for IAM support. (b/270770611)
* Changed to year 2022 in license header for service mapping and sample templates. (b/270770609)
* Cleaned up the unexpected `%` in idTemplate. (b/270770621)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
