### PR TITLE
google_logging_metric: add `disabled` argument

### DIFF
--- a/mmv1/products/logging/Metric.yaml
+++ b/mmv1/products/logging/Metric.yaml
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
---- !ruby/object:Api::Resource
+---
+!ruby/object:Api::Resource
 name: "Metric"
 base_url: projects/{{project}}/metrics
 # The % in self_link indicates that the name value should be URL-encoded.
@@ -75,6 +76,10 @@ properties:
     description: |
       The resource name of the Log Bucket that owns the Log Metric. Only Log Buckets in projects
       are supported. The bucket has to be in the same project as the metric.
+  - !ruby/object:Api::Type::Boolean
+    name: disabled
+    description: |
+      If set to True, then this metric is disabled and it does not generate any points.
   - !ruby/object:Api::Type::String
     name: filter
     description: |
@@ -155,7 +160,7 @@ properties:
               required: false
               default_value: :STRING
               immutable: true
-              custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+              custom_flatten: "templates/terraform/custom_flatten/default_if_empty.erb"
       - !ruby/object:Api::Type::String
         name: displayName
         description: |

--- a/mmv1/products/logging/Metric.yaml
+++ b/mmv1/products/logging/Metric.yaml
@@ -52,6 +52,11 @@ examples:
       logging_metric_name: "my-(custom)/metric"
     test_env_vars:
       project: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: "logging_metric_disabled"
+    primary_resource_id: "logging_metric"
+    vars:
+      logging_metric_name: "my-(custom)/metric"
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/self_link_as_name.erb
   post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/templates/terraform/examples/logging_metric_disabled.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_metric_disabled.tf.erb
@@ -1,0 +1,9 @@
+resource "google_logging_metric" "<%= ctx[:primary_resource_id] %>" {
+  name   = "<%= ctx[:vars]["logging_metric_name"] %>"
+  filter = "resource.type=gae_app AND severity>=ERROR"
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+  disabled = true
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Closes https://github.com/hashicorp/terraform-provider-google/issues/14119

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added support for `disabled` to `google_logging_metric`
```
