### PR TITLE
Randomize NEG name to avoid 409 error

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_region_network_endpoint_group_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_network_endpoint_group_test.go.erb
@@ -40,38 +40,38 @@ func TestAccComputeRegionNetworkEndpointGroup_negWithServerlessDeployment(t *tes
 func testAccComputeRegionNetworkEndpointGroup_negWithServerlessDeployment(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_api_gateway_api" "api_gw" {
-	api_id = "tf-test-%{random_suffix}"
+  api_id = "tf-test-%{random_suffix}"
 }
-		
+
 resource "google_api_gateway_api_config" "api_gw" {
-	api = google_api_gateway_api.api_gw.api_id
-	api_config_id = "tf-test-config-%{random_suffix}"
+  api = google_api_gateway_api.api_gw.api_id
+  api_config_id = "tf-test-config-%{random_suffix}"
 
-	openapi_documents {
-		document {
-			path = "spec.yaml"
-			contents = filebase64("test-fixtures/apigateway/openapi.yaml")
-		}
-	}
+  openapi_documents {
+    document {
+      path = "spec.yaml"
+      contents = filebase64("test-fixtures/apigateway/openapi.yaml")
+    }
+  }
 
-	lifecycle {
-		create_before_destroy = true
-	}
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_api_gateway_gateway" "api_gw" {
-	api_config = google_api_gateway_api_config.api_gw.id
-	gateway_id = "tf-test-%{random_suffix}"
+  api_config = google_api_gateway_api_config.api_gw.id
+  gateway_id = "tf-test-%{random_suffix}"
 }
 
 resource "google_compute_region_network_endpoint_group" "test_neg" {
-	name                  = "test-serverless-neg"
-	network_endpoint_type = "SERVERLESS"
-	region                = "us-central1"
-	serverless_deployment {
-		platform = "apigateway.googleapis.com"
-		url_mask = format("<gateway>%s/hello", trimprefix(google_api_gateway_gateway.api_gw.default_hostname, "tf-test-%{random_suffix}"))
-	}
+  name                  = "tf-test-neg-%{random_suffix}"
+  network_endpoint_type = "SERVERLESS"
+  region                = "us-central1"
+  serverless_deployment {
+    platform = "apigateway.googleapis.com"
+    url_mask = format("<gateway>%s/hello", trimprefix(google_api_gateway_gateway.api_gw.default_hostname, "tf-test-%{random_suffix}"))
+  }
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/13717

Also made the indentation more consistent with the rest of the tests.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
