### PR TITLE
Adds support for lastModifiedSince and lastModifiedBefore fields in storage_transfer_job

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -19,6 +19,8 @@ var (
 		"transfer_spec.0.object_conditions.0.max_time_elapsed_since_last_modification",
 		"transfer_spec.0.object_conditions.0.include_prefixes",
 		"transfer_spec.0.object_conditions.0.exclude_prefixes",
+		"transfer_spec.0.object_conditions.0.last_modified_since",
+		"transfer_spec.0.object_conditions.0.last_modified_before",
 	}
 
 	transferOptionsKeys = []string{
@@ -292,6 +294,20 @@ func objectConditionsSchema() *schema.Schema {
 						Type:     schema.TypeString,
 					},
 					Description: `exclude_prefixes must follow the requirements described for include_prefixes.`,
+				},
+				"last_modified_since": {
+					Type:         schema.TypeString,
+					ValidateFunc: validateRFC3339Date(),
+					Optional:     true,
+					AtLeastOneOf: objectConditionsKeys,
+					Description:  `If specified, only objects with a "last modification time" on or after this timestamp and objects that don't have a "last modification time" are transferred. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
+				},
+				"last_modified_before": {
+					Type:         schema.TypeString,
+					ValidateFunc: validateRFC3339Date(),
+					Optional:     true,
+					AtLeastOneOf: objectConditionsKeys,
+					Description:  `If specified, only objects with a "last modification time" before this timestamp and objects that don't have a "last modification time" are transferred. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
 				},
 			},
 		},
@@ -1033,6 +1049,8 @@ func expandObjectConditions(conditions []interface{}) *storagetransfer.ObjectCon
 		IncludePrefixes:                     convertStringArr(condition["include_prefixes"].([]interface{})),
 		MaxTimeElapsedSinceLastModification: condition["max_time_elapsed_since_last_modification"].(string),
 		MinTimeElapsedSinceLastModification: condition["min_time_elapsed_since_last_modification"].(string),
+		LastModifiedSince: condition["last_modified_since"].(string),
+		LastModifiedBefore: condition["last_modified_before"].(string),
 	}
 }
 
@@ -1042,6 +1060,8 @@ func flattenObjectCondition(condition *storagetransfer.ObjectConditions) []map[s
 		"include_prefixes":                         condition.IncludePrefixes,
 		"max_time_elapsed_since_last_modification": condition.MaxTimeElapsedSinceLastModification,
 		"min_time_elapsed_since_last_modification": condition.MinTimeElapsedSinceLastModification,
+		"last_modified_since": condition.LastModifiedSince,
+		"last_modified_before": condition.LastModifiedBefore,
 	}
 	return []map[string]interface{}{data}
 }

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -297,14 +297,14 @@ func objectConditionsSchema() *schema.Schema {
 				},
 				"last_modified_since": {
 					Type:         schema.TypeString,
-					ValidateFunc: validateRFC3339Date(),
+					ValidateFunc: validateRFC3339Date,
 					Optional:     true,
 					AtLeastOneOf: objectConditionsKeys,
 					Description:  `If specified, only objects with a "last modification time" on or after this timestamp and objects that don't have a "last modification time" are transferred. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
 				},
 				"last_modified_before": {
 					Type:         schema.TypeString,
-					ValidateFunc: validateRFC3339Date(),
+					ValidateFunc: validateRFC3339Date,
 					Optional:     true,
 					AtLeastOneOf: objectConditionsKeys,
 					Description:  `If specified, only objects with a "last modification time" before this timestamp and objects that don't have a "last modification time" are transferred. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -1049,8 +1049,8 @@ func expandObjectConditions(conditions []interface{}) *storagetransfer.ObjectCon
 		IncludePrefixes:                     convertStringArr(condition["include_prefixes"].([]interface{})),
 		MaxTimeElapsedSinceLastModification: condition["max_time_elapsed_since_last_modification"].(string),
 		MinTimeElapsedSinceLastModification: condition["min_time_elapsed_since_last_modification"].(string),
-		LastModifiedSince: condition["last_modified_since"].(string),
-		LastModifiedBefore: condition["last_modified_before"].(string),
+		LastModifiedSince: 					 condition["last_modified_since"].(string),
+		LastModifiedBefore: 				 condition["last_modified_before"].(string),
 	}
 }
 
@@ -1060,8 +1060,8 @@ func flattenObjectCondition(condition *storagetransfer.ObjectConditions) []map[s
 		"include_prefixes":                         condition.IncludePrefixes,
 		"max_time_elapsed_since_last_modification": condition.MaxTimeElapsedSinceLastModification,
 		"min_time_elapsed_since_last_modification": condition.MinTimeElapsedSinceLastModification,
-		"last_modified_since": condition.LastModifiedSince,
-		"last_modified_before": condition.LastModifiedBefore,
+		"last_modified_since": 						condition.LastModifiedSince,
+		"last_modified_before": 					condition.LastModifiedBefore,
 	}
 	return []map[string]interface{}{data}
 }

--- a/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -1049,8 +1049,8 @@ func expandObjectConditions(conditions []interface{}) *storagetransfer.ObjectCon
 		IncludePrefixes:                     convertStringArr(condition["include_prefixes"].([]interface{})),
 		MaxTimeElapsedSinceLastModification: condition["max_time_elapsed_since_last_modification"].(string),
 		MinTimeElapsedSinceLastModification: condition["min_time_elapsed_since_last_modification"].(string),
-		LastModifiedSince: 					 condition["last_modified_since"].(string),
-		LastModifiedBefore: 				 condition["last_modified_before"].(string),
+		LastModifiedSince:                   condition["last_modified_since"].(string),
+		LastModifiedBefore:                  condition["last_modified_before"].(string),
 	}
 }
 
@@ -1060,8 +1060,8 @@ func flattenObjectCondition(condition *storagetransfer.ObjectConditions) []map[s
 		"include_prefixes":                         condition.IncludePrefixes,
 		"max_time_elapsed_since_last_modification": condition.MaxTimeElapsedSinceLastModification,
 		"min_time_elapsed_since_last_modification": condition.MinTimeElapsedSinceLastModification,
-		"last_modified_since": 						condition.LastModifiedSince,
-		"last_modified_before": 					condition.LastModifiedBefore,
+		"last_modified_since":                      condition.LastModifiedSince,
+		"last_modified_before":                     condition.LastModifiedBefore,
 	}
 	return []map[string]interface{}{data}
 }

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -924,7 +924,7 @@ resource "google_storage_transfer_job" "transfer_job" {
       bucket_name = google_storage_bucket.data_sink.name
       path  = "foo/bar/"
     }
-    transfer_options {
+    object_conditions {
       last_modified_since = %s
       last_modified_before = %s
     }

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -197,6 +197,42 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 	})
 }
 
+
+func testAccStorageTransferJob_objectConditions(t *testing.T) {
+	t.Parallel()
+
+	testDataSourceBucketName := randString(t, 10)
+	testDataSinkName := randString(t, 10)
+	testTransferJobDescription := randString(t, 10)
+	testModifiedSince := time.Now().Format(time.RFC3339)
+	testModifiedBefore := time.Now().Format(time.RFC3339)
+	testPubSubTopicName := fmt.Sprintf("tf-test-topic-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccStorageTransferJobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageTransferJob_basic(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testPubSubTopicName),
+			},
+			{
+				ResourceName:      "google_storage_transfer_job.transfer_job",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccStorageTransferJob_objectConditions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testModifiedSince, testModifiedBefore, testPubSubTopicName),
+			},
+			{
+				ResourceName:      "google_storage_transfer_job.transfer_job",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccStorageTransferJob_notificationConfig(t *testing.T) {
 	t.Parallel()
 
@@ -831,6 +867,105 @@ resource "google_storage_transfer_job" "transfer_job" {
   ]
 }
 `, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project, overwriteObjectsAlreadyExistingInSink, deleteObjectsUniqueInSink, deleteObjectsFromSourceAfterTransfer, overwriteWhenVal)
+}
+
+func testAccStorageTransferJob_objectConditions(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, testModifiedSince string, testModifiedBefore string, pubSubTopicName string) string {
+	return fmt.Sprintf(`
+data "google_storage_transfer_project_service_account" "default" {
+  project = "%s"
+}
+
+resource "google_storage_bucket" "data_source" {
+  name          = "%s"
+  project       = "%s"
+  location      = "US"
+  force_destroy = true
+}
+
+resource "google_storage_bucket_iam_member" "data_source" {
+  bucket = google_storage_bucket.data_source.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+}
+
+resource "google_storage_bucket" "data_sink" {
+  name          = "%s"
+  project       = "%s"
+  location      = "US"
+  force_destroy = true
+}
+
+resource "google_storage_bucket_iam_member" "data_sink" {
+  bucket = google_storage_bucket.data_sink.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+}
+
+resource "google_pubsub_topic" "topic" {
+  name = "%s"
+}
+
+resource "google_pubsub_topic_iam_member" "notification_config" {
+  topic = google_pubsub_topic.topic.id
+  role = "roles/pubsub.publisher"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+}
+
+resource "google_storage_transfer_job" "transfer_job" {
+  description = "%s"
+  project     = "%s"
+
+  transfer_spec {
+    gcs_data_source {
+      bucket_name = google_storage_bucket.data_source.name
+      path  = "foo/bar/"
+    }
+    gcs_data_sink {
+      bucket_name = google_storage_bucket.data_sink.name
+      path  = "foo/bar/"
+    }
+    transfer_options {
+      last_modified_since = %s
+      last_modified_before = %s
+    }
+  }
+
+  schedule {
+    schedule_start_date {
+      year  = 2018
+      month = 10
+      day   = 1
+    }
+    schedule_end_date {
+      year  = 2019
+      month = 10
+      day   = 1
+    }
+    start_time_of_day {
+      hours   = 0
+      minutes = 30
+      seconds = 0
+      nanos   = 0
+    }
+	  repeat_interval = "604800s"
+  }
+
+  notification_config {
+    pubsub_topic  = google_pubsub_topic.topic.id
+    event_types   = [
+      "TRANSFER_OPERATION_SUCCESS",
+      "TRANSFER_OPERATION_FAILED"
+    ]
+    payload_format = "JSON"
+  }
+
+  depends_on = [
+    google_storage_bucket_iam_member.data_source,
+    google_storage_bucket_iam_member.data_sink,
+    google_pubsub_topic_iam_member.notification_config,
+  ]
+}
+`, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project, testModifiedSince, testModifiedBefore,  overwriteWhenVal)
 }
 
 func testAccStorageTransferJob_notificationPayloadFormat(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, pubsubTopicName string, notificationPayloadFormat string) string {

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -201,20 +201,18 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 func TestAccStorageTransferJob_objectConditions(t *testing.T) {
 	t.Parallel()
 
-	testDataSourceBucketName := randString(t, 10)
-	testDataSinkName := randString(t, 10)
-	testTransferJobDescription := randString(t, 10)
-	testModifiedSince := time.Now().Format(time.RFC3339)
-	testModifiedBefore := time.Now().Format(time.RFC3339)
-	testPubSubTopicName := fmt.Sprintf("tf-test-topic-%s", randString(t, 10))
+	testDataSourceBucketName := RandString(t, 10)
+	testDataSinkName := RandString(t, 10)
+	testTransferJobDescription := RandString(t, 10)
+	testPubSubTopicName := fmt.Sprintf("tf-test-topic-%s", RandString(t, 10))
 
-	vcrTest(t, resource.TestCase{
+	VcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccStorageTransferJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStorageTransferJob_basic(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testPubSubTopicName),
+				Config: testAccStorageTransferJob_basic(GetTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testPubSubTopicName),
 			},
 			{
 				ResourceName:      "google_storage_transfer_job.transfer_job",
@@ -222,7 +220,7 @@ func TestAccStorageTransferJob_objectConditions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStorageTransferJob_objectConditions(getTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testModifiedSince, testModifiedBefore, testPubSubTopicName),
+				Config: testAccStorageTransferJob_objectConditions(GetTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testPubSubTopicName),
 			},
 			{
 				ResourceName:      "google_storage_transfer_job.transfer_job",
@@ -336,6 +334,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -349,6 +348,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -391,6 +391,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -404,6 +405,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -466,6 +468,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -479,6 +482,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -561,6 +565,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -574,6 +579,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -628,6 +634,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -704,6 +711,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -779,6 +787,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -792,6 +801,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -869,7 +879,7 @@ resource "google_storage_transfer_job" "transfer_job" {
 `, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project, overwriteObjectsAlreadyExistingInSink, deleteObjectsUniqueInSink, deleteObjectsFromSourceAfterTransfer, overwriteWhenVal)
 }
 
-func testAccStorageTransferJob_objectConditions(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, testModifiedSince string, testModifiedBefore string, pubSubTopicName string) string {
+func testAccStorageTransferJob_objectConditions(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, pubSubTopicName string) string {
 	return fmt.Sprintf(`
 data "google_storage_transfer_project_service_account" "default" {
   project = "%s"
@@ -880,6 +890,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -893,6 +904,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -925,8 +937,8 @@ resource "google_storage_transfer_job" "transfer_job" {
       path  = "foo/bar/"
     }
     object_conditions {
-      last_modified_since = %s
-      last_modified_before = %s
+      last_modified_since = "2020-01-01T00:00:00Z"
+      last_modified_before = "2020-01-01T00:00:00Z"
     }
   }
 
@@ -965,7 +977,7 @@ resource "google_storage_transfer_job" "transfer_job" {
     google_pubsub_topic_iam_member.notification_config,
   ]
 }
-`, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project, testModifiedSince, testModifiedBefore,  overwriteWhenVal)
+`, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project)
 }
 
 func testAccStorageTransferJob_notificationPayloadFormat(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, pubsubTopicName string, notificationPayloadFormat string) string {
@@ -979,6 +991,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -992,6 +1005,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -1074,6 +1088,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -1087,6 +1102,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {
@@ -1168,6 +1184,7 @@ resource "google_storage_bucket" "data_source" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_source" {
@@ -1181,6 +1198,7 @@ resource "google_storage_bucket" "data_sink" {
   project       = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "data_sink" {

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -197,7 +197,6 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 	})
 }
 
-
 func TestAccStorageTransferJob_objectConditions(t *testing.T) {
 	t.Parallel()
 
@@ -207,9 +206,9 @@ func TestAccStorageTransferJob_objectConditions(t *testing.T) {
 	testPubSubTopicName := fmt.Sprintf("tf-test-topic-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccStorageTransferJobDestroyProducer(t),
+		CheckDestroy:             testAccStorageTransferJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStorageTransferJob_basic(GetTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, testPubSubTopicName),

--- a/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_storage_transfer_job_test.go
@@ -198,7 +198,7 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 }
 
 
-func testAccStorageTransferJob_objectConditions(t *testing.T) {
+func TestAccStorageTransferJob_objectConditions(t *testing.T) {
 	t.Parallel()
 
 	testDataSourceBucketName := randString(t, 10)

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -172,6 +172,10 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 
 * `exclude_prefixes` - (Optional) `exclude_prefixes` must follow the requirements described for `include_prefixes`. See [Requirements](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/TransferSpec#ObjectConditions).
 
+* `last_modified_since` - (Optional) If specified, only objects with a "last modification time" on or after this timestamp and objects that don't have a "last modification time" are transferred. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+* `last_modified_before` - (Optional) If specified, only objects with a "last modification time" before this timestamp and objects that don't have a "last modification time" are transferred. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
 <a name="nested_transfer_options"></a>The `transfer_options` block supports:
 
 * `overwrite_objects_already_existing_in_sink` - (Optional) Whether overwriting objects that already exist in the sink is allowed.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/10770

Adds support for ```lastModifiedSince``` and ```lastModifiedBefore``` in the [object conditions](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/TransferSpec#ObjectConditions) field within storage_transfer_job. Updates handwritten resource and tests.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

storagetransfer: add support for 'last_modified_since' and 'last_modified_before' fields to 'google_storage_transfer_job' resource
```
