### PR TITLE
compute/backend_bucket: Fix default behavior with `USE_ORIGIN_HEADERS`

### DIFF
--- a/mmv1/products/compute/BackendBucket.yaml
+++ b/mmv1/products/compute/BackendBucket.yaml
@@ -114,6 +114,7 @@ examples:
       backend_bucket_name: "image-backend-bucket"
       bucket_name: "image-store-bucket"
 custom_code: !ruby/object:Provider::Terraform::CustomCode
+  encoder: 'templates/terraform/encoders/compute_backend_bucket.go.erb'
   post_create: 'templates/terraform/post_create/compute_backend_bucket_security_policy.go.erb'
   post_update: 'templates/terraform/post_create/compute_backend_bucket_security_policy.go.erb'
 properties:

--- a/mmv1/templates/terraform/encoders/compute_backend_bucket.go.erb
+++ b/mmv1/templates/terraform/encoders/compute_backend_bucket.go.erb
@@ -1,0 +1,40 @@
+// This custom encoder helps prevent sending 0 for clientTtl, defaultTtl and
+// maxTtl in API calls to update these values  when unset in the provider
+// (doing so results in an API level error)
+c, cdnPolicyOk := d.GetOk("cdn_policy")
+
+// Only apply during updates
+if !cdnPolicyOk || obj["cdnPolicy"] == nil {
+	return obj, nil
+}
+
+currentCdnPolicies := c.([]interface{})
+
+// state does not contain cdnPolicy, so we can return early here as well
+if len(currentCdnPolicies) == 0 {
+	return obj, nil
+}
+
+futureCdnPolicy := obj["cdnPolicy"].(map[string]interface{})
+currentCdnPolicy := currentCdnPolicies[0].(map[string]interface{})
+
+cacheMode, ok := futureCdnPolicy["cache_mode"].(string)
+// Fallback to state if doesn't exist in object
+if !ok {
+	cacheMode = currentCdnPolicy["cache_mode"].(string)
+}
+
+switch cacheMode {
+case "USE_ORIGIN_HEADERS":
+	if _, ok := futureCdnPolicy["clientTtl"]; ok {
+		delete(futureCdnPolicy, "clientTtl")
+	}
+	if _, ok := futureCdnPolicy["defaultTtl"]; ok {
+		delete(futureCdnPolicy, "defaultTtl")
+	}
+	if _, ok := futureCdnPolicy["maxTtl"]; ok {
+		delete(futureCdnPolicy, "maxTtl")
+	}
+}
+
+return obj, nil

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_bucket_test.go
@@ -91,6 +91,14 @@ func TestAccComputeBackendBucket_withCdnPolicy(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeBackendBucket_withCdnPolicy4(backendName, storageName, 0, 404, 0),
+			},
+			{
+				ResourceName:      "google_compute_backend_bucket.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -310,4 +318,28 @@ resource "google_storage_bucket" "bucket_one" {
   location = "EU"
 }
 `, backendName, compressionMode, storageName)
+}
+
+func testAccComputeBackendBucket_withCdnPolicy4(backendName, storageName string, age, code, ttl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_bucket" "foobar" {
+  name        = "%s"
+  bucket_name = google_storage_bucket.bucket.name
+  enable_cdn  = true
+  cdn_policy {
+	cache_mode                   = "USE_ORIGIN_HEADERS"
+	signed_url_cache_max_age_sec = %d
+	serve_while_stale            = %d
+	negative_caching_policy {
+		code = %d
+		ttl = %d
+	}
+	negative_caching = true
+  }
+}
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "EU"
+}
+`, backendName, age, ttl, code, ttl, storageName)
 }


### PR DESCRIPTION
Since the send_empty_value field breaks the use of "USE_ORIGIN_HEADERS" cache_mode, adding a custom encoder to remove those fields when necessary.
    
Cherry-picked from @Alan-pad's rework of a commit by @d10i in #7062 
    
Fixes https://github.com/hashicorp/terraform-provider-google/issues/10622
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13939
Closes #7062

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue with TTLs being sent when `USE_ORIGIN_HEADERS` is set
```
