### PR TITLE
Change exec compiler references to exec compiler.rb

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -117,7 +117,7 @@ if [ "$REPO" == "terraform-validator" ] || [ "$REPO" == "tf-conversion" ]; then
     find ./test/** -type f -exec git rm {} \;
 
     popd
-    bundle exec compiler -a -e terraform -f validator -o $LOCAL_PATH -v $VERSION
+    bundle exec compiler.rb -a -e terraform -f validator -o $LOCAL_PATH -v $VERSION
     pushd $LOCAL_PATH
 
     if [ "$COMMAND" == "downstream" ]; then
@@ -146,14 +146,14 @@ if [ "$REPO" == "terraform-validator" ] || [ "$REPO" == "tf-conversion" ]; then
     popd
 elif [ "$REPO" == "tf-oics" ]; then
     # use terraform generator with oics override
-    bundle exec compiler -a -e terraform -f oics -o $LOCAL_PATH -v $VERSION
+    bundle exec compiler.rb -a -e terraform -f oics -o $LOCAL_PATH -v $VERSION
 else
     if [ "$REPO" == "terraform" ]; then
         if [ "$VERSION" == "ga" ]; then
-            bundle exec compiler -a -e $REPO -o $LOCAL_PATH -v $VERSION --no-docs
-            bundle exec compiler -a -e $REPO -o $LOCAL_PATH -v beta --no-code
+            bundle exec compiler.rb -a -e $REPO -o $LOCAL_PATH -v $VERSION --no-docs
+            bundle exec compiler.rb -a -e $REPO -o $LOCAL_PATH -v beta --no-code
         else
-            bundle exec compiler -a -e $REPO -o $LOCAL_PATH -v $VERSION
+            bundle exec compiler.rb -a -e $REPO -o $LOCAL_PATH -v $VERSION
         fi
         pushd ../
         make tpgtools OUTPUT_PATH=$LOCAL_PATH VERSION=$VERSION

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,7 +63,7 @@ terraform build provider:
 mmv1:
 	cd mmv1;\
 		bundle; \
-		bundle exec compiler -e terraform -o $(OUTPUT_PATH) -v $(VERSION) $(mmv1_compile);
+		bundle exec compiler.rb -e terraform -o $(OUTPUT_PATH) -v $(VERSION) $(mmv1_compile);
 
 tpgtools:
 	make serialize
@@ -73,7 +73,7 @@ tpgtools:
 validator:
 	cd mmv1;\
 		bundle; \
-		bundle exec compiler -e terraform -f validator -o $(OUTPUT_PATH) $(mmv1_compile);
+		bundle exec compiler.rb -e terraform -f validator -o $(OUTPUT_PATH) $(mmv1_compile);
 
 test:
 	cd mmv1; \


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`compiler` is a symlink to `compiler.rb` that I'd like to remove eventually- it was used to give a slightly cleaner name, I think, but it's just an added gotcha nowadays. Nobody should be running it directly at the moment, since we interface through `make` nowadays. Change script executions to execute the `.rb` file directly instead of through the symlink.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
