### PR TITLE
Simplify camelize rules, remove our dependency on ActiveSupport for inflections

### DIFF
--- a/mmv1/Gemfile
+++ b/mmv1/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'activesupport'
 gem 'binding_of_caller'
 gem 'rake'
 

--- a/mmv1/Gemfile.lock
+++ b/mmv1/Gemfile.lock
@@ -1,22 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
     ast (2.4.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    concurrent-ruby (1.2.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
-    i18n (1.12.0)
-      concurrent-ruby (~> 1.0)
     json (2.6.3)
     metaclass (0.0.4)
-    minitest (5.17.0)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     parallel (1.22.1)
@@ -52,15 +43,12 @@ GEM
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
   binding_of_caller
   mocha (~> 1.3.0)
   rake

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -401,7 +401,7 @@ module Api
     end
 
     def exact_version
-      return nil if @exact_version.nil? || @exact_version.blank?
+      return nil if @exact_version.nil? || @exact_version.empty?
 
       @__resource.__product.version_obj(@exact_version)
     end

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -21,7 +21,6 @@ Dir.chdir(File.dirname(__FILE__))
 # generation.
 ENV['TZ'] = 'UTC'
 
-require 'active_support/inflector'
 require 'api/compiler'
 require 'google/logger'
 require 'optparse'

--- a/mmv1/google/extensions.rb
+++ b/mmv1/google/extensions.rb
@@ -45,9 +45,7 @@ class String
     when :lower
       Google::StringUtils.camelize(self, false)
     else
-      raise ArgumentError, "Invalid option, use either :upper or :lower."
+      raise ArgumentError, 'Invalid option, use either :upper or :lower.'
     end
   end
-  alias_method :camelcase, :camelize
-
 end

--- a/mmv1/google/extensions.rb
+++ b/mmv1/google/extensions.rb
@@ -37,4 +37,17 @@ class String
   def title
     Google::StringUtils.title(self)
   end
+
+  def camelize(first_letter = :upper)
+    case first_letter
+    when :upper
+      Google::StringUtils.camelize(self, true)
+    when :lower
+      Google::StringUtils.camelize(self, false)
+    else
+      raise ArgumentError, "Invalid option, use either :upper or :lower."
+    end
+  end
+  alias_method :camelcase, :camelize
+
 end

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -76,19 +76,18 @@ module Google
     end
 
     # Slimmed down version of ActiveSupport::Inflector code
-    def self.camelize(term, uppercase_first_letter = true)
-      acronyms_camelize_regex   = /^(?:(?=a)b(?=\b|[A-Z_])|\w)/
+    def self.camelize(term, uppercase_first_letter)
+      acronyms_camelize_regex = /^(?:(?=a)b(?=\b|[A-Z_])|\w)/
 
       string = term.to_s
-      # String#camelize takes a symbol (:upper or :lower), so here we also support :lower to keep the methods consistent.
-      if !uppercase_first_letter || uppercase_first_letter == :lower
-        string = string.sub(acronyms_camelize_regex) { |match| match.downcase! || match }
-      else
-        string = string.sub(/^[a-z\d]*/) { |match| match.capitalize! || match }
-      end
+      string = if uppercase_first_letter
+                 string.sub(/^[a-z\d]*/) { |match| match.capitalize! || match }
+               else
+                 string.sub(acronyms_camelize_regex) { |match| match.downcase! || match }
+               end
       # handle snake case
       string.gsub!(/(?:_)([a-z\d]*)/i) do
-        word = $1
+        word = ::Regexp.last_match(1)
         word.capitalize! || word
       end
       string

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -75,48 +75,23 @@ module Google
       "#{source}s"
     end
 
-    # ActiveSupport::Inflector code
-    # Converts strings to UpperCamelCase.
-    # If the +uppercase_first_letter+ parameter is set to false, then produces
-    # lowerCamelCase.
-    #
-    # Also converts '/' to '::' which is useful for converting
-    # paths to namespaces.
-    #
-    #   camelize('active_model')                # => "ActiveModel"
-    #   camelize('active_model', false)         # => "activeModel"
-    #   camelize('active_model/errors')         # => "ActiveModel::Errors"
-    #   camelize('active_model/errors', false)  # => "activeModel::Errors"
-    #
-    # As a rule of thumb you can think of +camelize+ as the inverse of
-    # #underscore, though there are cases where that does not hold:
-    #
-    #   camelize(underscore('SSLError'))        # => "SslError"
+    # Slimmed down version of ActiveSupport::Inflector code
     def self.camelize(term, uppercase_first_letter = true)
-      # patched in to this fn
-      define_acronym_regex_patterns
-      inflections = {"tpu": "TPU", "vpc": "VPC"}
+      acronyms_camelize_regex   = /^(?:(?=a)b(?=\b|[A-Z_])|\w)/
 
       string = term.to_s
       # String#camelize takes a symbol (:upper or :lower), so here we also support :lower to keep the methods consistent.
       if !uppercase_first_letter || uppercase_first_letter == :lower
-        string = string.sub(@acronyms_camelize_regex) { |match| match.downcase! || match }
+        string = string.sub(acronyms_camelize_regex) { |match| match.downcase! || match }
       else
-        string = string.sub(/^[a-z\d]*/) { |match| inflections[match] || match.capitalize! || match }
+        string = string.sub(/^[a-z\d]*/) { |match| match.capitalize! || match }
       end
-      string.gsub!(/(?:_|(\/))([a-z\d]*)/i) do
-        word = $2
-        substituted = inflections[word] || word.capitalize! || word
-        $1 ? "::#{substituted}" : substituted
+      # handle snake case
+      string.gsub!(/(?:_)([a-z\d]*)/i) do
+        word = $1
+        word.capitalize! || word
       end
       string
-    end
-
-    def self.define_acronym_regex_patterns
-      @acronyms = {}
-      @acronym_regex             = @acronyms.empty? ? /(?=a)b/ : /#{@acronyms.values.join("|")}/
-      @acronyms_camelize_regex   = /^(?:#{@acronym_regex}(?=\b|[A-Z_])|\w)/
-      @acronyms_underscore_regex = /(?:(?<=([A-Za-z\d]))|\b)(#{@acronym_regex})(?=\b|[^a-z])/
     end
   end
 end

--- a/mmv1/spec/compiler_spec.rb
+++ b/mmv1/spec/compiler_spec.rb
@@ -13,7 +13,6 @@
 
 require 'spec_helper'
 require 'api/compiler'
-require 'active_support/inflector'
 
 describe Api::Compiler do
   context 'should fail if file does not exist' do

--- a/mmv1/templates/terraform/resource_iam.html.markdown.erb
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.erb
@@ -223,7 +223,7 @@ The following arguments are supported:
 * `<%= param.name.underscore -%>` - (Required) <%= param.description -%> Used to find the parent resource to bind the IAM policy to
 <% end -%>
 <% end -%>
-<% if object.iam_policy.base_url.present? -%>
+<% if !object.iam_policy.base_url.nil? -%>
 <% if object.iam_policy.base_url.include?("{{project}}") -%>
 <%# The following new line allow for project to be bullet-formatted properly. -%>
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/7579, https://github.com/GoogleCloudPlatform/magic-modules/pull/7591, https://github.com/GoogleCloudPlatform/magic-modules/pull/7593, https://github.com/GoogleCloudPlatform/magic-modules/pull/7598, https://github.com/GoogleCloudPlatform/magic-modules/pull/7597

This changes our `camelize` implementation to one defined in MMv1 rather than an external library, switching to a simpler set of rules in the process. Long-term I'd like to align our string rules with the ones in https://github.com/GoogleCloudPlatform/declarative-resource-client-library/blob/main/dcl/strings.go, but wanted to get off ActiveSupport first.

This was the last piece before I could remove that dependency, so I've done that here. Some of the more surprising discoveries were that `present?` and `blank?` came from an inflections library- exactly the kind of surprises removing this will help avoid! Those were replaced with less powerful checks from the standard library that fulfilled the same purpose.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
