### PR TITLE
Remove ActiveSupport titleize uses

### DIFF
--- a/mmv1/google/extensions.rb
+++ b/mmv1/google/extensions.rb
@@ -33,4 +33,8 @@ class String
   def plural
     Google::StringUtils.plural(self)
   end
+
+  def title
+    Google::StringUtils.title(self)
+  end
 end

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -32,6 +32,12 @@ module Google
       tmp[0].upcase.concat(tmp[1..])
     end
 
+    # Converts a string to space-separated capitalized words
+    def self.title(source)
+      ss = space_separated(source)
+      ss.gsub(/\b(?<!\w['’`()])[a-z]/, &:capitalize)
+    end
+
     # rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0
     def self.symbolize(key)
       key.to_sym unless key.nil?

--- a/mmv1/templates/terraform/examples/base_configs/tutorial.md.erb
+++ b/mmv1/templates/terraform/examples/base_configs/tutorial.md.erb
@@ -1,5 +1,5 @@
 <% autogen_exception -%>
-<%= "# #{example.name.camelize(:upper).titleize} - Terraform" %>
+<%= "# #{example.name.camelize(:upper).title} - Terraform" %>
 
 ## Setup
 

--- a/mmv1/templates/terraform/resource.html.markdown.erb
+++ b/mmv1/templates/terraform/resource.html.markdown.erb
@@ -105,7 +105,7 @@ values will be stored in the raw state as plain text: <%=sense_props%>.
   </a>
 </div>
     <%- end -%>
-## Example Usage - <%= example.name.camelize(:upper).titleize %>
+## Example Usage - <%= example.name.camelize(:upper).title %>
 
 
 <%= example.config_documentation(pwd) -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Similar to https://github.com/GoogleCloudPlatform/magic-modules/pull/7591. This one slightly changes our example names, some for the better & some for the worse. There's some overlap with https://github.com/GoogleCloudPlatform/magic-modules/pull/7597, which removes initialisms, where both will change `VPC`- > `Vpc` & `TPU` -> `Tpu`


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
