### PR TITLE
Set networkFirewallPolicyEnforcementOrder as mutable and default value from API

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -233,4 +233,4 @@ properties:
     values:
       - :BEFORE_CLASSIC_FIREWALL
       - :AFTER_CLASSIC_FIREWALL
-    default_from_api: true
+    default_value: :AFTER_CLASSIC_FIREWALL

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -228,8 +228,6 @@ properties:
     update_url: projects/{{project}}/global/networks/{{name}}
     description: |
       Set the order that Firewall Rules and Firewall Policies are evaluated.
-      Needs to be either `AFTER_CLASSIC_FIREWALL` or `BEFORE_CLASSIC_FIREWALL`.
-      Defaults to `AFTER_CLASSIC_FIREWALL`.
     values:
       - :BEFORE_CLASSIC_FIREWALL
       - :AFTER_CLASSIC_FIREWALL

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -224,10 +224,13 @@ properties:
     default_from_api: true
   - !ruby/object:Api::Type::Enum
     name: 'networkFirewallPolicyEnforcementOrder'
+    update_verb: :PATCH
+    update_url: projects/{{project}}/global/networks/{{name}}
     description: |
-      Set the order that Firewall Rules and Firewall Policies are evaluated. Needs to be either 'AFTER_CLASSIC_FIREWALL' or 'BEFORE_CLASSIC_FIREWALL' Default 'AFTER_CLASSIC_FIREWALL'
-    immutable: true
+      Set the order that Firewall Rules and Firewall Policies are evaluated.
+      Needs to be either `AFTER_CLASSIC_FIREWALL` or `BEFORE_CLASSIC_FIREWALL`.
+      Defaults to `AFTER_CLASSIC_FIREWALL`.
     values:
       - :BEFORE_CLASSIC_FIREWALL
       - :AFTER_CLASSIC_FIREWALL
-    default_value: :AFTER_CLASSIC_FIREWALL
+    default_from_api: true

--- a/mmv1/templates/terraform/examples/network_custom_firewall_enforcement_order.tf.erb
+++ b/mmv1/templates/terraform/examples/network_custom_firewall_enforcement_order.tf.erb
@@ -3,6 +3,6 @@ resource "google_compute_network" "<%= ctx[:primary_resource_id] %>" {
   project                                   = "<%= ctx[:test_env_vars]["project"] %>"
   name                                      = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks                   = true
-  network_firewall_policy_enforcement_order = "AFTER_CLASSIC_FIREWALL"
+  network_firewall_policy_enforcement_order = "BEFORE_CLASSIC_FIREWALL"
 }
 # [END vpc_auto_create]

--- a/mmv1/templates/terraform/examples/network_custom_firewall_enforcement_order.tf.erb
+++ b/mmv1/templates/terraform/examples/network_custom_firewall_enforcement_order.tf.erb
@@ -1,8 +1,8 @@
 # [START vpc_auto_create]
 resource "google_compute_network" "<%= ctx[:primary_resource_id] %>" {
-  project                 = "<%= ctx[:test_env_vars]["project"] %>"
-  name                    = "<%= ctx[:vars]['network_name'] %>"
-  auto_create_subnetworks = true
-  network_firewall_policy_enforcement_order = "BEFORE_CLASSIC_FIREWALL"
+  project                                   = "<%= ctx[:test_env_vars]["project"] %>"
+  name                                      = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks                   = true
+  network_firewall_policy_enforcement_order = "AFTER_CLASSIC_FIREWALL"
 }
 # [END vpc_auto_create]

--- a/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
@@ -395,7 +395,7 @@ resource "google_compute_network" "acc_network_firewall_policy_enforcement_order
 func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderUpdate(network, order string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
-  name         								= "tf-test-network-firewall-policy-enforcement-order-%s"
+  name                                      = "tf-test-network-firewall-policy-enforcement-order-%s"
   network_firewall_policy_enforcement_order = "%s"
 }
 `, network, order)

--- a/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
@@ -153,6 +153,43 @@ func TestAccComputeNetwork_networkDeleteDefaultRoute(t *testing.T) {
 	})
 }
 
+func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	var network compute.Network
+	networkName := RandString(t, 10)
+
+	defaultNetworkFirewallPolicyEnforcementOrder := "AFTER_CLASSIC_FIREWALL"
+	explicitNetworkFirewallPolicyEnforcementOrder := "BEFORE_CLASSIC_FIREWALL"
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNetwork_network_firewall_policy_enforcement_order_default(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network),
+					testAccCheckComputeNetworkHasNetworkFirewallPolicyEnforcementOrder(
+						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network, defaultNetworkFirewallPolicyEnforcementOrder),
+				),
+			},
+			// Test updating the enforcement order
+			{
+				Config: testAccComputeNetwork_network_firewall_policy_enforcement_order_explicit(networkName, explicitNetworkFirewallPolicyEnforcementOrder),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network),
+					testAccCheckComputeNetworkHasNetworkFirewallPolicyEnforcementOrder(
+						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network, explicitNetworkFirewallPolicyEnforcementOrder),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeNetworkExists(t *testing.T, n string, network *compute.Network) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -281,6 +318,35 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 	}
 }
 
+func testAccCheckComputeNetworkHasNetworkFirewallPolicyEnforcementOrder(t *testing.T, n string, network *compute.Network, order string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := GoogleProviderConfig(t)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["network_firewall_policy_enforcement_order"] == "" {
+			return fmt.Errorf("Network firewall policy enforcement order not found on resource")
+		}
+
+		found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
+			config.Project, network.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		foundNetworkFirewallPolicyEnforcementOrder := found.NetworkFirewallPolicyEnforcementOrder
+
+		if order != foundNetworkFirewallPolicyEnforcementOrder {
+			return fmt.Errorf("Expected network firewall policy enforcement order %s to match %s", order, foundNetworkFirewallPolicyEnforcementOrder)
+		}
+
+		return nil
+	}
+}
+
 func testAccComputeNetwork_basic(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "bar" {
@@ -316,4 +382,21 @@ resource "google_compute_network" "bar" {
   auto_create_subnetworks         = false
 }
 `, suffix)
+}
+
+func testAccComputeNetwork_network_firewall_policy_enforcement_order_default(network string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
+  name = "tf-test-network-firewall-policy-enforcement-order-%s"
+}
+`, network)
+}
+
+func testAccComputeNetwork_network_firewall_policy_enforcement_order_explicit(network, order string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
+  name         								= "tf-test-network-firewall-policy-enforcement-order-%s"
+  network_firewall_policy_enforcement_order = "%s"
+}
+`, network, order)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
@@ -168,7 +168,7 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_network_firewall_policy_enforcement_order_default(networkName),
+				Config: testAccComputeNetwork_networkFirewallPolicyEnforcementOrderDefault(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network),
@@ -178,7 +178,7 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 			},
 			// Test updating the enforcement order
 			{
-				Config: testAccComputeNetwork_network_firewall_policy_enforcement_order_explicit(networkName, explicitNetworkFirewallPolicyEnforcementOrder),
+				Config: testAccComputeNetwork_networkFirewallPolicyEnforcementOrderUpdate(networkName, explicitNetworkFirewallPolicyEnforcementOrder),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network),
@@ -384,7 +384,7 @@ resource "google_compute_network" "bar" {
 `, suffix)
 }
 
-func testAccComputeNetwork_network_firewall_policy_enforcement_order_default(network string) string {
+func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderDefault(network string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
   name = "tf-test-network-firewall-policy-enforcement-order-%s"
@@ -392,7 +392,7 @@ resource "google_compute_network" "acc_network_firewall_policy_enforcement_order
 `, network)
 }
 
-func testAccComputeNetwork_network_firewall_policy_enforcement_order_explicit(network, order string) string {
+func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderUpdate(network, order string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
   name         								= "tf-test-network-firewall-policy-enforcement-order-%s"

--- a/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
@@ -157,6 +157,7 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 	t.Parallel()
 
 	var network compute.Network
+	var updatedNetwork compute.Network
 	networkName := RandString(t, 10)
 
 	defaultNetworkFirewallPolicyEnforcementOrder := "AFTER_CLASSIC_FIREWALL"
@@ -176,15 +177,28 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network, defaultNetworkFirewallPolicyEnforcementOrder),
 				),
 			},
-			// Test updating the enforcement order
+			{
+				ResourceName: 				"google_compute_network.acc_network_firewall_policy_enforcement_order",
+				ImportState: 				true,
+				ImportStateVerify: 			true,
+				ImportStateVerifyIgnore: 	[]string{"force_destroy"},
+			},
+			// Test updating the enforcement order works and updates in-place
 			{
 				Config: testAccComputeNetwork_networkFirewallPolicyEnforcementOrderUpdate(networkName, explicitNetworkFirewallPolicyEnforcementOrder),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
-						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network),
+						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &updatedNetwork),
 					testAccCheckComputeNetworkHasNetworkFirewallPolicyEnforcementOrder(
-						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &network, explicitNetworkFirewallPolicyEnforcementOrder),
+						t, "google_compute_network.acc_network_firewall_policy_enforcement_order", &updatedNetwork, explicitNetworkFirewallPolicyEnforcementOrder),
+					testAccCheckComputeNetworkWasUpdated(&updatedNetwork, &network),
 				),
+			},
+			{
+				ResourceName: 				"google_compute_network.acc_network_firewall_policy_enforcement_order",
+				ImportState: 				true,
+				ImportStateVerify: 			true,
+				ImportStateVerifyIgnore: 	[]string{"force_destroy"},
 			},
 		},
 	})
@@ -345,6 +359,15 @@ func testAccCheckComputeNetworkHasNetworkFirewallPolicyEnforcementOrder(t *testi
 
 		return nil
 	}
+}
+
+func testAccCheckComputeNetworkWasUpdated(newNetwork *compute.Network, oldNetwork *compute.Network) resource.TestCheckFunc {
+        return func(s *terraform.State) error {
+                if oldNetwork.CreationTimestamp != newNetwork.CreationTimestamp {
+                        return fmt.Errorf("expected compute network to have been updated (had same creation time), instead was recreated - old creation time %s, new creation time %s", oldNetwork.CreationTimestamp, newNetwork.CreationTimestamp)
+                }
+                return nil
+        }
 }
 
 func testAccComputeNetwork_basic(suffix string) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_test.go.erb
@@ -163,7 +163,7 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 	explicitNetworkFirewallPolicyEnforcementOrder := "BEFORE_CLASSIC_FIREWALL"
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Set `networkFirewallPolicyEnforcementOrder` as mutable. Updating this field should not force the resource to be recreated.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14231
Original PR: https://github.com/hashicorp/terraform-provider-google/issues/13952

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: made `network_firewall_policy_enforcement_order` field mutable in `google_compute_network`.
```