### PR TITLE
Remove activesupport array extensions

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -22,7 +22,6 @@ Dir.chdir(File.dirname(__FILE__))
 ENV['TZ'] = 'UTC'
 
 require 'active_support/inflector'
-require 'active_support/core_ext/array/conversions'
 require 'api/compiler'
 require 'google/logger'
 require 'optparse'

--- a/mmv1/templates/terraform/property_documentation.erb
+++ b/mmv1/templates/terraform/property_documentation.erb
@@ -24,12 +24,12 @@
 <% unless property.item_type.default_value.nil? || property.item_type.default_value == "" -%>
   Default value is [`<%= property.item_type.default_value %>`].
 <% end -%>
-  Each value may be one of <%= property.item_type.values.select { |v| v != "" }.map { |v| "`#{v}`" }.to_sentence %>.
+  Each value may be one of: <%= property.item_type.values.select { |v| v != "" }.map { |v| "`#{v}`" }.join(', ') %>.
 <% elsif property.is_a?(Api::Type::Enum) && !property.output && !property.skip_docs_values -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
   Default value is `<%= property.default_value %>`.
 <% end -%>
-  Possible values are <%= property.values.select { |v| v != "" }.map { |v| "`#{v}`" }.to_sentence %>.
+  Possible values are: <%= property.values.select { |v| v != "" }.map { |v| "`#{v}`" }.join(', ') %>.
 <% end -%>
 <% if property.sensitive -%>
   **Note**: This property is sensitive and will not be displayed in the plan.

--- a/mmv1/templates/terraform/resource.html.markdown.erb
+++ b/mmv1/templates/terraform/resource.html.markdown.erb
@@ -86,11 +86,12 @@ To get more information about <%= object.name -%>, see:
 <%- end -%>
 <%- if !sensitive_props.empty? -%>
 <%-
-  sense_props = sensitive_props.map! {|prop| "`"+prop.lineage+"`"}.to_sentence
+  sense_props = sensitive_props.map! {|prop| "`"+prop.lineage+"`"}.join(', ')
 -%>
 
-~> **Warning:** All arguments including <%= sense_props -%> will be stored in the raw
-state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+~> **Warning:** All arguments including the following potentially sensitive
+values will be stored in the raw state as plain text: <%=sense_props%>.
+[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
 <%- end -%>
 
 <%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily intended for this provider version.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

ActiveSupport is a part of Ruby on Rails that we use for string processing in MMv1. While it can make reasonable assumptions about translating between pluralisms/acronyms/cases, it ultimately makes our generated code less predictable. 

ActiveSupport methods are added to preexisting types, extending them with new methods. That can make what is/isn't coming from a library unpredictable. This removes the cases where arrays were extended, with `.to_sentence`. I've shifted the affected pieces of documentation to present a list rather than work field names in naturally.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
