### PR TITLE
Update Subnetwork.yaml to include API Gateway requirements

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -168,9 +168,10 @@ properties:
     description: |
       The purpose of the resource. A subnetwork with purpose set to
       INTERNAL_HTTPS_LOAD_BALANCER is a user-created subnetwork that is
-      reserved for Internal HTTP(S) Load Balancing.
+      reserved for Internal HTTP(S) Load Balancing, and REGIONAL_MANAGED_PROXY is 
+      for proxy-only subnets.
 
-      If set to INTERNAL_HTTPS_LOAD_BALANCER you must also set the `role` field.
+      If set to INTERNAL_HTTPS_LOAD_BALANCER or REGIONAL_MANAGED_PROXY you must also set the `role` field.
     default_from_api: true
   - !ruby/object:Api::Type::Enum
     name: 'role'
@@ -183,10 +184,10 @@ properties:
       - :BACKUP
     description: |
       The role of subnetwork. Currently, this field is only used when
-      purpose = INTERNAL_HTTPS_LOAD_BALANCER. The value can be set to ACTIVE
-      or BACKUP. An ACTIVE subnetwork is one that is currently being used
-      for Internal HTTP(S) Load Balancing. A BACKUP subnetwork is one that
-      is ready to be promoted to ACTIVE or is currently draining.
+      purpose = INTERNAL_HTTPS_LOAD_BALANCER or REGIONAL_MANAGED_PROXY. 
+      The value can be set to ACTIVE or BACKUP. An ACTIVE subnetwork is 
+      one that is currently being used for Internal HTTP(S) Load Balancing. 
+      A BACKUP subnetwork is one that is ready to be promoted to ACTIVE or is currently draining.
   - !ruby/object:Api::Type::Array
     name: 'secondaryIpRange'
     api_name: secondaryIpRanges


### PR DESCRIPTION
I'm just following the guide to deploy [Gateway API](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#configure_a_proxy-only_subnet) and noticed this is missing in the docs.


If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
Adds REGIONAL_MANAGED_PROXY subnet purpose to support deploying proxy-only subnets for Google API Gateway.
```
