### PR TITLE
Add new getter for Config.userAgent and Config.client and add iam_storage_bucket for terraform validator

### DIFF
--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -329,7 +329,9 @@ module Provider
                        ['converters/google/resources/storage_bucket_iam.go',
                         'third_party/validator/storage_bucket_iam.go'],
                        ['converters/google/resources/organization_policy.go',
-                        'third_party/validator/organization_policy.go']
+                        'third_party/validator/organization_policy.go'],
+                       ['converters/google/resources/iam_storage_bucket.go',
+                        'third_party/validator/iam_storage_bucket.go']
                      ])
     end
 

--- a/mmv1/third_party/validator/getconfig.go
+++ b/mmv1/third_party/validator/getconfig.go
@@ -17,6 +17,16 @@ func (c *Config) Client() *http.Client {
 	return c.client
 }
 
+// Return the value of the private userAgent field
+func (c *Config) GetUserAgent() string {
+	return c.userAgent
+}
+
+// Return the value of the private client field
+func (c *Config) GetClient() *http.Client {
+	return c.client
+}
+
 func NewConfig(ctx context.Context, project, zone, region string, offline bool, userAgent string, client *http.Client) (*Config, error) {
 	cfg := &Config{
 		Project:   project,

--- a/mmv1/third_party/validator/getconfig_test.go
+++ b/mmv1/third_party/validator/getconfig_test.go
@@ -122,7 +122,7 @@ func TestNewConfigUserAgent(t *testing.T) {
 				t.Fatalf("error building config: %s", err)
 			}
 
-			assert.Equal(t, c.expected, cfg.UserAgent())
+			assert.Equal(t, c.expected, cfg.GetUserAgent())
 		})
 	}
 }
@@ -135,7 +135,7 @@ func TestNewConfigUserAgent_nilClientUsesDefault(t *testing.T) {
 		t.Fatalf("error building config: %s", err)
 	}
 
-	assert.NotEmpty(t, cfg.Client())
+	assert.NotEmpty(t, cfg.GetClient())
 }
 
 func TestNewConfigUserAgent_usesPassedClient(t *testing.T) {
@@ -147,5 +147,5 @@ func TestNewConfigUserAgent_usesPassedClient(t *testing.T) {
 		t.Fatalf("error building config: %s", err)
 	}
 
-	assert.Exactly(t, client, cfg.Client())
+	assert.Exactly(t, client, cfg.GetClient())
 }

--- a/mmv1/third_party/validator/iam_storage_bucket.go
+++ b/mmv1/third_party/validator/iam_storage_bucket.go
@@ -1,0 +1,160 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+var StorageBucketIamSchema = map[string]*schema.Schema{
+	"bucket": {
+		Type:             schema.TypeString,
+		Required:         true,
+		ForceNew:         true,
+		DiffSuppressFunc: StorageBucketDiffSuppress,
+	},
+}
+
+func StorageBucketDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	return compareResourceNames("", old, new, nil)
+}
+
+type StorageBucketIamUpdater struct {
+	bucket string
+	d      TerraformResourceData
+	Config *Config
+}
+
+func StorageBucketIamUpdaterProducer(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
+	values := make(map[string]string)
+
+	if v, ok := d.GetOk("bucket"); ok {
+		values["bucket"] = v.(string)
+	}
+
+	// We may have gotten either a long or short name, so attempt to parse long name if possible
+	m, err := getImportIdQualifiers([]string{"b/(?P<bucket>[^/]+)", "(?P<bucket>[^/]+)"}, d, config, d.Get("bucket").(string))
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range m {
+		values[k] = v
+	}
+
+	u := &StorageBucketIamUpdater{
+		bucket: values["bucket"],
+		d:      d,
+		Config: config,
+	}
+
+	if err := d.Set("bucket", u.GetResourceId()); err != nil {
+		return nil, fmt.Errorf("Error setting bucket: %s", err)
+	}
+
+	return u, nil
+}
+
+func StorageBucketIdParseFunc(d *schema.ResourceData, config *Config) error {
+	values := make(map[string]string)
+
+	m, err := getImportIdQualifiers([]string{"b/(?P<bucket>[^/]+)", "(?P<bucket>[^/]+)"}, d, config, d.Id())
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		values[k] = v
+	}
+
+	u := &StorageBucketIamUpdater{
+		bucket: values["bucket"],
+		d:      d,
+		Config: config,
+	}
+	if err := d.Set("bucket", u.GetResourceId()); err != nil {
+		return fmt.Errorf("Error setting bucket: %s", err)
+	}
+	d.SetId(u.GetResourceId())
+	return nil
+}
+
+func (u *StorageBucketIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
+	url, err := u.qualifyBucketUrl("iam")
+	if err != nil {
+		return nil, err
+	}
+
+	var obj map[string]interface{}
+	url, err = addQueryParams(url, map[string]string{"optionsRequestedPolicyVersion": fmt.Sprintf("%d", iamPolicyVersion)})
+	if err != nil {
+		return nil, err
+	}
+
+	userAgent, err := generateUserAgentString(u.d, u.Config.userAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := sendRequest(u.Config, "GET", "", url, userAgent, obj)
+	if err != nil {
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
+	}
+
+	out := &cloudresourcemanager.Policy{}
+	err = Convert(policy, out)
+	if err != nil {
+		return nil, errwrap.Wrapf("Cannot convert a policy to a resource manager policy: {{err}}", err)
+	}
+
+	return out, nil
+}
+
+func (u *StorageBucketIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Policy) error {
+	json, err := ConvertToMap(policy)
+	if err != nil {
+		return err
+	}
+
+	obj := json
+
+	url, err := u.qualifyBucketUrl("iam")
+	if err != nil {
+		return err
+	}
+
+	userAgent, err := generateUserAgentString(u.d, u.Config.userAgent)
+	if err != nil {
+		return err
+	}
+
+	_, err = sendRequestWithTimeout(u.Config, "PUT", "", url, userAgent, obj, u.d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
+	}
+
+	return nil
+}
+
+func (u *StorageBucketIamUpdater) qualifyBucketUrl(methodIdentifier string) (string, error) {
+	urlTemplate := fmt.Sprintf("{{StorageBasePath}}%s/%s", fmt.Sprintf("b/%s", u.bucket), methodIdentifier)
+	url, err := replaceVars(u.d, u.Config, urlTemplate)
+	if err != nil {
+		return "", err
+	}
+	return url, nil
+}
+
+func (u *StorageBucketIamUpdater) GetResourceId() string {
+	return fmt.Sprintf("b/%s", u.bucket)
+}
+
+func (u *StorageBucketIamUpdater) GetMutexKey() string {
+	return fmt.Sprintf("iam-storage-bucket-%s", u.GetResourceId())
+}
+
+func (u *StorageBucketIamUpdater) DescribeResource() string {
+	return fmt.Sprintf("storage bucket %q", u.GetResourceId())
+}


### PR DESCRIPTION
…rage_bucket for terraform validator

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

1. Add new getter for Config.userAgent and Config.client. Then there will be another PR to remove the current methods UserAgent and Client.  Because the fields UserAgent and Client of Config will become public by capitalizing the names. The field names and method names cannot be the same.

2. Add iam_storage_bucket for terraform validator



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
