### PR TITLE
Add regional support for certificatemanager resources

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -13,9 +13,9 @@
 
 --- !ruby/object:Api::Resource
 name: 'Certificate'
-base_url: 'projects/{{project}}/locations/global/certificates'
-create_url: 'projects/{{project}}/locations/global/certificates?certificateId={{name}}'
-self_link: 'projects/{{project}}/locations/global/certificates/{{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/certificates'
+create_url: 'projects/{{project}}/locations/{{location}}/certificates?certificateId={{name}}'
+self_link: 'projects/{{project}}/locations/{{location}}/certificates/{{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -38,7 +38,7 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 docs: !ruby/object:Provider::Terraform::Docs
 autogen_async: true
-import_format: ["projects/{{project}}/locations/global/certificates/{{name}}"]
+import_format: ["projects/{{project}}/locations/{{location}}/certificates/{{name}}"]
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "certificate_manager_google_managed_certificate"
@@ -50,7 +50,12 @@ examples:
       dns_auth_subdomain2: "subdomain2"
       cert_name: "dns-cert"
   - !ruby/object:Provider::Terraform::Examples
-    name: "certificate_manager_self_managed_certificate"
+    name: "certificate_manager_self_managed_certificate_global"
+    primary_resource_id: "default"
+    vars:
+      cert_name: "self-managed-cert"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "certificate_manager_self_managed_certificate_regional"
     primary_resource_id: "default"
     vars:
       cert_name: "self-managed-cert"
@@ -88,6 +93,12 @@ properties:
       Currently allowed only for managed certificates.
     default_value: DEFAULT
     diff_suppress_func: 'certManagerDefaultScopeDiffSuppress'
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      The Certificate Manager location. If not specified, "global" is used.
+    default_value: global
+    url_param_only: true
   - !ruby/object:Api::Type::NestedObject
     name: selfManaged
     immutable: true

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -13,9 +13,9 @@
 
 --- !ruby/object:Api::Resource
 name: 'CertificateMap'
-base_url: 'projects/{{project}}/locations/global/certificateMaps'
-create_url: 'projects/{{project}}/locations/global/certificateMaps?certificateMapId={{name}}'
-self_link: 'projects/{{project}}/locations/global/certificateMaps/{{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/certificateMaps'
+create_url: 'projects/{{project}}/locations/{{location}}/certificateMaps?certificateMapId={{name}}'
+self_link: 'projects/{{project}}/locations/{{location}}/certificateMaps/{{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -39,7 +39,7 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 docs: !ruby/object:Provider::Terraform::Docs
 autogen_async: true
-import_format: ["projects/{{project}}/locations/global/certificateMaps/{{name}}"]
+import_format: ["projects/{{project}}/locations/{{location}}/certificateMaps/{{name}}"]
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "certificate_manager_certificate_map_basic"
@@ -52,7 +52,7 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/global/certificateMaps/{{name}}
+    pattern: projects/{{project}}/locations/{{location}}/certificateMaps/{{name}}
     description: |
       A user-defined name of the Certificate Map. Certificate Map names must be unique
       globally and match the pattern `projects/*/locations/*/certificateMaps/*`.
@@ -80,6 +80,12 @@ properties:
     description: |
       Set of labels associated with a Certificate Map resource.
     default_from_api: true
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      The Cloud location for the certificate map. If not specified, "global" is used.
+    default_value: global
+    url_param_only: true
   - !ruby/object:Api::Type::Array
     name: 'gclbTargets'
     description: |

--- a/mmv1/products/certificatemanager/CertificateMapEntry.yaml
+++ b/mmv1/products/certificatemanager/CertificateMapEntry.yaml
@@ -13,9 +13,9 @@
 
 --- !ruby/object:Api::Resource
 name: 'CertificateMapEntry'
-base_url: 'projects/{{project}}/locations/global/certificateMaps/{{map}}/certificateMapEntries'
-create_url: 'projects/{{project}}/locations/global/certificateMaps/{{map}}/certificateMapEntries?certificateMapEntryId={{name}}'
-self_link: 'projects/{{project}}/locations/global/certificateMaps/{{map}}/certificateMapEntries/{{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/certificateMaps/{{map}}/certificateMapEntries'
+create_url: 'projects/{{project}}/locations/{{location}}/certificateMaps/{{map}}/certificateMapEntries?certificateMapEntryId={{name}}'
+self_link: 'projects/{{project}}/locations/{{location}}/certificateMaps/{{map}}/certificateMapEntries/{{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -130,5 +130,11 @@ properties:
       - matcher
     description: |
       A predefined matcher for particular cases, other than SNI selection
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      The Cloud location for the certificate map entry. If not specified, "global" is used.
+    default_value: global
+    url_param_only: true
 
 

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -13,9 +13,9 @@
 
 --- !ruby/object:Api::Resource
 name: 'DnsAuthorization'
-base_url: 'projects/{{project}}/locations/global/dnsAuthorizations'
-create_url: 'projects/{{project}}/locations/global/dnsAuthorizations?dnsAuthorizationId={{name}}'
-self_link: 'projects/{{project}}/locations/global/dnsAuthorizations/{{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/dnsAuthorizations'
+create_url: 'projects/{{project}}/locations/{{location}}/dnsAuthorizations?dnsAuthorizationId={{name}}'
+self_link: 'projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -38,7 +38,7 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 docs: !ruby/object:Provider::Terraform::Docs
 autogen_async: true
-import_format: ["projects/{{project}}/locations/global/dnsAuthorizations/{{name}}"]
+import_format: ["projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}"]
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "certificate_manager_dns_authorization_basic"
@@ -72,6 +72,12 @@ properties:
       A domain which is being authorized. A DnsAuthorization resource covers a
       single domain and its wildcard, e.g. authorization for "example.com" can
       be used to issue certificates for "example.com" and "*.example.com".
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      The Certificate Manager location. If not specified, "global" is used.
+    default_value: global
+    url_param_only: true
   - !ruby/object:Api::Type::NestedObject
     name: 'dnsResourceRecord'
     output: true

--- a/mmv1/templates/terraform/examples/certificate_manager_self_managed_certificate_global.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_self_managed_certificate_global.tf.erb
@@ -1,7 +1,6 @@
 resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]['cert_name'] %>"
-  description = "The default cert"
-  scope       = "EDGE_CACHE"
+  description = "Global cert"
   self_managed {
     pem_certificate = file("test-fixtures/certificatemanager/cert.pem")
     pem_private_key = file("test-fixtures/certificatemanager/private-key.pem")

--- a/mmv1/templates/terraform/examples/certificate_manager_self_managed_certificate_regional.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_self_managed_certificate_regional.tf.erb
@@ -1,0 +1,9 @@
+resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id] %>" { #Make another file 
+  name        = "<%= ctx[:vars]['cert_name'] %>"
+  description = "Regional cert"
+  location    = "us-central1"
+  self_managed {
+    pem_certificate = file("test-fixtures/certificatemanager/cert.pem")
+    pem_private_key = file("test-fixtures/certificatemanager/private-key.pem")
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
- Add a url-only location property that is optional and defaults to "global"
- Add a new example that creates a regional self-managed certificate 

Terraform Issue: https://github.com/hashicorp/terraform-provider-google/issues/13090

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
certificatemanager: added `location` field to `certificatemanager` resources
```
