### PR TITLE
ImportVerifyState is not compatible with custom diff

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_instance_test.go
@@ -66,7 +66,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 			{
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
-				ImportStateVerify:       true,
+				ImportStateVerify:       false,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
@@ -75,7 +75,8 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 			{
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
-				ImportStateVerify:       true,
+				PlanOnly:                true,
+				ImportStateVerify:       false,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
@@ -84,7 +85,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 			{
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
-				ImportStateVerify:       true,
+				ImportStateVerify:       false,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
@@ -93,7 +94,8 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 			{
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
-				ImportStateVerify:       true,
+				PlanOnly:                true,
+				ImportStateVerify:       false,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
@@ -102,7 +104,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 			{
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
-				ImportStateVerify:       true,
+				ImportStateVerify:       false,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 		},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

As you can see here in the terraform documentation https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestStep , `ImportStateVerify` is not compatible with DiffSuppressFunc or CustomizeDiff. Therefore even though there is a custom diff function for clusters that can handle the ordering changes of clusters, this test can fail if the order of cluster change just because of ImportStateVerify = true
bug 263130303


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug

```
