### PR TITLE
Update privateca_certificate related tests and examples to not use shared CaPool

### DIFF
--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -131,46 +131,37 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "privateca_certificate_config"
         primary_resource_id: "default"
         vars:
-          certificate_authority_id: "my-certificate-authority"
+          ca_pool_id: "my-pool"
           certificate_name: "my-certificate"
         test_env_vars:
           project: :PROJECT_NAME
-        test_vars_overrides:
-          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_with_template"
         primary_resource_id: "default"
         vars:
+          ca_pool_id: "my-pool"
           certificate_name: "my-certificate"
-          certificate_authority_id: "my-certificate-authority"
           certificate_template_name: "my-certificate-template"
         test_env_vars:
           project: :PROJECT_NAME
-        test_vars_overrides:
-          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_csr"
         primary_resource_id: "default"
         vars:
           certificate_name: "my-certificate"
-          certificate_authority_id: "my-certificate-authority"
+          ca_pool_id: "my-pool"
         test_env_vars:
           project: :PROJECT_NAME
-        test_vars_overrides:
-          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_no_authority"
         primary_resource_id: "default"
         vars:
           certificate_name: "my-certificate"
-          certificate_authority_id: "my-authority"
+          ca_pool_id: "my-pool"
         test_env_vars:
           project: :PROJECT_NAME
-        test_vars_overrides:
-          pool: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/privateca_certificate.go.erb
-      test_check_destroy: templates/terraform/custom_check_destroy/privateca_certificate.go.erb
   CaPool: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       issuancePolicy.baselineValues: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
@@ -1,8 +1,14 @@
 # [START privateca_create_certificate_config]
-resource "google_privateca_certificate_authority" "test-ca" {
-  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+resource "google_privateca_ca_pool" "default" {
   location = "us-central1"
-  pool = "<%= ctx[:vars]["pool"] %>"
+  name = "<%= ctx[:vars]["ca_pool_id"] %>"
+  tier = "ENTERPRISE"
+}
+
+resource "google_privateca_certificate_authority" "default" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority_id = "my-authority"
   config {
     subject_config {
       subject {
@@ -39,9 +45,9 @@ resource "google_privateca_certificate_authority" "test-ca" {
 }
 
 resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
-  pool = "<%= ctx[:vars]["pool"] %>"
   location = "us-central1"
-  certificate_authority = google_privateca_certificate_authority.test-ca.certificate_authority_id
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority = google_privateca_certificate_authority.default.certificate_authority_id
   lifetime = "860s"
   name = "<%= ctx[:vars]["certificate_name"] %>"
   config {

--- a/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
@@ -1,8 +1,14 @@
 # [START privateca_create_certificate_csr]
-resource "google_privateca_certificate_authority" "test-ca" {
-  pool = "<%= ctx[:vars]["pool"] %>"
-  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+resource "google_privateca_ca_pool" "default" {
   location = "us-central1"
+  name = "<%= ctx[:vars]["ca_pool_id"] %>"
+  tier = "ENTERPRISE"
+}
+
+resource "google_privateca_certificate_authority" "default" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority_id = "my-authority"
   config {
     subject_config {
       subject {
@@ -42,11 +48,11 @@ resource "google_privateca_certificate_authority" "test-ca" {
 
 
 resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
-  pool = "<%= ctx[:vars]["pool"] %>"
   location = "us-central1"
-  certificate_authority = google_privateca_certificate_authority.test-ca.certificate_authority_id
-  lifetime = "860s"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority = google_privateca_certificate_authority.default.certificate_authority_id
   name = "<%= ctx[:vars]["certificate_name"] %>"
+  lifetime = "860s"
   pem_csr = file("test-fixtures/rsa_csr.pem")
 }
 # [END privateca_create_certificate_csr]

--- a/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
@@ -1,10 +1,14 @@
 # [START privateca_create_certificate]
-resource "google_privateca_certificate_authority" "authority" {
-  // This example assumes this pool already exists.
-  // Pools cannot be deleted in normal test circumstances, so we depend on static pools
-  pool = "<%= ctx[:vars]["pool"] %>"
-  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+resource "google_privateca_ca_pool" "default" {
   location = "us-central1"
+  name = "<%= ctx[:vars]["ca_pool_id"] %>"
+  tier = "ENTERPRISE"
+}
+
+resource "google_privateca_certificate_authority" "default" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority_id = "my-authority"
   config {
     subject_config {
       subject {
@@ -44,10 +48,10 @@ resource "google_privateca_certificate_authority" "authority" {
 
 
 resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
-  pool = "<%= ctx[:vars]["pool"] %>"
   location = "us-central1"
-  lifetime = "860s"
+  pool = google_privateca_ca_pool.default.name
   name = "<%= ctx[:vars]["certificate_name"] %>"
+  lifetime = "860s"
   config {
     subject_config  {
       subject {
@@ -81,6 +85,6 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
   }
   // Certificates require an authority to exist in the pool, though they don't
   // need to be explicitly connected to it
-  depends_on = [google_privateca_certificate_authority.authority]
+  depends_on = [google_privateca_certificate_authority.default]
 }
 # [END privateca_create_certificate]

--- a/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
@@ -1,5 +1,11 @@
 # [START privateca_create_certificate_template]
-resource "google_privateca_certificate_template" "template" {
+resource "google_privateca_ca_pool" "default" {
+  location = "us-central1"
+  name = "<%= ctx[:vars]["ca_pool_id"] %>"
+  tier = "ENTERPRISE"
+}
+
+resource "google_privateca_certificate_template" "default" {
   location    = "us-central1"
   name = "<%= ctx[:vars]["certificate_template_name"] %>"
   description = "An updated sample certificate template"
@@ -74,10 +80,10 @@ resource "google_privateca_certificate_template" "template" {
   }
 }
 
-resource "google_privateca_certificate_authority" "test-ca" {
-  pool = "<%= ctx[:vars]["pool"] %>"
-  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+resource "google_privateca_certificate_authority" "default" {
   location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority_id = "my-authority"
   config {
     subject_config {
       subject {
@@ -117,12 +123,12 @@ resource "google_privateca_certificate_authority" "test-ca" {
 
 
 resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
-  pool = "<%= ctx[:vars]["pool"] %>"
   location = "us-central1"
-  certificate_authority = google_privateca_certificate_authority.test-ca.certificate_authority_id
-  lifetime = "860s"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority = google_privateca_certificate_authority.default.certificate_authority_id
   name = "<%= ctx[:vars]["certificate_name"] %>"
+  lifetime = "860s"
   pem_csr = file("test-fixtures/rsa_csr.pem")
-  certificate_template = google_privateca_certificate_template.template.id
+  certificate_template = google_privateca_certificate_template.default.id
 }
 # [END privateca_create_certificate_template]


### PR DESCRIPTION

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix https://github.com/hashicorp/terraform-provider-google/issues/13715


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: none

```
