### PR TITLE
Ignore cloud_run_v2_job.launch_stage in tests

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_job_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_basic.tf.erb
@@ -10,4 +10,10 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
 }

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
@@ -26,6 +26,12 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
 }
 
 data "google_project" "project" {

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
@@ -35,6 +35,12 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
 }
 
 data "google_project" "project" {

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_vpcaccess.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_vpcaccess.tf.erb
@@ -14,6 +14,12 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
 }
 
 resource "google_vpc_access_connector" "connector" {

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_job_test.go
@@ -25,7 +25,7 @@ func TestAccCloudRunV2Job_cloudrunv2JobFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_job.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "launch_stage"},
 			},
 			{
 				Config: testAccCloudRunV2Job_cloudrunv2JobFullUpdate(context),
@@ -34,7 +34,7 @@ func TestAccCloudRunV2Job_cloudrunv2JobFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_job.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "launch_stage"},
 			},
 		},
 	})


### PR DESCRIPTION
This is a mitigation for https://github.com/hashicorp/terraform-provider-google/issues/14083 until we determine the best resolution. When we have a better option, this change should be reverted.

Since the API requires a `BETA` launch stage, but then returns a `GA` launch stage when complete, we get a permadiff that cannot be resolved. This change ignores the field for now to avoid the permadiff and allow all other testing to proceed.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
