### PR TITLE
Fix alloydb_cluster permadiff

### DIFF
--- a/mmv1/products/alloydb/terraform.yaml
+++ b/mmv1/products/alloydb/terraform.yaml
@@ -24,6 +24,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         sensitive: true
       network: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: "projectNumberDiffSuppress"
+      automatedBackupPolicy: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      automatedBackupPolicy.weeklySchedule: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     autogen_async: true
     examples:
       - !ruby/object:Provider::Terraform::Examples


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/13943

There appears to have been a change on the API side to start sending a default backup policy in the response for these clusters, so we need to make sure these fields are computed to support that.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
alloydb: fix permadiff on `automated_backup_policy.weekly_schedule` of `google_alloydb_cluster`
```
