### PR TITLE
fix: google_cloud_identity_group initialGroupConfig

### DIFF
--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -67,6 +67,7 @@ parameters:
       - "EMPTY"
     default_value: :EMPTY
     url_param_only: true
+    immutable: true
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'


### PR DESCRIPTION
According to [1] initialGroupConfig is an immutable parameter in both v1 and v1beta of the Cloud Identity groups API, and the `updateMask` for `groups.patch` does not accept it (it's a URL parameter in groups.create). Aside from the current implementation not correctly destroying and re-creating the resource when `initial_group_config` changes, requests in which no `updateMask` fields change results in a URL containing `updateMask=` which causes the API to error:

```
PATCH /v1/{name=groups/*}&updateMask=

{
"error": {
    "code": 400,
    "message": "Request contains an invalid argument.",
    "status": "INVALID_ARGUMENT"
}
```

[1]: https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups/create

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudidentity: fixed immutability issue on `initialGroupConfig` field for resource `google_cloud_identity_group`
```
