### PR TITLE
Don't reuse liveapp service name in examples

### DIFF
--- a/mmv1/products/appengine/ServiceNetworkSettings.yaml
+++ b/mmv1/products/appengine/ServiceNetworkSettings.yaml
@@ -51,9 +51,8 @@
   examples:
     - !ruby/object:Provider::Terraform::Examples
       name: "app_engine_service_network_settings"
-      primary_resource_id: 'liveapp'
+      primary_resource_id: 'internalapp'
       vars:
-        service_id: "default"
         bucket_name: "appengine-static-content"
   properties:
     - !ruby/object:Api::Type::String

--- a/mmv1/templates/terraform/examples/app_engine_service_network_settings.tf.erb
+++ b/mmv1/templates/terraform/examples/app_engine_service_network_settings.tf.erb
@@ -9,9 +9,9 @@ resource "google_storage_bucket_object" "object" {
 	source = "./test-fixtures/appengine/hello-world.zip"
 }
 
-resource "google_app_engine_standard_app_version" "liveapp_v1" {
+resource "google_app_engine_standard_app_version" "internalapp" {
   version_id = "v1"
-  service = "liveapp"
+  service = "internalapp"
   delete_service_on_destroy = true
 
   runtime = "nodejs10"
@@ -29,7 +29,7 @@ resource "google_app_engine_standard_app_version" "liveapp_v1" {
 }
 
 resource "google_app_engine_service_network_settings" "<%= ctx[:primary_resource_id] %>" {
-  service = google_app_engine_standard_app_version.liveapp_v1.service
+  service = google_app_engine_standard_app_version.internalapp.service
   network_settings {
     ingress_traffic_allowed = "INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY"
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9996

Fixes TestAccAppEngineServiceNetworkSettings_appEngineServiceNetworkSettingsExample, may fix TestAccAppEngineServiceSplitTraffic_appEngineServiceSplitTrafficExample

Seems like we reused an appengine service name. I think they're impossible to delete, so we don't add a random suffix. Also remove the unused service_id vars entry.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
