### PR TITLE
Switch downstream-builder to use a Ruby image rather than a Go one

### DIFF
--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -1,62 +1,39 @@
-from golang:1.18-stretch as resource
+FROM ruby:3.1-bullseye
+
+# golang
+COPY --from=golang:1.18-stretch /usr/local/go /usr/local/go
+ENV GOPATH /go
+ENV PATH /usr/local/go/bin:$PATH
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH
+
+# terraform binary used by tfv/tgc
+COPY --from=hashicorp/terraform:1.4.2 /bin/terraform /bin/terraform
 
 SHELL ["/bin/bash", "-c"]
 
-RUN go install golang.org/x/tools/cmd/goimports@d088b475e3360caabc032aaee1dc66351d4e729a
-RUN go install github.com/github/hub@v2.11.2+incompatible
+ENV GO111MODULE "on"
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends git openssh-client apt-transport-https ca-certificates curl netbase wget gcc make jq libjq1
+
+RUN git config --global user.name "Modular Magician"
+RUN git config --global user.email "magic-modules@google.com"
 
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts
 RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
 
-ENV GO111MODULE "on"
-
-# Install Ruby from source.
-RUN apt-get update
-RUN apt-get install -y bzip2 libssl-dev libreadline-dev zlib1g-dev unzip sed rsync libyaml-dev
-RUN git clone https://github.com/rbenv/rbenv.git /rbenv
-ENV PATH /rbenv/bin:/root/.rbenv/shims:$PATH
-
-ENV RUBY_VERSION 3.1.0
-ENV RUBYGEMS_VERSION 3.4.1
-ENV BUNDLER_VERSION 2.4.6
-
-RUN /rbenv/bin/rbenv init || true
-RUN eval "$(rbenv init -)"
-RUN mkdir -p "$(rbenv root)"/plugins
-RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
-
-RUN rbenv install $RUBY_VERSION
-RUN rbenv global $RUBY_VERSION
-RUN rbenv rehash
-
-RUN gem update --system "$RUBYGEMS_VERSION"
-RUN gem install bundler --version "$BUNDLER_VERSION" --force
-
-RUN apt-get update
-RUN apt-get install -y git build-essential libbz2-dev libssl-dev libreadline-dev \
-                        libffi-dev libsqlite3-dev tk-dev libpng-dev libfreetype6-dev \
-                        make build-essential libssl-dev zlib1g-dev libbz2-dev \
-                        libreadline-dev libsqlite3-dev curl llvm libncurses5-dev libncursesw5-dev \
-                        xz-utils tk-dev libffi-dev liblzma-dev jq
-
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
+RUN go install golang.org/x/tools/cmd/goimports@d088b475e3360caabc032aaee1dc66351d4e729a
+RUN go install github.com/github/hub@v2.11.2+incompatible
 
 ADD "https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/main/mmv1/Gemfile" Gemfile
 ADD "https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/main/mmv1/Gemfile.lock" Gemfile.lock
 RUN bundle install
-RUN rbenv rehash
 RUN rm Gemfile Gemfile.lock
 
-RUN git config --global user.name "Modular Magician"
-RUN git config --global user.email "magic-modules@google.com"
-
 ADD generate_downstream.sh /generate_downstream.sh
-
-
-RUN wget https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip
-RUN unzip terraform_0.13.7_linux_amd64.zip && rm terraform_0.13.7_linux_amd64.zip
-RUN mv ./terraform /bin/terraform
 
 ENTRYPOINT ["/generate_downstream.sh"]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Go's relatively easy to install, while Ruby's relatively difficult. We get Go for free from our container, while we install Ruby the hard way. Let's flip that!

After https://github.com/GoogleCloudPlatform/magic-modules/pull/7561 it took me 600s to rebuild the image in my Cloud Shell. After this change, it takes around 1/20th as long:

```
rileykarson@cloudshell:~/magic-modules/.ci/containers/downstream-builder (graphite-docker-images)$ docker build --no-cache -t gcr.io/graphite-docker-images/downstream-builder:rileykarson .
[+] Building 32.4s (28/28) FINISHED
```

This change:
* Drops rbenv and uses a Ruby container
* Unpins Rubygems as a reasonable version is installed alongside Ruby, and locally we just take the default for our Ruby version
* Unpins Bundler, and moves Bundler after the Gemfile/Gemfile.lock is available. I'm not sure if that affects the version we install- if it doesn't, this picks a reasonable version anyways.
* Installs Go in the image, rather than through a Go container

I've reordered things in order of change frequency as well, so that fixed environment variables and our Terraform version are near the top, while Go dependencies are further down. We don't use the cache in CI rebuilds at the moment so this doesn't matter, but this may change in the future.

It's probably worth flagging the `COPY --from=` bits- those are [multi-stage builds](https://docs.docker.com/build/building/multi-stage/), where binaries are prepared in another build and used in this one. While it doesn't make the _most_ sense where `terraform` and `go` are readily available as prebuilt binaries w/ curl/wget, we can specify a minor version and pick up the latest patch on rebuilds. With wget we'd need to specify a specific patch version. I'd been hoping to remove the Go environment entirely and keep fmt/goimports/hub binaries, but I think we need one for tfv/tgc anyways.

We now install a bunch of system utilities (`git openssh-client apt-transport-https ca-certificates curl netbase wget gcc make`) directly now- they're likely already installed by the Ruby image, but I did this in stages locally going from `golang:1.18-stretch` -> `stretch` (which did not install them by default) -> `ruby:3.1-bullseye`. I'd personally prefer to keep them, to keep dependencies explicit, but would be glad to tune out if we desired.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
