### PR TITLE
Docs: Add hidden user agent extension env var info to terraform website

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -321,7 +321,7 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 * `enable_batching` - (Optional) Defaults to true. If false, disables global
 batching and each request is sent normally.
 
-## User Agent Extension
+---
 
 You can extend the user agent header for each request made by the provider by setting the `GOOGLE_TERRAFORM_USERAGENT_EXTENSION` environment variable. This can be helpful for tracking (e.g. compliance through [audit logs](https://cloud.google.com/logging/docs/audit)) or debugging purposes.
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -321,6 +321,18 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 * `enable_batching` - (Optional) Defaults to true. If false, disables global
 batching and each request is sent normally.
 
+## User Agent Extension
+
+You can extend the user agent header for each request made by the provider by setting the `GOOGLE_TERRAFORM_USERAGENT_EXTENSION` environment variable. This can be helpful for tracking (e.g. compliance through [audit logs](https://cloud.google.com/logging/docs/audit)) or debugging purposes.
+
+Example:
+
+```sh
+export GOOGLE_TERRAFORM_USERAGENT_EXTENSION="my-extension/1.0"
+```
+
+See [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent) for format compliance of user agent header fields. 
+
 [OAuth 2.0 access token]: https://developers.google.com/identity/protocols/OAuth2
 [service account key file]: https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 [manage key files using the Cloud Console]: https://console.cloud.google.com/apis/credentials/serviceaccountkey


### PR DESCRIPTION
Add hidden user agent extension env var information to terraform website document.

See undocumented environment variable check for `GOOGLE_TERRAFORM_USER_AGENT_EXTENSION` in the [`providerConfigure`](https://github.com/hashicorp/terraform-provider-google/blob/c0c2e42de049c5a0c37ba460626ac7ae113c1f0e/google/provider.go#L1608) function.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:none
```

See [corresponding issue on the terraform-provider-google repository](https://github.com/hashicorp/terraform-provider-google/issues/14011).
