### PR TITLE
Fix docs value for service account examples, change notebooks instanc…

### DIFF
--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -160,7 +160,7 @@ module Provider
           ORG_TARGET: '123456789',
           BILLING_ACCT: '000000-0000000-0000000-000000',
           MASTER_BILLING_ACCT: '000000-0000000-0000000-000000',
-          SERVICE_ACCT: 'emailAddress:my@service-account.com',
+          SERVICE_ACCT: 'my@service-account.com',
           CUST_ID: 'A01b123xz',
           IDENTITY_USER: 'cloud_identity_user'
         }

--- a/mmv1/templates/terraform/examples/notebook_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/notebook_instance_full.tf.erb
@@ -8,7 +8,7 @@ resource "google_notebooks_instance" "<%= ctx[:primary_resource_id] %>" {
     image_family = "tf-latest-cpu"
   }
 
-  instance_owners = ["admin@hashicorptest.com"]
+  instance_owners = [ "<%= ctx[:test_env_vars]["service_account"] %>"]
   service_account = "<%= ctx[:test_env_vars]["service_account"] %>"
 
   install_gpu_driver = true

--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -410,7 +410,7 @@ var translationMap = map[string]translationIndex{
 		contextValue: "GetTestBillingAccountFromEnv(t)",
 	},
 	"test_service_account": {
-		docsValue:    "emailAddress:my@service-account.com",
+		docsValue:    "my@service-account.com",
 		contextKey:   "service_acct",
 		contextValue: "GetTestServiceAccountFromEnv(t)",
 	},


### PR DESCRIPTION
…e_owners

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The GOOGLE_SERVICE_ACCOUNT environment variable is just an email, but our example in documentation included an `emailAddress:` prefix. Fix that.

Additionally, the `instance_owners` value in the notebooks full example appeared to correspond to a GCP account, not an outside one. For simplicity, just use the same SA- the owner needs permission to act as the notebooks SA.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14082


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
