### PR TITLE
Update TestAccBillingBudget_budgetFilterProjectsOrdering to avoid access issues

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
@@ -579,10 +579,6 @@ func TestAccBillingBudget_budgetFilterProjectsOrdering(t *testing.T) {
 func testAccBillingBudget_budgetFilterProjectsOrdering1(context map[string]interface{}) string {
 	return Nprintf(`
 
-data "google_billing_account" "project_account" {
-	billing_account = "%{project_billing_acct}"
-}
-
 data "google_billing_account" "account" {
 	billing_account = "%{billing_acct}"
 }
@@ -591,14 +587,14 @@ resource "google_project" "project1" {
 	project_id      = "tf-test-%{random_suffix_1}"
 	name            = "tf-test-%{random_suffix_1}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.project_account.id
+	billing_account = "%{project_billing_acct}"
 }
 
 resource "google_project" "project2" {
 	project_id      = "tf-test-%{random_suffix_2}"
 	name            = "tf-test-%{random_suffix_2}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.project_account.id
+	billing_account = "%{project_billing_acct}"
 }
 
 resource "google_billing_budget" "budget" {
@@ -627,10 +623,6 @@ resource "google_billing_budget" "budget" {
 func testAccBillingBudget_budgetFilterProjectsOrdering2(context map[string]interface{}) string {
 	return Nprintf(`
 
-data "google_billing_account" "project_account" {
-	billing_account = "%{project_billing_acct}"
-}
-
 data "google_billing_account" "account" {
 	billing_account = "%{billing_acct}"
 }
@@ -639,14 +631,14 @@ resource "google_project" "project1" {
 	project_id      = "tf-test-%{random_suffix_1}"
 	name            = "tf-test-%{random_suffix_1}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.project_account.id
+	billing_account = "%{project_billing_acct}"
 }
 
 resource "google_project" "project2" {
 	project_id      = "tf-test-%{random_suffix_2}"
 	name            = "tf-test-%{random_suffix_2}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.project_account.id
+	billing_account = "%{project_billing_acct}"
 }
 
 resource "google_billing_budget" "budget" {

--- a/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
@@ -541,10 +541,11 @@ func TestAccBillingBudget_budgetFilterProjectsOrdering(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org":             GetTestOrgFromEnv(t),
-		"billing_acct":    GetTestMasterBillingAccountFromEnv(t),
-		"random_suffix_1": RandString(t, 10),
-		"random_suffix_2": RandString(t, 10),
+		"org":                  GetTestOrgFromEnv(t),
+		"billing_acct":         GetTestMasterBillingAccountFromEnv(t),
+		"project_billing_acct": GetTestBillingAccountFromEnv(t),
+		"random_suffix_1":      RandString(t, 10),
+		"random_suffix_2":      RandString(t, 10),
 	}
 
 	VcrTest(t, resource.TestCase{
@@ -578,6 +579,10 @@ func TestAccBillingBudget_budgetFilterProjectsOrdering(t *testing.T) {
 func testAccBillingBudget_budgetFilterProjectsOrdering1(context map[string]interface{}) string {
 	return Nprintf(`
 
+data "google_billing_account" "project_account" {
+	billing_account = "%{project_billing_acct}"
+}
+
 data "google_billing_account" "account" {
 	billing_account = "%{billing_acct}"
 }
@@ -586,14 +591,14 @@ resource "google_project" "project1" {
 	project_id      = "tf-test-%{random_suffix_1}"
 	name            = "tf-test-%{random_suffix_1}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.account.id
+	billing_account = data.google_billing_account.project_account.id
 }
 
 resource "google_project" "project2" {
 	project_id      = "tf-test-%{random_suffix_2}"
 	name            = "tf-test-%{random_suffix_2}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.account.id
+	billing_account = data.google_billing_account.project_account.id
 }
 
 resource "google_billing_budget" "budget" {
@@ -622,6 +627,10 @@ resource "google_billing_budget" "budget" {
 func testAccBillingBudget_budgetFilterProjectsOrdering2(context map[string]interface{}) string {
 	return Nprintf(`
 
+data "google_billing_account" "project_account" {
+	billing_account = "%{project_billing_acct}"
+}
+
 data "google_billing_account" "account" {
 	billing_account = "%{billing_acct}"
 }
@@ -630,14 +639,14 @@ resource "google_project" "project1" {
 	project_id      = "tf-test-%{random_suffix_1}"
 	name            = "tf-test-%{random_suffix_1}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.account.id
+	billing_account = data.google_billing_account.project_account.id
 }
 
 resource "google_project" "project2" {
 	project_id      = "tf-test-%{random_suffix_2}"
 	name            = "tf-test-%{random_suffix_2}"
 	org_id          = "%{org}"
-	billing_account = data.google_billing_account.account.id
+	billing_account = data.google_billing_account.project_account.id
 }
 
 resource "google_billing_budget" "budget" {


### PR DESCRIPTION
With the billing accounts/permissions changing for our test projects, we've missed a case here with `TestAccBillingBudget_budgetFilterProjectsOrdering`. This test tries to create new projects (requires a billing account that can be charged), and update the budget config (requires billing admin access on the billing account) using the "master" billing account. We actually don't have a billing account that can support both of these operations, so instead this fix avoids the need to create new projects.

My first attempt here is to use fake project ids, but if that fails, we can potentially use existing project ids, or create projects using a different billing account.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
