### PR TITLE
Support IPV6 for HA VPN.

### DIFF
--- a/mmv1/products/compute/VpnGateway.yaml
+++ b/mmv1/products/compute/VpnGateway.yaml
@@ -133,7 +133,7 @@ properties:
     required: true
     immutable: true
   - !ruby/object:Api::Type::Enum
-    name: 'stack_type'
+    name: 'stackType'
     description: |
       The stack type for this VPN gateway to identify the IP protocols that are enbaled.
       If not specified, IPV4_ONLY will be used.
@@ -141,8 +141,7 @@ properties:
     values:
       - :IPV4_ONLY
       - :IPV4_IPV6
-    immutable: true
-    ignore_read: true    
+    immutable: true  
   - !ruby/object:Api::Type::Array
     name: 'vpnInterfaces'
     description: |

--- a/mmv1/products/compute/VpnGateway.yaml
+++ b/mmv1/products/compute/VpnGateway.yaml
@@ -53,6 +53,12 @@ examples:
       ha_vpn_gateway1_name: "ha-vpn-1"
       network1_name: "network1"
   - !ruby/object:Provider::Terraform::Examples
+    name: "ha_vpn_gateway_ipv6"
+    primary_resource_id: "ha_gateway1"
+    vars:
+      ha_vpn_gateway1_name: "ha-vpn-1"
+      network1_name: "network1"
+  - !ruby/object:Provider::Terraform::Examples
     name: "ha_vpn_gateway_gcp_to_gcp"
     primary_resource_id: "ha_gateway1"
         # Multiple fine-grained resources
@@ -126,6 +132,17 @@ properties:
       The network this VPN gateway is accepting traffic for.
     required: true
     immutable: true
+  - !ruby/object:Api::Type::Enum
+    name: 'stack_type'
+    description: |
+      The stack type for this VPN gateway to identify the IP protocols that are enbaled.
+      If not specified, IPV4_ONLY will be used.
+    default_value: :IPV4_ONLY
+    values:
+      - :IPV4_ONLY
+      - :IPV4_IPV6
+    immutable: true
+    ignore_read: true    
   - !ruby/object:Api::Type::Array
     name: 'vpnInterfaces'
     description: |

--- a/mmv1/templates/terraform/examples/ha_vpn_gateway_ipv6.tf.erb
+++ b/mmv1/templates/terraform/examples/ha_vpn_gateway_ipv6.tf.erb
@@ -1,0 +1,11 @@
+resource "google_compute_ha_vpn_gateway" "ha_gateway1" {
+  region   = "us-central1"
+  name     = "<%= ctx[:vars]['ha_vpn_gateway1_name'] %>"
+  network  = google_compute_network.network1.id
+  stack_type = "IPV4_IPV6"
+}
+
+resource "google_compute_network" "network1" {
+  name                    = "<%= ctx[:vars]['network1_name'] %>"
+  auto_create_subnetworks = false
+}

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_ha_vpn_gateway_test.go
@@ -18,14 +18,7 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceComputeHaVpnGatewayConfig(gwName),
-				// Check:  checkDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
-				Check: resource.ComposeTestCheckFunc(
-					checkDataSourceStateMatchesResourceStateWithIgnores(
-						"data.google_compute_ha_vpn_gateway.ha_gateway",
-						"google_compute_ha_vpn_gateway.ha_gateway",
-						map[string]struct{}{"stack_type": {}},
-					),
-				),
+				Check:  checkDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_ha_vpn_gateway_test.go
@@ -18,7 +18,14 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceComputeHaVpnGatewayConfig(gwName),
-				Check:  checkDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
+				// Check:  checkDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_compute_ha_vpn_gateway.ha_gateway",
+						"google_compute_ha_vpn_gateway.ha_gateway",
+						map[string]struct{}{"stack_type": {}},
+					),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Support IPV6/dual stack in HA VPN gateway
https://github.com/hashicorp/terraform-provider-google/issues/13752


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added stack_type to resource `ha_vpn_gateway`
```
