### PR TITLE
support for IPv6 prefix exchange in router bgp peer.

### DIFF
--- a/mmv1/products/compute/RouterBgpPeer.yaml
+++ b/mmv1/products/compute/RouterBgpPeer.yaml
@@ -55,6 +55,8 @@ legacy_name: 'google_compute_router_peer'
 exclude_validator: true
 id_format: "projects/{{project}}/regions/{{region}}/routers/{{router}}/{{name}}"
 mutex: router/{{region}}/{{router}}
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: templates/terraform/constants/router_bgp_peer.erb
 examples:
   # These examples are not used to autogenerate tests, as fine-grained
   # resources do not fit the normal test flow - we need to test deletion
@@ -282,3 +284,31 @@ properties:
       such as Next Gen Firewalls, Virtual Routers, or Router Appliances.
       The VM instance must be located in zones contained in the same region as
       this Cloud Router. The VM instance is the peer side of the BGP session.
+  - !ruby/object:Api::Type::Boolean
+    name: 'enableIpv6'
+    description: |
+      Enable IPv6 traffic over BGP Peer. If not specified, it is disabled by default.
+    default_value: false
+    send_empty_value: true
+  - !ruby/object:Api::Type::String
+    name: 'ipv6NexthopAddress'
+    description: |
+      IPv6 address of the interface inside Google Cloud Platform.
+      The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
+      If you do not specify the next hop addresses, Google Cloud automatically
+      assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.
+    default_from_api: true
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'validateIpAddress'
+    diff_suppress_func: ipv6RepresentationDiffSuppress
+  - !ruby/object:Api::Type::String
+    name: 'peerIpv6NexthopAddress'
+    description: |
+      IPv6 address of the BGP interface outside Google Cloud Platform.
+      The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
+      If you do not specify the next hop addresses, Google Cloud automatically
+      assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.
+    default_from_api: true
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'validateIpAddress'
+    diff_suppress_func: ipv6RepresentationDiffSuppress

--- a/mmv1/templates/terraform/constants/router_bgp_peer.erb
+++ b/mmv1/templates/terraform/constants/router_bgp_peer.erb
@@ -1,0 +1,13 @@
+func ipv6RepresentationDiffSuppress(_, old, new string, d *schema.ResourceData) bool {
+    //Diff suppress any equal IPV6 address in different representations
+    //An IPV6 address can have long or short representations
+    //E.g 2001:0cb0:0000:0000:0fc0:0000:0000:0abc, after compression:
+    //A) 2001:0cb0::0fc0:0000:0000:0abc (Omit groups of all zeros)
+    //B) 2001:cb0:0:0:fc0::abc (Omit leading zeros)
+    //C) 2001:cb0::fc0:0:0:abc (Combining A and B)
+    //The GCP API follows rule B) for normalzation
+
+    oldIp := net.ParseIP(old)
+    newIp := net.ParseIP(new)
+    return oldIp.Equal(newIp)
+}

--- a/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
@@ -178,6 +178,126 @@ func TestAccComputeRouterPeer_routerApplianceInstance(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouterPeer_Ipv6Basic(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerIpv6(routerName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterPeer_UpdateIpv6Address(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerIpv6(routerName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerUpdateIpv6Address(routerName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterPeer_EnableDisableIpv6(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerNoIpv6(routerName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerIpv6(routerName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerIpv6(routerName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouterPeerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := GoogleProviderConfig(t)
@@ -863,4 +983,236 @@ resource "google_compute_router_peer" "foobar" {
   }
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, bfdMode)
+}
+
+func testAccComputeRouterPeerUpdateIpv6Address(routerName string, enableIpv6 bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.id
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  stack_type = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+}
+
+resource "google_compute_ha_vpn_gateway" "foobar" {
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.id
+  region  = google_compute_subnetwork.foobar.region
+  stack_type = "IPV4_IPV6"
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.id
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  name               = "%s"
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "foobar" {
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  ip_range   = "169.254.3.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_peer" "foobar" {
+  name                      = "%s"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  ip_address                = "169.254.3.1"
+  peer_ip_address           = "169.254.3.2"
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+
+  enable_ipv6               = %v
+  ipv6_nexthop_address      = "2600:2d00:0000:0002:0000:0000:0000:0002"
+  peer_ipv6_nexthop_address = "2600:2d00:0:2::1"
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enableIpv6)
+}
+
+func testAccComputeRouterPeerNoIpv6(routerName string, enableIpv6 bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.id
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  stack_type = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+}
+
+resource "google_compute_ha_vpn_gateway" "foobar" {
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.id
+  region  = google_compute_subnetwork.foobar.region
+  stack_type = "IPV4_IPV6"
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.id
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  name               = "%s"
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "foobar" {
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  ip_range   = "169.254.3.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_peer" "foobar" {
+  name                      = "%s"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  ip_address                = "169.254.3.1"
+  peer_ip_address           = "169.254.3.2"
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+
+  enable_ipv6               = %v
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enableIpv6)
+}
+
+func testAccComputeRouterPeerIpv6(routerName string, enableIpv6 bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.id
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  stack_type = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+}
+
+resource "google_compute_ha_vpn_gateway" "foobar" {
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.id
+  region  = google_compute_subnetwork.foobar.region
+  stack_type = "IPV4_IPV6"
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.id
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  name               = "%s"
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "foobar" {
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  ip_range   = "169.254.3.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_peer" "foobar" {
+  name                      = "%s"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  ip_address                = "169.254.3.1"
+  peer_ip_address           = "169.254.3.2"
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+
+  enable_ipv6               = %v
+  ipv6_nexthop_address      = "2600:2d00:0000:0002:0000:0000:0000:0001"
+  peer_ipv6_nexthop_address = "2600:2d00:0:2::2"
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enableIpv6)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
support for IPv6 prefix exchange in router bgp peer
https://github.com/hashicorp/terraform-provider-google/issues/13852


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for IPv6 prefix exchange in `google_compute_router_peer`
```
