### PR TITLE
artifact registry - bump fields to ga

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -56,7 +56,6 @@
         kms_key_name: 'BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     - !ruby/object:Provider::Terraform::Examples
       name: "artifact_registry_repository_virtual"
-      min_version: beta
       primary_resource_id: "my-repo"
       vars:
         repository_id: "my-repository"
@@ -66,7 +65,6 @@
         upstream_policy_id: "my-repository-upstream"
     - !ruby/object:Provider::Terraform::Examples
       name: "artifact_registry_repository_remote"
-      min_version: beta
       primary_resource_id: "my-repo"
       vars:
         repository_id: "my-repository"
@@ -161,7 +159,6 @@
           default_value: :VERSION_POLICY_UNSPECIFIED
     - !ruby/object:Api::Type::Enum
       name: 'mode'
-      min_version: beta
       description: |-
         The mode configures the repository to serve artifacts from different sources.
       immutable: true
@@ -172,7 +169,6 @@
       default_value: :STANDARD_REPOSITORY
     - !ruby/object:Api::Type::NestedObject
       name: 'virtualRepositoryConfig'
-      min_version: beta
       conflicts:
         - remote_repository_config
       description: |-
@@ -200,7 +196,6 @@
                   Entries with a greater priority value take precedence in the pull order.
     - !ruby/object:Api::Type::NestedObject
       name: 'remoteRepositoryConfig'
-      min_version: beta
       conflicts:
         - virtual_repository_config
       description: |-

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_remote.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_remote.tf.erb
@@ -1,5 +1,4 @@
 resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>" {
-  provider      = google-beta
   location      = "us-central1"
   repository_id = "<%= ctx[:vars]['repository_id'] %>"
   description   = "<%= ctx[:vars]['description'] %>"

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_virtual.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_virtual.tf.erb
@@ -1,5 +1,4 @@
 resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>-upstream" {
-  provider      = google-beta
   location      = "us-central1"
   repository_id = "<%= ctx[:vars]['upstream_repository_id'] %>"
   description   = "<%= ctx[:vars]['upstream_description'] %>"
@@ -8,7 +7,6 @@ resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>
 
 resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>" {
   depends_on    = []
-  provider      = google-beta
   location      = "us-central1"
   repository_id = "<%= ctx[:vars]['repository_id'] %>"
   description   = "<%= ctx[:vars]['description'] %>"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
artifactregistry: promoted `mode`, `virtual_repository_config`, and `remote_repository_config` to GA
```
