### PR TITLE
Adding support for big query capacity commitments

### DIFF
--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -86,10 +86,3 @@ properties:
     name: 'renewalPlan'
     description: |
       The plan this capacity commitment is converted to after commitmentEndTime passes. Once the plan is changed, committed period is extended according to commitment plan. Only applicable for ANNUAL and TRIAL commitments.
-  - !ruby/object:Api::Type::Boolean
-    name: 'multiRegionAuxiliary'
-    input: true
-    description: |
-      Applicable only for commitments located within one of the BigQuery multi-regions (US or EU).
-
-      If set to true, this commitment is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this commitment is placed in the organization's default region.

--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -1,0 +1,95 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'CapacityCommitment'
+base_url: projects/{{project}}/locations/{{location}}/capacityCommitments
+create_url: projects/{{project}}/locations/{{location}}/capacityCommitments?capacityCommitmentId={{capacity_commitment_id}}
+self_link: "{{name}}"
+update_verb: :PATCH
+update_mask: true
+description: |
+  Capacity commitment is a way to purchase compute capacity for BigQuery jobs (in the form of slots) with some committed period of usage. Annual commitments renew by default. Commitments can be removed after their commitment end time passes.
+
+  In order to remove annual commitment, its plan needs to be changed to monthly or flex first.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    "Introduction to Reservations": "https://cloud.google.com/bigquery/docs/reservations-intro"
+  api: "https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1/projects.locations.capacityCommitments"
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'capacityCommitmentId'
+    url_param_only: true
+    input: true
+    description: |
+      The optional capacity commitment ID. Capacity commitment name will be generated automatically if this field is
+      empty. This field must only contain lower case alphanumeric characters or dashes. The first and last character
+      cannot be a dash. Max length is 64 characters. NOTE: this ID won't be kept if the capacity commitment is split
+      or merged.
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    url_param_only: true
+    input: true
+    default_value: US
+    description: |
+      The geographic location where the transfer config should reside.
+      Examples: US, EU, asia-northeast1. The default value is US.
+  - !ruby/object:Api::Type::String
+    name: 'enforceSingleAdminProjectPerOrg'
+    url_param_only: true
+    input: true
+    description: |
+      If true, fail the request if another project in the organization has a capacity commitment.
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    output: true
+    description: |
+      The resource name of the capacity commitment, e.g., projects/myproject/locations/US/capacityCommitments/123
+  - !ruby/object:Api::Type::Integer
+    name: 'slotCount'
+    required: true
+    input: true
+    description: |
+      Number of slots in this commitment.
+  - !ruby/object:Api::Type::String
+    name: 'plan'
+    required: true
+    description: |
+      Capacity commitment plan. Valid values are FLEX, TRIAL, MONTHLY, ANNUAL
+  - !ruby/object:Api::Type::String
+    name: 'state'
+    output: true
+    description: |
+      State of the commitment
+  - !ruby/object:Api::Type::Time
+    name: 'commitmentStartTime'
+    output: true
+    description: |
+      The start of the current commitment period. It is applicable only for ACTIVE capacity commitments.
+  - !ruby/object:Api::Type::Time
+    name: 'commitmentEndTime'
+    output: true
+    description: |
+      The start of the current commitment period. It is applicable only for ACTIVE capacity commitments.
+  - !ruby/object:Api::Type::String
+    name: 'renewalPlan'
+    description: |
+      The plan this capacity commitment is converted to after commitmentEndTime passes. Once the plan is changed, committed period is extended according to commitment plan. Only applicable for ANNUAL and TRIAL commitments.
+  - !ruby/object:Api::Type::Boolean
+    name: 'multiRegionAuxiliary'
+    input: true
+    description: |
+      Applicable only for commitments located within one of the BigQuery multi-regions (US or EU).
+
+      If set to true, this commitment is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this commitment is placed in the organization's default region.

--- a/mmv1/products/bigqueryreservation/terraform.yaml
+++ b/mmv1/products/bigqueryreservation/terraform.yaml
@@ -24,12 +24,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           name: 'my-reservation'
   CapacityCommitment: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "{{name}}"
+    import_format: ["{{name}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_reservation_capacity_commitment_basic"
+        pull_external: true
         primary_resource_id: "commitment"
-        vars:
-          name: 'my-commitment'          
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/self_link_as_name.erb
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/products/bigqueryreservation/terraform.yaml
+++ b/mmv1/products/bigqueryreservation/terraform.yaml
@@ -23,6 +23,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "reservation"
         vars:
           name: 'my-reservation'
+  CapacityCommitment: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_reservation_capacity_commitment_basic"
+        primary_resource_id: "commitment"
+        vars:
+          name: 'my-commitment'          
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/products/bigqueryreservation/terraform.yaml
+++ b/mmv1/products/bigqueryreservation/terraform.yaml
@@ -30,7 +30,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_reservation_capacity_commitment_basic"
         pull_external: true
+        skip_docs: true
         primary_resource_id: "commitment"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_reservation_capacity_commitment_docs"
+        skip_test: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
 # This is for copying files over

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -1,8 +1,11 @@
 resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
-	capacity_commitment_id = "<%= ctx[:vars]['name'] %>"
-	location               = "asia-northeast1"
-	// Set to 0 for testing purposes
-	// In reality this would be larger than zero
-	slot_count = 0
+	location   = "us-west1"
+	slot_count = 100
 	plan       = "FLEX"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+	depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
+  # Only needed for CI tests to be able to tear down the commitment once it's expired
+  create_duration = "61s"
 }

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -4,8 +4,9 @@ resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>
 	plan       = "FLEX"
 }
 
-resource "time_sleep" "wait_60_seconds" {
+resource "time_sleep" "wait_61_seconds" {
 	depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
-  # Only needed for CI tests to be able to tear down the commitment once it's expired
-  create_duration = "61s"
+    
+	# Only needed for CI tests to be able to tear down the commitment once it's expired
+    create_duration = "61s"
 }

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -1,0 +1,8 @@
+resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
+	capacity_commitment_id = "<%= ctx[:vars]['name'] %>"
+	location               = "asia-northeast1"
+	// Set to 0 for testing purposes
+	// In reality this would be larger than zero
+	slot_count = 0
+	plan       = "FLEX"
+}

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_docs.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_docs.tf.erb
@@ -1,0 +1,7 @@
+resource "google_bigquery_capacity_commitment" "example" {
+	capacity_commitment_id = "example-commitment"
+
+	location   = "us-west1"
+	slot_count = 100
+	plan       = "FLEX"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

New resource for making big query capacity commitments

Borrowed lovingly from https://github.com/GoogleCloudPlatform/magic-modules/pull/6690
fixes: https://github.com/hashicorp/terraform-provider-google/issues/6694

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_bigquery_capacity_commitment`
```
