### PR TITLE
switch to use MultiEnvDefault

### DIFF
--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -304,13 +304,17 @@ func HandleSDKDefaults(d *schema.ResourceData) error {
 	}
 
 	if _, ok := d.GetOk("user_project_override"); !ok {
-		b, err := strconv.ParseBool(MultiEnvDefault([]string{
+		override := MultiEnvDefault([]string{
 			"USER_PROJECT_OVERRIDE",
-		}, nil).(string))
-		if err != nil {
-			return err
+		}, nil)
+
+		if override != nil {
+			b, err := strconv.ParseBool(override.(string))
+			if err != nil {
+				return err
+			}
+			d.Set("user_project_override", b)
 		}
-		d.Set("user_project_override", b)
 	}
 
 	if d.Get("request_reason") == "" {

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -303,7 +303,7 @@ func HandleSDKDefaults(d *schema.ResourceData) error {
 		}, nil))
 	}
 
-	if _, ok := d.GetOk("user_project_override"); !ok {
+	if _, ok := d.GetOkExists("user_project_override"); !ok {
 		override := MultiEnvDefault([]string{
 			"USER_PROJECT_OVERRIDE",
 		}, nil)

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -265,54 +265,58 @@ var DefaultClientScopes = []string{
 	"https://www.googleapis.com/auth/userinfo.email",
 }
 
-func HandleSDKDefaults(d *schema.ResourceData) {
+func HandleSDKDefaults(d *schema.ResourceData) error {
 	if d.Get("impersonate_service_account") == "" {
-		d.Set("impersonate_service_account", MultiEnvSearch([]string{
+		d.Set("impersonate_service_account", MultiEnvDefault([]string{
 			"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
-		}))
+		}, nil))
 	}
 
 	if d.Get("project") == "" {
-		d.Set("project", MultiEnvSearch([]string{
+		d.Set("project", MultiEnvDefault([]string{
 			"GOOGLE_PROJECT",
 			"GOOGLE_CLOUD_PROJECT",
 			"GCLOUD_PROJECT",
 			"CLOUDSDK_CORE_PROJECT",
-		}))
+		}, nil))
 	}
 
 	if d.Get("billing_project") == "" {
-		d.Set("billing_project", MultiEnvSearch([]string{
+		d.Set("billing_project", MultiEnvDefault([]string{
 			"GOOGLE_BILLING_PROJECT",
-		}))
+		}, nil))
 	}
 
 	if d.Get("region") == "" {
-		d.Set("region", MultiEnvSearch([]string{
+		d.Set("region", MultiEnvDefault([]string{
 			"GOOGLE_REGION",
 			"GCLOUD_REGION",
 			"CLOUDSDK_COMPUTE_REGION",
-		}))
+		}, nil))
 	}
 
 	if d.Get("zone") == "" {
-		d.Set("zone", MultiEnvSearch([]string{
+		d.Set("zone", MultiEnvDefault([]string{
 			"GOOGLE_ZONE",
 			"GCLOUD_ZONE",
 			"CLOUDSDK_COMPUTE_ZONE",
-		}))
+		}, nil))
 	}
 
-	if d.Get("user_project_override") == "" {
-		d.Set("user_project_override", MultiEnvSearch([]string{
+	if _, ok := d.GetOk("user_project_override"); !ok {
+		b, err := strconv.ParseBool(MultiEnvDefault([]string{
 			"USER_PROJECT_OVERRIDE",
-		}))
+		}, nil).(string))
+		if err != nil {
+			return err
+		}
+		d.Set("user_project_override", b)
 	}
 
 	if d.Get("request_reason") == "" {
-		d.Set("request_reason", MultiEnvSearch([]string{
+		d.Set("request_reason", MultiEnvDefault([]string{
 			"CLOUDSDK_CORE_REQUEST_REASON",
-		}))
+		}, nil))
 	}
 
 	// Generated Products
@@ -397,6 +401,8 @@ func HandleSDKDefaults(d *schema.ResourceData) {
 			"GOOGLE_CONTAINERAZURE_CUSTOM_ENDPOINT",
 		}, DefaultBasePaths[ContainerAzureBasePathKey]))
 	}
+
+	return nil
 }
 
 func (c *Config) LoadAndValidate(ctx context.Context) error {

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -527,7 +527,10 @@ end     # products.each do
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Provider) (interface{}, diag.Diagnostics) {
-	HandleSDKDefaults(d)
+	err := HandleSDKDefaults(d)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
 	HandleDCLCustomEndpointDefaults(d)
 
 	config := Config{

--- a/tpgtools/templates/provider_dcl_endpoints.go.tmpl
+++ b/tpgtools/templates/provider_dcl_endpoints.go.tmpl
@@ -66,9 +66,9 @@ func HandleDCLCustomEndpointDefaults(d *schema.ResourceData) {
 {{- range $index, $pkg := . }}
 {{- if $pkg.ShouldWriteProductBasePath }}
 	if d.Get({{$pkg.BasePathIdentifier.ToTitle}}EndpointEntryKey) == "" {
-		d.Set({{$pkg.BasePathIdentifier.ToTitle}}EndpointEntryKey, MultiEnvSearch([]string{
+		d.Set({{$pkg.BasePathIdentifier.ToTitle}}EndpointEntryKey, MultiEnvDefault([]string{
 			"GOOGLE_{{$pkg.BasePathIdentifier.ToUpper}}_CUSTOM_ENDPOINT",
-		}))
+		}, ""))
 	}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14201

In the past these defaults would be set on the schema, however now that they can't be we have to check if they're set and, if not, set them to the defaults manually.

We have 2 functions `MultiEnvSearch` which assumes its a string and `MultiEnvDefault` which returns an interface and allows a default value to be set in the case the env var isn't set.

All of these were using `MultiEnvSearch` - most are strings except `USER_PROJECT_OVERRIDE` - in this case we need it to be a bool.

On top of that we were checking `d.Get() == ""`, but in this case `d.Get` was `false` so we have to check `d.GetOk`, from here we need to make it a bool rather than a string, so added in the ParseBool.

I checked the rest of these defaults that moved from the schema to here and they indeed are all strings, so I put the logic on this individual case rather than in the `MultiEnvDefault` function




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed an issue where the `USER_PROJECT_OVERRIDE` environment variable was not being read
```
