### PR TITLE
Update BootstrapProject to support use across multiple projects/environments

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -4447,7 +4447,7 @@ func TestAccContainerCluster_failedCreation(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", RandString(t, 10))
 
-	project := BootstrapProject(t, "tf-fail-cluster-test", GetTestBillingAccountFromEnv(t), []string{"container.googleapis.com"})
+	project := BootstrapProject(t, "tf-fail-cluster-", GetTestBillingAccountFromEnv(t), []string{"container.googleapis.com"})
 	removeContainerServiceAgentRoleFromContainerEngineRobot(t, project)
 
 	VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -418,11 +418,16 @@ func removeContainerServiceAgentRoleFromContainerEngineRobot(t *testing.T, proje
 	}
 }
 
-func BootstrapProject(t *testing.T, projectID, billingAccount string, services []string) *cloudresourcemanager.Project {
+// BootstrapProject will create or get a project named "<projectIDPrefix><testProjectFromEnv>"
+// that will persist across test runs. The reason for the naming is to isolate
+// bootstrapped projects by test environment.
+func BootstrapProject(t *testing.T, projectIDPrefix, billingAccount string, services []string) *cloudresourcemanager.Project {
 	config := BootstrapConfig(t)
 	if config == nil {
 		return nil
 	}
+
+	projectID := fmt.Printf("%s%s", projectIDPrefix, getTestProjectFromEnv(t))
 
 	crmClient := config.NewResourceManagerClient(config.UserAgent)
 

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -427,7 +427,7 @@ func BootstrapProject(t *testing.T, projectIDPrefix, billingAccount string, serv
 		return nil
 	}
 
-	projectID := fmt.Sprintf("%s%s", projectIDPrefix, getTestProjectFromEnv(t))
+	projectID := fmt.Sprintf("%s%s", projectIDPrefix, getTestProjectFromEnv())
 
 	crmClient := config.NewResourceManagerClient(config.UserAgent)
 

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -430,7 +430,7 @@ func BootstrapProject(t *testing.T, projectIDPrefix, billingAccount string, serv
 		return nil
 	}
 
-	projectIDSuffix := strings.Replace(getTestProjectFromEnv(), "ci-test-project-", "", 1)
+	projectIDSuffix := strings.Replace(GetTestProjectFromEnv(), "ci-test-project-", "", 1)
 	projectID := projectIDPrefix + projectIDSuffix
 
 	crmClient := config.NewResourceManagerClient(config.UserAgent)

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -427,7 +427,7 @@ func BootstrapProject(t *testing.T, projectIDPrefix, billingAccount string, serv
 		return nil
 	}
 
-	projectID := fmt.Printf("%s%s", projectIDPrefix, getTestProjectFromEnv(t))
+	projectID := fmt.Sprintf("%s%s", projectIDPrefix, getTestProjectFromEnv(t))
 
 	crmClient := config.NewResourceManagerClient(config.UserAgent)
 

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -418,16 +418,20 @@ func removeContainerServiceAgentRoleFromContainerEngineRobot(t *testing.T, proje
 	}
 }
 
-// BootstrapProject will create or get a project named "<projectIDPrefix><testProjectFromEnv>"
-// that will persist across test runs. The reason for the naming is to isolate
-// bootstrapped projects by test environment.
+// BootstrapProject will create or get a project named
+// "<projectIDPrefix><projectIDSuffix>" that will persist across test runs,
+// where projectIDSuffix is based off of getTestProjectFromEnv(). The reason
+// for the naming is to isolate bootstrapped projects by test environment.
+// Given the existing projects being used by our team, the prefix provided to
+// this function can be no longer than 18 characters.
 func BootstrapProject(t *testing.T, projectIDPrefix, billingAccount string, services []string) *cloudresourcemanager.Project {
 	config := BootstrapConfig(t)
 	if config == nil {
 		return nil
 	}
 
-	projectID := fmt.Sprintf("%s%s", projectIDPrefix, getTestProjectFromEnv())
+	projectIDSuffix = strings.Replace(getTestProjectFromEnv(), "ci-test-project-", "", 1)
+	projectID := projectIDPrefix + projectIDSuffix
 
 	crmClient := config.NewResourceManagerClient(config.UserAgent)
 

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -430,7 +430,7 @@ func BootstrapProject(t *testing.T, projectIDPrefix, billingAccount string, serv
 		return nil
 	}
 
-	projectIDSuffix = strings.Replace(getTestProjectFromEnv(), "ci-test-project-", "", 1)
+	projectIDSuffix := strings.Replace(getTestProjectFromEnv(), "ci-test-project-", "", 1)
 	projectID := projectIDPrefix + projectIDSuffix
 
 	crmClient := config.NewResourceManagerClient(config.UserAgent)


### PR DESCRIPTION
Only affects tests

With the project split work coming soon to support isolating our test environments, one of the issues we run into is that the projects for all 3 environments are occupying the same space. This is problematic for bootstrapped projects, because each environment will attempt to use the same project for these tests (and potentially do other things like change billing account or permissions).

The fix proposed here is to simply append the "environment test project" id to the end of the bootstrapped project id. This way, each environment will end up creating a unique project that is owned by that environment.

I'm not sure if this will fix https://github.com/hashicorp/terraform-provider-google/issues/13711, but it's possible, because I think we started seeing issues that as soon as the new GA project started running. If not, then I can follow up after this gets merged to double check that there is not some other issue related to the multiple environments.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
