### PR TITLE
Added support for Persistent Disk Asynchronous Replication (part 2)

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_disk_async_replication.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_disk_async_replication.go.erb
@@ -22,7 +22,6 @@ func ResourceComputeDiskAsyncReplication() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDiskAsyncReplicationCreate,
 		Read:   resourceDiskAsyncReplicationRead,
-		Update: resourceDiskAsyncReplicationUpdate,
 		Delete: resourceDiskAsyncReplicationDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -30,9 +29,8 @@ func ResourceComputeDiskAsyncReplication() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(300 * time.Second),
-			Update: schema.DefaultTimeout(300 * time.Second),
-			Delete: schema.DefaultTimeout(300 * time.Second),
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -46,6 +44,7 @@ func ResourceComputeDiskAsyncReplication() *schema.Resource {
 			"secondary_disk": {
 				Type:        schema.TypeList,
 				Required:    true,
+				ForceNew:    true,
 				MaxItems:    1,
 				Description: `Secondary disk for asynchronous replication.`,
 				Elem: &schema.Resource{
@@ -70,7 +69,7 @@ func ResourceComputeDiskAsyncReplication() *schema.Resource {
 	}
 }
 
-func getComputeClientForAsyncReplication(d *schema.ResourceData, meta interface{}) (*compute.Service, error) {
+func asyncReplicationGetComputeClient(d *schema.ResourceData, meta interface{}) (*compute.Service, error) {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := generateUserAgentString(d, config.UserAgent)
 	if err != nil {
@@ -81,10 +80,9 @@ func getComputeClientForAsyncReplication(d *schema.ResourceData, meta interface{
 	return clientCompute, nil
 }
 
-func getDiskFromConfig(disk string, d *schema.ResourceData, meta interface{}) (zonal bool, zv *ZonalFieldValue, rv *RegionalFieldValue, resourceId string, err error) {
+func asyncReplicationGetDiskFromConfig(disk string, d *schema.ResourceData, meta interface{}) (zv *ZonalFieldValue, rv *RegionalFieldValue, resourceId string, err error) {
 	config := meta.(*transport_tpg.Config)
 
-	zonal = true
 	var zonalMatch bool
 	zonalMatch, err = regexp.MatchString(fmt.Sprintf(zonalLinkBasePattern, "disks"), disk)
 	if err != nil {
@@ -92,7 +90,6 @@ func getDiskFromConfig(disk string, d *schema.ResourceData, meta interface{}) (z
 	}
 	zv, parseErr := ParseDiskFieldValue(disk, d, config)
 	if !zonalMatch || parseErr != nil {
-		zonal = false
 		rv, err = ParseRegionDiskFieldValue(disk, d, config)
 		if err != nil {
 			return
@@ -110,8 +107,8 @@ func getDiskFromConfig(disk string, d *schema.ResourceData, meta interface{}) (z
 	return
 }
 
-func getComputeDiskStatus(client *compute.Service, zonal bool, zv *ZonalFieldValue, rv *RegionalFieldValue) (diskStatus *compute.Disk, err error) {
-	if zonal {
+func asyncReplicationGetDiskStatus(client *compute.Service, zv *ZonalFieldValue, rv *RegionalFieldValue) (diskStatus *compute.Disk, err error) {
+	if rv == nil { // Zonal disk
 		diskStatus, err = client.Disks.Get(zv.Project, zv.Zone, zv.Name).Do()
 		log.Printf("[DEBUG] Get disk zones/%s/%s: %v", zv.Zone, zv.Name, diskStatus)
 	} else {
@@ -122,68 +119,63 @@ func getComputeDiskStatus(client *compute.Service, zonal bool, zv *ZonalFieldVal
 }
 
 func resourceDiskAsyncReplicationCreate(d *schema.ResourceData, meta interface{}) error {
-	clientCompute, err := getComputeClientForAsyncReplication(d, meta)
+	clientCompute, err := asyncReplicationGetComputeClient(d, meta)
 	if err != nil {
 		return err
 	}
 
-	zonal, zv, rv, resourceId, err := getDiskFromConfig(d.Get("primary_disk").(string), d, meta)
+	zv, rv, resourceId, err := asyncReplicationGetDiskFromConfig(d.Get("primary_disk").(string), d, meta)
 	if err != nil {
 		return err
 	}
 
-	for _, secondaryDiskIter := range d.Get("secondary_disk").([]interface{}) {
-		secondaryDiskMap := secondaryDiskIter.(map[string]interface{})
-		secondaryDisk := secondaryDiskMap["disk"].(string)
-		if zonal {
-			replicationRequest := compute.DisksStartAsyncReplicationRequest{
-				AsyncSecondaryDisk: secondaryDisk,
-			}
-			_, err = clientCompute.Disks.StartAsyncReplication(zv.Project, zv.Zone, zv.Name, &replicationRequest).Do()
-			if err != nil {
-				return err
-			}
-		} else {
-			replicationRequest := compute.RegionDisksStartAsyncReplicationRequest{
-				AsyncSecondaryDisk: secondaryDisk,
-			}
-			_, err = clientCompute.RegionDisks.StartAsyncReplication(rv.Project, rv.Region, rv.Name, &replicationRequest).Do()
-			if err != nil {
-				return err
-			}
+	secondaryDiskList := d.Get("secondary_disk").([]interface{})
+	secondaryDiskMap := secondaryDiskList[0].(map[string]interface{})
+	secondaryDisk := secondaryDiskMap["disk"].(string)
+	if rv == nil { // Zonal disk
+		replicationRequest := compute.DisksStartAsyncReplicationRequest{
+			AsyncSecondaryDisk: secondaryDisk,
 		}
-		err = resource.Retry(time.Minute*time.Duration(5), func() *resource.RetryError {
-			diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-			if diskStatus.ResourceStatus == nil {
-				return resource.NonRetryableError(fmt.Errorf("no resource status for disk: %s", resourceId))
-			}		
-			if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[secondaryDisk]; ok {
-				if secondaryState.State != "ACTIVE" {
-					time.Sleep(5 * time.Second)
-					return resource.RetryableError(fmt.Errorf("secondary disk %s state (%s) is not: ACTIVE", secondaryDisk, secondaryState))
-				}
-				return nil
-			}
-			time.Sleep(5 * time.Second)
-			return resource.RetryableError(fmt.Errorf("secondary disk %s state not available", secondaryDisk))
-		})
+		_, err = clientCompute.Disks.StartAsyncReplication(zv.Project, zv.Zone, zv.Name, &replicationRequest).Do()
 		if err != nil {
 			return err
 		}
+	} else {
+		replicationRequest := compute.RegionDisksStartAsyncReplicationRequest{
+			AsyncSecondaryDisk: secondaryDisk,
+		}
+		_, err = clientCompute.RegionDisks.StartAsyncReplication(rv.Project, rv.Region, rv.Name, &replicationRequest).Do()
+		if err != nil {
+			return err
+		}
+	}
+	err = resource.Retry(time.Minute*time.Duration(5), func() *resource.RetryError {
+		diskStatus, err := asyncReplicationGetDiskStatus(clientCompute, zv, rv)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		if diskStatus.ResourceStatus == nil {
+			return resource.NonRetryableError(fmt.Errorf("no resource status for disk: %s", resourceId))
+		}		
+		if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[secondaryDisk]; ok {
+			if secondaryState.State != "ACTIVE" {
+				time.Sleep(5 * time.Second)
+				return resource.RetryableError(fmt.Errorf("secondary disk %s state (%s) is not: ACTIVE", secondaryDisk, secondaryState))
+			}
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+		return resource.RetryableError(fmt.Errorf("secondary disk %s state not available", secondaryDisk))
+	})
+	if err != nil {
+		return err
 	}
 	d.SetId(resourceId)
 	return resourceDiskAsyncReplicationRead(d, meta)
 }
 
-func resourceDiskAsyncReplicationUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceDiskAsyncReplicationRead(d, meta)
-}
-
 func resourceDiskAsyncReplicationRead(d *schema.ResourceData, meta interface{}) error {
-	clientCompute, err := getComputeClientForAsyncReplication(d, meta)
+	clientCompute, err := asyncReplicationGetComputeClient(d, meta)
 	if err != nil {
 		return err
 	}
@@ -194,12 +186,12 @@ func resourceDiskAsyncReplicationRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("primary_disk", primaryDisk)
 	}
 
-	zonal, zv, rv, resourceId, err := getDiskFromConfig(primaryDisk, d, meta)
+	zv, rv, resourceId, err := asyncReplicationGetDiskFromConfig(primaryDisk, d, meta)
 	if err != nil {
 		return err
 	}
 
-	diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
+	diskStatus, err := asyncReplicationGetDiskStatus(clientCompute, zv, rv)
 	if err != nil {
 		return err
 	}
@@ -209,7 +201,7 @@ func resourceDiskAsyncReplicationRead(d *schema.ResourceData, meta interface{}) 
 	for _, disk := range diskStatus.AsyncSecondaryDisks {
 		secondaryDisk := make(map[string]string)
 
-		_, _, _, resourceName, err := getDiskFromConfig(disk.AsyncReplicationDisk.Disk, d, meta)
+		_, _, resourceName, err := asyncReplicationGetDiskFromConfig(disk.AsyncReplicationDisk.Disk, d, meta)
 		if err != nil {
 			return err
 		}
@@ -221,7 +213,7 @@ func resourceDiskAsyncReplicationRead(d *schema.ResourceData, meta interface{}) 
 		secondaryDisk["disk"] = resourceName
 		existingSecondaryDisks[resourceName] = true
 		if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
-			// Note this mi:ght be other than ACTIVE or STOPPED, but we wait for proper state
+			// Note this might be other than ACTIVE or STOPPED, but we wait for proper state
 			// on replication start/stop so it shouldnt affect Terraform
 			log.Printf("[DEBUG] Secondary disk %s is in state: %s", resourceName, secondaryState.State)
 			secondaryDisk["state"] = secondaryState.State
@@ -238,80 +230,75 @@ func resourceDiskAsyncReplicationRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceDiskAsyncReplicationDelete(d *schema.ResourceData, meta interface{}) error {
-	clientCompute, err := getComputeClientForAsyncReplication(d, meta)
+	clientCompute, err := asyncReplicationGetComputeClient(d, meta)
 	if err != nil {
 		return err
 	}
 
-	zonal, zv, rv, _, err := getDiskFromConfig(d.Get("primary_disk").(string), d, meta)
+	zv, rv, _, err := asyncReplicationGetDiskFromConfig(d.Get("primary_disk").(string), d, meta)
 	if err != nil {
 		return err
 	}
 
 	var replicationStopped bool = false
-	for _, secondaryDiskIter := range d.Get("secondary_disk").([]interface{}) {
-		secondaryDiskMap := secondaryDiskIter.(map[string]interface{})
-		secondaryDisk := secondaryDiskMap["disk"].(string)
+	secondaryDiskList := d.Get("secondary_disk").([]interface{})
+	secondaryDiskMap := secondaryDiskList[0].(map[string]interface{})
+	secondaryDisk := secondaryDiskMap["disk"].(string)
+	_, _, resourceName, err := asyncReplicationGetDiskFromConfig(secondaryDisk, d, meta)
+	if err != nil {
+		return err
+	}
 
-		_, _, _, resourceName, err := getDiskFromConfig(secondaryDisk, d, meta)
-		if err != nil {
-			return err
-		}
+	diskStatus, err := asyncReplicationGetDiskStatus(clientCompute, zv, rv)
+	if err != nil {
+		return err
+	}
 
-		diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
-		if err != nil {
-			return err
-		}
+	if diskStatus.ResourceStatus == nil {
+		// Nothing to do, replication not running
+		return nil
+	}
 
-		if diskStatus.ResourceStatus == nil {
-			continue
-		}
-
-		if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
-			if secondaryState.State != "STOPPED" {
-				replicationStopped = true
-				if zonal {
-					_, err = clientCompute.Disks.StopAsyncReplication(zv.Project, zv.Zone, zv.Name).Do()
-					if err != nil {
-						return err
-					}
-				} else {
-					_, err = clientCompute.RegionDisks.StopAsyncReplication(rv.Project, rv.Region, rv.Name).Do()
-					if err != nil {
-						return err
-					}
+	if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
+		if secondaryState.State != "STOPPED" {
+			replicationStopped = true
+			if rv == nil { // Zonal disk
+				_, err = clientCompute.Disks.StopAsyncReplication(zv.Project, zv.Zone, zv.Name).Do()
+				if err != nil {
+					return err
 				}
-				err = resource.Retry(time.Minute*time.Duration(5), func() *resource.RetryError {
-					diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
-					if err != nil {
-						return resource.NonRetryableError(err)
-					}
-					if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
-						if secondaryState.State != "STOPPED" {
-							time.Sleep(5 * time.Second)
-							return resource.RetryableError(fmt.Errorf("secondary disk %s state (%s) is not STOPPED", secondaryDisk, secondaryState))
-						}
-						return nil
-					}
-					return resource.NonRetryableError(fmt.Errorf("secondary disk %s state not available", secondaryDisk))
-				})
+			} else {
+				_, err = clientCompute.RegionDisks.StopAsyncReplication(rv.Project, rv.Region, rv.Name).Do()
 				if err != nil {
 					return err
 				}
 			}
-		} else {
-			return fmt.Errorf("could not find secondary disk: %s", secondaryDisk)
+			err = resource.Retry(time.Minute*time.Duration(5), func() *resource.RetryError {
+				diskStatus, err := asyncReplicationGetDiskStatus(clientCompute, zv, rv)
+				if err != nil {
+					return resource.NonRetryableError(err)
+				}
+				if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
+					if secondaryState.State != "STOPPED" {
+						time.Sleep(5 * time.Second)
+						return resource.RetryableError(fmt.Errorf("secondary disk %s state (%s) is not STOPPED", secondaryDisk, secondaryState))
+					}
+					return nil
+				}
+				return resource.NonRetryableError(fmt.Errorf("secondary disk %s state not available", secondaryDisk))
+			})
+			if err != nil {
+				return err
+			}
 		}
+	} else {
+		return fmt.Errorf("could not find secondary disk: %s", secondaryDisk)
 	}
+
 	if replicationStopped {
 		// Allow the replication to quiescence
 		time.Sleep(5000 * time.Millisecond)
 	}
-
 	return nil
-}
-
-func resourceDiskAsyncReplicationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	return []*schema.ResourceData{}, nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/resources/resource_compute_disk_async_replication.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_disk_async_replication.go.erb
@@ -1,0 +1,317 @@
+<% autogen_exception -%>
+package google
+<% if version != "ga" -%>
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+	"log"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+<% if version == "ga" -%>
+	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
+)
+
+func ResourceComputeDiskAsyncReplication() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDiskAsyncReplicationCreate,
+		Read:   resourceDiskAsyncReplicationRead,
+		Update: resourceDiskAsyncReplicationUpdate,
+		Delete: resourceDiskAsyncReplicationDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(300 * time.Second),
+			Update: schema.DefaultTimeout(300 * time.Second),
+			Delete: schema.DefaultTimeout(300 * time.Second),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"primary_disk": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				Description:      `Primary disk for asynchronous replication.`,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
+			},
+			"secondary_disk": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: `Secondary disk for asynchronous replication.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"disk": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: `Secondary disk for asynchronous replication.`,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
+						},
+						"state": {
+							Type:         schema.TypeString,
+							Computed:     true,
+							Description:  `Output-only. Status of replication on the secondary disk.`,
+						},
+					},
+				},
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func getComputeClientForAsyncReplication(d *schema.ResourceData, meta interface{}) (*compute.Service, error) {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCompute := config.NewComputeClient(userAgent)
+	return clientCompute, nil
+}
+
+func getDiskFromConfig(disk string, d *schema.ResourceData, meta interface{}) (zonal bool, zv *ZonalFieldValue, rv *RegionalFieldValue, resourceId string, err error) {
+	config := meta.(*transport_tpg.Config)
+
+	zonal = true
+	var zonalMatch bool
+	zonalMatch, err = regexp.MatchString(fmt.Sprintf(zonalLinkBasePattern, "disks"), disk)
+	if err != nil {
+		return
+	}
+	zv, parseErr := ParseDiskFieldValue(disk, d, config)
+	if !zonalMatch || parseErr != nil {
+		zonal = false
+		rv, err = ParseRegionDiskFieldValue(disk, d, config)
+		if err != nil {
+			return
+		}
+		var regionalMatch bool
+		regionalMatch, err = regexp.MatchString(fmt.Sprintf(regionalLinkBasePattern, "disks"), disk)
+		if !regionalMatch || err != nil {
+			err = fmt.Errorf("regional disk expected: %s", disk)
+			return
+		}
+		resourceId = fmt.Sprintf(regionalLinkTemplate, rv.Project, rv.Region, "disks", rv.Name)
+	} else {
+		resourceId = fmt.Sprintf(zonalLinkTemplate, zv.Project, zv.Zone, "disks", zv.Name)
+	}
+	return
+}
+
+func getComputeDiskStatus(client *compute.Service, zonal bool, zv *ZonalFieldValue, rv *RegionalFieldValue) (diskStatus *compute.Disk, err error) {
+	if zonal {
+		diskStatus, err = client.Disks.Get(zv.Project, zv.Zone, zv.Name).Do()
+		log.Printf("[DEBUG] Get disk zones/%s/%s: %v", zv.Zone, zv.Name, diskStatus)
+	} else {
+		diskStatus, err = client.RegionDisks.Get(rv.Project, rv.Region, rv.Name).Do()
+		log.Printf("[DEBUG] Get disk regions/%s/%s: %v", rv.Region, rv.Name, diskStatus)
+	}
+	return
+}
+
+func resourceDiskAsyncReplicationCreate(d *schema.ResourceData, meta interface{}) error {
+	clientCompute, err := getComputeClientForAsyncReplication(d, meta)
+	if err != nil {
+		return err
+	}
+
+	zonal, zv, rv, resourceId, err := getDiskFromConfig(d.Get("primary_disk").(string), d, meta)
+	if err != nil {
+		return err
+	}
+
+	for _, secondaryDiskIter := range d.Get("secondary_disk").([]interface{}) {
+		secondaryDiskMap := secondaryDiskIter.(map[string]interface{})
+		secondaryDisk := secondaryDiskMap["disk"].(string)
+		if zonal {
+			replicationRequest := compute.DisksStartAsyncReplicationRequest{
+				AsyncSecondaryDisk: secondaryDisk,
+			}
+			_, err = clientCompute.Disks.StartAsyncReplication(zv.Project, zv.Zone, zv.Name, &replicationRequest).Do()
+			if err != nil {
+				return err
+			}
+		} else {
+			replicationRequest := compute.RegionDisksStartAsyncReplicationRequest{
+				AsyncSecondaryDisk: secondaryDisk,
+			}
+			_, err = clientCompute.RegionDisks.StartAsyncReplication(rv.Project, rv.Region, rv.Name, &replicationRequest).Do()
+			if err != nil {
+				return err
+			}
+		}
+		err = resource.Retry(time.Minute*time.Duration(5), func() *resource.RetryError {
+			diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if diskStatus.ResourceStatus == nil {
+				return resource.NonRetryableError(fmt.Errorf("no resource status for disk: %s", resourceId))
+			}		
+			if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[secondaryDisk]; ok {
+				if secondaryState.State != "ACTIVE" {
+					time.Sleep(5 * time.Second)
+					return resource.RetryableError(fmt.Errorf("secondary disk %s state (%s) is not: ACTIVE", secondaryDisk, secondaryState))
+				}
+				return nil
+			}
+			time.Sleep(5 * time.Second)
+			return resource.RetryableError(fmt.Errorf("secondary disk %s state not available", secondaryDisk))
+		})
+		if err != nil {
+			return err
+		}
+	}
+	d.SetId(resourceId)
+	return resourceDiskAsyncReplicationRead(d, meta)
+}
+
+func resourceDiskAsyncReplicationUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceDiskAsyncReplicationRead(d, meta)
+}
+
+func resourceDiskAsyncReplicationRead(d *schema.ResourceData, meta interface{}) error {
+	clientCompute, err := getComputeClientForAsyncReplication(d, meta)
+	if err != nil {
+		return err
+	}
+
+	primaryDisk := d.Get("primary_disk").(string)
+	if primaryDisk == "" {
+		primaryDisk = d.Id()
+		d.Set("primary_disk", primaryDisk)
+	}
+
+	zonal, zv, rv, resourceId, err := getDiskFromConfig(primaryDisk, d, meta)
+	if err != nil {
+		return err
+	}
+
+	diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
+	if err != nil {
+		return err
+	}
+
+	secondaryDisks := make([]map[string]string, 0)
+	existingSecondaryDisks := make(map[string]bool, 0)
+	for _, disk := range diskStatus.AsyncSecondaryDisks {
+		secondaryDisk := make(map[string]string)
+
+		_, _, _, resourceName, err := getDiskFromConfig(disk.AsyncReplicationDisk.Disk, d, meta)
+		if err != nil {
+			return err
+		}
+
+		if diskStatus.ResourceStatus == nil {
+			return fmt.Errorf("no resource status for disk: %s", resourceId)
+		}
+
+		secondaryDisk["disk"] = resourceName
+		existingSecondaryDisks[resourceName] = true
+		if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
+			// Note this mi:ght be other than ACTIVE or STOPPED, but we wait for proper state
+			// on replication start/stop so it shouldnt affect Terraform
+			log.Printf("[DEBUG] Secondary disk %s is in state: %s", resourceName, secondaryState.State)
+			secondaryDisk["state"] = secondaryState.State
+		}
+		secondaryDisks = append(secondaryDisks, secondaryDisk)
+	}
+
+	log.Printf("[DEBUG] Secondary disks: %v", secondaryDisks)
+	if err = d.Set("secondary_disk", secondaryDisks); err != nil {
+		return fmt.Errorf("Error setting secondary_disk: %s", err)
+	}
+	d.SetId(resourceId)
+	return nil
+}
+
+func resourceDiskAsyncReplicationDelete(d *schema.ResourceData, meta interface{}) error {
+	clientCompute, err := getComputeClientForAsyncReplication(d, meta)
+	if err != nil {
+		return err
+	}
+
+	zonal, zv, rv, _, err := getDiskFromConfig(d.Get("primary_disk").(string), d, meta)
+	if err != nil {
+		return err
+	}
+
+	var replicationStopped bool = false
+	for _, secondaryDiskIter := range d.Get("secondary_disk").([]interface{}) {
+		secondaryDiskMap := secondaryDiskIter.(map[string]interface{})
+		secondaryDisk := secondaryDiskMap["disk"].(string)
+
+		_, _, _, resourceName, err := getDiskFromConfig(secondaryDisk, d, meta)
+		if err != nil {
+			return err
+		}
+
+		diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
+		if err != nil {
+			return err
+		}
+
+		if diskStatus.ResourceStatus == nil {
+			continue
+		}
+
+		if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
+			if secondaryState.State != "STOPPED" {
+				replicationStopped = true
+				if zonal {
+					_, err = clientCompute.Disks.StopAsyncReplication(zv.Project, zv.Zone, zv.Name).Do()
+					if err != nil {
+						return err
+					}
+				} else {
+					_, err = clientCompute.RegionDisks.StopAsyncReplication(rv.Project, rv.Region, rv.Name).Do()
+					if err != nil {
+						return err
+					}
+				}
+				err = resource.Retry(time.Minute*time.Duration(5), func() *resource.RetryError {
+					diskStatus, err := getComputeDiskStatus(clientCompute, zonal, zv, rv)
+					if err != nil {
+						return resource.NonRetryableError(err)
+					}
+					if secondaryState, ok := diskStatus.ResourceStatus.AsyncSecondaryDisks[resourceName]; ok {
+						if secondaryState.State != "STOPPED" {
+							time.Sleep(5 * time.Second)
+							return resource.RetryableError(fmt.Errorf("secondary disk %s state (%s) is not STOPPED", secondaryDisk, secondaryState))
+						}
+						return nil
+					}
+					return resource.NonRetryableError(fmt.Errorf("secondary disk %s state not available", secondaryDisk))
+				})
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return fmt.Errorf("could not find secondary disk: %s", secondaryDisk)
+		}
+	}
+	if replicationStopped {
+		// Allow the replication to quiescence
+		time.Sleep(5000 * time.Millisecond)
+	}
+
+	return nil
+}
+
+func resourceDiskAsyncReplicationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{}, nil
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go
@@ -45,9 +45,25 @@ func TestAccComputeDiskAsyncReplication(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeDiskAsyncReplication_basicZonal(region, secondaryRegion, primaryDisk, secondaryDisk),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_disk_async_replication.replication", "secondary_disk.0.state", "ACTIVE"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_disk_async_replication.replication",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccComputeDiskAsyncReplication_basicRegional(region, secondaryRegion, primaryRegionalDisk, secondaryRegionalDisk),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_disk_async_replication.replication", "secondary_disk.0.state", "ACTIVE"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_disk_async_replication.replication",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go
@@ -1,0 +1,140 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccComputeDiskAsyncReplication(t *testing.T) {
+	t.Parallel()
+
+	region := GetTestRegionFromEnv()
+	if !stringInSlice([]string{"europe-west2", "europe-west1", "us-central1", "us-east1", "us-west1", "us-east4", "asia-east1", "australia-southeast1"}, region) {
+		return
+	}
+	secondaryRegion := region
+	switch region {
+	case "europe-west2":
+		secondaryRegion = "europe-west1"
+	case "europe-west1":
+		secondaryRegion = "europe-west2"
+	case "us-central1":
+		secondaryRegion = "us-east1"
+	case "us-east1", "us-west1", "us-east4":
+		secondaryRegion = "us-central1"
+	case "asia-east1":
+		secondaryRegion = "asia-southeast1"
+	case "asia-southeast1":
+		secondaryRegion = "asia-east1"
+	case "australia-southeast1":
+		secondaryRegion = "australia-southeast2"
+	case "australia-southeast2":
+		secondaryRegion = "australia-southeast1"
+	}
+
+	primaryDisk := fmt.Sprintf("tf-test-disk-primary-%s", RandString(t, 10))
+	secondaryDisk := fmt.Sprintf("tf-test-disk-secondary-%s", RandString(t, 10))
+	primaryRegionalDisk := fmt.Sprintf("tf-test-disk-rprimary-%s", RandString(t, 10))
+	secondaryRegionalDisk := fmt.Sprintf("tf-test-disk-rsecondary-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDiskAsyncReplication_basicZonal(region, secondaryRegion, primaryDisk, secondaryDisk),
+			},
+			{
+				Config: testAccComputeDiskAsyncReplication_basicRegional(region, secondaryRegion, primaryRegionalDisk, secondaryRegionalDisk),
+			},
+		},
+	})
+}
+
+func testAccComputeDiskAsyncReplication_basicZonal(region, secondaryRegion, primaryDisk, secondaryDisk string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "primary" {
+	provider = google-beta
+
+	zone = "%s-a"
+	name = "%s"
+	type = "pd-ssd"
+	
+	physical_block_size_bytes = 4096
+}
+	
+resource "google_compute_disk" "secondary" {
+	provider = google-beta
+	
+	name = "%s"
+	type = "pd-ssd"
+	zone = "%s-b"
+	
+	async_primary_disk {
+	    disk = google_compute_disk.primary.id
+	}
+	
+	physical_block_size_bytes = 4096
+}
+	
+resource "google_compute_disk_async_replication" "replication" {
+	provider = google-beta
+	
+	primary_disk = google_compute_disk.primary.id
+
+	secondary_disk {
+		disk  = google_compute_disk.secondary.id
+	}
+}	  
+`, region, primaryDisk, secondaryDisk, secondaryRegion)
+}
+
+func testAccComputeDiskAsyncReplication_basicRegional(region, secondaryRegion, primaryDisk, secondaryDisk string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_disk" "primary" {
+	provider = google-beta
+	
+	region = "%s"
+	name   = "%s"
+	type   = "pd-ssd"
+	
+	physical_block_size_bytes = 4096
+
+	replica_zones = [
+		"%s-a",
+		"%s-b"
+	]
+}
+	
+resource "google_compute_region_disk" "secondary" {
+    provider = google-beta
+	
+	region = "%s"
+	name   = "%s"
+	type   = "pd-ssd"
+	
+	async_primary_disk {
+	    disk = google_compute_region_disk.primary.id
+	}
+	
+	physical_block_size_bytes = 4096
+
+	replica_zones = [
+		"%s-b",
+		"%s-c"
+	]
+}
+	
+resource "google_compute_disk_async_replication" "replication" {
+	provider = google-beta
+	
+	primary_disk = google_compute_region_disk.primary.id
+
+	secondary_disk {
+		disk  = google_compute_region_disk.secondary.id
+	}
+}	  
+`, region, primaryDisk, region, region, secondaryRegion, secondaryDisk, secondaryRegion, secondaryRegion)
+}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -389,6 +389,7 @@ end     # products.each do
 				"google_compute_attached_disk":                 ResourceComputeAttachedDisk(),
 				"google_compute_instance":                      ResourceComputeInstance(),
 				<% unless version == 'ga' -%>
+				"google_compute_disk_async_replication":        ResourceComputeDiskAsyncReplication(),
 				"google_compute_instance_from_machine_image":   ResourceComputeInstanceFromMachineImage(),
 				<% end -%>
 				"google_compute_instance_from_template":        ResourceComputeInstanceFromTemplate(),

--- a/mmv1/third_party/terraform/website/docs/r/compute_disk_async_replication.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_disk_async_replication.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  Manage asynchronous Persistent Disk replication.
+---
+
+# google\_compute\_disk\_async\_replication
+
+Starts and stops asynchronous persistent disk replication. For more information
+see [the official documentation](https://cloud.google.com/compute/docs/disks/async-pd/about)
+and the [API](https://cloud.google.com/compute/docs/reference/rest/beta/disks).
+
+## Example Usage
+
+```tf
+resource "google_compute_disk" "primary-disk" {
+  name = "primary-disk"
+  type = "pd-ssd"
+  zone = "europe-west4-a"
+
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_disk" "secondary-disk" {
+  name = "secondary-disk"
+  type = "pd-ssd"
+  zone = "europe-west3-a"
+
+  async_primary_disk {
+    disk = google_compute_disk.primary-disk.id
+  }
+
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_disk_async_replication" "replication" {
+  primary_disk = google_compute_disk.primary-disk.id
+  secondary_disk {
+    disk  = google_compute_disk.secondary-disk.id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `primary_disk` - (Required) The primary disk (source of replication).
+
+* `secondary_disk` - (Required) The secondary disk (target of replication). You can specify only one value. Structure is documented below.
+
+The `secondary_disk` block includes:
+
+* `disk` - (Required) The secondary disk.
+
+* `state` - Output-only. Status of replication on the secondary disk.
+
+- - -


### PR DESCRIPTION
- Added support for Persistent Disk Asynchronous Replication binding resource
- Also bumps google.golang.org/api to v0.115

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
compute: new resource `google_compute_disk_async_replication` for Persistent Disk Asynchronous Replication
```
