### PR TITLE
Support for bigquery data masking v1 api options

### DIFF
--- a/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
+++ b/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
@@ -80,4 +80,8 @@ properties:
           - :SHA256
           - :ALWAYS_NULL
           - :DEFAULT_MASKING_VALUE
+          - :LAST_FOUR_CHARACTERS
+          - :FIRST_FOUR_CHARACTERS
+          - :EMAIL_MASK
+          - :DATE_YEAR_MASK
 

--- a/mmv1/products/bigquerydatapolicy/product.yaml
+++ b/mmv1/products/bigquerydatapolicy/product.yaml
@@ -20,7 +20,7 @@ scopes:
 versions:
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://bigquerydatapolicy.googleapis.com/v1beta1/
+    base_url: https://bigquerydatapolicy.googleapis.com/v1/
 apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: BigQuery Data Policy API

--- a/mmv1/third_party/terraform/tests/resource_bigquery_datapolicy_data_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_datapolicy_data_policy_test.go.erb
@@ -60,7 +60,18 @@ resource "google_bigquery_datapolicy_data_policy" "data_policy" {
     display_name = "Low security updated"
     description  = "A policy tag normally associated with low security items"
   }  
-  
+
+  resource "google_bigquery_datapolicy_data_policy" "policy_tag_with_data_masking_policy" {
+    provider         = google-beta
+    location         = "us-central1"
+    data_policy_id   = "masking_policy_test"
+    policy_tag       = google_data_catalog_policy_tag.policy_tag_updated.name
+    data_policy_type = "DATA_MASKING_POLICY"
+    data_masking_policy {
+        predefined_expression = "SHA256"
+    }
+  }
+
   resource "google_data_catalog_taxonomy" "taxonomy" {
     provider = google-beta
     region                 = "us-central1"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR is following up hashicorp/terraform-provider-google#13867
It'll be possible to use additional masking policies if this API version is upgraded.
https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest/v1/projects.locations.dataPolicies#predefinedexpression

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquerydatapolicy: updated api version from v1beta1 to v1 and made it possible to use additional data policies.
```