### PR TITLE
Add copyright headers to files in the TPG/B downsteam repos that are generated via templates

### DIFF
--- a/mmv1/compile/core.rb
+++ b/mmv1/compile/core.rb
@@ -211,6 +211,11 @@ module Compile
       end
     end
 
+    def hashicorp_copyright_header(lang, pwd)
+      Thread.current[:autogen] = true
+      comment_block(compile("#{pwd}/templates/hashicorp_copyright_header.erb").split("\n"), lang)
+    end
+
     def autogen_notice(lang, pwd)
       Thread.current[:autogen] = true
       comment_block(compile("#{pwd}/templates/autogen_notice.erb").split("\n"), lang)

--- a/mmv1/provider/file_template.rb
+++ b/mmv1/provider/file_template.rb
@@ -56,7 +56,7 @@ module Provider
       end
 
       ctx.local_variable_set('pwd', pwd)
-      ctx.local_variable_set('hc_downstream', provider.is_generating_hashicorp_repo?())
+      ctx.local_variable_set('hc_downstream', provider.generating_hashicorp_repo?())
 
       # check if the parent folder exists, and make it if not
       parent_path = File.dirname(path)

--- a/mmv1/provider/file_template.rb
+++ b/mmv1/provider/file_template.rb
@@ -56,7 +56,7 @@ module Provider
       end
 
       ctx.local_variable_set('pwd', pwd)
-      ctx.local_variable_set('hc_downstream', provider.generating_hashicorp_repo?())
+      ctx.local_variable_set('hc_downstream', provider.generating_hashicorp_repo?)
 
       # check if the parent folder exists, and make it if not
       parent_path = File.dirname(path)

--- a/mmv1/provider/file_template.rb
+++ b/mmv1/provider/file_template.rb
@@ -56,6 +56,7 @@ module Provider
       end
 
       ctx.local_variable_set('pwd', pwd)
+      ctx.local_variable_set('hc_downstream', provider.is_generating_hashicorp_repo?())
 
       # check if the parent folder exists, and make it if not
       parent_path = File.dirname(path)

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -31,6 +31,12 @@ module Provider
     include Provider::Terraform::SubTemplate
     include Google::GolangUtils
 
+    def is_generating_hashicorp_repo?()
+      # The default Provider is used to generate TPG and TPGB in HashiCorp-owned repos
+      # The compiler deviates from the default behaviour with a -f flag to produce non-HashiCorp downstreams
+      return true
+    end
+
     # ProductFileTemplate with Terraform specific fields
     class TerraformProductFileTemplate < Provider::ProductFileTemplate
       # The async object used for making operations.

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -31,10 +31,10 @@ module Provider
     include Provider::Terraform::SubTemplate
     include Google::GolangUtils
 
-    def is_generating_hashicorp_repo?()
+    def is_generating_hashicorp_repo?
       # The default Provider is used to generate TPG and TPGB in HashiCorp-owned repos
       # The compiler deviates from the default behaviour with a -f flag to produce non-HashiCorp downstreams
-      return true
+      true
     end
 
     # ProductFileTemplate with Terraform specific fields

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -31,7 +31,7 @@ module Provider
     include Provider::Terraform::SubTemplate
     include Google::GolangUtils
 
-    def is_generating_hashicorp_repo?
+    def generating_hashicorp_repo?
       # The default Provider is used to generate TPG and TPGB in HashiCorp-owned repos
       # The compiler deviates from the default behaviour with a -f flag to produce non-HashiCorp downstreams
       true

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -32,8 +32,9 @@ module Provider
     include Google::GolangUtils
 
     def generating_hashicorp_repo?
-      # The default Provider is used to generate TPG and TPGB in HashiCorp-owned repos
-      # The compiler deviates from the default behaviour with a -f flag to produce non-HashiCorp downstreams
+      # The default Provider is used to generate TPG and TPGB in HashiCorp-owned repos.
+      # The compiler deviates from the default behaviour with a -f flag to produce
+      # non-HashiCorp downstreams.
       true
     end
 

--- a/mmv1/provider/terraform_kcc.rb
+++ b/mmv1/provider/terraform_kcc.rb
@@ -43,9 +43,9 @@ module Provider
                         Ssl: 'SSL',
                         Url: 'URL' }.freeze
 
-    def is_generating_hashicorp_repo?()
+    def is_generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
-      return false
+      false
     end
 
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)

--- a/mmv1/provider/terraform_kcc.rb
+++ b/mmv1/provider/terraform_kcc.rb
@@ -43,7 +43,7 @@ module Provider
                         Ssl: 'SSL',
                         Url: 'URL' }.freeze
 
-    def is_generating_hashicorp_repo?
+    def generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
       false
     end

--- a/mmv1/provider/terraform_kcc.rb
+++ b/mmv1/provider/terraform_kcc.rb
@@ -43,6 +43,11 @@ module Provider
                         Ssl: 'SSL',
                         Url: 'URL' }.freeze
 
+    def is_generating_hashicorp_repo?()
+      # This code is not used when generating TPG/TPGB
+      return false
+    end
+
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)
       @base_url = @version.base_url
       generate_objects(output_folder, types, generate_code, generate_docs)

--- a/mmv1/provider/terraform_oics.rb
+++ b/mmv1/provider/terraform_oics.rb
@@ -17,14 +17,13 @@ module Provider
   # Code generator for runnable Terraform examples that can be run via an
   # Open in Cloud Shell link.
   class TerraformOiCS < Provider::Terraform
-    # We don't want *any* static generation, so we override generate to only
-    # generate objects.
-
     def generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
       false
     end
 
+    # We don't want *any* static generation, so we override generate to only
+    # generate objects.
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)
       generate_objects(
         output_folder,

--- a/mmv1/provider/terraform_oics.rb
+++ b/mmv1/provider/terraform_oics.rb
@@ -19,6 +19,12 @@ module Provider
   class TerraformOiCS < Provider::Terraform
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
+
+    def is_generating_hashicorp_repo?()
+      # This code is not used when generating TPG/TPGB
+      return false
+    end
+
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)
       generate_objects(
         output_folder,

--- a/mmv1/provider/terraform_oics.rb
+++ b/mmv1/provider/terraform_oics.rb
@@ -20,7 +20,7 @@ module Provider
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
 
-    def is_generating_hashicorp_repo?
+    def generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
       false
     end

--- a/mmv1/provider/terraform_oics.rb
+++ b/mmv1/provider/terraform_oics.rb
@@ -20,9 +20,9 @@ module Provider
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
 
-    def is_generating_hashicorp_repo?()
+    def is_generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
-      return false
+      false
     end
 
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -18,7 +18,7 @@ module Provider
   # Code generator for a library converting terraform state to gcp objects.
   class TerraformValidator < Provider::Terraform
 
-    def is_generating_hashicorp_repo?
+    def generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
       false
     end

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -17,7 +17,6 @@ require 'fileutils'
 module Provider
   # Code generator for a library converting terraform state to gcp objects.
   class TerraformValidator < Provider::Terraform
-
     def generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
       false

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -17,6 +17,12 @@ require 'fileutils'
 module Provider
   # Code generator for a library converting terraform state to gcp objects.
   class TerraformValidator < Provider::Terraform
+
+    def is_generating_hashicorp_repo?()
+      # This code is not used when generating TPG/TPGB
+      return false
+    end
+
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)
       # Temporary shim to generate the missing resources directory. Can be removed
       # once the folder exists downstream.

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -18,9 +18,9 @@ module Provider
   # Code generator for a library converting terraform state to gcp objects.
   class TerraformValidator < Provider::Terraform
 
-    def is_generating_hashicorp_repo?()
+    def is_generating_hashicorp_repo?
       # This code is not used when generating TPG/TPGB
-      return false
+      false
     end
 
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)

--- a/mmv1/templates/hashicorp_copyright_header.erb
+++ b/mmv1/templates/hashicorp_copyright_header.erb
@@ -1,0 +1,2 @@
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0

--- a/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
@@ -1,4 +1,6 @@
+<% if hc_downstream -%>
 <%= lines(hashicorp_copyright_header(:go, pwd)) -%>
+<% end -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 <%= lines(autogen_notice(:go, pwd)) -%>
 
 package google

--- a/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
@@ -1,5 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+<%= lines(hashicorp_copyright_header(:go, pwd)) -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -1,4 +1,6 @@
+<% if hc_downstream -%>
 <%= lines(hashicorp_copyright_header(:go, pwd)) -%>
+<% end -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 <%= lines(autogen_notice(:go, pwd)) -%>
 
 package google

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -1,5 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+<%= lines(hashicorp_copyright_header(:go, pwd)) -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+<% if hc_downstream -%>
 <%= lines(hashicorp_copyright_header(:go, pwd)) -%>
+<% end -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 <%= lines(autogen_notice(:go, pwd)) -%>
 
 package google

--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+<%= lines(hashicorp_copyright_header(:go, pwd)) -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -3,7 +3,9 @@
   has_project = object.base_url.include?("{{project}}")
   has_project = has_project || (object.async.is_a? Api::OpAsync and object.async.include_project)
 -%>
+<% if hc_downstream -%>
 <%= lines(hashicorp_copyright_header(:go, pwd)) -%>
+<% end -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -1,10 +1,9 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 <%
   product_name = object.__product.name
   has_project = object.base_url.include?("{{project}}")
   has_project = has_project || (object.async.is_a? Api::OpAsync and object.async.include_project)
 -%>
+<%= lines(hashicorp_copyright_header(:go, pwd)) -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 <%
   product_name = object.__product.name
   has_project = object.base_url.include?("{{project}}")

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+<% if hc_downstream -%>
 <%= lines(hashicorp_copyright_header(:go, pwd)) -%>
+<% end -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 <%= lines(autogen_notice(:go, pwd)) -%>
 
 package google

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+<%= lines(hashicorp_copyright_header(:go, pwd)) -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/sweeper_file.go.erb
+++ b/mmv1/templates/terraform/sweeper_file.go.erb
@@ -1,4 +1,6 @@
+<% if hc_downstream -%>
 <%= lines(hashicorp_copyright_header(:go, pwd)) -%>
+<% end -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/templates/terraform/sweeper_file.go.erb
+++ b/mmv1/templates/terraform/sweeper_file.go.erb
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 <%= lines(autogen_notice(:go, pwd)) -%>
 
 package google

--- a/mmv1/templates/terraform/sweeper_file.go.erb
+++ b/mmv1/templates/terraform/sweeper_file.go.erb
@@ -1,5 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+<%= lines(hashicorp_copyright_header(:go, pwd)) -%>
 
 <%= lines(autogen_notice(:go, pwd)) -%>
 

--- a/mmv1/third_party/terraform/main.go.erb
+++ b/mmv1/third_party/terraform/main.go.erb
@@ -1,4 +1,7 @@
 <% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package main
 
 import (


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

# Context

HashiCorp has this dependabot-style system for asserting that copyright headers are present in their public repos: https://github.com/hashicorp/terraform-provider-google/pull/13624

If we merge these automated PRs the changes will be lost as soon as the next update is merged from Magic Modules.

Instead, we need to update the code generator to add these headers 'at source'.

# Description

This PR acts to enable copyright headers to be included in the TPG/TPGB downstream repos by adding Ruby methods that allow the copyright header to be included in templated files only if TPG/TPGB is being generated. This is achieved by:
- Mimicking the way that the generated code notices are made; see `mmv1/compile/core.rb` and `mmv1/templates/hashicorp_copyright_header.erb`
- Making a boolean available to templates to let them know if the downstream being generated is TPG/TPGB or not; see `mmv1/provider/file_template.rb` for how the value is made available to the templating process, and the new `generating_hashicorp_repo?` functions in the changed `mmv1/provider/terraform*.rb` files

In a separate PR I hope to address how headers can be added to non-templated files that are copied as-is into the TPG/TPGB codebase (e.g. files that are in the transport package).

This PR corresponds to # 2 in the list below:

>1. Adding hardcoded headers to handwritten files that are used in TPG/TPGB and not used in terraform-google-conversion
>2. Provide Magic Modules with knowledge of what downstream it is making when logic in the templates is being evaluated, and have HashiCorp copyright be templated in only if TPG/TPGB is being generated.
>3. Handle handwritten files, specifically util files and packages like `transport`, that are copied into their downstream repo as-is and don't benefit from templating to introduce logic. The only edits to these files I'm aware of is the changing of import paths when the private version of the provider is built, and that's done without templating.


---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
