### PR TITLE
Bootstrap network cleanup

### DIFF
--- a/mmv1/products/alloydb/terraform.yaml
+++ b/mmv1/products/alloydb/terraform.yaml
@@ -76,11 +76,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           alloydb_instance_name: "alloydb-instance"
           network_name: "alloydb-network"
         test_vars_overrides:
-          network_name: 'BootstrapSharedTestNetwork(t, "alloydb")'
+          network_name: 'BootstrapSharedTestNetwork(t, "alloydb-basic")'
         ignore_read_extra:
           - "reconciling"
           - "update_time"
-    examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "alloydb_backup_full"
         primary_resource_id: "default"
@@ -90,7 +89,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           alloydb_instance_name: "alloydb-instance"
           network_name: "alloydb-network"
         test_vars_overrides:
-          network_name: 'BootstrapSharedTestNetwork(t, "alloydb")'
+          network_name: 'BootstrapSharedTestNetwork(t, "alloydb-full")'
         ignore_read_extra:
           - "reconciling"
           - "update_time"

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -46,7 +46,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           instance_name: "ha-memory-cache-persis"
           network_name: "redis-test-network"
         test_vars_overrides:
-          network_name: 'BootstrapSharedTestNetwork(t, "redis-mrr")'
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-full-persis")'
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_private_service"
         # Temporary for servicenetworking problems

--- a/mmv1/products/vertexai/terraform.yaml
+++ b/mmv1/products/vertexai/terraform.yaml
@@ -69,9 +69,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           address_name: "address-name"
           kms_key_name: "kms-name"
           network_name: "network-name"
-        test_vars_overrides:
-          kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
-          network_name: 'BootstrapSharedTestNetwork(t, "vertex")'
     properties:
       etag: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/third_party/terraform/tests/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_backup_test.go
@@ -10,7 +10,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  BootstrapSharedTestNetwork(t, "alloydb"),
+		"network_name":  BootstrapSharedTestNetwork(t, "alloydb-update"),
 		"random_suffix": RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_vertex_ai_endpoint_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vertex_ai_endpoint_test.go
@@ -29,7 +29,7 @@ func TestAccVertexAIEndpoint_vertexAiEndpointNetwork(t *testing.T) {
 	context := map[string]interface{}{
 		"endpoint_name": fmt.Sprint(RandInt(t) % 9999999999),
 		"kms_key_name":  BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
-		"network_name":  BootstrapSharedTestNetwork(t, "vertex"),
+		"network_name":  BootstrapSharedTestNetwork(t, "vertex-ai-endpoint-update"),
 		"random_suffix": RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -255,14 +255,23 @@ func BootstrapSharedTestADDomain(t *testing.T, testId string, networkName string
 
 const SharedTestNetworkPrefix = "tf-bootstrap-net-"
 
-// BootstrapSharedTestNetwork will return a shared compute network
-// for a test or set of tests. Often resources create complementing
-// tenant network resources, which we don't control and which don't get cleaned
-// up after our owned resource is deleted in test. These tenant resources
-// have quotas, so creating a shared test network prevents hitting these limits.
+// BootstrapSharedTestNetwork will return a persistent compute network for a
+// test or set of tests.
 //
-// testId specifies the test/suite for which a shared network is used/initialized.
-// Returns the name of an network, creating it if hasn't been created in the test projcet.
+// Resources like service_networking_connection use a consumer network and
+// create a complementing tenant network which we don't control. These tenant
+// networks never get cleaned up and they can accumulate to the point where a
+// limit is reached for the organization. By reusing a consumer network across
+// test runs, we can reduce the number of tenant networks that are needed.
+// See b/146351146 for more context.
+//
+// testId specifies the test for which a shared network is used/initialized.
+// Note that if the network is being used for a service_networking_connection,
+// the same testId should generally not be used across tests, to avoid race
+// conditions where multiple tests attempt to modify the connection at once.
+//
+// Returns the name of a network, creating it if it hasn't been created in the
+// test project.
 func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 	project := GetTestProjectFromEnv()
 	networkName := SharedTestNetworkPrefix + testId


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/13275
fixes https://github.com/hashicorp/terraform-provider-google/issues/13276

This change clarifies the way bootstrapped networks are intended to be used, and cleans up areas where we currently use them. In short, we almost always use these to avoid quota issues with `service_networking_connection`s, and when we do that, we cannot be reusing the `testId` across tests.

**NOTE:** After merging, we will want to clean up the bootstrapped networks that are no longer in use from all projects:
- `alloydb`
- `vertex`

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
