### PR TITLE
Replace ActiveSupport humanize with space_separated

### DIFF
--- a/mmv1/api/product.rb
+++ b/mmv1/api/product.rb
@@ -91,7 +91,7 @@ module Api
     # users to read in documentation; "Google Compute Engine", "Cloud Bigtable"
     def display_name
       if @display_name.nil?
-        name.underscore.humanize
+        name.space_separated
       else
         @display_name
       end

--- a/mmv1/google/extensions.rb
+++ b/mmv1/google/extensions.rb
@@ -25,4 +25,8 @@ class String
   def first_sentence
     Google::StringUtils.first_sentence(self)
   end
+
+  def space_separated
+    Google::StringUtils.space_separated(self)
+  end
 end

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -27,9 +27,9 @@ module Google
     # Converts from PascalCase to Space Separated
     def self.space_separated(source)
       tmp = source.gsub(/([A-Z]+)([A-Z][a-z])/, '\1 \2')
-            .gsub(/([a-z\d])([A-Z])/, '\1 \2')
-            .downcase
-      tmp[0].upcase.concat(tmp[1..-1])
+                  .gsub(/([a-z\d])([A-Z])/, '\1 \2')
+                  .downcase
+      tmp[0].upcase.concat(tmp[1..])
     end
 
     # rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -24,6 +24,14 @@ module Google
             .downcase
     end
 
+    # Converts from PascalCase to Space Separated
+    def self.space_separated(source)
+      tmp = source.gsub(/([A-Z]+)([A-Z][a-z])/, '\1 \2')
+            .gsub(/([a-z\d])([A-Z])/, '\1 \2')
+            .downcase
+      tmp[0].upcase.concat(tmp[1..-1])
+    end
+
     # rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0
     def self.symbolize(key)
       key.to_sym unless key.nil?


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Similar to https://github.com/GoogleCloudPlatform/magic-modules/pull/7579, slightly reduce our dependency on ActiveSupport. This implementation should cause no diffs with the current website but uses a much more predictable set of rules.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
