### PR TITLE
Skip VCR tests for resources converted to the plugin-framework

### DIFF
--- a/mmv1/products/firebase/WebApp.yaml
+++ b/mmv1/products/firebase/WebApp.yaml
@@ -49,6 +49,8 @@ autogen_async: true
 skip_sweeper: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
+    # TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+    skip_vcr: true
     name: "firebase_web_app_basic"
     min_version: "beta"
     primary_resource_id: "basic"

--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -36,7 +36,7 @@ func GetFwTestProvider(t *testing.T) *frameworkTestProvider {
 
 func TestAccFrameworkProviderMeta_setModuleName(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	moduleName := "my-module"
@@ -131,7 +131,7 @@ func TestAccFrameworkProviderBasePath_setInvalidBasePath(t *testing.T) {
 
 func TestAccFrameworkProviderBasePath_setBasePath(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -35,6 +35,8 @@ func GetFwTestProvider(t *testing.T) *frameworkTestProvider {
 }
 
 func TestAccFrameworkProviderMeta_setModuleName(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	moduleName := "my-module"
@@ -128,6 +130,8 @@ func TestAccFrameworkProviderBasePath_setInvalidBasePath(t *testing.T) {
 }
 
 func TestAccFrameworkProviderBasePath_setBasePath(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/data_source_dns_key_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_key_test.go.erb
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccDataSourceDNSKeys_basic(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	dnsZoneName := fmt.Sprintf("tf-test-dnskey-test-%s", RandString(t, 10))
@@ -59,6 +61,8 @@ func TestAccDataSourceDNSKeys_basic(t *testing.T) {
 }
 
 func TestAccDataSourceDNSKeys_noDnsSec(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	dnsZoneName := fmt.Sprintf("tf-test-dnskey-test-%s", RandString(t, 10))

--- a/mmv1/third_party/terraform/tests/data_source_dns_key_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_key_test.go.erb
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourceDNSKeys_basic(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	dnsZoneName := fmt.Sprintf("tf-test-dnskey-test-%s", RandString(t, 10))
@@ -62,7 +62,7 @@ func TestAccDataSourceDNSKeys_basic(t *testing.T) {
 
 func TestAccDataSourceDNSKeys_noDnsSec(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	dnsZoneName := fmt.Sprintf("tf-test-dnskey-test-%s", RandString(t, 10))

--- a/mmv1/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -12,7 +12,7 @@ import (
 
 func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go.erb
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccDataSourceDnsRecordSet_basic(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	var ttl1, ttl2 string // ttl is a computed string-type attribute that is easy to compare in the test

--- a/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go.erb
@@ -12,7 +12,7 @@ import (
 
 func TestAccDataSourceDnsRecordSet_basic(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	var ttl1, ttl2 string // ttl is a computed string-type attribute that is easy to compare in the test

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_config_test.go.erb
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourceGoogleFirebaseAppleAppConfig(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_apple_app_config_test.go.erb
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccDataSourceGoogleFirebaseAppleAppConfig(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	t.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
@@ -13,7 +13,7 @@ import (
 
 func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
-	t.SkipIfVcr(t)
+	SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-google/issues/14158

These tests seem to be doing something that the VCR doesn't like, so skipping them for now to reduce noise in PRs

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
