### PR TITLE
Added support for Persistent Disk Asynchronous Replication (part 1)

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -70,6 +70,15 @@ examples:
       ])"
     vars:
       disk_name: "test-disk"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "disk_async"
+    primary_resource_id: "primary"
+    primary_resource_name: "fmt.Sprintf(\"tf-test-test-disk%s\", context[\"random_suffix\"\
+      ])"
+    min_version: beta
+    vars:
+      disk_name: "async-test-disk"
+      secondary_disk_name: "async-secondary-test-disk"
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   method_name_separator: '/'
   fetch_iam_policy_verb: :GET
@@ -420,3 +429,13 @@ properties:
       Indicates how many IOPS must be provisioned for the disk.
     required: false
     default_from_api: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'asyncPrimaryDisk'
+    min_version: 'beta'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'disk'
+        description: |
+          Primary disk for asynchronous disk replication.
+        required: true
+    diff_suppress_func: 'compareSelfLinkRelativePaths'

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -71,6 +71,15 @@ examples:
       region_disk_name: "my-region-disk"
       disk_name: "my-disk"
       snapshot_name: "my-snapshot"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "region_disk_async"
+    primary_resource_id: "primary"
+    primary_resource_name: "fmt.Sprintf(\"tf-test-my-region-disk%s\", context[\"random_suffix\"\
+      ])"
+    min_version: beta
+    vars:
+      region_disk_name: "primary-region-disk"
+      secondary_region_disk_name: "secondary-region-disk"
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   method_name_separator: '/'
   fetch_iam_policy_verb: :GET
@@ -312,3 +321,13 @@ properties:
       be used to determine whether the image was taken from the current
       or a previous instance of a given disk name.
     output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'asyncPrimaryDisk'
+    min_version: 'beta'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'disk'
+        description: |
+          Primary disk for asynchronous disk replication.
+        required: true
+    diff_suppress_func: 'compareSelfLinkRelativePaths'

--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -70,6 +70,12 @@ examples:
     primary_resource_id: "hourly"
     vars:
       name: "gce-policy"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "resource_policy_consistency_group"
+    min_version: "beta"
+    primary_resource_id: "cgroup"
+    vars:
+      name: "gce-policy"
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: region
@@ -100,6 +106,7 @@ properties:
     conflicts:
       - 'group_placement_policy'
       - 'instance_schedule_policy'
+      - 'disk_consistency_group_policy'
     description: |
       Policy for creating snapshots of persistent disks.
     properties:
@@ -258,6 +265,7 @@ properties:
     conflicts:
       - 'instance_schedule_policy'
       - 'snapshot_schedule_policy'
+      - 'disk_consistency_group_policy'
     description: |
       Resource policy for instances used for placement configuration.
     properties:
@@ -291,6 +299,7 @@ properties:
     conflicts:
       - 'snapshot_schedule_policy'
       - 'group_placement_policy'
+      - 'disk_consistency_group_policy'
     description: |
       Resource policy for scheduling instance operations.
     properties:
@@ -334,3 +343,22 @@ properties:
         name: 'expirationTime'
         description: |
           The expiration time of the schedule. The timestamp is an RFC3339 string.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'diskConsistencyGroupPolicy'
+    min_version: 'beta'
+    conflicts:
+      - 'snapshot_schedule_policy'
+      - 'group_placement_policy'
+      - 'instance_schedule_policy'
+    description: |
+      Replication consistency group for asynchronous disk replication.
+    send_empty_value: true
+    properties: 
+      - !ruby/object:Api::Type::Boolean
+        name: 'enabled'
+        immutable: true
+        required: true
+        description: |
+          Enable disk consistency on the resource policy.
+    custom_expand: 'templates/terraform/custom_expand/disk_consistency_group_policy.erb'
+    custom_flatten: 'templates/terraform/custom_flatten/disk_consistency_group_policy.erb'

--- a/mmv1/templates/terraform/custom_expand/disk_consistency_group_policy.erb
+++ b/mmv1/templates/terraform/custom_expand/disk_consistency_group_policy.erb
@@ -1,0 +1,30 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+		l := v.([]interface{})
+
+		if len(l) == 0 || l[0] == nil {
+			return nil, nil
+		}
+		raw := l[0]
+		original := raw.(map[string]interface{})
+		if isEnabled, ok := original["enabled"]; ok {
+			if !isEnabled.(bool) {
+				return nil, nil
+			}
+		}
+		transformed := make(map[string]interface{})
+		return transformed, nil
+}

--- a/mmv1/templates/terraform/custom_flatten/disk_consistency_group_policy.erb
+++ b/mmv1/templates/terraform/custom_flatten/disk_consistency_group_policy.erb
@@ -1,0 +1,22 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2022 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+		if v == nil {
+			return nil
+		}
+		transformed := make(map[string]interface{})
+		transformed["enabled"] = true
+		return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/examples/disk_async.tf.erb
+++ b/mmv1/templates/terraform/examples/disk_async.tf.erb
@@ -1,0 +1,23 @@
+resource "google_compute_disk" "primary" {
+  provider = google-beta
+
+  name  = "<%= ctx[:vars]['disk_name'] %>"
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_disk" "secondary" {
+  provider = google-beta
+
+  name  = "<%= ctx[:vars]['secondary_disk_name'] %>"
+  type  = "pd-ssd"
+  zone  = "us-east1-c"
+
+  async_primary_disk {
+    disk = google_compute_disk.primary.id
+  }
+
+  physical_block_size_bytes = 4096
+}

--- a/mmv1/templates/terraform/examples/region_disk_async.tf.erb
+++ b/mmv1/templates/terraform/examples/region_disk_async.tf.erb
@@ -1,0 +1,26 @@
+resource "google_compute_region_disk" "primary" {
+  provider = google-beta
+
+  name                      = "<%= ctx[:vars]['region_disk_name'] %>"
+  type                      = "pd-ssd"
+  region                    = "us-central1"
+  physical_block_size_bytes = 4096
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_region_disk" "secondary" {
+  provider = google-beta
+
+  name                      = "<%= ctx[:vars]['secondary_region_disk_name'] %>"
+  type                      = "pd-ssd"
+  region                    = "us-east1"
+  physical_block_size_bytes = 4096
+
+  async_primary_disk {
+    disk = google_compute_region_disk.primary.id
+  }
+
+  replica_zones = ["us-east1-b", "us-east1-c"]
+}
+

--- a/mmv1/templates/terraform/examples/resource_policy_consistency_group.tf.erb
+++ b/mmv1/templates/terraform/examples/resource_policy_consistency_group.tf.erb
@@ -1,0 +1,9 @@
+resource "google_compute_resource_policy" "cgroup" {
+  provider = google-beta
+
+  name   = "<%= ctx[:vars]['name'] %>"
+  region = "europe-west1"
+  disk_consistency_group_policy {
+    enabled = true
+  }
+}


### PR DESCRIPTION
- Added support for Persistent Disk Asynchronous Replication
- Added support for consistency groups in resource policy

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added new field `async_primary_disk` to `google_compute_disk` and `google_compute_region_disk`
```

```release-note:enhancement
compute: added new field `disk_consistency_group_policy` to `google_compute_resource_policy`
```
