### PR TITLE
Fixed TFV compilation errors from logging_log_view MMv1 conversion

### DIFF
--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -268,6 +268,8 @@ module Provider
                         'third_party/terraform/utils/common_operation.go'],
                        ['converters/google/resources/convert.go',
                         'third_party/terraform/utils/convert.go'],
+                       ['converters/google/resources/extract.go',
+                        'third_party/terraform/utils/extract.go'],
                        ['converters/google/resources/service_scope.go',
                         'third_party/terraform/utils/service_scope.go'],
                        ['converters/google/resources/kms_utils.go',


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added extract.go to copy files list to resolve [compilation errors](https://pantheon.corp.google.com/cloud-build/builds/cb4d56f2-a8c1-467e-b04a-5068d204d991;step=0?jsmode=O&mods=logs_tg_staging&project=cloud-foundation-cicd) in TFV

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
