### PR TITLE
Configuration for traffic director Mesh resource.

### DIFF
--- a/mmv1/products/networkservices/Mesh.yaml
+++ b/mmv1/products/networkservices/Mesh.yaml
@@ -54,6 +54,12 @@ examples:
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-mesh'
+  - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
+    name: 'network_services_mesh_no_port'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-mesh-noport'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'name'

--- a/mmv1/products/networkservices/Mesh.yaml
+++ b/mmv1/products/networkservices/Mesh.yaml
@@ -1,0 +1,95 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'Mesh'
+base_url: 'projects/{{project}}/locations/global/meshes'
+create_url: 'projects/{{project}}/locations/global/meshes?meshId={{name}}'
+self_link: 'projects/{{project}}/locations/global/meshes/{{name}}'
+min_version: beta
+update_verb: :PATCH
+update_mask: true
+description: |
+  Mesh represents a logical configuration grouping for workload to workload communication within a 
+  service mesh. Routes that point to mesh dictate how requests are routed within this logical 
+  mesh boundary.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.meshes'
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 30
+      update_minutes: 30
+      delete_minutes: 30
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+autogen_async: true
+import_format: ['projects/{{project}}/locations/global/meshes/{{name}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
+    name: 'network_services_mesh_basic'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-mesh'
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    required: true
+    url_param_only: true
+    description: |
+      Short name of the Mesh resource to be created.
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'selfLink'
+    description: |
+      Server-defined URL of this resource.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    description: |
+      Time the Mesh was created in UTC.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    description: |
+      Time the Mesh was updated in UTC.
+    output: true
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'labels'
+    description: Set of label tags associated with the Mesh resource.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      A free-text description of the resource. Max length 1024 characters.
+  - !ruby/object:Api::Type::Integer
+    name: 'interceptionPort'
+    description: |
+      Optional. If set to a valid TCP port (1-65535), instructs the SIDECAR proxy to listen on the 
+      specified port of localhost (127.0.0.1) address. The SIDECAR proxy will expect all traffic to 
+      be redirected to this port regardless of its actual ip:port destination. If unset, a port 
+      '15001' is used as the interception port. This will is applicable only for sidecar proxy 
+      deployments.
+

--- a/mmv1/templates/terraform/examples/network_services_mesh_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_mesh_basic.tf.erb
@@ -1,0 +1,9 @@
+resource "google_network_services_mesh" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['resource_name'] %>"
+  labels      = {
+    foo = "bar"
+  }
+  description = "my description"
+  interception_port = 443
+}

--- a/mmv1/templates/terraform/examples/network_services_mesh_no_port.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_mesh_no_port.tf.erb
@@ -1,0 +1,9 @@
+resource "google_network_services_mesh" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['resource_name'] %>"
+  labels      = {
+    foo = "bar"
+  }
+  description = "my description"
+}
+

--- a/mmv1/third_party/terraform/tests/resource_network_services_mesh_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_services_mesh_test.go.erb
@@ -1,0 +1,63 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetworkServicesMesh_update(t *testing.T) {
+	t.Parallel()
+
+	meshName := fmt.Sprintf("tf-test-mesh-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    TestAccProviders,
+		CheckDestroy: testAccCheckNetworkServicesMeshDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkServicesMesh_basic(meshName),
+			},
+			{
+				ResourceName:      "google_network_services_mesh.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccNetworkServicesMesh_update(meshName),
+			},
+			{
+				ResourceName:      "google_network_services_mesh.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNetworkServicesMesh_basic(meshName string) string {
+	return fmt.Sprintf(`
+resource "google_network_services_mesh" "foobar" {
+  name        = "%s"
+  description = "my description"
+}
+`, meshName)
+}
+
+func testAccNetworkServicesMesh_update(meshName string) string {
+	return fmt.Sprintf(`
+resource "google_network_services_mesh" "foobar" {
+  name        = "%s"
+  description = "update description"
+  labels      = {
+    foo = "bar"
+  } 
+}
+`, meshName)
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_network_services_mesh_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_services_mesh_test.go.erb
@@ -16,8 +16,8 @@ func TestAccNetworkServicesMesh_update(t *testing.T) {
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    TestAccProviders,
-		CheckDestroy: testAccCheckNetworkServicesMeshDestroyProducer(t),
+                ProtoV5ProviderFactories: ProtoV5ProviderFactories(t), 
+                CheckDestroy: testAccCheckNetworkServicesMeshDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkServicesMesh_basic(meshName),


### PR DESCRIPTION
Add configuration for traffic director mesh resource

part of https://github.com/hashicorp/terraform-provider-google/issues/14037


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:new-resource
`google_networkservices_mesh`
```
