### PR TITLE
Relax boolean conversions to accept varying cases

### DIFF
--- a/tpgtools/handwritten/expanders.go
+++ b/tpgtools/handwritten/expanders.go
@@ -1,6 +1,10 @@
 package google
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 func expandStringArray(v interface{}) []string {
 	arr, ok := v.([]string)
@@ -53,13 +57,18 @@ func expandEnumBool(v interface{}) *bool {
 	if !ok {
 		return nil
 	}
-	switch s {
-	case "TRUE":
-		b := true
-		return &b
-	case "FALSE":
-		b := false
-		return &b
+
+	switch {
+	case strings.EqualFold(s, "true"):
+		return boolPtr(true)
+	case strings.EqualFold(s, "false"):
+		return boolPtr(false)
+	default:
+		return nil
 	}
-	return nil
+}
+
+// boolPtr returns a pointer to the given boolean.
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/tpgtools/handwritten/expanders_test.go
+++ b/tpgtools/handwritten/expanders_test.go
@@ -1,0 +1,74 @@
+package google
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExpandEnumBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		exp   *bool
+	}{
+		{
+			name:  "true",
+			input: "true",
+			exp:   boolPtr(true),
+		},
+		{
+			name:  "TRUE",
+			input: "TRUE",
+			exp:   boolPtr(true),
+		},
+		{
+			name:  "True",
+			input: "True",
+			exp:   boolPtr(true),
+		},
+		{
+			name:  "false",
+			input: "false",
+			exp:   boolPtr(false),
+		},
+		{
+			name:  "FALSE",
+			input: "FALSE",
+			exp:   boolPtr(false),
+		},
+		{
+			name:  "False",
+			input: "False",
+			exp:   boolPtr(false),
+		},
+		{
+			name:  "empty_string",
+			input: "",
+			exp:   nil,
+		},
+		{
+			name:  "apple",
+			input: "apple",
+			exp:   nil,
+		},
+		{
+			name:  "unicode",
+			input: "🚀",
+			exp:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := expandEnumBool(tc.input), tc.exp; !reflect.DeepEqual(got, want) {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Relax boolean conversions to DCL accept varying cases.

- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
orgpolicy: accepted variable cases for booleans such as true, True, and TRUE in `google_org_policy_policy`
```
