### PR TITLE
compute: document that firewalls accept IPv6 ranges

### DIFF
--- a/mmv1/products/compute/Firewall.yaml
+++ b/mmv1/products/compute/Firewall.yaml
@@ -167,7 +167,7 @@ properties:
     description: |
       If destination ranges are specified, the firewall will apply only to
       traffic that has destination IP address in these ranges. These ranges
-      must be expressed in CIDR format. Only IPv4 is supported.
+      must be expressed in CIDR format. IPv4 or IPv6 ranges are supported.
     is_set: true
     default_from_api: true
     item_type: Api::Type::String
@@ -266,8 +266,8 @@ properties:
       apply to traffic that has source IP address within sourceRanges OR the
       source IP that belongs to a tag listed in the sourceTags property. The
       connection does not need to match both properties for the firewall to
-      apply. Only IPv4 is supported. For INGRESS traffic, one of `source_ranges`,
-      `source_tags` or `source_service_accounts` is required.
+      apply. IPv4 or IPv6 ranges are supported. For INGRESS traffic, one of
+      `source_ranges`, `source_tags` or `source_service_accounts` is required.
     is_set: true
     diff_suppress_func: 'diffSuppressSourceRanges'
     item_type: Api::Type::String


### PR DESCRIPTION
See:

* https://cloud.google.com/compute/docs/reference/rest/v1/firewalls#Firewall.FIELDS.source_range
* https://cloud.google.com/compute/docs/reference/rest/v1/firewalls#Firewall.FIELDS.destination_range

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Update documentation of fields to reflect that source_range and destination_range both accept IPv6.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```

Fixes [#14004](https://github.com/hashicorp/terraform-provider-google/issues/14004)