### PR TITLE
Remove noisy logging of project sweeper being skipped

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_project_test.go
@@ -29,7 +29,6 @@ func init() {
 	// already be in-progress.
 	// Example: SKIP_PROJECT_SWEEPER=1 go test ./google -v -sweep=us-central1 -sweep-run=
 	if os.Getenv("SKIP_PROJECT_SWEEPER") != "" {
-		log.Printf("[INFO][SWEEPER_LOG] skipping the project sweeper because SKIP_PROJECT_SWEEPER is set")
 		return
 	}
 


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/7432

I like the idea of logging this, but unfortunately it seems to be triggered for every single test, and creates a lot of noisy in our logs when the environment variable is set.

For example:
```
[21:20:13] :			 [TestAccDataSourceGoogleBeyondcorpAppConnector_optionalRegion] [Test Error Output]
2023/03/09 21:19:00 [INFO][SWEEPER_LOG] skipping the project sweeper because SKIP_PROJECT_SWEEPER is set

[21:20:19] :		 [Step 2/2] TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic
[21:20:19] :			 [TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic] [Test Output]
=== RUN   TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic
=== PAUSE TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic
=== CONT  TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic
--- PASS: TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic (5.95s)
PASS

[21:20:19] :			 [TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic] [Test Error Output]
2023/03/09 21:20:13 [INFO][SWEEPER_LOG] skipping the project sweeper because SKIP_PROJECT_SWEEPER is set

[21:20:19] :		 [Step 2/2] TestAccDataSourceGoogleBeyondcorpAppConnector_basic
[21:20:19] :			 [TestAccDataSourceGoogleBeyondcorpAppConnector_basic] [Test Output]
=== RUN   TestAccDataSourceGoogleBeyondcorpAppConnector_basic
=== PAUSE TestAccDataSourceGoogleBeyondcorpAppConnector_basic
=== CONT  TestAccDataSourceGoogleBeyondcorpAppConnector_basic
--- PASS: TestAccDataSourceGoogleBeyondcorpAppConnector_basic (94.23s)
PASS

[21:20:19] :			 [TestAccDataSourceGoogleBeyondcorpAppConnector_basic] [Test Error Output]
2023/03/09 21:18:45 [INFO][SWEEPER_LOG] skipping the project sweeper because SKIP_PROJECT_SWEEPER is set
```

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
