### PR TITLE
Remove use of `make generate` from TPG/TPGB-specific step in CI

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -170,10 +170,6 @@ popd
 
 pushd $LOCAL_PATH
 
-if [ "$REPO" == "terraform" ]; then
-    make generate
-fi
-
 git config --local user.name "Modular Magician"
 git config --local user.email "magic-modules@google.com"
 git add .


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to this issue https://github.com/hashicorp/terraform-provider-google/issues/13864

This PR removes a step that was originally added to generate files used to control the sidebar in the Registry's UI for browsing documentation.

The sidebar of the documentation is now 100% controlled by [YAML frontmatter in documentation files](https://developer.hashicorp.com/terraform/registry/providers/docs#yaml-frontmatter). In [a recent cleanup](https://github.com/GoogleCloudPlatform/magic-modules/pull/6238/files#diff-db33af93ae5c09fe3bb4ad76bc3ad462d0dfd96f32d49d980d9c5782bf891271) the file used by the `make generate` command was removed. From this, we can see this step in the CI is not performing any function.

I figured it was safer to remove the step from the CI before to removing the target from the Makefile later.

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] ~~Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).~~
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~
- [x] ~~[Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.~~
- [x] ~~[Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).~~
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
