### PR TITLE
docs: Firestore and App Engine resources reference each other

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -19,7 +19,11 @@ update_verb: :PATCH
 update_mask: true
 description: |
   A Cloud Firestore Database. Currently only one database is allowed per
-  cloud project; this database must have a `database_id` of '(default)'.
+  Cloud project; this database must have a `database_id` of '(default)'.
+
+  If you wish to use Firestore with App Engine, use the
+  [`google_app_engine_application`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/app_engine_application)
+  resource instead.
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/firestore/docs/'
@@ -73,7 +77,7 @@ properties:
     name: name
     required: true
     description: |
-      Required. The ID to use for the database, which will become the final
+      The ID to use for the database, which will become the final
       component of the database's resource name. This value should be 4-63
       characters. Valid characters are /[a-z][0-9]-/ with first character
       a letter and the last a letter or a number. Must not be

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -46,8 +46,10 @@ The following arguments are supported:
 
 * `database_type` - (Optional) The type of the Cloud Firestore or Cloud Datastore database associated with this application.
    Can be `CLOUD_FIRESTORE` or `CLOUD_DATASTORE_COMPATIBILITY` for new
-   instances.  To support old instances, the value `CLOUD_DATASTORE` is accepted
-   by the provider, but will be rejected by the API.
+   instances.  To support old instances, the value `CLOUD_DATASTORE` is accepted by the provider, but will be rejected by the API.
+   To create a Cloud Firestore database without creating an App Engine application, use the
+   [`google_firestore_database`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/firestore_database)
+   resource instead.
 
 * `serving_status` - (Optional) The serving status of the app.
 


### PR DESCRIPTION
The two resources conflict when both attempt to manage a Firestore database, so we should point out to users that you should only use one or the other.

Came out of discussions about https://github.com/hashicorp/terraform-provider-google/issues/13891

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). **N/A**
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). **N/A**
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```
release-note:none
```