### PR TITLE
fix the OperationWaitTime method signature template

### DIFF
--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -1,7 +1,9 @@
 <%
   product_name = object.__product.name
   has_project = object.base_url.include?("{{project}}")
+  has_project = has_project || (object.async.is_a? Api::OpAsync and object.async.include_project)
 -%>
+
 <%= lines(autogen_notice(:go, pwd)) -%>
 
 package google


### PR DESCRIPTION
This commit fixes the OperationWaitTime method signature template not considering the project parameter for child resources which doesn't have {{project}} token in the URL

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
I got issue while generating resources for internal preview -
too many arguments in call to xxxxxOperationWaitTime
reason is one of the child resources doesn't has `{{project}}` token in the URL, URL looks like this `{{parent}}/clusters` but `object.async.include_project` flag is set.
Although call site of OperationWaitTime has appropriate checks which includes the flag `object.async.include_project` (see the links below), corresponding checks are missing in OperationWaitTime signature itself, so there is a mismatch in  method call and actual method signature generated  -

Method call templates -
1. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/resource.erb#L282
2. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/resource.erb#L334
3. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/resource.erb#L683
4. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/resource.erb#L817
5. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/resource.erb#L937

Method signature template -
1. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/operation.go.erb#L82
2. https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/operation.go.erb#L70

Signature doesn't consider `object.async.include_project` while call site have these checks.
There might be some other way, but I could not find solution for this issue. Adding these checks operation templates fixed the issue and worked for me. 
Creating this PR to validate if there is any wider impact or if there is any other solution for this.

This PR should not have any changes in the existing resources and its not meant for Terraform.
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:none
```