### PR TITLE
Use Go 1.19-bullseye for containers

### DIFF
--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/github-differ/Dockerfile
+++ b/.ci/containers/github-differ/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update

--- a/.ci/containers/terraform-tester/Dockerfile
+++ b/.ci/containers/terraform-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-validator-tester-integration/Dockerfile
+++ b/.ci/containers/terraform-validator-tester-integration/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-validator-tester/Dockerfile
+++ b/.ci/containers/terraform-validator-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/containers/terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/terraform-vcr-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.19-stretch as resource
+from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14102

Use Go 1.19-bullseye for containers as Go 1.19 stretch does not exit.

It looks like 1.19-bullseye and 1.19.7-bullseye are the same. https://hub.docker.com/_/golang


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
