### PR TITLE
Fix firebase_project to succeed on apply when the project already has firebase enabled

### DIFF
--- a/mmv1/products/firebase/Project.yaml
+++ b/mmv1/products/firebase/Project.yaml
@@ -40,6 +40,9 @@ examples:
       instance_name: "memory-cache"
     test_env_vars:
       org_id: :ORG_ID
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: templates/terraform/constants/firebase_project.go.erb
+  pre_create: templates/terraform/pre_create/firebase_project.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: projectNumber

--- a/mmv1/templates/terraform/constants/firebase_project.go.erb
+++ b/mmv1/templates/terraform/constants/firebase_project.go.erb
@@ -1,0 +1,21 @@
+func getExistingFirebaseProjectId(config *Config, d *schema.ResourceData, billingProject string, userAgent string) (string, error) {
+	url, err := replaceVars(d, config, "{{FirebaseBasePath}}projects/{{project}}")
+	if err != nil {
+		return "", err
+	}
+
+	_, err = SendRequest(config, "GET", billingProject, url, userAgent, nil)
+	if err == nil {
+		id, err := replaceVars(d, config, "projects/{{project}}")
+		if err != nil {
+			return "", fmt.Errorf("Error constructing id: %s", err)
+		}
+		return id, nil
+	}
+
+	if !IsGoogleApiErrorWithCode(err, 404) {
+		return "", err
+	}
+
+	return "", nil
+}

--- a/mmv1/templates/terraform/pre_create/firebase_project.go.erb
+++ b/mmv1/templates/terraform/pre_create/firebase_project.go.erb
@@ -1,0 +1,11 @@
+// Check if Firebase has already been enabled
+existingId, err := getExistingFirebaseProjectId(config, d, billingProject, userAgent)
+if err != nil {
+	return fmt.Errorf("Error checking if Firebase is already enabled: %s", err)
+}
+
+if existingId != "" {
+	log.Printf("[DEBUG] Firebase is already enabled for project %s", project)
+	d.SetId(existingId)
+	return resourceFirebaseProjectRead(d, meta)
+}

--- a/mmv1/third_party/terraform/tests/resource_firebase_project_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_project_test.go.erb
@@ -1,0 +1,57 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFirebaseProject_destroyAndReapply(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        GetTestOrgFromEnv(t),
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirebaseProject_firebaseProjectBasicExample(context),
+			},
+			{
+				Config: testAccFirebaseProject_firebaseProjectBasicExampleDestroyed(context),
+			},
+			{
+				Config: testAccFirebaseProject_firebaseProjectBasicExample(context),
+			},
+			{
+				ResourceName:      "google_firebase_project.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccFirebaseProject_firebaseProjectBasicExampleDestroyed(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_project" "default" {
+  provider = google-beta
+
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "%{org_id}"
+
+  labels = {
+    "firebase" = "enabled"
+  }
+}
+`, context)
+}
+
+<% end -%>


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/14036

This fixes an issue where if a project already had Firebase enabled, `terraform apply` would fail with a 409 error. This was problematic because Firebase cannot be disabled, so while a user would normally expect to be able to apply -> destroy -> apply successfully, it would fail on this resource.

There was a workaround for users to import, but it was not ideal to force users to do this just for a single boolean setting.

Note that the proposed solution here matches how `project_service` currently works, where it first checks the API for the current state, and breaks early if there are no changes needed.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firebase: fix `google_firebase_project` to succeed on apply when the project already has firebase enabled
```
