### PR TITLE
Remove additional_attributes check from TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_cloud_asset_resources_search_all_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_cloud_asset_resources_search_all_test.go.erb
@@ -28,8 +28,6 @@ func TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic(t *testing.T) {
 						"results.0.display_name", regexp.MustCompile(project)),
 					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
 						"results.0.name", regexp.MustCompile(fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project))),
-					resource.TestMatchResourceAttr("data.google_cloud_asset_resources_search_all.resources",
-						"results.0.additional_attributes.0", regexp.MustCompile(project)),
 					resource.TestCheckResourceAttrSet("data.google_cloud_asset_resources_search_all.resources", "results.0.location"),
 					resource.TestCheckResourceAttrSet("data.google_cloud_asset_resources_search_all.resources", "results.0.project"),
 				),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic

This seems to have been dropped from the API. Docs for the field state it's a possibility: "Additional searchable attributes of this resource. Informational only. The exact set of attributes is subject to change. For example: project id, DNS name etc."

I suspect we hit the tip of the rollout removing it, as [logs from last night](https://ci-oss.hashicorp.engineering/repository/download/GoogleCloudBeta_ProviderGoogleCloudBetaGoogleProject/384990:id/debug-google-beta-60416c5-TestAccDataSourceGoogleCloudAssetResourcesSearchAll_basic.log) showed it getting returned in one response and not the next, even though they're identical. Later VCR logs and my local testing show it not getting returned.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
