### PR TITLE
Added `is_case_insensitive` and `default_collation` fields for `google_bigquery_dataset` resource

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -268,3 +268,22 @@ properties:
           Describes the Cloud KMS encryption key that will be used to protect destination
           BigQuery table. The BigQuery Service Account associated with your project requires
           access to this encryption key.
+  - !ruby/object:Api::Type::Boolean
+    name: 'isCaseInsensitive'
+    description: |
+      TRUE if the dataset and its table names are case-insensitive, otherwise FALSE.
+      By default, this is FALSE, which means the dataset and its table names are
+      case-sensitive. This field does not affect routine references.
+  - !ruby/object:Api::Type::String
+    name: 'defaultCollation'
+    description: |
+      Defines the default collation specification of future tables created
+      in the dataset. If a table is created in this dataset without table-level
+      default collation, then the table inherits the dataset default collation,
+      which is applied to the string fields that do not have explicit collation
+      specified. A change to this field affects only tables created afterwards,
+      and does not alter the existing tables.
+
+      The following values are supported:
+      - 'und:ci': undetermined locale, case insensitive.
+      - '': empty string. Default to case-sensitive behavior.

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -57,6 +57,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           public_routine: "public_routine"
         test_env_vars:
           service_account: :SERVICE_ACCT
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_dataset_case_insensitive_names"
+        primary_resource_id: "dataset"
+        skip_docs: true
+        vars:
+          dataset_id: "example_dataset"
+          account_name: "bqowner"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_dataset_default_collation_set"
+        primary_resource_id: "dataset"
+        skip_docs: true
+        vars:
+          dataset_id: "example_dataset"
+          account_name: "bqowner"
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'delete_contents_on_destroy'
@@ -95,6 +109,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       friendlyName: !ruby/object:Overrides::Terraform::PropertyOverride
         send_empty_value: true
+      isCaseInsensitive: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      defaultCollation: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateDefaultCollation'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/bigquery_dataset.go.erb
     docs: !ruby/object:Provider::Terraform::Docs

--- a/mmv1/templates/terraform/constants/bigquery_dataset.go.erb
+++ b/mmv1/templates/terraform/constants/bigquery_dataset.go.erb
@@ -23,3 +23,12 @@ func validateDefaultTableExpirationMs(v interface{}, k string) (ws []string, err
 
     return
 }
+
+func validateDefaultCollation(v interface{}, k string) (ws []string, errors []error) {
+    value := v.(string)
+    if value != "und:ci" && value != "" {
+        errors = append(errors, fmt.Errorf("%q must be set to 'und:ci' or '' (empty string), got: %v", k, v))
+    }
+
+    return
+}

--- a/mmv1/templates/terraform/examples/bigquery_dataset_case_insensitive_names.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_case_insensitive_names.tf.erb
@@ -1,0 +1,26 @@
+resource "google_bigquery_dataset" "<%= ctx[:primary_resource_id] %>" {
+  dataset_id                  = "<%= ctx[:vars]['dataset_id'] %>"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  default_table_expiration_ms = 3600000
+  is_case_insensitive         = true
+
+  labels = {
+    env = "default"
+  }
+
+  access {
+    role          = "OWNER"
+    user_by_email = google_service_account.bqowner.email
+  }
+
+  access {
+    role   = "READER"
+    domain = "hashicorp.com"
+  }
+}
+
+resource "google_service_account" "bqowner" {
+  account_id = "<%= ctx[:vars]['account_name'] %>"
+}

--- a/mmv1/templates/terraform/examples/bigquery_dataset_default_collation_set.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_default_collation_set.tf.erb
@@ -1,0 +1,26 @@
+resource "google_bigquery_dataset" "<%= ctx[:primary_resource_id] %>" {
+  dataset_id                  = "<%= ctx[:vars]['dataset_id'] %>"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  default_table_expiration_ms = 3600000
+  default_collation           = "und:ci"
+
+  labels = {
+    env = "default"
+  }
+
+  access {
+    role          = "OWNER"
+    user_by_email = google_service_account.bqowner.email
+  }
+
+  access {
+    role   = "READER"
+    domain = "hashicorp.com"
+  }
+}
+
+resource "google_service_account" "bqowner" {
+  account_id = "<%= ctx[:vars]['account_name'] %>"
+}


### PR DESCRIPTION
Added `is_case_insensitive` and `default_collation` fields for `google_bigquery_dataset` resource

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `is_case_insensitive` and `default_collation` fields to `google_bigquery_dataset` resource
```
