### PR TITLE
Document `proxy_uri` user-experience on `notebook_instance`

### DIFF
--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -70,6 +70,9 @@ properties:
     name: 'proxyUri'
     description: |
         The proxy endpoint that is used to access the Jupyter notebook.
+        Only returned when the resource is in a `PROVISIONED` state. If
+        needed you can utilize `terraform apply -refresh-only` to await
+        the population of this value.
     output: true
   - !ruby/object:Api::Type::Array
     name: 'instanceOwners'


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/13920

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
