### PR TITLE
bigquery connection - spark connection type

### DIFF
--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -125,7 +125,7 @@ examples:
     region_override: "US"
     primary_resource_id: "connection"
     vars:
-      connection_id: "my-connection"      
+      connection_id: "my-connection"
 properties:
   - !ruby/object:Api::Type::String
     name: name

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -121,7 +121,6 @@ examples:
       database: 'projects/project/instances/instance/databases/database'
   - !ruby/object:Provider::Terraform::Examples
     name: "bigquery_connection_spark"
-    pull_external: true
     region_override: "US"
     primary_resource_id: "connection"
     vars:

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -119,6 +119,13 @@ examples:
     vars:
       connection_id: 'my-connection'
       database: 'projects/project/instances/instance/databases/database'
+  - !ruby/object:Provider::Terraform::Examples
+    name: "bigquery_connection_spark"
+    pull_external: true
+    region_override: "US"
+    primary_resource_id: "connection"
+    vars:
+      connection_id: "my-connection"      
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -167,6 +174,7 @@ properties:
       - azure
       - cloud_spanner
       - cloud_resource
+      - spark
     properties:
       - !ruby/object:Api::Type::String
         name: 'instanceId'
@@ -216,6 +224,7 @@ properties:
       - azure
       - cloud_spanner
       - cloud_resource
+      - spark
     update_mask_fields:
       - 'aws.access_role.iam_role_id'
     properties:
@@ -248,6 +257,7 @@ properties:
       - azure
       - cloud_spanner
       - cloud_resource
+      - spark
     update_mask_fields:
       - 'azure.customer_tenant_id'
       - 'azure.federated_application_client_id'
@@ -295,6 +305,7 @@ properties:
       - azure
       - cloud_spanner
       - cloud_resource
+      - spark
     properties:
       - !ruby/object:Api::Type::String
         name: 'database'
@@ -352,6 +363,7 @@ properties:
       - azure
       - cloud_spanner
       - cloud_resource
+      - spark
     send_empty_value: true
     properties:
       - !ruby/object:Api::Type::String
@@ -360,3 +372,35 @@ properties:
           The account ID of the service created for the purpose of this
           connection.
         output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: spark
+    description: Container for connection properties to execute stored procedures for Apache Spark.
+      resources.
+    exactly_one_of:
+      - cloud_sql
+      - aws
+      - azure
+      - cloud_spanner
+      - cloud_resource
+      - spark
+    send_empty_value: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccountId'
+        description: The account ID of the service created for the purpose of this
+          connection.
+        output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: metastoreServiceConfig
+        description: Dataproc Metastore Service configuration for the connection.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: metastoreService
+            description: Resource name of an existing Dataproc Metastore service in the form of projects/[projectId]/locations/[region]/services/[serviceId].
+      - !ruby/object:Api::Type::NestedObject
+        name: sparkHistoryServerConfig
+        description: Spark History Server configuration for the connection.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: dataprocCluster
+            description: Resource name of an existing Dataproc Cluster to act as a Spark History Server for the connection if the form of projects/[projectId]/regions/[region]/clusters/[cluster_name].

--- a/mmv1/templates/terraform/examples/bigquery_connection_spark.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_spark.tf.erb
@@ -3,6 +3,31 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
    location      = "US"
    friendly_name = "👋"
    description   = "a riveting description"
-   spark {}
+   spark {
+      spark_history_server_config {
+         dataproc_cluster = google_dataproc_cluster.basic.id
+      }
+   }
 }
 
+resource "google_dataproc_cluster" "basic" {
+   name   = "<%= ctx[:vars]['connection_id'] %>"
+   region = "us-central1"
+
+   cluster_config {
+     # Keep the costs down with smallest config we can get away with
+     software_config {
+       override_properties = {
+         "dataproc:dataproc.allow.zero.workers" = "true"
+       }
+     }
+ 
+     master_config {
+       num_instances = 1
+       machine_type  = "e2-standard-2"
+       disk_config {
+         boot_disk_size_gb = 35
+       }
+     }
+   }   
+ }

--- a/mmv1/templates/terraform/examples/bigquery_connection_spark.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_spark.tf.erb
@@ -1,0 +1,8 @@
+resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
+   connection_id = "<%= ctx[:vars]['connection_id'] %>"
+   location      = "US"
+   friendly_name = "👋"
+   description   = "a riveting description"
+   spark {}
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigqueryconnection - add `spark` support
```
