### PR TITLE
Add datasource for Firebase Android App Config

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_firebase_android_app_config.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_firebase_android_app_config.go.erb
@@ -1,0 +1,150 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/firebase/v1beta1"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces
+var (
+	_ datasource.DataSource              = &GoogleFirebaseAndroidAppConfigDataSource{}
+	_ datasource.DataSourceWithConfigure = &GoogleFirebaseAndroidAppConfigDataSource{}
+)
+
+func NewGoogleFirebaseAndroidAppConfigDataSource() datasource.DataSource {
+	return &GoogleFirebaseAndroidAppConfigDataSource{}
+}
+
+// GoogleFirebaseAndroidAppConfigDataSource defines the data source implementation
+type GoogleFirebaseAndroidAppConfigDataSource struct {
+	client  *firebase.Service
+	project types.String
+}
+
+type GoogleFirebaseAndroidAppConfigModel struct {
+	Id                 types.String `tfsdk:"id"`
+	AppId              types.String `tfsdk:"app_id"`
+	ConfigFilename     types.String `tfsdk:"config_filename"`
+	ConfigFileContents types.String `tfsdk:"config_file_contents"`
+	Project            types.String `tfsdk:"project"`
+}
+
+func (d *GoogleFirebaseAndroidAppConfigDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_firebase_android_app_config"
+}
+
+func (d *GoogleFirebaseAndroidAppConfigDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "A Google Cloud Firebase Android application configuration",
+
+		Attributes: map[string]schema.Attribute{
+			"app_id": schema.StringAttribute{
+				Description:         "The id of the Firebase Android App.",
+				MarkdownDescription: "The id of the Firebase Android App.",
+				Required:            true,
+			},
+
+			"project": schema.StringAttribute{
+				Description:         "The project id of the Firebase Android App.",
+				MarkdownDescription: "The project id of the Firebase Android App.",
+				Optional:            true,
+			},
+
+			"config_filename": schema.StringAttribute{
+				Description:         "The filename that the configuration artifact for the AndroidApp is typically saved as.",
+				MarkdownDescription: "The filename that the configuration artifact for the AndroidApp is typically saved as.",
+				Computed:            true,
+			},
+
+			"config_file_contents": schema.StringAttribute{
+				Description:         "The content of the XML configuration file as a base64-encoded string.",
+				MarkdownDescription: "The content of the XML configuration file as a base64-encoded string.",
+				Computed:            true,
+			},
+
+			"id": schema.StringAttribute{
+				Description:         "Firebase Android App Config identifier",
+				MarkdownDescription: "Firebase Android App Config identifier",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *GoogleFirebaseAndroidAppConfigDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	p, ok := req.ProviderData.(*frameworkProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *frameworkProvider, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = p.NewFirebaseClient(p.userAgent, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.project = p.project
+}
+
+func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data GoogleFirebaseAndroidAppConfigModel
+	var metaData *ProviderMetaModel
+
+	// Read Provider meta into the meta model
+	resp.Diagnostics.Append(req.ProviderMeta.Get(ctx, &metaData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	d.client.UserAgent = generateFrameworkUserAgentString(metaData, d.client.UserAgent)
+
+	client := firebase.NewProjectsAndroidAppsService(d.client)
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Project = getProjectFramework(data.Project, d.project, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	appName := fmt.Sprintf("projects/%s/androidApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())
+	data.Id = types.StringValue(appName)
+
+	clientResp, err := client.GetConfig(appName).Do()
+	if err != nil {
+		handleDatasourceNotFoundError(ctx, err, &resp.State, fmt.Sprintf("dataSourceFirebaseAndroidAppConfig %q", data.AppId.ValueString()), &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	tflog.Trace(ctx, "read firebase android app config data source")
+
+	data.ConfigFilename = types.StringValue(clientResp.ConfigFilename)
+	data.ConfigFileContents = types.StringValue(clientResp.ConfigFileContents)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_android_app_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_android_app_config_test.go.erb
@@ -1,0 +1,68 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceGoogleFirebaseAndroidAppConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":   GetTestProjectFromEnv(),
+		"package_name":    "android.app." + RandString(t, 5),
+		"display_name": "tf-test Display Name AndroidAppConfig DataSource",
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleFirebaseAndroidAppConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceFirebaseAndroidAppConfigCheck("data.google_firebase_android_app_config.my_app_config"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleFirebaseAndroidAppConfig(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_firebase_android_app" "my_app_config" {
+  project = "%{project_id}"
+  package_name = "%{package_name}"
+  display_name = "%{display_name}"
+}
+
+data "google_firebase_android_app_config" "my_app_config" {
+  project = "%{project_id}"
+  app_id = google_firebase_android_app.my_app_config.app_id
+}
+`, context)
+}
+
+func testAccDataSourceFirebaseAndroidAppConfigCheck(datasourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[datasourceName]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", datasourceName)
+		}
+
+		if ds.Primary.Attributes["config_filename"] == "" {
+			return fmt.Errorf("config filename not found in data source")
+		}
+
+		if ds.Primary.Attributes["config_file_contents"] == "" {
+			return fmt.Errorf("config file contents not found in data source")
+		}
+
+		return nil
+	}
+}
+<% end -%>

--- a/mmv1/third_party/terraform/utils/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/utils/framework_provider.go.erb
@@ -273,6 +273,7 @@ func (p *frameworkProvider) DataSources(_ context.Context) []func() datasource.D
         NewGoogleDnsRecordSetDataSource,
         NewGoogleDnsKeysDataSource,
         <% unless version == 'ga' -%>
+        NewGoogleFirebaseAndroidAppConfigDataSource,
         NewGoogleFirebaseAppleAppConfigDataSource,
         NewGoogleFirebaseWebAppConfigDataSource,
         <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add a data source for [Firebase Android App Config](https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects.androidApps/getConfig). Similar to [firebase_apple_app_config](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/firebase_apple_app_config)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:new-datasource

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
firebase_android_app_config
```
