### PR TITLE
Add tests for `CompileUserAgentString` func

### DIFF
--- a/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -44,7 +43,7 @@ func TestCompileUserAgentString(t *testing.T) {
 			// Arrange
 			ctx := context.Background()
 
-			os.Setenv(uaEnvVar, tc.EnvValue) // Use same global const as the CompileUserAgentString function
+			t.Setenv(uaEnvVar, tc.EnvValue) // Use same global const as the CompileUserAgentString function
 
 			// Act
 

--- a/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
@@ -1,11 +1,62 @@
 package google
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestCompileUserAgentString(t *testing.T) {
+	cases := map[string]struct {
+		Name              string // Name of the provider
+		TerraformVersion  string
+		ProviderVersion   string
+		EnvValue          string
+		ExpectedUserAgent string
+	}{
+		"the expected user agent is returned for given inputs": {
+			Name:              "terraform-provider-foobar",
+			TerraformVersion:  "1.2.3",
+			ProviderVersion:   "9.9.9",
+			ExpectedUserAgent: "Terraform/1.2.3 (+https://www.terraform.io) Terraform-Plugin-SDK/terraform-plugin-framework terraform-provider-foobar/9.9.9",
+		},
+		"the user agent can have values appended via an environment variable": {
+			Name:              "terraform-provider-foobar",
+			TerraformVersion:  "1.2.3",
+			ProviderVersion:   "9.9.9",
+			EnvValue:          "I'm appended at the end!",
+			ExpectedUserAgent: "Terraform/1.2.3 (+https://www.terraform.io) Terraform-Plugin-SDK/terraform-plugin-framework terraform-provider-foobar/9.9.9 I'm appended at the end!",
+		},
+		"values appended via an environment variable have whitespace trimmed": {
+			Name:              "terraform-provider-foobar",
+			TerraformVersion:  "1.2.3",
+			ProviderVersion:   "9.9.9",
+			EnvValue:          "              my surrounding white space is removed              ",
+			ExpectedUserAgent: "Terraform/1.2.3 (+https://www.terraform.io) Terraform-Plugin-SDK/terraform-plugin-framework terraform-provider-foobar/9.9.9 my surrounding white space is removed",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			ctx := context.Background()
+
+			os.Setenv(uaEnvVar, tc.EnvValue) // Use same global const as the CompileUserAgentString function
+
+			// Act
+
+			ua := CompileUserAgentString(ctx, tc.Name, tc.TerraformVersion, tc.ProviderVersion)
+
+			// Assert
+			if ua != tc.ExpectedUserAgent {
+				t.Fatalf("Incorrect user agent output: got %s, want %s", ua, tc.ExpectedUserAgent)
+			}
+		})
+	}
+}
 
 func TestGetProjectFramework(t *testing.T) {
 	cases := map[string]struct {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds a test for the `CompileUserAgentString` function, which was added at the time of the plugin framework being added to the provider

---



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
