### PR TITLE
Add SKIP_PROJECT_SWEEPER env variable for skipping the project sweeper

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_project_test.go
@@ -23,6 +23,16 @@ var (
 )
 
 func init() {
+	// SKIP_PROJECT_SWEEPER can be set for a sweeper run to prevent it from
+	// sweeping projects. This can be useful when running sweepers in
+	// organizations where acceptance tests intiated by another project may
+	// already be in-progress.
+	// Example: SKIP_PROJECT_SWEEPER=1 go test ./google -v -sweep=us-central1 -sweep-run=
+	if os.Getenv("SKIP_PROJECT_SWEEPER") != "" {
+		log.Printf("[INFO][SWEEPER_LOG] skipping the project sweeper because SKIP_PROJECT_SWEEPER is set")
+		return
+	}
+
 	resource.AddTestSweepers("GoogleProject", &resource.Sweeper{
 		Name: "GoogleProject",
 		F:    testSweepProject,


### PR DESCRIPTION
This is implemented as a general-purpose flag that can be used to skip the project sweeper any time it is useful.

However, the specific reason for adding it is for the upcoming project split for our nightly tests. When we have multiple projects initiating acceptance tests (GA, Beta, VCR), they will be sharing project-space, and can inadvertently sweep projects being used by one of the other environments.

Using this flag, we can choose one of the environments to sweep projects when no tests are being run, and then have the other environments skip the project sweeper.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
