### PR TITLE
Add configuration for tcp route.

### DIFF
--- a/mmv1/products/networkservices/TcpRoute.yaml
+++ b/mmv1/products/networkservices/TcpRoute.yaml
@@ -22,6 +22,8 @@ update_mask: true
 description: |
   TcpRoute is the resource defining how TCP traffic should be routed by a Mesh/Gateway resource.
 references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Setup TCP Services': 'https://cloud.google.com/traffic-director/docs/set-up-tcp-route'
   api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.tcpRoutes'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
@@ -62,6 +64,22 @@ examples:
       resource_name: 'my-tcp-route'
       backend_service_name: "my-backend-service"
       http_health_check_name: "backend-service-health-check"
+  - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
+    name: 'network_services_tcp_route_mesh_basic'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-tcp-route'
+      backend_service_name: "my-backend-service"
+      http_health_check_name: "backend-service-health-check"
+  - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
+    name: 'network_services_tcp_route_gateway_basic'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-tcp-route'
+      backend_service_name: "my-backend-service"
+      http_health_check_name: "backend-service-health-check"
 parameters:
   - !ruby/object:Api::Type::String
     name: 'name'
@@ -97,18 +115,22 @@ properties:
     name: meshes
     item_type: Api::Type::String
     description: |
-          List of meshes this TcpRoute is attached to, as one of the routing rules to route the requests served by the mesh.  
+          Meshes defines a list of meshes this TcpRoute is attached to, as one of the routing rules to route the requests served by the mesh.
+          Each mesh reference should match the pattern: projects/*/locations/global/meshes/<mesh_name>
+          The attached Mesh should be of a type SIDECAR
     send_empty_value: true 
   - !ruby/object:Api::Type::Array
     name: gateways
     item_type: Api::Type::String
     description: |
-          List of gateways this TcpRoute is attached to, as one of the routing rules to route the requests served by the gateway.  
+          Gateways defines a list of gateways this TcpRoute is attached to, as one of the routing rules to route the requests served by the gateway.
+          Each gateway reference should match the pattern: projects/*/locations/global/gateways/<gateway_name>
     send_empty_value: true
   - !ruby/object:Api::Type::Array
     name: rules
     description: |
-          Rules that define how traffic is routed and handled.  
+          Rules that define how traffic is routed and handled. At least one RouteRule must be supplied. 
+          If there are multiple rules then the action taken will be the first rule to match.
     required: true
     send_empty_value: true
     item_type: !ruby/object:Api::Type::NestedObject
@@ -116,30 +138,32 @@ properties:
         - !ruby/object:Api::Type::Array
           name: matches
           description: |
-            Matches define conditions used for matching the rule against incoming TCP requests.
+            RouteMatch defines the predicate used to match requests to a given action. Multiple match types are "OR"ed for evaluation. 
+            If no routeMatch field is specified, this rule will unconditionally match traffic.
           send_empty_value: true
           item_type: !ruby/object:Api::Type::NestedObject
             properties:
               - !ruby/object:Api::Type::String
                 name: address
                 description: |
-                  Required. Must be specified in the CIDR range format.
+                  Must be specified in the CIDR range format. A CIDR range consists of an IP Address and a prefix length to construct the subnet mask. 
+                  By default, the prefix length is 32 (i.e. matches a single IP address). Only IPV4 addresses are supported. Examples: "10.0.0.1" - matches against this exact IP address. "10.0.0.0/8" - matches against any IP address within the 10.0.0.0 subnet and 255.255.255.0 mask. "0.0.0.0/0" - matches against any IP address'.
                 required: true
               - !ruby/object:Api::Type::String
                 name: port
                 description: |
-                  Required. Specifies the destination port to match against.
+                  Specifies the destination port to match against.
                 required: true
         - !ruby/object:Api::Type::NestedObject
           name: action
           description: |
-              Required. A detailed rule defining how to route traffic.
+              A detailed rule defining how to route traffic.
           required: true
           properties:
             - !ruby/object:Api::Type::Array
               name: destinations
               description: |
-                The destination to which traffic should be forwarded.
+                The destination services to which traffic should be forwarded. At least one destination service is required.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   - !ruby/object:Api::Type::String
@@ -149,9 +173,12 @@ properties:
                   - !ruby/object:Api::Type::Integer
                     name: weight
                     description: |
-                      Specifies the proportion of requests forwarded to the backend referenced by the serviceName field.
+                      Specifies the proportion of requests forwarded to the backend referenced by the serviceName field. This is computed as: weight/Sum(weights in this destination list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports.
+                      If only one serviceName is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend.
+                      If weights are specified for any one service name, they need to be specified for all of them.
+                      If weights are unspecified for all services, then, traffic is distributed in equal proportions to all of them.
             - !ruby/object:Api::Type::Boolean
               name: originalDestination
               description: |
-                If true, Router will use the destination IP and port of the original connection as the destination of the request.
+                If true, Router will use the destination IP and port of the original connection as the destination of the request. 
 

--- a/mmv1/products/networkservices/TcpRoute.yaml
+++ b/mmv1/products/networkservices/TcpRoute.yaml
@@ -1,0 +1,157 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'TcpRoute'
+base_url: 'projects/{{project}}/locations/global/tcpRoutes'
+create_url: 'projects/{{project}}/locations/global/tcpRoutes?tcpRouteId={{name}}'
+self_link: 'projects/{{project}}/locations/global/tcpRoutes/{{name}}'
+min_version: beta
+update_verb: :PATCH
+update_mask: true
+description: |
+  TcpRoute is the resource defining how TCP traffic should be routed by a Mesh/Gateway resource.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.tcpRoutes'
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 30
+      update_minutes: 30
+      delete_minutes: 30
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+autogen_async: true
+import_format: ['projects/{{project}}/locations/global/tcpRoutes/{{name}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
+    name: 'network_services_tcp_route_basic'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-tcp-route'
+      backend_service_name: "my-backend-service"
+      http_health_check_name: "backend-service-health-check"
+  - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
+    name: 'network_services_tcp_route_actions'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-tcp-route'
+      backend_service_name: "my-backend-service"
+      http_health_check_name: "backend-service-health-check"
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    required: true
+    url_param_only: true
+    immutable: true
+    description: |
+      Name of the TcpRoute resource.
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'selfLink'
+    description: |
+      Server-defined URL of this resource.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    description: |
+      Time the TcpRoute was created in UTC.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    description: |
+      Time the TcpRoute was updated in UTC.
+    output: true
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'labels'
+    description: Set of label tags associated with the TcpRoute resource.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      A free-text description of the resource. Max length 1024 characters.
+  - !ruby/object:Api::Type::Array
+    name: meshes
+    item_type: Api::Type::String
+    description: |
+          List of meshes this TcpRoute is attached to, as one of the routing rules to route the requests served by the mesh.  
+    send_empty_value: true 
+  - !ruby/object:Api::Type::Array
+    name: gateways
+    item_type: Api::Type::String
+    description: |
+          List of gateways this TcpRoute is attached to, as one of the routing rules to route the requests served by the gateway.  
+    send_empty_value: true
+  - !ruby/object:Api::Type::Array
+    name: rules
+    description: |
+          Rules that define how traffic is routed and handled.  
+    required: true
+    send_empty_value: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties: 
+        - !ruby/object:Api::Type::Array
+          name: matches
+          description: |
+            Matches define conditions used for matching the rule against incoming TCP requests.
+          send_empty_value: true
+          item_type: !ruby/object:Api::Type::NestedObject
+            properties:
+              - !ruby/object:Api::Type::String
+                name: address
+                description: |
+                  Required. Must be specified in the CIDR range format.
+                required: true
+              - !ruby/object:Api::Type::String
+                name: port
+                description: |
+                  Required. Specifies the destination port to match against.
+                required: true
+        - !ruby/object:Api::Type::NestedObject
+          name: action
+          description: |
+              Required. A detailed rule defining how to route traffic.
+          required: true
+          properties:
+            - !ruby/object:Api::Type::Array
+              name: destinations
+              description: |
+                The destination to which traffic should be forwarded.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: serviceName
+                    description: |
+                      The URL of a BackendService to route traffic to.
+                  - !ruby/object:Api::Type::Integer
+                    name: weight
+                    description: |
+                      Specifies the proportion of requests forwarded to the backend referenced by the serviceName field.
+            - !ruby/object:Api::Type::Boolean
+              name: originalDestination
+              description: |
+                If true, Router will use the destination IP and port of the original connection as the destination of the request.
+

--- a/mmv1/templates/terraform/examples/network_services_tcp_route_actions.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_tcp_route_actions.tf.erb
@@ -1,0 +1,32 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider               = google-beta
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_network_services_tcp_route" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name                   = "<%= ctx[:vars]['resource_name'] %>"
+  labels                 = {
+    foo = "bar"
+  }
+  description             = "my description"
+  rules                   {
+    action {
+      destinations {
+        service_name = google_compute_backend_service.<%= ctx[:primary_resource_id] %>.id
+        weight = 1
+      }
+      original_destination = false
+    }
+  }
+}
+

--- a/mmv1/templates/terraform/examples/network_services_tcp_route_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_tcp_route_basic.tf.erb
@@ -1,0 +1,36 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider               = google-beta
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_network_services_tcp_route" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name                   = "<%= ctx[:vars]['resource_name'] %>"
+  labels                 = {
+    foo = "bar"
+  }
+  description             = "my description"
+  rules                   {
+    matches {
+      address = "10.0.0.1/32"
+      port = "8081"
+    }
+    action {
+      destinations {
+        service_name = google_compute_backend_service.<%= ctx[:primary_resource_id] %>.id
+        weight = 1
+      }
+      original_destination = false
+    }
+  }
+}
+

--- a/mmv1/templates/terraform/examples/network_services_tcp_route_gateway_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_tcp_route_gateway_basic.tf.erb
@@ -1,0 +1,48 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider               = google-beta
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['resource_name'] %>"
+  labels      = {
+    foo = "bar"
+  }
+  description = "my description"
+}
+
+
+resource "google_network_services_tcp_route" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name                   = "<%= ctx[:vars]['resource_name'] %>"
+  labels                 = {
+    foo = "bar"
+  }
+  description             = "my description"
+  gateways = [
+    google_network_services_gateway.<%= ctx[:primary_resource_id] %>.id
+  ]
+  rules                   {
+    matches {
+      address = "10.0.0.1/32"
+      port = "8081"
+    }
+    action {
+      destinations {
+        service_name = google_compute_backend_service.<%= ctx[:primary_resource_id] %>.id
+        weight = 1
+      }
+      original_destination = false
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/network_services_tcp_route_gateway_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_tcp_route_gateway_basic.tf.erb
@@ -19,6 +19,9 @@ resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
     foo = "bar"
   }
   description = "my description"
+  scope = "my-scope"
+  type = "OPEN_MESH"
+  ports = [443]
 }
 
 

--- a/mmv1/templates/terraform/examples/network_services_tcp_route_mesh_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_tcp_route_mesh_basic.tf.erb
@@ -1,0 +1,48 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider               = google-beta
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_network_services_mesh" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['resource_name'] %>"
+  labels      = {
+    foo = "bar"
+  }
+  description = "my description"
+}
+
+
+resource "google_network_services_tcp_route" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  name                   = "<%= ctx[:vars]['resource_name'] %>"
+  labels                 = {
+    foo = "bar"
+  }
+  description             = "my description"
+  meshes = [
+    google_network_services_mesh.<%= ctx[:primary_resource_id] %>.id
+  ]
+  rules                   {
+    matches {
+      address = "10.0.0.1/32"
+      port = "8081"
+    }
+    action {
+      destinations {
+        service_name = google_compute_backend_service.<%= ctx[:primary_resource_id] %>.id
+        weight = 1
+      }
+      original_destination = false
+    }
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_network_services_tcp_route_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_services_tcp_route_test.go.erb
@@ -1,0 +1,124 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetworkServicesTcpRoute_update(t *testing.T) {
+	t.Parallel()
+
+  tcpServiceName := fmt.Sprintf("tf-test-tcp-service-%s", RandString(t, 10))
+  tcpHealthCheckName := fmt.Sprintf("tf-test-tcp-healthcheck-%s", RandString(t, 10))
+	tcpRouteName := fmt.Sprintf("tf-test-tcp-route-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckNetworkServicesTcpRouteDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+  Config: testAccNetworkServicesTcpRoute_basic(tcpServiceName, tcpHealthCheckName, tcpRouteName),
+			},
+			{
+				ResourceName:      "google_network_services_tcp_route.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccNetworkServicesTcpRoute_update(tcpServiceName, tcpHealthCheckName, tcpRouteName),
+			},
+			{
+				ResourceName:      "google_network_services_tcp_route.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNetworkServicesTcpRoute_basic(tcpServiceName string, tcpHealthCheckName string, tcpRouteName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foo" {
+  provider               = google-beta
+  name          = "%s"
+  health_checks = [google_compute_http_health_check.bar.id]
+}
+
+resource "google_compute_http_health_check" "bar" {
+  provider               = google-beta
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_network_services_tcp_route" "foobar" {
+  provider               = google-beta
+  name                   = "%s"
+  labels                 = {
+    foo = "bar"
+  }
+  description             = "my description"
+  rules                   {
+    matches {
+      address = "10.0.0.1/32"
+      port = "8081"
+    }
+    action {
+      destinations {
+        service_name = google_compute_backend_service.foo.id
+        weight = 1
+      }
+      original_destination = false
+    }
+  }
+}
+`, tcpServiceName, tcpHealthCheckName, tcpRouteName)
+}
+
+func testAccNetworkServicesTcpRoute_update(tcpServiceName string, tcpHealthCheckName string, tcpRouteName string) string {
+	return fmt.Sprintf(`
+  resource "google_compute_backend_service" "foo" {
+  provider               = google-beta
+  name          = "%s"
+  health_checks = [google_compute_http_health_check.bar.id]
+}
+
+resource "google_compute_http_health_check" "bar" {
+  provider               = google-beta
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_network_services_tcp_route" "foobar" {
+  provider               = google-beta
+  name                   = "%s"
+  labels                 = {
+    foo = "bar"
+  }
+  description             = "update description"
+  rules                   {
+    matches {
+      address = "10.0.0.1/32"
+      port = "8081"
+    }
+    action {
+      destinations {
+        service_name = google_compute_backend_service.foo.id
+        weight = 1
+      }
+      original_destination = false
+    }
+  }
+}
+`, tcpServiceName, tcpHealthCheckName, tcpRouteName)
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_network_services_tcp_route_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_services_tcp_route_test.go.erb
@@ -44,21 +44,18 @@ func TestAccNetworkServicesTcpRoute_update(t *testing.T) {
 func testAccNetworkServicesTcpRoute_basic(tcpServiceName string, tcpHealthCheckName string, tcpRouteName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foo" {
-  provider               = google-beta
   name          = "%s"
   health_checks = [google_compute_http_health_check.bar.id]
 }
 
 resource "google_compute_http_health_check" "bar" {
-  provider               = google-beta
   name               = "%s"
   request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
 }
 
-resource "google_network_services_tcp_route" "foobar" {
-  provider               = google-beta
+resource "google_network_services_tcp_route" "foobar" { 
   name                   = "%s"
   labels                 = {
     foo = "bar"
@@ -84,13 +81,11 @@ resource "google_network_services_tcp_route" "foobar" {
 func testAccNetworkServicesTcpRoute_update(tcpServiceName string, tcpHealthCheckName string, tcpRouteName string) string {
 	return fmt.Sprintf(`
   resource "google_compute_backend_service" "foo" {
-  provider               = google-beta
   name          = "%s"
   health_checks = [google_compute_http_health_check.bar.id]
 }
 
 resource "google_compute_http_health_check" "bar" {
-  provider               = google-beta
   name               = "%s"
   request_path       = "/"
   check_interval_sec = 1
@@ -98,7 +93,6 @@ resource "google_compute_http_health_check" "bar" {
 }
 
 resource "google_network_services_tcp_route" "foobar" {
-  provider               = google-beta
   name                   = "%s"
   labels                 = {
     foo = "bar"


### PR DESCRIPTION
Add configuration for traffic director tcpRoute resource

part of https://github.com/hashicorp/terraform-provider-google/issues/14040


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:new-resource
`google_networkservices_tcp_route` (beta)
```
