### PR TITLE
Documentation fix: tilde is not expanded in quotation marks

### DIFF
--- a/docs/content/docs/getting-started/use-built-provider.md
+++ b/docs/content/docs/getting-started/use-built-provider.md
@@ -144,10 +144,10 @@ Assuming that a configuration file was created at `~/tf-dev-override.tfrc`, you 
 
 ```bash
 # either export the environment variable for your session
-export TF_CLI_CONFIG_FILE="~/tf-dev-override.tfrc"
+export TF_CLI_CONFIG_FILE=~/tf-dev-override.tfrc
 
 # OR, set the environment variable value per command
-TF_CLI_CONFIG_FILE="~/tf-dev-override.tfrc" terraform plan
+TF_CLI_CONFIG_FILE=~/tf-dev-override.tfrc terraform plan
 ```
 
 To check that the developer override is working, run a `terraform plan` command and look for a warning near the start of the terminal output that looks like the example below. It is not necessary to run the terraform init command to use development overrides.


### PR DESCRIPTION
This is just a simple documentation fix for a developer page.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
