### PR TITLE
Fix certificate_manager_dns_authorization examples to use sweepable names

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_https_proxy_test.go.erb
@@ -333,7 +333,7 @@ resource "google_certificate_manager_certificate" "certificate" {
 }
 
 resource "google_certificate_manager_dns_authorization" "instance" {
-  name   = "dnsauthorization-test-%s"
+  name   = "tf-test-dnsauthorization-%s"
   domain = "mysite.com"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_https_proxy_test.go.erb
@@ -36,7 +36,7 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 					testAccCheckComputeTargetHttpsProxyExists(
 						t, "google_compute_target_https_proxy.foobar", &proxy),
 					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
-					testAccComputeTargetHttpsProxyHasSslCertificate(t, "httpsproxy-test-cert1-"+resourceSuffix, &proxy),
+					testAccComputeTargetHttpsProxyHasSslCertificate(t, "tf-test-httpsproxy-cert1-"+resourceSuffix, &proxy),
 				),
 			},
 
@@ -46,8 +46,8 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 					testAccCheckComputeTargetHttpsProxyExists(
 						t, "google_compute_target_https_proxy.foobar", &proxy),
 					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
-					testAccComputeTargetHttpsProxyHasSslCertificate(t, "httpsproxy-test-cert1-"+resourceSuffix, &proxy),
-					testAccComputeTargetHttpsProxyHasSslCertificate(t, "httpsproxy-test-cert2-"+resourceSuffix, &proxy),
+					testAccComputeTargetHttpsProxyHasSslCertificate(t, "tf-test-httpsproxy-cert1-"+resourceSuffix, &proxy),
+					testAccComputeTargetHttpsProxyHasSslCertificate(t, "tf-test-httpsproxy-cert2-"+resourceSuffix, &proxy),
 				),
 			},
 		},
@@ -71,7 +71,7 @@ func TestAccComputeTargetHttpsProxy_certificateMap(t *testing.T) {
                     testAccCheckComputeTargetHttpsProxyExists(
                         t, "google_compute_target_https_proxy.foobar", &proxy),
                     testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
-                    testAccComputeTargetHttpsProxyHasCertificateMap(t, "certificatemap-test-"+resourceSuffix, &proxy),
+                    testAccComputeTargetHttpsProxyHasCertificateMap(t, "tf-test-certmap-"+resourceSuffix, &proxy),
                 ),
             },
         },

--- a/mmv1/third_party/terraform/tests/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_https_proxy_test.go.erb
@@ -149,26 +149,26 @@ func testAccComputeTargetHttpsProxy_basic1(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_https_proxy" "foobar" {
   description      = "Resource created for Terraform acceptance testing"
-  name             = "httpsproxy-test-%s"
+  name             = "tf-test-httpsproxy-%s"
   url_map          = google_compute_url_map.foobar.self_link
   ssl_certificates = [google_compute_ssl_certificate.foobar1.self_link]
   ssl_policy       = google_compute_ssl_policy.foobar.self_link
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "httpsproxy-test-backend-%s"
+  name          = "tf-test-httpsproxy-backend-%s"
   health_checks = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
-  name               = "httpsproxy-test-health-check-%s"
+  name               = "tf-test-httpsproxy-check-%s"
   request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-  name            = "httpsproxy-test-url-map-%s"
+  name            = "tf-test-httpsproxy-urlmap-%s"
   default_service = google_compute_backend_service.foobar.self_link
   host_rule {
     hosts        = ["mysite.com", "myothersite.com"]
@@ -190,21 +190,21 @@ resource "google_compute_url_map" "foobar" {
 }
 
 resource "google_compute_ssl_policy" "foobar" {
-  name            = "sslproxy-test-%s"
+  name            = "tf-test-sslproxy-%s"
   description     = "my-description"
   min_tls_version = "TLS_1_2"
   profile         = "MODERN"
 }
 
 resource "google_compute_ssl_certificate" "foobar1" {
-  name        = "httpsproxy-test-cert1-%s"
+  name        = "tf-test-httpsproxy-cert1-%s"
   description = "very descriptive"
   private_key = file("test-fixtures/ssl_cert/test.key")
   certificate = file("test-fixtures/ssl_cert/test.crt")
 }
 
 resource "google_compute_ssl_certificate" "foobar2" {
-  name        = "httpsproxy-test-cert2-%s"
+  name        = "tf-test-httpsproxy-cert2-%s"
   description = "very descriptive"
   private_key = file("test-fixtures/ssl_cert/test.key")
   certificate = file("test-fixtures/ssl_cert/test.crt")
@@ -216,7 +216,7 @@ func testAccComputeTargetHttpsProxy_basic2(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_https_proxy" "foobar" {
   description = "Resource created for Terraform acceptance testing"
-  name        = "httpsproxy-test-%s"
+  name        = "tf-test-httpsproxy-%s"
   url_map     = google_compute_url_map.foobar.self_link
   ssl_certificates = [
     google_compute_ssl_certificate.foobar1.self_link,
@@ -226,19 +226,19 @@ resource "google_compute_target_https_proxy" "foobar" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "httpsproxy-test-backend-%s"
+  name          = "tf-test-httpsproxy-backend-%s"
   health_checks = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
-  name               = "httpsproxy-test-health-check-%s"
+  name               = "tf-test-httpsproxy-check-%s"
   request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-  name            = "httpsproxy-test-url-map-%s"
+  name            = "tf-test-httpsproxy-urlmap-%s"
   default_service = google_compute_backend_service.foobar.self_link
   host_rule {
     hosts        = ["mysite.com", "myothersite.com"]
@@ -260,21 +260,21 @@ resource "google_compute_url_map" "foobar" {
 }
 
 resource "google_compute_ssl_policy" "foobar" {
-  name            = "sslproxy-test-%s"
+  name            = "tf-test-sslproxy-%s"
   description     = "my-description"
   min_tls_version = "TLS_1_2"
   profile         = "MODERN"
 }
 
 resource "google_compute_ssl_certificate" "foobar1" {
-  name        = "httpsproxy-test-cert1-%s"
+  name        = "tf-test-httpsproxy-cert1-%s"
   description = "very descriptive"
   private_key = file("test-fixtures/ssl_cert/test.key")
   certificate = file("test-fixtures/ssl_cert/test.crt")
 }
 
 resource "google_compute_ssl_certificate" "foobar2" {
-  name        = "httpsproxy-test-cert2-%s"
+  name        = "tf-test-httpsproxy-cert2-%s"
   description = "very descriptive"
   private_key = file("test-fixtures/ssl_cert/test.key")
   certificate = file("test-fixtures/ssl_cert/test.crt")
@@ -286,41 +286,41 @@ func testAccComputeTargetHttpsProxy_certificateMap(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_https_proxy" "foobar" {
   description      = "Resource created for Terraform acceptance testing"
-  name             = "httpsproxy-test-%s"
+  name             = "tf-test-httpsproxy-%s"
   url_map          = google_compute_url_map.foobar.self_link
   certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map.id}"
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "httpsproxy-test-backend-%s"
+  name          = "tf-test-httpsproxy-backend-%s"
   health_checks = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
-  name               = "httpsproxy-test-health-check-%s"
+  name               = "tf-test-httpsproxy-check-%s"
   request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-  name            = "httpsproxy-test-url-map-%s"
+  name            = "tf-test-httpsproxy-urlmap-%s"
   default_service = google_compute_backend_service.foobar.self_link
 }
 
 resource "google_certificate_manager_certificate_map" "map" {
-  name = "certificatemap-test-%s"
+  name = "tf-test-certmap-%s"
 }
 
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
-  name         = "certificatemapentry-test-%s"
+  name         = "tf-test-certmapentry-%s"
   map          = google_certificate_manager_certificate_map.map.name
   certificates = [google_certificate_manager_certificate.certificate.id]
   matcher      = "PRIMARY"
 }
 
 resource "google_certificate_manager_certificate" "certificate" {
-  name        = "certificate-test-%s"
+  name        = "tf-test-cert-%s"
   scope       = "DEFAULT"
   managed {
     domains = [
@@ -333,7 +333,7 @@ resource "google_certificate_manager_certificate" "certificate" {
 }
 
 resource "google_certificate_manager_dns_authorization" "instance" {
-  name   = "tf-test-dnsauthorization-%s"
+  name   = "tf-test-dnsauthz-%s"
   domain = "mysite.com"
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
@@ -277,7 +277,7 @@ resource "google_certificate_manager_certificate" "certificate" {
 }
 
 resource "google_certificate_manager_dns_authorization" "instance" {
-  name   = "dnsauthorization-test-%s"
+  name   = "tf-test-dnsauthorization-%s"
   domain = "mysite.com"
 }
 `, id, id, id, id, id, id, id)

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
@@ -16,13 +16,13 @@ import (
 )
 
 func TestAccComputeTargetSslProxy_update(t *testing.T) {
-	target := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
-	sslPolicy := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
-	cert1 := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
-	cert2 := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
-	backend1 := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
-	backend2 := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
-	hc := fmt.Sprintf("tssl-test-%s", RandString(t, 10))
+	target := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
+	sslPolicy := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
+	cert1 := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
+	cert2 := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
+	backend1 := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
+	backend2 := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
+	hc := fmt.Sprintf("tf-test-tssl-%s", RandString(t, 10))
 
 	resourceSuffix := RandString(t, 10)
 	var proxy compute.TargetSslProxy
@@ -233,19 +233,19 @@ func testAccComputeTargetSslProxy_certificateMap1(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_ssl_proxy" "with_certificate_map" {
   description      = "Resource created for Terraform acceptance testing"
-  name             = "ssl-proxy-%s"
+  name             = "tf-test-ssl-proxy-%s"
   backend_service  = google_compute_backend_service.foo.self_link
 	certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map1.id}"
 }
 
 resource "google_compute_backend_service" "foo" {
-  name          = "backend-service-%s"
+  name          = "tf-test-backend-%s"
   protocol      = "SSL"
   health_checks = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_health_check" "zero" {
-  name               = "health-check-%s"
+  name               = "tf-test-check-%s"
   check_interval_sec = 1
   timeout_sec        = 1
   tcp_health_check {
@@ -254,17 +254,17 @@ resource "google_compute_health_check" "zero" {
 }
 
 resource "google_certificate_manager_certificate_map" "map1" {
-  name = "certificatemap-test-1-%s"
+  name = "tf-test-certmap-1-%s"
 }
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
-  name         = "certificatemapentry-test-%s"
+  name         = "tf-test-certmapentry-%s"
   map          = google_certificate_manager_certificate_map.map1.name
   certificates = [google_certificate_manager_certificate.certificate.id]
   matcher      = "PRIMARY"
 }
 
 resource "google_certificate_manager_certificate" "certificate" {
-  name        = "certificate-test-%s"
+  name        = "tf-test-cert-%s"
   scope       = "DEFAULT"
   managed {
     domains = [
@@ -277,7 +277,7 @@ resource "google_certificate_manager_certificate" "certificate" {
 }
 
 resource "google_certificate_manager_dns_authorization" "instance" {
-  name   = "tf-test-dnsauthorization-%s"
+  name   = "tf-test-dnsauthz-%s"
   domain = "mysite.com"
 }
 `, id, id, id, id, id, id, id)
@@ -287,19 +287,19 @@ func testAccComputeTargetSslProxy_certificateMap2(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_ssl_proxy" "with_certificate_map" {
   description      = "Resource created for Terraform acceptance testing"
-  name             = "ssl-proxy-%s"
+  name             = "tf-test-ssl-proxy-%s"
   backend_service  = google_compute_backend_service.foo.self_link
 	certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map2.id}"
 }
 
 resource "google_compute_backend_service" "foo" {
-  name          = "backend-service-%s"
+  name          = "tf-test-backend-%s"
   protocol      = "SSL"
   health_checks = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_health_check" "zero" {
-  name               = "health-check-%s"
+  name               = "tf-test-check-%s"
   check_interval_sec = 1
   timeout_sec        = 1
   tcp_health_check {
@@ -308,22 +308,22 @@ resource "google_compute_health_check" "zero" {
 }
 
 resource "google_certificate_manager_certificate_map" "map1" {
-  name = "certificatemap-test-1-%s"
+  name = "tf-test-certmap-1-%s"
 }
 
 resource "google_certificate_manager_certificate_map" "map2" {
-  name = "certificatemap-test-2-%s"
+  name = "tf-test-certmap-2-%s"
 }
 
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
-  name         = "certificatemapentry-test-%s"
+  name         = "tf-test-certmapentry-%s"
   map          = google_certificate_manager_certificate_map.map1.name
   certificates = [google_certificate_manager_certificate.certificate.id]
   matcher      = "PRIMARY"
 }
 
 resource "google_certificate_manager_certificate" "certificate" {
-  name        = "certificate-test-%s"
+  name        = "tf-test-cert-%s"
   scope       = "DEFAULT"
   managed {
     domains = [
@@ -336,7 +336,7 @@ resource "google_certificate_manager_certificate" "certificate" {
 }
 
 resource "google_certificate_manager_dns_authorization" "instance" {
-  name   = "dnsauthorization-test-%s"
+  name   = "tf-test-dnsauthz-%s"
   domain = "mysite.com"
 }
 `, id, id, id, id, id, id, id, id)

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go.erb
@@ -55,7 +55,7 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetSslProxyExists(
 						t, "google_compute_target_ssl_proxy.with_certificate_map", &proxy),
-					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "certificatemap-test-1-"+resourceSuffix, &proxy),
+					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "tf-test-certmap-1-"+resourceSuffix, &proxy),
 				),
 			},
 			{
@@ -63,7 +63,7 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetSslProxyExists(
 						t, "google_compute_target_ssl_proxy.with_certificate_map", &proxy),
-					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "certificatemap-test-2-"+resourceSuffix, &proxy),
+					testAccCheckComputeTargetSslProxyHasCertificateMap(t, "tf-test-certmap-2-"+resourceSuffix, &proxy),
 				),
 			},
 		},


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/14066

I've already deleted the leftover resources causing the issue, so this change just attempts to make these resources sweepable. Note that these particular resource need to be deleted in order, so it remains to be seen how this actually behaves in sweeper runs, but this is at least a step in the right direction.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
