### PR TITLE
Remove unused `conflicts_with` attr from Ruby code

### DIFF
--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -128,9 +128,6 @@ module Api
       # This should be avoided for new fields, and only used with old ones.
       attr_reader :schema_config_mode_attr
 
-      # Names of attributes that can't be set alongside this one
-      attr_reader :conflicts_with
-
       # Names of fields that should be included in the updateMask.
       attr_reader :update_mask_fields
 

--- a/mmv1/products/osconfig/GuestPolicies.yaml
+++ b/mmv1/products/osconfig/GuestPolicies.yaml
@@ -334,7 +334,7 @@ properties:
                 name: 'remote'
                 description: |
                   A generic remote artifact.
-                # TODO (mbang): add conflicts_with when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
+                # TODO (mbang): add `conflicts` when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
                 properties:
                   - !ruby/object:Api::Type::String
                     name: 'uri'
@@ -350,7 +350,7 @@ properties:
                 name: 'gcs'
                 description: |
                   A Google Cloud Storage artifact.
-                # TODO (mbang): add conflicts_with when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
+                # TODO (mbang): add `conflicts` when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
                 properties:
                   - !ruby/object:Api::Type::String
                     name: 'bucket'

--- a/tpgtools/mmv1.md
+++ b/tpgtools/mmv1.md
@@ -126,7 +126,7 @@ OpenAPI spec.
     * `set_hash_func`: `"SET_HASH_FUNC"` in `tpgtools`.
     * `default_from_api`: `x-dcl-server-default` in the DCL OpenAPI spec.
     * `schema_config_mode_attr`: Requires a future override in `tpgtools`.
-    * `conflicts_with`, `at_least_one_of`, `exactly_one_of`: Will be exposed by
+    * `at_least_one_of`, `exactly_one_of`: Will be exposed by
 the DCL in the future. http://b/159243366
     * `update_mask_fields`: Handled by the DCL.
     * `key_expander`, `key_diff_suppress_func`: Unknown. Likely implemented in


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to (but doesn't close) : https://github.com/hashicorp/terraform-provider-google/issues/13814

The `conflicts_with` property override attribute appears to have been added [added in 2019 in this PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/1242/files#diff-4f715458b60f8c7e9b3d8613ff95345d33a539bb2860f05a7012db599756295e). Currently it is not used anywhere in our YAML and instead there is a widely used `conflicts` attribute.

---



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). ~~
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
