### PR TITLE
Fix cloudrun release stage used in examples

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_job_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_basic.tf.erb
@@ -1,7 +1,6 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
-  launch_stage = "BETA"
 
   template {
     template {

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
@@ -1,7 +1,6 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
-  launch_stage = "BETA"
 
   template {
     template {

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
@@ -1,7 +1,6 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
-  launch_stage = "BETA"
   
   template {
     template{

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_vpcaccess.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_vpcaccess.tf.erb
@@ -1,7 +1,6 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
-  launch_stage = "BETA"
 
   template {
     template{

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_job_test.go
@@ -45,7 +45,6 @@ func testAccCloudRunV2Job_cloudrunv2JobFull(context map[string]interface{}) stri
   resource "google_cloud_run_v2_job" "default" {
     name     = "tf-test-cloudrun-job%{random_suffix}"
     location = "us-central1"
-    launch_stage = "BETA"
     labels = {
       label-1 = "value-1"
     }
@@ -102,7 +101,6 @@ func testAccCloudRunV2Job_cloudrunv2JobFullUpdate(context map[string]interface{}
 resource "google_cloud_run_v2_job" "default" {
   name     = "tf-test-cloudrun-job%{random_suffix}"
   location = "us-central1"
-  launch_stage = "BETA"
   binary_authorization {
     use_default = true
     breakglass_justification = "Some justification"


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/14083

It appears that the default release stage is now GA, so we should be able to remove it from the examples and rely on the API default now.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
