### PR TITLE
Rework + reflow provider reference, touch up index

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -8,9 +8,11 @@ description: |-
 
 The `google` and `google-beta` provider blocks are used to configure the
 credentials you use to authenticate with GCP, as well as a default project and
-location (`zone` and/or `region`) for your resources.
+location (`zone` and/or `region`) for your resources. The same values are
+available between the provider versions, but must be configured in separate
+provider blocks.
 
-## Example Usage - Basic provider blocks
+### Example Usage - Basic provider blocks
 
 ```hcl
 provider "google" {
@@ -28,7 +30,7 @@ provider "google-beta" {
 }
 ```
 
-## Example Usage - Using beta features with `google-beta`
+### Example Usage - Using beta features with `google-beta`
 
 To use Google Cloud Platform features that are in beta, you need to both:
 
@@ -58,9 +60,7 @@ provider "google-beta" {}
 
 ## Authentication
 
-### Primary Authentication
-
-#### Running Terraform on your workstation.
+### Running Terraform on your workstation.
 
 If you are using Terraform on your workstation we recommend that you install
 `gcloud` and authenticate using [User Application Default Credentials ("ADCs")](https://cloud.google.com/sdk/gcloud/reference/auth/application-default)
@@ -73,7 +73,7 @@ from the `core/project` value. You can override this project by specifying the
 should return this message if you have set the correct billing project:
 `Quota project "your-project" was added to ADC which can be used by Google client libraries for billing and quota.`
 
-#### Running Terraform on Google Cloud
+### Running Terraform on Google Cloud
 
 If you are running Terraform in a machine on Google Cloud, you can configure
 that instance or cluster to use a [Google Service Account](https://cloud.google.com/compute/docs/authentication).
@@ -81,7 +81,7 @@ This allows Terraform to authenticate to Google Cloud without a separate
 credential/authentication file. Ensure that the scope of the VM/Cluster is set
 to or includes `https://www.googleapis.com/auth/cloud-platform`.
 
-#### Running Terraform Outside of Google Cloud
+### Running Terraform Outside of Google Cloud
 
 If you are running Terraform outside of Google Cloud, generate an external
 credential configuration file ([example for OIDC based federation](https://cloud.google.com/iam/docs/access-resources-oidc#generate-automatic))
@@ -90,7 +90,7 @@ environment variable to the path of the JSON file. Terraform will use that file
 for authentication. Terraform supports the full range of
 authentication options [documented for Google Cloud](https://cloud.google.com/docs/authentication).
 
-#### Using Terraform Cloud
+### Using Terraform Cloud
 
 Place your credentials in a Terraform Cloud [environment variable](https://www.terraform.io/docs/cloud/workspaces/variables.html):
 1. Create an environment variable called `GOOGLE_CREDENTIALS` in your Terraform Cloud workspace.
@@ -102,92 +102,15 @@ All runs within the workspace will use the `GOOGLE_CREDENTIALS` variable to auth
 ### Impersonating Service Accounts
 
 Terraform can [impersonate a Google service account](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials),
-allowing you to act as an appropriate service account regardless of your primary
-authentication mechanism. If you authenticate as a service account, Google Cloud
-derives your quota project and permissions from that service account rather than
-your primary authentication method, even if your primary authentication method
-was another service account.
+acting as a service account without managing its key locally.
 
-A valid primary authentication mechanism must be provided for the impersonation
-call, and your primary identity must have the `roles/iam.serviceAccountTokenCreator`
-role on the service account you are impersonating.
+To impersonate a service account, you must use another authentication method
+to act as a primary identity, and the primary identity must have the
+`roles/iam.serviceAccountTokenCreator` role on the service account Terraform is
+impersonating. Google Cloud Platform checks permissions and quotas against the
+impersonated service account regardless of the primary identity in use.
 
-## Configuration Reference
-
-You can use the following attributes to configure the provider. The quick
-reference should be sufficient for most use cases, but see the full reference
-if you're interested in more details. Both `google` and `google-beta` share the
-same configuration.
-
-### Quick Reference
-
-* `project` - (Optional) The default project to manage resources in. If another
-project is specified on a resource, it will take precedence.
-
-* `region` - (Optional) The default region to manage resources in. If another
-region is specified on a regional resource, it will take precedence.
-
-* `zone` - (Optional) The default zone to manage resources in. Generally, this
-zone should be within the default region you specified. If another zone is
-specified on a zonal resource, it will take precedence.
-
-* `impersonate_service_account` - (Optional) The service account to impersonate for all Google API Calls.
-You must have `roles/iam.serviceAccountTokenCreator` role on that account for the impersonation to succeed.
-
-* `credentials` - (Optional) Either the path to or the contents of a
-[service account key file] in JSON format. You can
-[manage key files using the Cloud Console].  If not provided, the
-application default credentials will be used.
-
-* `scopes` - (Optional) The list of OAuth 2.0 [scopes] requested when generating
-an access token using the service account key specified in `credentials`.
-
-* `access_token` - (Optional) A temporary [OAuth 2.0 access token] obtained from
-the Google Authorization server, i.e. the `Authorization: Bearer` token used to
-authenticate HTTP requests to GCP APIs. This is an alternative to `credentials`,
-and ignores the `scopes` field.
-
-* `user_project_override` - (Optional) Defaults to `false`. Controls the quota
-project used in requests to GCP APIs for the purpose of preconditions, quota,
-and billing. If `false`, the quota project is determined by the API and may be
-the project associated with your credentials, or the resource project. If `true`,
-most resources in the provider will explicitly supply their resource project, as
-described in their documentation. Otherwise, a `billing_project` value must be
-supplied.
-
-* `billing_project` - (Optional) A quota project to send in `user_project_override`,
-used for all requests sent from the provider. If set on a resource that supports
-sending the resource project, this value will supersede the resource project.
-This field is ignored if `user_project_override` is set to false or unset.
-
-* `{{service}}_custom_endpoint` - (Optional) The endpoint for a service's APIs,
-such as `compute_custom_endpoint`. Defaults to the production GCP endpoint for
-the service. This can be used to configure the Google provider to communicate
-with GCP-like APIs such as [the Cloud Functions emulator](https://github.com/googlearchive/cloud-functions-emulator).
-Values are expected to include the version of the service, such as
-`https://www.googleapis.com/compute/v1/`.
-
-* `batching` - (Optional) This block controls batching GCP calls for groups of specific resource types. Structure is documented below.
-~>**NOTE:** Batching is not implemented for the majority or resources/request types and is bounded by two values. If you are running into issues with slow batches
-resources, you may need to adjust one or both of 1) the core [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n) flag, which controls how many concurrent resources are being operated on and 2) `send_after`, the time interval after which a batch is sent.
-
-* `request_timeout` - (Optional) A duration string controlling the amount of time
-the provider should wait for a single HTTP request.  This will not adjust the
-amount of time the provider will wait for a logical operation - use the resource
-timeout blocks for that.
-
-* `request_reason` - (Optional) Send a Request Reason [System Parameter](https://cloud.google.com/apis/docs/system-parameters) for each API call made by the provider.  The `X-Goog-Request-Reason` header value is used to provide a user-supplied justification into GCP AuditLogs.
-
-The `batching` fields supports:
-
-* `send_after` - (Optional) A duration string representing the amount of time
-after which a request should be sent. Defaults to 3s. Note that if you increase
-`parallelism` you should also increase this value.
-
-* `enable_batching` - (Optional) Defaults to true. If false, disables batching
-   so requests that have batching capabilities are instead is sent one by one.
-
-### Full Reference
+## Authentication Configuration
 
 * `credentials` - (Optional) Either the path to or the contents of a
 [service account key file] in JSON format. You can
@@ -215,8 +138,18 @@ are automatically available. See
 [Creating and Enabling Service Accounts for Instances][gce-service-account]
 for more details.
 
-* On your computer, you can make your Google identity available by
+* On your workstation, you can make your Google identity available by
 running [`gcloud auth application-default login`][gcloud adc].
+
+---
+
+* `scopes` - (Optional) The list of OAuth 2.0 [scopes] requested when generating
+an access token using the service account key specified in `credentials`.
+
+By default, the following scopes are configured:
+
+    * https://www.googleapis.com/auth/cloud-platform
+    * https://www.googleapis.com/auth/userinfo.email
 
 ---
 
@@ -242,7 +175,37 @@ variable.
 
 * `impersonate_service_account_delegates` - (Optional) The delegation chain for an impersonating a service account as described [here](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-delegated).
 
+## Quota Management Configuration
+
+* `user_project_override` - (Optional) Defaults to `false`. Controls the quota
+project used in requests to GCP APIs for the purpose of preconditions, quota,
+and billing. If `false`, the quota project is determined by the API and may be
+the project associated with your credentials, or the resource project. If `true`,
+most resources in the provider will explicitly supply their resource project, as
+described in their documentation. Otherwise, a `billing_project` value must be
+supplied. Alternatively, this can be specified using the `USER_PROJECT_OVERRIDE`
+environment variable.
+
+Service account credentials are associated with the project the service account
+was created in. Credentials that come from the gcloud tool are associated with a
+project owned by Google. In order to properly use credentials that come from
+gcloud with Terraform, it is recommended to set this property to true.
+
+`user_project_override` uses the `X-Goog-User-Project`
+[system parameter](https://cloud.google.com/apis/docs/system-parameters). When
+set to true, the caller must have `serviceusage.services.use` permission on the
+quota project.
+
 ---
+
+* `billing_project` - (Optional) A quota project to send in `user_project_override`,
+used for all requests sent from the provider. If set on a resource that supports
+sending the resource project, this value will supersede the resource project.
+This field is ignored if `user_project_override` is set to false or unset.
+Alternatively, this can be specified using the `GOOGLE_BILLING_PROJECT`
+environment variable.
+
+## Provider Default Values Configuration
 
 * `project` - (Optional) The default project to manage resources in. If another
 project is specified on a resource, it will take precedence. This can also be
@@ -277,17 +240,26 @@ following ordered by precedence.
     * GCLOUD_ZONE
     * CLOUDSDK_COMPUTE_ZONE
 
+## Advanced Settings Configuration
+
+* `request_timeout` - (Optional) A duration string controlling the amount of time
+the provider should wait for individual HTTP requests. This will not adjust the
+amount of time the provider will wait for a logical operation - use the resource
+timeout blocks for that. This will adjust only the amount of time that a single
+synchronous request will wait for a response. The default is 30 seconds, and
+that should be a suitable value in most cases. Many GCP APIs will cancel a
+request if no response is forthcoming within 30 seconds in any event. In
+limited cases, such as DNS record set creation, there is a synchronous request
+to create the resource. This may help in those cases.
+
+
 ---
 
-* `scopes` - (Optional) The list of OAuth 2.0 [scopes] requested when generating
-an access token using the service account key specified in `credentials`.
-
-    By default, the following scopes are configured:
-
-    * https://www.googleapis.com/auth/cloud-platform
-    * https://www.googleapis.com/auth/userinfo.email
-
-* `request_reason` - (Optional) Send a Request Reason [System Parameter](https://cloud.google.com/apis/docs/system-parameters) for each API call made by the provider.  The `X-Goog-Request-Reason` header value is used to provide a user-supplied justification into GCP AuditLogs. Alternatively, this can be specified using the `CLOUDSDK_CORE_REQUEST_REASON` environment variable.
+* `request_reason` - (Optional) Send a Request Reason [System Parameter](https://cloud.google.com/apis/docs/system-parameters)
+for each API call made by the provider.  The `X-Goog-Request-Reason` header
+value is used to provide a user-supplied justification into GCP AuditLogs.
+Alternatively, this can be specified using the `CLOUDSDK_CORE_REQUEST_REASON`
+environment variable.
 
 ---
 
@@ -296,91 +268,36 @@ such as `compute_custom_endpoint`. Defaults to the production GCP endpoint for
 the service. This can be used to configure the Google provider to communicate
 with GCP-like APIs such as [the Cloud Functions emulator](https://github.com/googlearchive/cloud-functions-emulator).
 Values are expected to include the version of the service, such as
-`https://www.googleapis.com/compute/v1/`.
+`https://www.googleapis.com/compute/v1/`:
 
-~> Support for custom endpoints is on a best-effort basis. The underlying
+```
+provider "google" {
+  alias                   = "compute_beta_endpoint"
+  compute_custom_endpoint = "https://www.googleapis.com/compute/beta/"
+}
+```
+
+Custom endpoints are an advanced feature. To determine the possible values you
+can set, consult the implementation in [provider.go](https://github.com/hashicorp/terraform-provider-google-beta/blob/main/google-beta/provider.go)
+and [config.go](https://github.com/hashicorp/terraform-provider-google-beta/blob/main/google-beta/config.go).
+
+Support for custom endpoints is on a best-effort basis. The underlying
 endpoint and default values for a resource can be changed at any time without
 being considered a breaking change.
-
-A full list of configurable keys, their default value (in the `google` provider
-followed by `google-beta` if they differ), and an environment variable that can
-be used for configuration are below:
-
-* `access_context_manager_custom_endpoint` (`GOOGLE_ACCESS_CONTEXT_MANAGER_CUSTOM_ENDPOINT`) - `https://accesscontextmanager.googleapis.com/v1/`
-* `app_engine_custom_endpoint` (`GOOGLE_APP_ENGINE_CUSTOM_ENDPOINT`) - `https://appengine.googleapis.com/v1/`
-* `bigquery_custom_endpoint` (`GOOGLE_BIGQUERY_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/bigquery/v2/`
-* `bigtable_custom_endpoint` (`GOOGLE_BIGTABLE_CUSTOM_ENDPOINT`) - `https://bigtableadmin.googleapis.com/v2/`
-* `binary_authorization_custom_endpoint` (`GOOGLE_BINARY_AUTHORIZATION_CUSTOM_ENDPOINT`) - `https://binaryauthorization.googleapis.com/v1/`
-* `cloud_billing_custom_endpoint` (`GOOGLE_CLOUD_BILLING_CUSTOM_ENDPOINT`) - `https://cloudbilling.googleapis.com/v1/`
-* `cloud_build_custom_endpoint` (`GOOGLE_CLOUD_BUILD_CUSTOM_ENDPOINT`) - `https://cloudbuild.googleapis.com/v1/`
-* `cloud_functions_custom_endpoint` (`GOOGLE_CLOUD_FUNCTIONS_CUSTOM_ENDPOINT`) - `https://cloudfunctions.googleapis.com/v1/`
-* `cloud_iot_custom_endpoint` (`GOOGLE_CLOUD_IOT_CUSTOM_ENDPOINT`) - `https://cloudiot.googleapis.com/v1/`
-* `cloud_scheduler_custom_endpoint` (`GOOGLE_CLOUD_SCHEDULER_CUSTOM_ENDPOINT`) - `https://cloudscheduler.googleapis.com/v1/`
-* `composer_custom_endpoint` (`GOOGLE_COMPOSER_CUSTOM_ENDPOINT`) - `https://composer.googleapis.com/v1beta1/`
-* `compute_custom_endpoint` (`GOOGLE_COMPUTE_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/compute/v1/` | `https://www.googleapis.com/compute/beta/`
-* `container_custom_endpoint` (`GOOGLE_CONTAINER_CUSTOM_ENDPOINT`) - `https://container.googleapis.com/v1/`
-* `dataproc_custom_endpoint` (`GOOGLE_DATAPROC_CUSTOM_ENDPOINT`) - `https://dataproc.googleapis.com/v1/`
-* `dataproc_beta_custom_endpoint` (`GOOGLE_DATAPROC_BETA_CUSTOM_ENDPOINT`) - `https://dataproc.googleapis.com/v1beta2/`
-* `dataflow_custom_endpoint` (`GOOGLE_DATAFLOW_CUSTOM_ENDPOINT`) - `https://dataflow.googleapis.com/v1b3/`
-* `dns_custom_endpoint` (`GOOGLE_DNS_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/dns/v1/` | `https://www.googleapis.com/dns/v1beta2/`
-* `dns_beta_custom_endpoint` (`GOOGLE_DNS_BETA_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/dns/v1beta2/`
-* `filestore_custom_endpoint` (`GOOGLE_FILESTORE_CUSTOM_ENDPOINT`) - `https://file.googleapis.com/v1/`
-* `firestore_custom_endpoint` (`GOOGLE_FIRESTORE_CUSTOM_ENDPOINT`) - `https://firestore.googleapis.com/v1/`
-* `iam_custom_endpoint` (`GOOGLE_IAM_CUSTOM_ENDPOINT`) - `https://iam.googleapis.com/v1/`
-* `iam_credentials_custom_endpoint` (`GOOGLE_IAM_CREDENTIALS_CUSTOM_ENDPOINT`) - `https://iamcredentials.googleapis.com/v1/`
-* `kms_custom_endpoint` (`GOOGLE_KMS_CUSTOM_ENDPOINT`) - `https://cloudkms.googleapis.com/v1/`
-* `logging_custom_endpoint` (`GOOGLE_LOGGING_CUSTOM_ENDPOINT`) - `https://logging.googleapis.com/v2/`
-* `monitoring_custom_endpoint` (`GOOGLE_MONITORING_CUSTOM_ENDPOINT`) - `https://monitoring.googleapis.com/`
-* `pubsub_custom_endpoint` (`GOOGLE_PUBSUB_CUSTOM_ENDPOINT`) - `https://pubsub.googleapis.com/v1/`
-* `redis_custom_endpoint` (`GOOGLE_REDIS_CUSTOM_ENDPOINT`) - `https://redis.googleapis.com/v1/` | `https://redis.googleapis.com/v1beta1/`
-* `resource_manager_custom_endpoint` (`GOOGLE_RESOURCE_MANAGER_CUSTOM_ENDPOINT`) - `https://cloudresourcemanager.googleapis.com/v1/`
-* `resource_manager_v2beta1_custom_endpoint` (`GOOGLE_RESOURCE_MANAGER_V2BETA1_CUSTOM_ENDPOINT`) - `https://cloudresourcemanager.googleapis.com/v2beta1/`
-* `runtimeconfig_custom_endpoint` (`GOOGLE_RUNTIMECONFIG_CUSTOM_ENDPOINT`) - `https://runtimeconfig.googleapis.com/v1beta1/`
-* `security_center_custom_endpoints` (`GOOGLE_SECURITY_CENTER_CUSTOM_ENDPOINT`) - `https://securitycenter.googleapis.com/v1/`
-* `service_management_custom_endpoint` (`GOOGLE_SERVICE_MANAGEMENT_CUSTOM_ENDPOINT`) - `https://servicemanagement.googleapis.com/v1/`
-* `service_networking_custom_endpoint` (`GOOGLE_SERVICE_NETWORKING_CUSTOM_ENDPOINT`) - `https://servicenetworking.googleapis.com/v1/`
-* `service_usage_custom_endpoint` (`GOOGLE_SERVICE_USAGE_CUSTOM_ENDPOINT`) - `https://serviceusage.googleapis.com/v1/`
-* `source_repo_custom_endpoint` (`GOOGLE_SOURCE_REPO_CUSTOM_ENDPOINT`) - `https://sourcerepo.googleapis.com/v1/`
-* `spanner_custom_endpoint` (`GOOGLE_SPANNER_CUSTOM_ENDPOINT`) - `https://spanner.googleapis.com/v1/`
-* `sql_custom_endpoint` (`GOOGLE_SQL_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/sql/v1beta4/`
-* `storage_custom_endpoint` (`GOOGLE_STORAGE_CUSTOM_ENDPOINT`) - `https://www.googleapis.com/storage/v1/`
-* `storage_transfer_custom_endpoint` (`GOOGLE_STORAGE_TRANSFER_CUSTOM_ENDPOINT`) - `https://storagetransfer.googleapis.com/v1/`
-* `tpu_custom_endpoint` (`GOOGLE_TPU_CUSTOM_ENDPOINT`) - `https://tpu.googleapis.com/v1/`
-
-The following keys are available exclusively in the `google-beta` provider:
-
-* `container_analysis_custom_endpoint` (`GOOGLE_CONTAINER_ANALYSIS_CUSTOM_ENDPOINT`) - `https://containeranalysis.googleapis.com/v1beta1/`
-* `iap_custom_endpoint` (`GOOGLE_IAP_CUSTOM_ENDPOINT`) - `https://iap.googleapis.com/v1beta1/`
-* `monitoring_custom_endpoint` (`GOOGLE_MONITORING_CUSTOM_ENDPOINT`) - `https://monitoring.googleapis.com/v3/`
-* `security_scanner_custom_endpoint` (`GOOGLE_SECURITY_SCANNER_CUSTOM_ENDPOINT`) - `https://websecurityscanner.googleapis.com/v1beta/`
-
--> Note that some endpoints are a versioned variant of another. These exist in
-cases where the `google` provider uses multiple distinct endpoints, and both
-need to be set. Additionally, in `google-beta`, they'll often use the same value
-as their versioned counterpart but that won't necessarily always be the case.
-
-[OAuth 2.0 access token]: https://developers.google.com/identity/protocols/OAuth2
-[service account key file]: https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-[manage key files using the Cloud Console]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
-[adc]: https://cloud.google.com/docs/authentication/production
-[gce-service-account]: https://cloud.google.com/compute/docs/authentication
-[gcloud adc]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
-[service accounts]: https://cloud.google.com/docs/authentication/getting-started
-[GCE metadata]: https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions
-[scopes]: https://developers.google.com/identity/protocols/googlescopes
 
 ---
 
 * `batching` - (Optional) Controls batching for specific GCP request types
-  where users have encountered quota or speed issues using `count` with
-  resources that affect the same GCP resource (e.g. `google_project_service`).
-  It is not used for every resource/request type and can only group parallel
-  similar calls for nodes at a similar traversal time in the graph during
-  `terraform apply` (e.g. resources created using `count` that affect a single
-  `project`). Thus, it is also bounded by the `terraform`
-  [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n)
-  flag, as reducing the number of parallel calls will reduce the number of
-  simultaneous requests being added to a batcher.
+where users have encountered quota or speed issues using many resources of
+the same type, typically `google_project_service`.
+
+Batching is not used for every resource/request type and can only group parallel
+similar calls for nodes at a similar traversal time in the graph during
+`terraform apply` (e.g. resources created using `count` that affect a single
+`project`). Thus, it is also bounded by the `terraform`
+[`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n)
+flag, as reducing the number of parallel calls will reduce the number of
+simultaneous requests being added to a batcher.
 
   ~> **NOTE** Most resources/GCP request do not have batching implemented (see
   below for requests which use batching) Batching is really only needed for
@@ -392,57 +309,7 @@ as their versioned counterpart but that won't necessarily always be the case.
 **So far, batching is implemented for below resources**:
 
 * `google_project_service`
-* `google_api_gateway_api_config_iam_*`
-* `google_api_gateway_api_iam_*`
-* `google_api_gateway_gateway_iam_*`
-* `google_bigquery_dataset_iam_*`
-* `google_bigquery_table_iam_*`
-* `google_notebooks_instance_iam_*`
-* `google_bigtable_instance_iam_*`
-* `google_bigtable_table_iam_*`
-* `google_billing_account_iam_*`
-* `google_endpoints_service_iam_*`
-* `google_healthcare_consent_store_iam_*`
-* `google_healthcare_dataset_iam_*`
-* `google_healthcare_dicom_store_iam_*`
-* `google_healthcare_fhir_store_iam_*`
-* `google_healthcare_hl7_v2_store_iam_*`
-* `google_kms_crypto_key_iam_*`
-* `google_kms_key_ring_iam_*`
-* `google_folder_iam_*`
-* `google_organization_iam_*`
-* `google_project_iam_*`
-* `google_service_account_iam_*`
-* `google_project_service_*`
-* `google_pubsub_subscription_iam_*`
-* `google_pubsub_topic_iam_*`
-* `google_cloud_run_service_iam_*`
-* `google_sourcerepo_repository_iam_*`
-* `google_spanner_database_iam_*`
-* `google_spanner_instance_iam_*`
-* `google_storage_bucket_iam_*`
-* `google_compute_disk_iam_*`
-* `google_compute_image_iam_*`
-* `google_compute_instance_iam_*`
-* `google_compute_machine_image_iam_*`
-* `google_compute_region_disk_iam_*`
-* `google_compute_subnetwork_iam_*`
-* `google_data_catalog_entry_group_iam_*`
-* `google_data_catalog_policy_tag_iam_*`
-* `google_data_catalog_taxonomy_iam_*`
-* `google_dataproc_cluster_iam_*`
-* `google_dataproc_job_iam_*`
-* `google_iap_app_engine_service_iam_*`
-* `google_iap_app_engine_version_iam_*`
-* `google_iap_tunnel_iam_*`
-* `google_iap_tunnel_instance_iam_*`
-* `google_iap_web_backend_service_iam_*`
-* `google_iap_web_iam_*`
-* `google_iap_web_type_app_engine_iam_*`
-* `google_iap_web_type_compute_iam_*`
-* `google_runtimeconfig_config_iam_*`
-* `google_secret_manager_secret_iam_*`
-* `google_service_directory_service_iam_*`
+* All `google_*_iam_*` resources
 
 The `batching` block supports the following fields.
 
@@ -454,44 +321,11 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 * `enable_batching` - (Optional) Defaults to true. If false, disables global
 batching and each request is sent normally.
 
----
-* `request_timeout` - (Optional) A duration string controlling the amount of time
-the provider should wait for a single HTTP request.  This will not adjust the
-amount of time the provider will wait for a logical operation - use the resource
-timeout blocks for that.  This will adjust only the amount of time that a single
-synchronous request will wait for a response.  The default is 30 seconds, and
-that should be a suitable value in most cases.  Many GCP APIs will cancel a
-request if no response is forthcoming within 30 seconds in any event.  In
-limited cases, such as DNS record set creation, there is a synchronous request
-to create the resource.  This may help in those cases.
-
-
----
-
-* `user_project_override` - (Optional) Defaults to `false`. Controls the quota
-project used in requests to GCP APIs for the purpose of preconditions, quota,
-and billing. If `false`, the quota project is determined by the API and may be
-the project associated with your credentials, or the resource project. If `true`,
-most resources in the provider will explicitly supply their resource project, as
-described in their documentation. Otherwise, a `billing_project` value must be
-supplied. Alternatively, this can be specified using the `USER_PROJECT_OVERRIDE`
-environment variable.
-
-Service account credentials are associated with the project the service account
-was created in. Credentials that come from the gcloud tool are associated with a
-project owned by Google. In order to properly use credentials that come from
-gcloud with Terraform, it is recommended to set this property to true.
-
-`user_project_override` uses the `X-Goog-User-Project`
-[system parameter](https://cloud.google.com/apis/docs/system-parameters). When
-set to true, the caller must have `serviceusage.services.use` permission on the
-quota project.
-
----
-
-* `billing_project` - (Optional) A quota project to send in `user_project_override`,
-used for all requests sent from the provider. If set on a resource that supports
-sending the resource project, this value will supersede the resource project.
-This field is ignored if `user_project_override` is set to false or unset.
-Alternatively, this can be specified using the `GOOGLE_BILLING_PROJECT`
-environment variable.
+[OAuth 2.0 access token]: https://developers.google.com/identity/protocols/OAuth2
+[service account key file]: https://cloud.google.com/iam/docs/creating-managing-service-account-keys
+[manage key files using the Cloud Console]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
+[adc]: https://cloud.google.com/docs/authentication/production
+[gce-service-account]: https://cloud.google.com/compute/docs/authentication
+[gcloud adc]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
+[service accounts]: https://cloud.google.com/docs/authentication/getting-started
+[scopes]: https://developers.google.com/identity/protocols/googlescopes

--- a/mmv1/third_party/terraform/website/docs/index.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/index.html.markdown
@@ -7,10 +7,16 @@ description: |-
 # Google Cloud Platform Provider
 
 The Google provider is used to configure your [Google Cloud Platform](https://cloud.google.com/) infrastructure.
-See the [Getting Started](/docs/providers/google/guides/getting_started.html) page for an introduction to using the provider.
 
-To learn the basics of Terraform using this provider, follow the
-hands-on [get started tutorials](https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/gcp-get-started). For more involved examples, try [provisioning a GKE cluster](https://learn.hashicorp.com/tutorials/terraform/gke) and deploying [Consul-backed Vault into it using Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/kubernetes-consul-vault-pipeline).
+To learn the basics of Terraform using this provider, follow the hands-on
+[get started tutorials](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/infrastructure-as-code).
+For more involved examples, try [provisioning a GKE cluster](https://learn.hashicorp.com/tutorials/terraform/gke)
+and deploying [Consul-backed Vault into it using Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/kubernetes-consul-vault-pipeline).
+
+Already experienced with Terraform? Check out the [Getting Started](/docs/providers/google/guides/getting_started.html)
+page for a short introduction to using Terraform with Google Cloud Platform.
+
+## Example Usage
 
 A typical provider configuration will look something like:
 
@@ -22,7 +28,7 @@ provider "google" {
 ```
 
 See the [provider reference](/docs/providers/google/guides/provider_reference.html)
-for more details on authentication or otherwise configuring the provider.
+page for details on authentication and configuring the provider.
 
 Take advantage of [Modules](https://www.terraform.io/docs/modules/index.html)
 to simplify your config by browsing the [Module Registry for GCP modules](https://registry.terraform.io/browse?provider=google).
@@ -34,6 +40,7 @@ The Google provider is jointly maintained by:
 
 If you have configuration questions, or general questions about using the provider, try checking out:
 
+* [The Google category on discuss.hashicorp.com](https://discuss.hashicorp.com/c/terraform-providers/tf-google/32)
 * The [Google Cloud Platform Community Slack](https://googlecloud-community.slack.com/) `#terraform` channel. If you are not registered with that Slack Workspace yet, the up-to-date **public sign-up link** can be found in the "Stay Connected" section of the [Google Developer Center](https://cloud.google.com/developers#stay-connected).
 * [Terraform's community resources](https://www.terraform.io/docs/extend/community/index.html)
 * [HashiCorp support](https://support.hashicorp.com) for Terraform Enterprise customers
@@ -41,8 +48,8 @@ If you have configuration questions, or general questions about using the provid
 ## Releases
 
 Interested in the provider's latest features, or want to make sure you're up to date?
-Check out the [`google` provider changelog](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md)
-and the [`google-beta` provider changelog](https://github.com/hashicorp/terraform-provider-google-beta/blob/main/CHANGELOG.md))
+Check out the [`google` provider Releases](https://github.com/hashicorp/terraform-provider-google/releases)
+and the [`google-beta` provider Releases](https://github.com/hashicorp/terraform-provider-google-beta/releases
 for release notes and additional information.
 
 Per [Terraform Provider Versioning](https://www.hashicorp.com/blog/hashicorp-terraform-provider-versioning),
@@ -96,11 +103,15 @@ on the issue
 * An issue assigned to `hashibot` indicates a member of the community has taken on
 the issue!
 
+## Argument reference
+
+See the [provider reference](/docs/providers/google/guides/provider_reference.html)
+page for details on configuring the provider.
+
 ## Contributing
 
 If you'd like to help extend the Google provider, we gladly accept community
-contributions! Our full contribution guide is available at [CONTRIBUTING.md](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md)
-
-Pull requests can be made against either provider repo where a maintainer will
-apply them to both `google` and `google-beta`, or against [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules)
-directly.
+contributions! Development on the providers is done through the
+[Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules)
+repository. Our full contribution guide is available on the
+[Magic Modules Documentation Site](https://googlecloudplatform.github.io/magic-modules/)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Use https://registry.terraform.io/tools/doc-preview to preview. Sorry, this ended up being a larger change than expected!

Remove the "Quick Reference" from the docsite, it was annoying to link to the full reference in practice because both items shared links. Instead, break it up by use cases: auth, quota, provider defaults, advanced (networking minutiae really).

Also clean up the endpoint and batching references. They were not up-to-date. For endpoints, we should add them to generated resource references directly out-of-band with this.

Argument reference appears on the landing page for AWS and Azure, add it to ours for consistency (but just link the preexisting page). Also update very old contribution instructions, link to discuss.hashicorp.com, and flip around the learn links + getting started link.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
