### PR TITLE
Improve tests for SDK-based util functions, add tests to the new plugin framework equivalents

### DIFF
--- a/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
@@ -1,0 +1,52 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestGetProjectFramework(t *testing.T) {
+	cases := map[string]struct {
+		ResourceProject types.String
+		ProviderProject types.String
+		ExpectedProject types.String
+		ExpectedError   bool
+	}{
+		"project is pulled from the resource config value instead of the provider config value, even if both set": {
+			ResourceProject: types.StringValue("foo"),
+			ProviderProject: types.StringValue("bar"),
+			ExpectedProject: types.StringValue("foo"),
+		},
+		"project is pulled from the provider config value when unset on the resource": {
+			// Note - ResourceProject is not set to non-zero value here
+			ProviderProject: types.StringValue("bar"),
+			ExpectedProject: types.StringValue("bar"),
+		},
+		"error when project is not set on the provider or the resource": {
+			ExpectedError: true,
+		},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			var diags diag.Diagnostics
+
+			// Act
+			project := getProjectFramework(tc.ResourceProject, tc.ProviderProject, &diags)
+
+			// Assert
+			if diags.HasError() {
+				if tc.ExpectedError {
+					return
+				}
+				t.Fatalf("Got %d unexpected error(s) during test: %s", diags.ErrorsCount(), diags.Errors())
+			}
+
+			if project != tc.ExpectedProject {
+				t.Fatalf("Incorrect project: got %s, want %s", project, tc.ExpectedProject)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
@@ -20,7 +20,7 @@ func TestGetProjectFramework(t *testing.T) {
 			ExpectedProject: types.StringValue("foo"),
 		},
 		"project is pulled from the provider config value when unset on the resource": {
-			// Note - ResourceProject is not set to non-zero value here
+			ResourceProject: types.StringNull(),
 			ProviderProject: types.StringValue("bar"),
 			ExpectedProject: types.StringValue("bar"),
 		},

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -166,14 +166,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func TestProvider_getRegionFromZone(t *testing.T) {
-	expected := "us-central1"
-	actual := getRegionFromZone("us-central1-f")
-	if expected != actual {
-		t.Fatalf("Region (%s) did not match expected value: %s", actual, expected)
-	}
-}
-
 func TestProvider_loadCredentialsFromFile(t *testing.T) {
 	ws, es := validateCredentials(testFakeCredentialsPath, "")
 	if len(ws) != 0 {

--- a/mmv1/third_party/terraform/utils/transport_test.go
+++ b/mmv1/third_party/terraform/utils/transport_test.go
@@ -199,30 +199,32 @@ func TestReplaceVars(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		d := &ResourceDataMock{
-			FieldsInSchema: tc.SchemaValues,
-		}
-
-		config := tc.Config
-		if config == nil {
-			config = &Config{}
-		}
-
-		v, err := replaceVars(d, config, tc.Template)
-
-		if err != nil {
-			if !tc.ExpectedError {
-				t.Errorf("bad: %s; unexpected error %s", tn, err)
+		t.Run(tn, func(t *testing.T) {
+			d := &ResourceDataMock{
+				FieldsInSchema: tc.SchemaValues,
 			}
-			continue
-		}
 
-		if tc.ExpectedError {
-			t.Errorf("bad: %s; expected error", tn)
-		}
+			config := tc.Config
+			if config == nil {
+				config = &Config{}
+			}
 
-		if v != tc.Expected {
-			t.Errorf("bad: %s; expected %q, got %q", tn, tc.Expected, v)
-		}
+			v, err := replaceVars(d, config, tc.Template)
+
+			if err != nil {
+				if !tc.ExpectedError {
+					t.Errorf("bad: %s; unexpected error %s", tn, err)
+				}
+				return
+			}
+
+			if tc.ExpectedError {
+				t.Errorf("bad: %s; expected error", tn)
+			}
+
+			if v != tc.Expected {
+				t.Errorf("bad: %s; expected %q, got %q", tn, tc.Expected, v)
+			}
+		})
 	}
 }

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -49,6 +49,9 @@ type TerraformResourceDiff interface {
 }
 
 // getRegionFromZone returns the region from a zone for Google cloud.
+// This is by removing the last two chars from the zone name to leave the region
+// If there aren't enough characters in the input string, an empty string is returned
+// e.g. southamerica-west1-a => southamerica-west1
 func getRegionFromZone(zone string) string {
 	if zone != "" && len(zone) > 2 {
 		region := zone[:len(zone)-2]

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -175,7 +175,7 @@ func TestGetProject(t *testing.T) {
 			}
 
 			// Create resource config
-			// Here use ResourceComputeDisk schema as example  - because it has a zone field in schema
+			// Here use ResourceComputeDisk schema as example
 			emptyConfigMap := map[string]interface{}{}
 			d := schema.TestResourceDataRaw(t, ResourceComputeDisk().Schema, emptyConfigMap)
 			if tc.ResourceProject != "" {

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -307,9 +307,9 @@ func TestGetRegion(t *testing.T) {
 			}
 
 			// Create resource config
-			// Here use ComputeRegionInstanceTemplate schema as example - because it has a region field in schema
+			// Here use ResourceComputeSubnetwork schema as example - because it has a region field in schema
 			emptyConfigMap := map[string]interface{}{}
-			d := schema.TestResourceDataRaw(t, ResourceComputeRegionInstanceTemplate().Schema, emptyConfigMap)
+			d := schema.TestResourceDataRaw(t, ResourceComputeSubnetwork().Schema, emptyConfigMap)
 			if tc.ResourceRegion != "" {
 				if err := d.Set("region", tc.ResourceRegion); err != nil {
 					t.Fatalf("Cannot set region: %s", err)

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -175,10 +175,9 @@ func TestGetProject(t *testing.T) {
 			}
 
 			// Create resource config
-			// Here use ResourceComputeDisk schema as example
-			d := schema.TestResourceDataRaw(t, ResourceComputeDisk().Schema, map[string]interface{}{
-				"project": tc.ResourceProject,
-			})
+			// Here use ResourceComputeDisk schema as example  - because it has a zone field in schema
+			emptyConfigMap := map[string]interface{}{}
+			d := schema.TestResourceDataRaw(t, ResourceComputeDisk().Schema, emptyConfigMap)
 			if tc.ResourceProject != "" {
 				if err := d.Set("project", tc.ResourceProject); err != nil {
 					t.Fatalf("Cannot set project: %s", err)
@@ -239,10 +238,9 @@ func TestGetZone(t *testing.T) {
 			}
 
 			// Create resource config
-			// Here use ResourceComputeDisk schema as example
-			d := schema.TestResourceDataRaw(t, ResourceComputeDisk().Schema, map[string]interface{}{
-				"zone": tc.ResourceZone,
-			})
+			// Here use ResourceComputeDisk schema as example - because it has a zone field in schema
+			emptyConfigMap := map[string]interface{}{}
+			d := schema.TestResourceDataRaw(t, ResourceComputeDisk().Schema, emptyConfigMap)
 			if tc.ResourceZone != "" {
 				if err := d.Set("zone", tc.ResourceZone); err != nil {
 					t.Fatalf("Cannot set zone: %s", err)

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -292,7 +292,7 @@ func TestGetRegion(t *testing.T) {
 	}
 }
 
-func TestProvider_getRegionFromZone(t *testing.T) {
+func TestGetRegionFromZone(t *testing.T) {
 	expected := "us-central1"
 	actual := getRegionFromZone("us-central1-f")
 	if expected != actual {

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -292,6 +292,14 @@ func TestGetRegion(t *testing.T) {
 	}
 }
 
+func TestProvider_getRegionFromZone(t *testing.T) {
+	expected := "us-central1"
+	actual := getRegionFromZone("us-central1-f")
+	if expected != actual {
+		t.Fatalf("Region (%s) did not match expected value: %s", actual, expected)
+	}
+}
+
 func TestDatasourceSchemaFromResourceSchema(t *testing.T) {
 	type args struct {
 		rs map[string]*schema.Schema


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR:

- Adds unit tests for the `getProject` function that depends on the provider SDK
- Adds unit tests for the `getProjectFramework` function, a version that that depends on the plugin framework instead of the SDK
- Refactors existing unit tests for util functions:
    - `TestGetRegion`
    - `TestGetZone`
    - Made one pre-existing test use sub-tests
    - Moved the location and name of another pre-existing test


---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
