### PR TITLE
Feat name constraints

### DIFF
--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -351,6 +351,7 @@ properties:
             - !ruby/object:Api::Type::Boolean
               name: 'critical'
               description: Indicates whether or not the name constraints are marked critical.
+              required: true
             - !ruby/object:Api::Type::Array
               name: 'permittedDnsNames'
               description: |

--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -343,6 +343,78 @@ properties:
                       item_type: Api::Type::Integer
                       description: |
                         An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'nameConstraints'
+            description: |
+              Describes the X.509 name constraints extension.
+            properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'critical'
+              description: Indicates whether or not the name constraints are marked critical.
+            - !ruby/object:Api::Type::Array
+              name: 'permittedDnsNames'
+              description: |
+                Contains permitted DNS names. Any DNS name that can be
+                constructed by simply adding zero or more labels to
+                the left-hand side of the name satisfies the name constraint.
+                For example, `example.com`, `www.example.com`, `www.sub.example.com`
+                would satisfy `example.com` while `example1.com` does not.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedDnsNames'
+              description: |
+                Contains excluded DNS names. Any DNS name that can be
+                constructed by simply adding zero or more labels to
+                the left-hand side of the name satisfies the name constraint.
+                For example, `example.com`, `www.example.com`, `www.sub.example.com`
+                would satisfy `example.com` while `example1.com` does not.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedIpRanges'
+              description: |
+                Contains the permitted IP ranges. For IPv4 addresses, the ranges
+                are expressed using CIDR notation as specified in RFC 4632.
+                For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+                addresses.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedIpRanges'
+              description: |
+                Contains the excluded IP ranges. For IPv4 addresses, the ranges
+                are expressed using CIDR notation as specified in RFC 4632.
+                For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+                addresses.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedEmailAddresses'
+              description: |
+                Contains the permitted email addresses. The value can be a particular
+                email address, a hostname to indicate all email addresses on that host or
+                a domain with a leading period (e.g. `.example.com`) to indicate
+                all email addresses in that domain.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedEmailAddresses'
+              description: |
+                Contains the excluded email addresses. The value can be a particular
+                email address, a hostname to indicate all email addresses on that host or
+                a domain with a leading period (e.g. `.example.com`) to indicate
+                all email addresses in that domain.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedUris'
+              description: |
+                Contains the permitted URIs that apply to the host part of the name.
+                The value can be a hostname or a domain with a
+                leading period (like `.example.com`)
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedUris'
+              description: |
+                Contains the excluded URIs that apply to the host part of the name.
+                The value can be a hostname or a domain with a
+                leading period (like `.example.com`)
+              item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'publishingOptions'
     description: |

--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -413,6 +413,88 @@ properties:
                       description: |
                         An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.
                       output: true
+          - !ruby/object:Api::Type::NestedObject
+            name: 'nameConstraints'
+            description: |
+              Describes the X.509 name constraints extension.
+            output: true
+            properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'critical'
+              description: Indicates whether or not the name constraints are marked critical.
+              output: true
+            - !ruby/object:Api::Type::Array
+              name: 'permittedDnsNames'
+              description: |
+                Contains permitted DNS names. Any DNS name that can be
+                constructed by simply adding zero or more labels to
+                the left-hand side of the name satisfies the name constraint.
+                For example, `example.com`, `www.example.com`, `www.sub.example.com`
+                would satisfy `example.com` while `example1.com` does not.
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedDnsNames'
+              description: |
+                Contains excluded DNS names. Any DNS name that can be
+                constructed by simply adding zero or more labels to
+                the left-hand side of the name satisfies the name constraint.
+                For example, `example.com`, `www.example.com`, `www.sub.example.com`
+                would satisfy `example.com` while `example1.com` does not.
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedIpRanges'
+              description: |
+                Contains the permitted IP ranges. For IPv4 addresses, the ranges
+                are expressed using CIDR notation as specified in RFC 4632.
+                For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+                addresses.
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedIpRanges'
+              description: |
+                Contains the excluded IP ranges. For IPv4 addresses, the ranges
+                are expressed using CIDR notation as specified in RFC 4632.
+                For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+                addresses.
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedEmailAddresses'
+              description: |
+                Contains the permitted email addresses. The value can be a particular
+                email address, a hostname to indicate all email addresses on that host or
+                a domain with a leading period (e.g. `.example.com`) to indicate
+                all email addresses in that domain.
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedEmailAddresses'
+              description: |
+                Contains the excluded email addresses. The value can be a particular
+                email address, a hostname to indicate all email addresses on that host or
+                a domain with a leading period (e.g. `.example.com`) to indicate
+                all email addresses in that domain.
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedUris'
+              description: |
+                Contains the permitted URIs that apply to the host part of the name.
+                The value can be a hostname or a domain with a
+                leading period (like `.example.com`)
+              output: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedUris'
+              description: |
+                Contains the excluded URIs that apply to the host part of the name.
+                The value can be a hostname or a domain with a
+                leading period (like `.example.com`)
+              output: true
+              item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'configValues'
         deprecation_message: Deprecated in favor of `x509_description`.
@@ -864,6 +946,88 @@ properties:
                     description: |
                       An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.
                     immutable: true
+        - !ruby/object:Api::Type::NestedObject
+          name: 'nameConstraints'
+          description: |
+            Describes the X.509 name constraints extension.
+          immutable: true
+          properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'critical'
+            description: Indicates whether or not the name constraints are marked critical.
+            immutable: true
+          - !ruby/object:Api::Type::Array
+            name: 'permittedDnsNames'
+            description: |
+              Contains permitted DNS names. Any DNS name that can be
+              constructed by simply adding zero or more labels to
+              the left-hand side of the name satisfies the name constraint.
+              For example, `example.com`, `www.example.com`, `www.sub.example.com`
+              would satisfy `example.com` while `example1.com` does not.
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'excludedDnsNames'
+            description: |
+              Contains excluded DNS names. Any DNS name that can be
+              constructed by simply adding zero or more labels to
+              the left-hand side of the name satisfies the name constraint.
+              For example, `example.com`, `www.example.com`, `www.sub.example.com`
+              would satisfy `example.com` while `example1.com` does not.
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'permittedIpRanges'
+            description: |
+              Contains the permitted IP ranges. For IPv4 addresses, the ranges
+              are expressed using CIDR notation as specified in RFC 4632.
+              For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+              addresses.
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'excludedIpRanges'
+            description: |
+              Contains the excluded IP ranges. For IPv4 addresses, the ranges
+              are expressed using CIDR notation as specified in RFC 4632.
+              For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+              addresses.
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'permittedEmailAddresses'
+            description: |
+              Contains the permitted email addresses. The value can be a particular
+              email address, a hostname to indicate all email addresses on that host or
+              a domain with a leading period (e.g. `.example.com`) to indicate
+              all email addresses in that domain.
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'excludedEmailAddresses'
+            description: |
+              Contains the excluded email addresses. The value can be a particular
+              email address, a hostname to indicate all email addresses on that host or
+              a domain with a leading period (e.g. `.example.com`) to indicate
+              all email addresses in that domain.
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'permittedUris'
+            description: |
+              Contains the permitted URIs that apply to the host part of the name.
+              The value can be a hostname or a domain with a
+              leading period (like `.example.com`)
+            immutable: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'excludedUris'
+            description: |
+              Contains the excluded URIs that apply to the host part of the name.
+              The value can be a hostname or a domain with a
+              leading period (like `.example.com`)
+            immutable: true
+            item_type: Api::Type::String
     - !ruby/object:Api::Type::NestedObject
       name: 'subjectConfig'
       description: |

--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -956,6 +956,7 @@ properties:
             name: 'critical'
             description: Indicates whether or not the name constraints are marked critical.
             immutable: true
+            required: true
           - !ruby/object:Api::Type::Array
             name: 'permittedDnsNames'
             description: |

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -313,6 +313,88 @@ properties:
                       item_type: Api::Type::Integer
                       description: |
                         An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'nameConstraints'
+            description: |
+              Describes the X.509 name constraints extension.
+            input: true
+            properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'critical'
+              description: Indicates whether or not the name constraints are marked critical.
+              input: true
+            - !ruby/object:Api::Type::Array
+              name: 'permittedDnsNames'
+              description: |
+                Contains permitted DNS names. Any DNS name that can be
+                constructed by simply adding zero or more labels to
+                the left-hand side of the name satisfies the name constraint.
+                For example, `example.com`, `www.example.com`, `www.sub.example.com`
+                would satisfy `example.com` while `example1.com` does not.
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedDnsNames'
+              description: |
+                Contains excluded DNS names. Any DNS name that can be
+                constructed by simply adding zero or more labels to
+                the left-hand side of the name satisfies the name constraint.
+                For example, `example.com`, `www.example.com`, `www.sub.example.com`
+                would satisfy `example.com` while `example1.com` does not.
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedIpRanges'
+              description: |
+                Contains the permitted IP ranges. For IPv4 addresses, the ranges
+                are expressed using CIDR notation as specified in RFC 4632.
+                For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+                addresses.
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedIpRanges'
+              description: |
+                Contains the excluded IP ranges. For IPv4 addresses, the ranges
+                are expressed using CIDR notation as specified in RFC 4632.
+                For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
+                addresses.
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedEmailAddresses'
+              description: |
+                Contains the permitted email addresses. The value can be a particular
+                email address, a hostname to indicate all email addresses on that host or
+                a domain with a leading period (e.g. `.example.com`) to indicate
+                all email addresses in that domain.
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedEmailAddresses'
+              description: |
+                Contains the excluded email addresses. The value can be a particular
+                email address, a hostname to indicate all email addresses on that host or
+                a domain with a leading period (e.g. `.example.com`) to indicate
+                all email addresses in that domain.
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'permittedUris'
+              description: |
+                Contains the permitted URIs that apply to the host part of the name.
+                The value can be a hostname or a domain with a
+                leading period (like `.example.com`)
+              input: true
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'excludedUris'
+              description: |
+                Contains the excluded URIs that apply to the host part of the name.
+                The value can be a hostname or a domain with a
+                leading period (like `.example.com`)
+              input: true
+              item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'subjectConfig'
         immutable: true

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -317,12 +317,13 @@ properties:
             name: 'nameConstraints'
             description: |
               Describes the X.509 name constraints extension.
-            input: true
+            immutable: true
             properties:
             - !ruby/object:Api::Type::Boolean
               name: 'critical'
               description: Indicates whether or not the name constraints are marked critical.
-              input: true
+              immutable: true
+              required: true
             - !ruby/object:Api::Type::Array
               name: 'permittedDnsNames'
               description: |
@@ -331,7 +332,7 @@ properties:
                 the left-hand side of the name satisfies the name constraint.
                 For example, `example.com`, `www.example.com`, `www.sub.example.com`
                 would satisfy `example.com` while `example1.com` does not.
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'excludedDnsNames'
@@ -341,7 +342,7 @@ properties:
                 the left-hand side of the name satisfies the name constraint.
                 For example, `example.com`, `www.example.com`, `www.sub.example.com`
                 would satisfy `example.com` while `example1.com` does not.
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'permittedIpRanges'
@@ -350,7 +351,7 @@ properties:
                 are expressed using CIDR notation as specified in RFC 4632.
                 For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
                 addresses.
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'excludedIpRanges'
@@ -359,7 +360,7 @@ properties:
                 are expressed using CIDR notation as specified in RFC 4632.
                 For IPv6 addresses, the ranges are expressed in similar encoding as IPv4
                 addresses.
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'permittedEmailAddresses'
@@ -368,7 +369,7 @@ properties:
                 email address, a hostname to indicate all email addresses on that host or
                 a domain with a leading period (e.g. `.example.com`) to indicate
                 all email addresses in that domain.
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'excludedEmailAddresses'
@@ -377,7 +378,7 @@ properties:
                 email address, a hostname to indicate all email addresses on that host or
                 a domain with a leading period (e.g. `.example.com`) to indicate
                 all email addresses in that domain.
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'permittedUris'
@@ -385,7 +386,7 @@ properties:
                 Contains the permitted URIs that apply to the host part of the name.
                 The value can be a hostname or a domain with a
                 leading period (like `.example.com`)
-              input: true
+              immutable: true
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'excludedUris'
@@ -393,7 +394,7 @@ properties:
                 Contains the excluded URIs that apply to the host part of the name.
                 The value can be a hostname or a domain with a
                 leading period (like `.example.com`)
-              input: true
+              immutable: true
               item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'subjectConfig'

--- a/mmv1/templates/terraform/custom_expand/privateca_certificate_509_config.go.erb
+++ b/mmv1/templates/terraform/custom_expand/privateca_certificate_509_config.go.erb
@@ -44,5 +44,10 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
         }
         transformed["additionalExtensions"] = addExts
 
+        nameConstraints, err := expandPrivatecaCertificateConfigX509ConfigNameConstraints(original["name_constraints"], d, config)
+        if err != nil {
+                return nil, err
+        }
+        transformed["nameConstraints"] = nameConstraints
         return transformed, nil
 }

--- a/mmv1/templates/terraform/custom_flatten/privateca_certificate_509_config.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/privateca_certificate_509_config.go.erb
@@ -14,5 +14,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		flattenPrivatecaCertificateConfigX509ConfigCaOptions(original["caOptions"], d, config)
 	transformed["key_usage"] =
 		flattenPrivatecaCertificateConfigX509ConfigKeyUsage(original["keyUsage"], d, config)
+	transformed["name_constraints"] =
+		flattenPrivatecaCertificateConfigX509ConfigNameConstraints(original["nameConstraints"], d, config)
 	return []interface{}{transformed}
 }

--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
@@ -73,6 +73,17 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
           time_stamping = true
         }
       }
+      name_constraints {
+        critical                  = true
+        permitted_dns_names       = ["*.example.com"]
+        excluded_dns_names        = ["*.deny.example.com"]
+        permitted_ip_ranges       = ["10.0.0.0/8"]
+        excluded_ip_ranges        = ["10.1.1.0/24"]
+        permitted_email_addresses = [".example.com"]
+        excluded_email_addresses  = [".deny.example.com"]
+        permitted_uris            = [".example.com"]
+        excluded_uris             = [".deny.example.com"]
+      }
     }
   }
 }

--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
@@ -75,14 +75,14 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
       }
       name_constraints {
         critical                  = true
-        permitted_dns_names       = ["*.example.com"]
-        excluded_dns_names        = ["*.deny.example.com"]
-        permitted_ip_ranges       = ["10.0.0.0/8"]
-        excluded_ip_ranges        = ["10.1.1.0/24"]
-        permitted_email_addresses = [".example.com"]
-        excluded_email_addresses  = [".deny.example.com"]
-        permitted_uris            = [".example.com"]
-        excluded_uris             = [".deny.example.com"]
+        permitted_dns_names       = ["*.example1.com", "*.example2.com"]
+        excluded_dns_names        = ["*.deny.example1.com", "*.deny.example2.com"]
+        permitted_ip_ranges       = ["10.0.0.0/8", "11.0.0.0/8"]
+        excluded_ip_ranges        = ["10.1.1.0/24", "11.1.1.0/24"]
+        permitted_email_addresses = [".example1.com", ".example2.com"]
+        excluded_email_addresses  = [".deny.example1.com", ".deny.example2.com"]
+        permitted_uris            = [".example1.com", ".example2.com"]
+        excluded_uris             = [".deny.example1.com", ".deny.example2.com"]
       }
     }
   }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
@@ -54,6 +54,17 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
           server_auth = false
         }
       }
+      name_constraints {
+        critical                  = true
+        permitted_dns_names       = ["*.example.com"]
+        excluded_dns_names        = ["*.deny.example.com"]
+        permitted_ip_ranges       = ["10.0.0.0/8"]
+        excluded_ip_ranges        = ["10.1.1.0/24"]
+        permitted_email_addresses = [".example.com"]
+        excluded_email_addresses  = [".deny.example.com"]
+        permitted_uris            = [".example.com"]
+        excluded_uris             = [".deny.example.com"]
+      }
     }
   }
 

--- a/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
@@ -48,7 +48,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
   location = "us-central1"
   pool = google_privateca_ca_pool.default.name
   certificate_authority = google_privateca_certificate_authority.default.certificate_authority_id
-  lifetime = "860s"
+  lifetime = "86000s"
   name = "<%= ctx[:vars]["certificate_name"] %>"
   config {
     subject_config  {
@@ -69,7 +69,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
-        is_ca = false
+        is_ca = true
       }
       key_usage {
         base_key_usage {
@@ -79,6 +79,17 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
         extended_key_usage {
           server_auth = false
         }
+      }
+      name_constraints {
+        critical                  = true
+        permitted_dns_names       = ["*.example.com"]
+        excluded_dns_names        = ["*.deny.example.com"]
+        permitted_ip_ranges       = ["10.0.0.0/8"]
+        excluded_ip_ranges        = ["10.1.1.0/24"]
+        permitted_email_addresses = [".example.com"]
+        excluded_email_addresses  = [".deny.example.com"]
+        permitted_uris            = [".example.com"]
+        excluded_uris             = [".deny.example.com"]
       }
     }
     public_key {

--- a/mmv1/third_party/terraform/utils/privateca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_utils.go
@@ -230,6 +230,37 @@ func expandPrivatecaCertificateConfigX509ConfigAiaOcspServers(v interface{}, d T
 	return v, nil
 }
 
+func expandPrivatecaCertificateConfigX509ConfigNameConstraints(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	if len(original) == 0 {
+		// Ignore empty name constraints
+		return nil, nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["critical"] = original["critical"]
+	transformed["permittedDnsNames"] = original["permitted_dns_names"]
+	transformed["excludedDnsNames"] = original["excluded_dns_names"]
+	transformed["permittedIpRanges"] = original["permitted_ip_ranges"]
+	transformed["excludedIpRanges"] = original["excluded_ip_ranges"]
+	transformed["permittedEmailAddresses"] = original["permitted_email_addresses"]
+	transformed["excludedEmailAddresses"] = original["excluded_email_addresses"]
+	transformed["permittedUris"] = original["permitted_uris"]
+	transformed["excludedUris"] = original["excluded_uris"]
+
+	return transformed, nil
+}
+
 // Flattener utilities
 
 func flattenPrivatecaCertificateConfigX509ConfigAdditionalExtensions(v interface{}, d *schema.ResourceData, config *Config) interface{} {
@@ -489,4 +520,24 @@ func flattenPrivatecaCertificateConfigX509ConfigKeyUsageUnknownExtendedKeyUsages
 }
 func flattenPrivatecaCertificateConfigX509ConfigKeyUsageUnknownExtendedKeyUsagesObjectIdPath(v interface{}, d *schema.ResourceData, config *Config) interface{} {
 	return v
+}
+
+func flattenPrivatecaCertificateConfigX509ConfigNameConstraints(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformed["critical"] = original["critical"]
+	transformed["permitted_dns_names"] = original["permittedDnsNames"]
+	transformed["excluded_dns_names"] = original["excludedDnsNames"]
+	transformed["permitted_ip_ranges"] = original["permittedIpRanges"]
+	transformed["excluded_ip_ranges"] = original["excludedIpRanges"]
+	transformed["permitted_email_addresses"] = original["permittedEmailAddresses"]
+	transformed["excluded_email_addresses"] = original["excludedEmailAddresses"]
+	transformed["permitted_uris"] = original["permittedUris"]
+	transformed["excluded_uris"] = original["excludedUris"]
+
+	return []interface{}{transformed}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for X.509 name constraints.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: added support for X.509 name constraints
```
