### PR TITLE
Revert "Simplify camelize rules, remove our dependency on ActiveSupport for inflections"

### DIFF
--- a/mmv1/Gemfile
+++ b/mmv1/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activesupport'
 gem 'binding_of_caller'
 gem 'rake'
 

--- a/mmv1/Gemfile.lock
+++ b/mmv1/Gemfile.lock
@@ -1,13 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    concurrent-ruby (1.2.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.3)
     metaclass (0.0.4)
+    minitest (5.17.0)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     parallel (1.22.1)
@@ -43,12 +52,15 @@ GEM
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   binding_of_caller
   mocha (~> 1.3.0)
   rake

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -401,7 +401,7 @@ module Api
     end
 
     def exact_version
-      return nil if @exact_version.nil? || @exact_version.empty?
+      return nil if @exact_version.nil? || @exact_version.blank?
 
       @__resource.__product.version_obj(@exact_version)
     end

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -21,6 +21,7 @@ Dir.chdir(File.dirname(__FILE__))
 # generation.
 ENV['TZ'] = 'UTC'
 
+require 'active_support/inflector'
 require 'api/compiler'
 require 'google/logger'
 require 'optparse'

--- a/mmv1/google/extensions.rb
+++ b/mmv1/google/extensions.rb
@@ -37,15 +37,4 @@ class String
   def title
     Google::StringUtils.title(self)
   end
-
-  def camelize(first_letter = :upper)
-    case first_letter
-    when :upper
-      Google::StringUtils.camelize(self, true)
-    when :lower
-      Google::StringUtils.camelize(self, false)
-    else
-      raise ArgumentError, 'Invalid option, use either :upper or :lower.'
-    end
-  end
 end

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -74,23 +74,5 @@ module Google
 
       "#{source}s"
     end
-
-    # Slimmed down version of ActiveSupport::Inflector code
-    def self.camelize(term, uppercase_first_letter)
-      acronyms_camelize_regex = /^(?:(?=a)b(?=\b|[A-Z_])|\w)/
-
-      string = term.to_s
-      string = if uppercase_first_letter
-                 string.sub(/^[a-z\d]*/) { |match| match.capitalize! || match }
-               else
-                 string.sub(acronyms_camelize_regex) { |match| match.downcase! || match }
-               end
-      # handle snake case
-      string.gsub!(/(?:_)([a-z\d]*)/i) do
-        word = ::Regexp.last_match(1)
-        word.capitalize! || word
-      end
-      string
-    end
   end
 end

--- a/mmv1/spec/compiler_spec.rb
+++ b/mmv1/spec/compiler_spec.rb
@@ -13,6 +13,7 @@
 
 require 'spec_helper'
 require 'api/compiler'
+require 'active_support/inflector'
 
 describe Api::Compiler do
   context 'should fail if file does not exist' do

--- a/mmv1/templates/terraform/resource_iam.html.markdown.erb
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.erb
@@ -223,7 +223,7 @@ The following arguments are supported:
 * `<%= param.name.underscore -%>` - (Required) <%= param.description -%> Used to find the parent resource to bind the IAM policy to
 <% end -%>
 <% end -%>
-<% if !object.iam_policy.base_url.nil? -%>
+<% if object.iam_policy.base_url.present? -%>
 <% if object.iam_policy.base_url.include?("{{project}}") -%>
 <%# The following new line allow for project to be bullet-formatted properly. -%>
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#7599

```release-note:none
```