### PR TITLE
Update http_target uri of scheduler_job_http_tf

### DIFF
--- a/mmv1/templates/terraform/examples/scheduler_job_http.tf.erb
+++ b/mmv1/templates/terraform/examples/scheduler_job_http.tf.erb
@@ -11,7 +11,7 @@ resource "google_cloud_scheduler_job" "job" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://example.com/ping"
+    uri         = "https://example.com/"
     body        = base64encode("{\"foo\":\"bar\"}")
   }
 }


### PR DESCRIPTION
The http_target uri https://example.com/ping which is present in the given code gives an 404 error for a POST request. Hence I changed this uri to https://example.com/ which works fine. I know that this is just for user understanding and user can enter uri of his choice but still confusing since most of the people directly run this resource for testing purposes and since the uri gives an error the scheduler status on gcp spots as failed.

![image](https://user-images.githubusercontent.com/60532803/222710640-9759ca3a-05bd-43d4-a76b-a30ce46f0915.png)
 
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudscheduler: updated http_target uri of scheduler_job_http_tf
```