### PR TITLE
Fix ComposerEnvironment tests to use explicit image version

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_composer_environment_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_composer_environment_test.go
@@ -86,6 +86,9 @@ resource "google_composer_environment" "test" {
 			subnetwork = google_compute_subnetwork.test.self_link
 			zone       = "us-central1-a"
 		}
+		software_config {
+			image_version = "composer-1-airflow-2"
+		}
 	}
 }
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1005,6 +1005,9 @@ resource "google_composer_environment" "test" {
         cluster_ipv4_cidr_block = "10.0.0.0/16"
       }
     }
+    software_config {
+      image_version = "composer-1-airflow-2"
+    }
   }
 }
 
@@ -1040,6 +1043,9 @@ resource "google_composer_environment" "test" {
         use_ip_aliases          = true
         cluster_ipv4_cidr_block = "10.0.0.0/16"
       }
+    }
+    software_config {
+      image_version = "composer-1-airflow-2"
     }
     private_environment_config {
       enable_private_endpoint = true
@@ -1130,6 +1136,9 @@ resource "google_composer_environment" "test" {
       cloud_sql_ipv4_cidr_block = "10.32.0.0/12"
       master_ipv4_cidr_block =  "172.17.50.0/28"
     }
+    software_config {
+      image_version = "composer-1-airflow-2"
+    }
     web_server_network_access_control {
       allowed_ip_range {
         value = "192.168.0.1"
@@ -1182,6 +1191,9 @@ resource "google_composer_environment" "test" {
       cloud_sql_ipv4_cidr_block = "10.32.0.0/12"
       master_ipv4_cidr_block =  "172.17.50.0/28"
     }
+    software_config {
+      image_version = "composer-1-airflow-2"
+    }
     web_server_network_access_control {
       allowed_ip_range {
         value = "192.168.0.1"
@@ -1225,6 +1237,9 @@ resource "google_composer_environment" "test" {
     database_config {
       machine_type  = "db-n1-standard-4"
     }
+    software_config {
+      image_version = "composer-1-airflow-2"
+    }
   }
 }
 
@@ -1258,6 +1273,9 @@ resource "google_composer_environment" "test" {
     database_config {
       machine_type  = "db-n1-standard-8"
     }
+    software_config {
+      image_version = "composer-1-airflow-2"
+    }
   }
 }
 
@@ -1287,6 +1305,9 @@ resource "google_composer_environment" "test" {
       network    = google_compute_network.test.self_link
       subnetwork = google_compute_subnetwork.test.self_link
       zone       = "us-central1-a"
+    }
+    software_config {
+      image_version = "composer-1-airflow-2"
     }
     web_server_config {
       machine_type  = "composer-n1-webserver-4"
@@ -1320,6 +1341,9 @@ resource "google_composer_environment" "test" {
       network    = google_compute_network.test.self_link
       subnetwork = google_compute_subnetwork.test.self_link
       zone       = "us-central1-a"
+    }
+    software_config {
+      image_version = "composer-1-airflow-2"
     }
     web_server_config {
       machine_type  = "composer-n1-webserver-8"
@@ -1884,6 +1908,9 @@ resource "google_composer_environment" "test" {
         cluster_ipv4_cidr_block = "10.0.0.0/16"
       }
     }
+    software_config {
+      image_version = "composer-1-airflow-2"
+    }
   }
   depends_on = [google_project_iam_member.composer-worker]
 }
@@ -2051,6 +2078,7 @@ resource "google_composer_environment" "test" {
       zone       = "us-central1-a"
     }
     software_config {
+      image_version = "composer-1-airflow-2"
       pypi_packages = {
         numpy = ""
       }

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1006,7 +1006,7 @@ resource "google_composer_environment" "test" {
       }
     }
     software_config {
-      image_version = "composer-1-airflow-2"
+      image_version = "composer-1-airflow-2.3"
     }
   }
 }
@@ -1761,7 +1761,7 @@ resource "google_composer_environment" "test" {
     }
 
     software_config {
-      image_version = "composer-1-airflow-1"
+      image_version = "composer-1-airflow-2"
 
       airflow_config_overrides = {
         core-load_example = "True"


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/13879

This change fixes our tests to pass again. Meanwhile, we have filed a bug for the default version change with https://github.com/hashicorp/terraform-provider-google/issues/13901 and will be working with the team internally to find a resolution.

Depending on the outcome of that bug, we can consider reverting this PR to test the behavior when no version is set.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
