### PR TITLE
Add Region Instance Template resource and datasource into beta provider

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_instance_template.go.erb
@@ -1,0 +1,123 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+<% if version == "ga" -%>
+	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
+)
+
+func DataSourceGoogleComputeRegionInstanceTemplate() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := datasourceSchemaFromResourceSchema(ResourceComputeRegionInstanceTemplate().Schema)
+
+	dsSchema["filter"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+	dsSchema["most_recent"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+	}
+
+	// Set 'Optional' schema elements
+	addOptionalFieldsToSchema(dsSchema, "name", "filter", "most_recent", "region", "project")
+
+	dsSchema["name"].ExactlyOneOf = []string{"name", "filter"}
+	dsSchema["filter"].ExactlyOneOf = []string{"name", "filter"}
+
+	return &schema.Resource{
+		Read:   datasourceComputeRegionInstanceTemplateRead,
+		Schema: dsSchema,
+	}
+}
+
+func datasourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		return retrieveInstances(d, meta, project, region, v.(string))
+	}
+	if v, ok := d.GetOk("filter"); ok {
+		userAgent, err := generateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return err
+		}
+
+		params := map[string]string{
+			"filter": v.(string),
+		}
+
+		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates")
+		if err != nil {
+			return err
+		}
+
+		url, err = addQueryParams(url, params)
+		if err != nil {
+			return err
+		}
+
+		templates, err := SendRequest(config, "GET", project, url, userAgent, nil)
+		if err != nil {
+			return fmt.Errorf("error retrieving list of region instance templates: %s", err)
+		}
+
+		instanceTemplates := templates["items"]
+
+		instanceTemplatesList, err := json.Marshal(instanceTemplates)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		var items []*compute.InstanceTemplate
+
+		if err := json.Unmarshal(instanceTemplatesList, &items); err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		mostRecent := d.Get("most_recent").(bool)
+		if mostRecent {
+			sort.Sort(ByCreationTimestamp(items))
+		}
+
+		count := len(items)
+		if count == 1 || count > 1 && mostRecent {
+			return retrieveInstances(d, meta, project, region, items[0].Name)
+		}
+
+		return fmt.Errorf("your filter has returned %d region instance template(s). Please refine your filter or set most_recent to return exactly one region instance template", len(items))
+	}
+
+	return fmt.Errorf("one of name or filters must be set")
+}
+
+func retrieveInstances(d *schema.ResourceData, meta interface{}, project, region, name string) error {
+	d.SetId("projects/" + project + "/regions/" + region + "/instanceTemplates/" + name)
+
+	return resourceComputeRegionInstanceTemplateRead(d, meta)
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_instance_template.go.erb
@@ -68,12 +68,12 @@ func datasourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta in
 			"filter": v.(string),
 		}
 
-		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates")
+		url, err := ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates")
 		if err != nil {
 			return err
 		}
 
-		url, err = addQueryParams(url, params)
+		url, err = AddQueryParams(url, params)
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go.erb
@@ -2,8 +2,10 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -127,14 +129,53 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	it, err := config.NewComputeClient(userAgent).InstanceTemplates.Get(project, tpl.Name).Do()
-	if err != nil {
-		return err
-	}
+	it := compute.InstanceTemplate{}
+	var relativeUrl string
 
-	instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, it, zone, project)
-	if err != nil {
-		return err
+	if strings.Contains(sourceInstanceTemplate, "global/instanceTemplates") {
+		instanceTemplate, err := config.NewComputeClient(userAgent).InstanceTemplates.Get(project, tpl.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		it = *instanceTemplate
+		relativeUrl = tpl.RelativeLink()
+
+		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, zone, project, false)
+		if err != nil {
+			return err
+		}
+	} else {
+		relativeUrl, err = replaceVars(d, config, "projects/{{project}}/regions/{{region}}/instanceTemplates/"+tpl.Name)
+		if err != nil {
+			return err
+		}
+
+		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/" + tpl.Name)
+		if err != nil {
+			return err
+		}
+
+		instanceTemplate, err := SendRequest(config, "GET", project, url, userAgent, nil)
+		if err != nil {
+			return err
+		}
+
+		instancePropertiesObj, err := json.Marshal(instanceTemplate)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		if err := json.Unmarshal(instancePropertiesObj, &it); err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, zone, project, true)
+		if err != nil {
+			return err
+		}
 	}
 
 	// when we make the original call to expandComputeInstance expandScheduling is called, which sets default values.
@@ -164,7 +205,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Requesting instance creation")
-	op, err := config.NewComputeClient(userAgent).Instances.Insert(project, zone.Name, instance).SourceInstanceTemplate(tpl.RelativeLink()).Do()
+	op, err := config.NewComputeClient(userAgent).Instances.Insert(project, zone.Name, instance).SourceInstanceTemplate(relativeUrl).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating instance: %s", err)
 	}
@@ -186,7 +227,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 
 // Instances have disks spread across multiple schema properties. This function
 // ensures that overriding one of these properties does not override the others.
-func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it *compute.InstanceTemplate, zone *compute.Zone, project string) ([]*compute.AttachedDisk, error) {
+func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it *compute.InstanceTemplate, zone *compute.Zone, project string, isFromRegionalTemplate bool) ([]*compute.AttachedDisk, error) {
 	disks := []*compute.AttachedDisk{}
 	if _, hasBootDisk := d.GetOk("boot_disk"); hasBootDisk {
 		bootDisk, err := expandBootDisk(d, config, project)
@@ -198,7 +239,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		// boot disk was not overridden, so use the one from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Boot {
-				if disk.Source != "" {
+				if disk.Source != "" && !isFromRegionalTemplate {
 					// Instances need a URL for the disk, but instance templates only have the name
 					disk.Source = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone.Name, disk.Source)
 				}
@@ -252,7 +293,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		// attached disks were not overridden, so use the ones from the instance template
 		for _, disk := range it.Properties.Disks {
 			if !disk.Boot && disk.Type != "SCRATCH" {
-				if s := disk.Source; s != "" {
+				if s := disk.Source; s != ""  && !isFromRegionalTemplate {
 					// Instances need a URL for the disk source, but instance templates
 					// only have the name (since they're global).
 					disk.Source = fmt.Sprintf("zones/%s/disks/%s", zone.Name, s)

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go.erb
@@ -146,12 +146,12 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 			return err
 		}
 	} else {
-		relativeUrl, err = replaceVars(d, config, "projects/{{project}}/regions/{{region}}/instanceTemplates/"+tpl.Name)
+		relativeUrl, err = ReplaceVars(d, config, "projects/{{project}}/regions/{{region}}/instanceTemplates/"+tpl.Name)
 		if err != nil {
 			return err
 		}
 
-		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/" + tpl.Name)
+		url, err := ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/" + tpl.Name)
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
@@ -458,7 +458,7 @@ Google Cloud KMS.`,
 										Type:             schema.TypeString,
 										Required:         true,
 										ForceNew:         true,
-										DiffSuppressFunc: ipCidrRangeDiffSuppress,
+										DiffSuppressFunc: IpCidrRangeDiffSuppress,
 										Description:      `The IP CIDR range represented by this alias IP range. This IP CIDR range must belong to the specified subnetwork and cannot contain IP addresses reserved by system or used by other network interfaces. At the time of writing only a netmask (e.g. /24) may be supplied, with a CIDR format resulting in an API error.`,
 									},
 									"subnetwork_range_name": {
@@ -576,7 +576,7 @@ Google Cloud KMS.`,
 							AtLeastOneOf:     schedulingInstTemplateKeys,
 							ForceNew:         true,
 							Elem:             instanceSchedulingNodeAffinitiesElemSchema(),
-							DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
+							DiffSuppressFunc: EmptyOrDefaultStringSuppress(""),
 							Description:      `Specifies node affinities or anti-affinities to determine which sole-tenant nodes your instances and managed instance groups will use as host systems.`,
 						},
 						"min_node_cpus": {
@@ -686,7 +686,7 @@ be from 0 to 999,999,999 inclusive.`,
 				// Since this block is used by the API based on which
 				// image being used, the field needs to be marked as Computed.
 				Computed:         true,
-				DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
+				DiffSuppressFunc: EmptyOrDefaultStringSuppress(""),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enable_secure_boot": {
@@ -974,7 +974,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 	instanceTemplate["properties"] = instanceProperties
 	instanceTemplate["name"] = itName
 
-	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates")
+	url, err := ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates")
 	if err != nil {
 		return err
 	}
@@ -1010,7 +1010,7 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	splits := strings.Split(d.Id(), "/")
 	name := splits[len(splits)-1]
 
-	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/" + name)
+	url, err := ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/" + name)
 	if err != nil {
 		return err
 	}
@@ -1204,7 +1204,7 @@ func resourceComputeRegionInstanceTemplateDelete(d *schema.ResourceData, meta in
 		return err
 	}
 
-	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}")
+	url, err := ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}")
 	if err != nil {
 		return err
 	}
@@ -1227,12 +1227,12 @@ func resourceComputeRegionInstanceTemplateDelete(d *schema.ResourceData, meta in
 
 func resourceComputeRegionInstanceTemplateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	if err := parseImportId([]string{"projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/instanceTemplates/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config); err != nil {
+	if err := ParseImportId([]string{"projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/instanceTemplates/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config); err != nil {
 		return nil, err
 	}
 
 	// Replace import id for the resource id
-	id, err := replaceVars(d, config, "projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}")
+	id, err := ReplaceVars(d, config, "projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}")
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)
 	}

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
@@ -1,0 +1,1244 @@
+<% autogen_exception -%>
+
+package google
+
+<% unless version == 'ga' -%>
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+<% if version == "ga" -%>
+	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
+)
+
+func ResourceComputeRegionInstanceTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeRegionInstanceTemplateCreate,
+		Read:   resourceComputeRegionInstanceTemplateRead,
+		Delete: resourceComputeRegionInstanceTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceComputeRegionInstanceTemplateImportState,
+		},
+		SchemaVersion: 1,
+		CustomizeDiff: customdiff.All(
+			resourceComputeInstanceTemplateSourceImageCustomizeDiff,
+			resourceComputeInstanceTemplateScratchDiskCustomizeDiff,
+			resourceComputeInstanceTemplateBootDiskCustomizeDiff,
+		),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(4 * time.Minute),
+			Delete: schema.DefaultTimeout(4 * time.Minute),
+		},
+
+		// A compute region instance template is more or less a subset of a compute
+		// instance. Please attempt to maintain consistency with the
+		// resource_compute_instance schema when updating this one.
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which the instance template is located. If it is not provided, the provider region is used.`,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateGCEName,
+				Description:   `The name of the instance template. If you leave this blank, Terraform will auto-generate a unique name.`,
+			},
+
+			"name_prefix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Creates a unique name beginning with the specified prefix. Conflicts with name.`,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					// https://cloud.google.com/compute/docs/reference/latest/instanceTemplates#resource
+					// uuid is 26 characters, limit the prefix to 37.
+					value := v.(string)
+					if len(value) > 37 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 37 characters, name is limited to 63", k))
+					}
+					return
+				},
+			},
+
+			"disk": {
+				Type:        schema.TypeList,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Disks to attach to instances created from this template. This can be specified multiple times for multiple disks.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auto_delete": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							ForceNew:    true,
+							Description: `Whether or not the disk should be auto-deleted. This defaults to true.`,
+						},
+
+						"boot": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Indicates that this is a boot disk.`,
+						},
+
+						"device_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: `A unique device name that is reflected into the /dev/ tree of a Linux operating system running within the instance. If not specified, the server chooses a default device name to apply to this disk.`,
+						},
+
+						"disk_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Name of the disk. When not provided, this defaults to the name of the instance.`,
+						},
+
+						"disk_size_gb": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The size of the image in gigabytes. If not specified, it will inherit the size of its base image. For SCRATCH disks, the size must be one of 375 or 3000 GB, with a default of 375 GB.`,
+						},
+
+						"disk_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The Google Compute Engine disk type. Such as "pd-ssd", "local-ssd", "pd-balanced" or "pd-standard".`,
+						},
+
+						"labels": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Description: `A set of key/value label pairs to assign to disks,`,
+						},
+
+						"source_image": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: `The image from which to initialize this disk. This can be one of: the image's self_link, projects/{project}/global/images/{image}, projects/{project}/global/images/family/{family}, global/images/{image}, global/images/family/{family}, family/{family}, {project}/{family}, {project}/{image}, {family}, or {image}. ~> Note: Either source or source_image is required when creating a new instance except for when creating a local SSD.`,
+						},
+						"source_image_encryption_key": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Description: `The customer-supplied encryption key of the source
+image. Required if the source image is protected by a
+customer-supplied encryption key.
+
+Instance templates do not store customer-supplied
+encryption keys, so you cannot create disks for
+instances in a managed instance group if the source
+images are encrypted with your own keys.`,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_service_account": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Description: `The service account being used for the encryption
+request for the given KMS key. If absent, the Compute
+Engine default service account is used.`,
+									},
+									"kms_key_self_link": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+										Description: `The self link of the encryption key that is stored in
+Google Cloud KMS.`,
+									},
+								},
+							},
+						},
+						"source_snapshot": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Description: `The source snapshot to create this disk. When creating
+a new instance, one of initializeParams.sourceSnapshot,
+initializeParams.sourceImage, or disks.source is
+required except for local SSD.`,
+						},
+						"source_snapshot_encryption_key": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The customer-supplied encryption key of the source snapshot.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_service_account": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Description: `The service account being used for the encryption
+request for the given KMS key. If absent, the Compute
+Engine default service account is used.`,
+									},
+									"kms_key_self_link": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+										Description: `The self link of the encryption key that is stored in
+Google Cloud KMS.`,
+									},
+								},
+							},
+						},
+
+						"interface": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Specifies the disk interface to use for attaching this disk.`,
+						},
+
+						"mode": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The mode in which to attach this disk, either READ_WRITE or READ_ONLY. If you are attaching or creating a boot disk, this must read-write mode.`,
+						},
+
+						"source": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The name (not self_link) of the disk (such as those managed by google_compute_disk) to attach. ~> Note: Either source or source_image is required when creating a new instance except for when creating a local SSD.`,
+						},
+
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The type of Google Compute Engine disk, can be either "SCRATCH" or "PERSISTENT".`,
+						},
+
+						"disk_encryption_key": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							MaxItems:    1,
+							Description: `Encrypts or decrypts a disk using a customer-supplied encryption key.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_self_link": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ForceNew:         true,
+										DiffSuppressFunc: compareSelfLinkRelativePaths,
+										Description:      `The self link of the encryption key that is stored in Google Cloud KMS.`,
+									},
+								},
+							},
+						},
+
+						"resource_policies": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							MaxItems:    1,
+							Description: `A list (short name or id) of resource policies to attach to this disk. Currently a max of 1 resource policy is supported.`,
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								DiffSuppressFunc: compareResourceNames,
+							},
+						},
+					},
+				},
+			},
+
+			"machine_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The machine type to create. To create a machine with a custom type (such as extended memory), format the value like custom-VCPUS-MEM_IN_MB like custom-6-20480 for 6 vCPU and 20GB of RAM.`,
+			},
+
+			"can_ip_forward": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: `Whether to allow sending and receiving of packets with non-matching source or destination IPs. This defaults to false.`,
+			},
+
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `A brief description of this resource.`,
+			},
+
+<% unless version == 'ga' -%>
+			"enable_display": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Enable Virtual Displays on this instance. Note: allow_stopping_for_update must be set to true in order to update this field.`,
+			},
+<% end -%>
+
+			"instance_description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `A description of the instance.`,
+			},
+
+			"metadata": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Metadata key/value pairs to make available from within instances created from this template.`,
+			},
+
+			"metadata_startup_script": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `An alternative to using the startup-script metadata key, mostly to match the compute_instance resource. This replaces the startup-script metadata key on the created instance and thus the two mechanisms are not allowed to be used simultaneously.`,
+			},
+
+			"metadata_fingerprint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The unique fingerprint of the metadata.`,
+			},
+
+<% unless version == 'ga' -%>
+			"network_performance_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Configures network performance settings for the instance. If not specified, the instance will be created with its default network performance configuration.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"total_egress_bandwidth_tier": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"TIER_1", "DEFAULT"}, false),
+							Description:  `The egress bandwidth tier to enable. Possible values:TIER_1, DEFAULT`,
+						},
+					},
+				},
+			},
+<% end -%>
+
+			"network_interface": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Networks to attach to instances created from this template. This can be specified multiple times for multiple networks.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"network": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         true,
+							Computed:         true,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
+							Description:      `The name or self_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks.`,
+						},
+
+						"subnetwork": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         true,
+							Computed:         true,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
+							Description:      `The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided.`,
+						},
+
+						"subnetwork_project": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used.`,
+						},
+
+						"network_ip": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The private IP address to assign to the instance. If empty, the address will be automatically assigned.`,
+						},
+
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the network_interface.`,
+						},
+						"nic_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
+							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
+						},
+						"access_config": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Access configurations, i.e. IPs via which this instance can be accessed via the Internet. Omit to ensure that the instance is not accessible from the Internet (this means that ssh provisioners will not work unless you are running Terraform can send traffic to the instance's network (e.g. via tunnel or because it is running on another cloud instance on that network). This block can be repeated multiple times.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"nat_ip": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										ForceNew:    true,
+										Computed:    true,
+										Description: `The IP address that will be 1:1 mapped to the instance's network ip. If not given, one will be generated.`,
+									},
+									"network_tier": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										ForceNew:    true,
+										Description: `The networking tier used for configuring this instance template. This field can take the following values: PREMIUM, STANDARD, FIXED_STANDARD. If this field is not specified, it is assumed to be PREMIUM.`,
+									},
+									// Possibly configurable- this was added so we don't break if it's inadvertently set
+									"public_ptr_domain_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The DNS domain name for the public PTR record.The DNS domain name for the public PTR record.`,
+									},
+								},
+							},
+						},
+
+						"alias_ip_range": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `An array of alias IP ranges for this network interface. Can only be specified for network interfaces on subnet-mode networks.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip_cidr_range": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ForceNew:         true,
+										DiffSuppressFunc: ipCidrRangeDiffSuppress,
+										Description:      `The IP CIDR range represented by this alias IP range. This IP CIDR range must belong to the specified subnetwork and cannot contain IP addresses reserved by system or used by other network interfaces. At the time of writing only a netmask (e.g. /24) may be supplied, with a CIDR format resulting in an API error.`,
+									},
+									"subnetwork_range_name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										ForceNew:    true,
+										Description: `The subnetwork secondary range name specifying the secondary range from which to allocate the IP CIDR range for this alias IP range. If left unspecified, the primary range of the subnetwork will be used.`,
+									},
+								},
+							},
+						},
+
+						"stack_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
+							Description:  `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
+						},
+
+						"ipv6_access_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `One of EXTERNAL, INTERNAL to indicate whether the IP can be accessed from the Internet. This field is always inherited from its subnetwork.`,
+						},
+
+						"ipv6_access_config": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"network_tier": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
+									},
+									// Possibly configurable- this was added so we don't break if it's inadvertently set
+									// (assuming the same ass access config)
+									"public_ptr_domain_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
+									},
+									"external_ipv6": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
+									},
+									"external_ipv6_prefix_length": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The prefix length of the external IPv6 range.`,
+									},
+								},
+							},
+						},
+						"queue_count": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It will be empty if not specified.`,
+						},
+					},
+				},
+			},
+
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The ID of the project in which the resource belongs. If it is not provided, the provider project is used.`,
+			},
+
+			"scheduling": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: `The scheduling strategy to use.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"preemptible": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Default:      false,
+							ForceNew:     true,
+							Description:  `Allows instance to be preempted. This defaults to false.`,
+						},
+
+						"automatic_restart": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Default:      true,
+							ForceNew:     true,
+							Description:  `Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine (not terminated by a user). This defaults to true.`,
+						},
+
+						"on_host_maintenance": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							ForceNew:     true,
+							Description:  `Defines the maintenance behavior for this instance.`,
+						},
+
+						"node_affinities": {
+							Type:             schema.TypeSet,
+							Optional:         true,
+							AtLeastOneOf:     schedulingInstTemplateKeys,
+							ForceNew:         true,
+							Elem:             instanceSchedulingNodeAffinitiesElemSchema(),
+							DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
+							Description:      `Specifies node affinities or anti-affinities to determine which sole-tenant nodes your instances and managed instance groups will use as host systems.`,
+						},
+						"min_node_cpus": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Description:  `Minimum number of cpus for the instance.`,
+						},
+						"provisioning_model": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Description:  `Whether the instance is spot. If this is set as SPOT.`,
+						},
+						"instance_termination_action": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Description:  `Specifies the action GCE should take when SPOT VM is preempted.`,
+						},
+<% unless version == 'ga' -%>
+						"max_run_duration" : {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `The timeout for new network connections to hosts.`,
+							MaxItems:    1,
+							ForceNew:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"seconds": {
+										Type:     schema.TypeInt,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Span of time at a resolution of a second.
+Must be from 0 to 315,576,000,000 inclusive.`,
+									},
+									"nanos": {
+										Type:     schema.TypeInt,
+										Optional:    true,
+									        ForceNew:    true,
+										Description: `Span of time that's a fraction of a second at nanosecond
+resolution. Durations less than one second are represented
+with a 0 seconds field and a positive nanos field. Must
+be from 0 to 999,999,999 inclusive.`,
+									},
+								},
+							},
+						},
+						"maintenance_interval" : {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the frequency of planned maintenance events. The accepted values are: PERIODIC`,
+						},
+<% end -%>
+					},
+				},
+			},
+
+			"self_link": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URI of the created resource.`,
+			},
+
+			"service_account": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Service account to attach to the instance.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: `The service account e-mail address. If not given, the default Google Compute Engine service account is used.`,
+						},
+
+						"scopes": {
+							Type:        schema.TypeSet,
+							Required:    true,
+							ForceNew:    true,
+							Description: `A list of service scopes. Both OAuth2 URLs and gcloud short names are supported. To allow full access to all Cloud APIs, use the cloud-platform scope.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								StateFunc: func(v interface{}) string {
+									return canonicalizeServiceScope(v.(string))
+								},
+							},
+							Set: stringScopeHashcode,
+						},
+					},
+				},
+			},
+
+			"shielded_instance_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Enable Shielded VM on this instance. Shielded VM provides verifiable integrity to prevent against malware and rootkits. Defaults to disabled. Note: shielded_instance_config can only be used with boot images with shielded vm support.`,
+				// Since this block is used by the API based on which
+				// image being used, the field needs to be marked as Computed.
+				Computed:         true,
+				DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_secure_boot": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							AtLeastOneOf: shieldedInstanceTemplateConfigKeys,
+							Default:      false,
+							ForceNew:     true,
+							Description:  `Verify the digital signature of all boot components, and halt the boot process if signature verification fails. Defaults to false.`,
+						},
+
+						"enable_vtpm": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							AtLeastOneOf: shieldedInstanceTemplateConfigKeys,
+							Default:      true,
+							ForceNew:     true,
+							Description:  `Use a virtualized trusted platform module, which is a specialized computer chip you can use to encrypt objects like keys and certificates. Defaults to true.`,
+						},
+
+						"enable_integrity_monitoring": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							AtLeastOneOf: shieldedInstanceTemplateConfigKeys,
+							Default:      true,
+							ForceNew:     true,
+							Description:  `Compare the most recent boot measurements to the integrity policy baseline and return a pair of pass/fail results depending on whether they match or not. Defaults to true.`,
+						},
+					},
+				},
+			},
+			"confidential_instance_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The Confidential VM config being used by the instance. on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_confidential_compute": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							ForceNew:    true,
+							Description: `Defines whether the instance should have confidential compute enabled.`,
+						},
+					},
+				},
+			},
+			"advanced_machine_features": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Controls for advanced machine-related behavior features.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_nested_virtualization": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							ForceNew:    true,
+							Description: `Whether to enable nested virtualization or not.`,
+						},
+						"threads_per_core": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    false,
+							ForceNew:    true,
+							Description: `The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.`,
+						},
+						"visible_core_count": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The number of physical cores to expose to an instance. Multiply by the number of threads per core to compute the total number of virtual CPUs to expose to the instance. If unset, the number of cores is inferred from the instance\'s nominal CPU count and the underlying platform\'s SMT width.`,
+						},
+					},
+				},
+			},
+			"guest_accelerator": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `List of the type and count of accelerator cards attached to the instance.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"count": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The number of the guest accelerator cards exposed to this instance.`,
+						},
+						"type": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ForceNew:         true,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
+							Description:      `The accelerator type resource to expose to this instance. E.g. nvidia-tesla-k80.`,
+						},
+					},
+				},
+			},
+
+			"min_cpu_platform": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as Intel Haswell or Intel Skylake.`,
+			},
+
+			"tags": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: `Tags to attach to the instance.`,
+			},
+
+			"tags_fingerprint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The unique fingerprint of the tags.`,
+			},
+
+			"labels": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: `A set of key/value label pairs to assign to instances created from this template,`,
+			},
+
+			"resource_policies": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: `A list of self_links of resource policies to attach to the instance. Currently a max of 1 resource policy is supported.`,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: compareResourceNames,
+				},
+			},
+
+			"reservation_affinity": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the reservations that this instance can consume from.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ANY_RESERVATION", "SPECIFIC_RESERVATION", "NO_RESERVATION"}, false),
+							Description:  `The type of reservation from which this instance can consume resources.`,
+						},
+
+						"specific_reservation": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Specifies the label selector for the reservation to use.`,
+
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify compute.googleapis.com/reservation-name as the key and specify the name of your reservation as the only value.`,
+									},
+									"values": {
+										Type:        schema.TypeList,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label values of a reservation resource.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	disks, err := buildDisks(d, config)
+	if err != nil {
+		return err
+	}
+
+	metadata, err := resourceInstanceMetadata(d)
+	if err != nil {
+		return err
+	}
+
+	networks, err := expandNetworkInterfaces(d, config)
+	if err != nil {
+		return err
+	}
+
+	scheduling, err := expandResourceComputeInstanceTemplateScheduling(d, config)
+	if err != nil {
+		return err
+	}
+<% unless version == 'ga' -%>
+	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
+	if err != nil {
+		return nil
+	}
+<% end -%>
+	reservationAffinity, err := expandReservationAffinity(d)
+	if err != nil {
+		return err
+	}
+	resourcePolicies := expandInstanceTemplateResourcePolicies(d, "resource_policies")
+
+	instanceProperties := &compute.InstanceProperties{
+		CanIpForward:               d.Get("can_ip_forward").(bool),
+		Description:                d.Get("instance_description").(string),
+		GuestAccelerators:          expandInstanceTemplateGuestAccelerators(d, config),
+		MachineType:                d.Get("machine_type").(string),
+		MinCpuPlatform:             d.Get("min_cpu_platform").(string),
+		Disks:                      disks,
+		Metadata:                   metadata,
+		NetworkInterfaces:          networks,
+<% unless version == 'ga' -%>
+		NetworkPerformanceConfig:   networkPerformanceConfig,
+<% end -%>
+		Scheduling:                 scheduling,
+		ServiceAccounts:            expandServiceAccounts(d.Get("service_account").([]interface{})),
+		Tags:                       resourceInstanceTags(d),
+		ConfidentialInstanceConfig: expandConfidentialInstanceConfig(d),
+		ShieldedInstanceConfig:     expandShieldedVmConfigs(d),
+		AdvancedMachineFeatures:    expandAdvancedMachineFeatures(d),
+<% unless version == 'ga' -%>
+		DisplayDevice:              expandDisplayDevice(d),
+<% end -%>
+		ResourcePolicies:           resourcePolicies,
+		ReservationAffinity:        reservationAffinity,
+	}
+
+	if _, ok := d.GetOk("labels"); ok {
+		instanceProperties.Labels = expandLabels(d)
+	}
+
+	var itName string
+	if v, ok := d.GetOk("name"); ok {
+		itName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		itName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		itName = resource.UniqueId()
+	}
+
+	instanceTemplate := make(map[string]interface{})
+	instanceTemplate["description"] = d.Get("description").(string)
+	instanceTemplate["properties"] = instanceProperties
+	instanceTemplate["name"] = itName
+
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates")
+	if err != nil {
+		return err
+	}
+
+	op, err := SendRequestWithTimeout(config, "POST", project, url, userAgent, instanceTemplate, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("Error creating RegionInstanceTemplate: %s", err)
+	}
+
+	// Store the ID now
+	d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceTemplates/%s", project, region, instanceTemplate["name"]))
+
+	err = ComputeOperationWaitTime(config, op, project, "Creating Region Instance Template", userAgent, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return err
+	}
+
+	return resourceComputeRegionInstanceTemplateRead(d, meta)
+}
+
+func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	splits := strings.Split(d.Id(), "/")
+	name := splits[len(splits)-1]
+
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/" + name)
+	if err != nil {
+		return err
+	}
+
+	instanceTemplate, err := SendRequest(config, "GET", project, url, userAgent, nil)
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("ComputeRegionInstanceTemplate %q", d.Id()))
+	}
+
+	instancePropertiesMap := instanceTemplate["properties"]
+
+	instancePropertiesObj, err := json.Marshal(instancePropertiesMap)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	instanceProperties := compute.InstanceProperties{}
+
+	if err := json.Unmarshal(instancePropertiesObj, &instanceProperties); err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	// Set the metadata fingerprint if there is one.
+	if instanceProperties.Metadata != nil {
+		if err = d.Set("metadata_fingerprint", instanceProperties.Metadata.Fingerprint); err != nil {
+			return fmt.Errorf("Error setting metadata_fingerprint: %s", err)
+		}
+
+		md := instanceProperties.Metadata
+
+		_md := flattenMetadataBeta(md)
+
+		if script, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {
+			if err = d.Set("metadata_startup_script", script); err != nil {
+				return fmt.Errorf("Error setting metadata_startup_script: %s", err)
+			}
+
+			delete(_md, "startup-script")
+		}
+
+		if err = d.Set("metadata", _md); err != nil {
+			return fmt.Errorf("Error setting metadata: %s", err)
+		}
+	}
+
+	// Set the tags fingerprint if there is one.
+	if instanceProperties.Tags != nil {
+		if err = d.Set("tags_fingerprint", instanceProperties.Tags.Fingerprint); err != nil {
+			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
+		}
+	} else {
+		if err := d.Set("tags_fingerprint", ""); err != nil {
+			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
+		}
+	}
+	if instanceProperties.Labels != nil {
+		if err := d.Set("labels", instanceProperties.Labels); err != nil {
+			return fmt.Errorf("Error setting labels: %s", err)
+		}
+	}
+	if err = d.Set("self_link", instanceTemplate["selfLink"]); err != nil {
+		return fmt.Errorf("Error setting self_link: %s", err)
+	}
+	if err = d.Set("name", instanceTemplate["name"]); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
+	if instanceProperties.Disks != nil {
+		disks, err := flattenDisks(instanceProperties.Disks, d, project)
+		if err != nil {
+			return fmt.Errorf("error flattening disks: %s", err)
+		}
+		if err = d.Set("disk", disks); err != nil {
+			return fmt.Errorf("Error setting disk: %s", err)
+		}
+	}
+	if err = d.Set("description", instanceTemplate["description"]); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err = d.Set("machine_type", instanceProperties.MachineType); err != nil {
+		return fmt.Errorf("Error setting machine_type: %s", err)
+	}
+	if err = d.Set("min_cpu_platform", instanceProperties.MinCpuPlatform); err != nil {
+		return fmt.Errorf("Error setting min_cpu_platform: %s", err)
+	}
+
+	if err = d.Set("can_ip_forward", instanceProperties.CanIpForward); err != nil {
+		return fmt.Errorf("Error setting can_ip_forward: %s", err)
+	}
+
+	if err = d.Set("instance_description", instanceProperties.Description); err != nil {
+		return fmt.Errorf("Error setting instance_description: %s", err)
+	}
+	if err = d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+<% unless version == 'ga' -%>
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceProperties.NetworkPerformanceConfig)); err != nil {
+		return err
+	}
+<% end -%>
+	if instanceProperties.NetworkInterfaces != nil {
+		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceProperties.NetworkInterfaces)
+		if err != nil {
+			return err
+		}
+		if err = d.Set("network_interface", networkInterfaces); err != nil {
+			return fmt.Errorf("Error setting network_interface: %s", err)
+		}
+		// region is where to look up the subnetwork if there is one attached to the instance template
+		if region != "" {
+			if err = d.Set("region", region); err != nil {
+				return fmt.Errorf("Error setting region: %s", err)
+			}
+		}
+	}
+	if instanceProperties.Scheduling != nil {
+		scheduling := flattenScheduling(instanceProperties.Scheduling)
+		if err = d.Set("scheduling", scheduling); err != nil {
+			return fmt.Errorf("Error setting scheduling: %s", err)
+		}
+	}
+	if instanceProperties.Tags != nil {
+		if err = d.Set("tags", instanceProperties.Tags.Items); err != nil {
+			return fmt.Errorf("Error setting tags: %s", err)
+		}
+	} else {
+		if err = d.Set("tags", nil); err != nil {
+			return fmt.Errorf("Error setting empty tags: %s", err)
+		}
+	}
+	if instanceProperties.ServiceAccounts != nil {
+		if err = d.Set("service_account", flattenServiceAccounts(instanceProperties.ServiceAccounts)); err != nil {
+			return fmt.Errorf("Error setting service_account: %s", err)
+		}
+	}
+	if instanceProperties.GuestAccelerators != nil {
+		if err = d.Set("guest_accelerator", flattenGuestAccelerators(instanceProperties.GuestAccelerators)); err != nil {
+			return fmt.Errorf("Error setting guest_accelerator: %s", err)
+		}
+	}
+	if instanceProperties.ShieldedInstanceConfig != nil {
+		if err = d.Set("shielded_instance_config", flattenShieldedVmConfig(instanceProperties.ShieldedInstanceConfig)); err != nil {
+			return fmt.Errorf("Error setting shielded_instance_config: %s", err)
+		}
+	}
+
+	if instanceProperties.ConfidentialInstanceConfig != nil {
+		if err = d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(instanceProperties.ConfidentialInstanceConfig)); err != nil {
+			return fmt.Errorf("Error setting confidential_instance_config: %s", err)
+		}
+	}
+	if instanceProperties.AdvancedMachineFeatures != nil {
+		if err = d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(instanceProperties.AdvancedMachineFeatures)); err != nil {
+			return fmt.Errorf("Error setting advanced_machine_features: %s", err)
+		}
+	}
+<% unless version == 'ga' -%>
+	if instanceProperties.DisplayDevice != nil {
+		if err = d.Set("enable_display", flattenEnableDisplay(instanceProperties.DisplayDevice)); err != nil {
+			return fmt.Errorf("Error setting enable_display: %s", err)
+		}
+	}
+<% end -%>
+
+	if instanceProperties.ResourcePolicies != nil {
+		if err = d.Set("resource_policies", instanceProperties.ResourcePolicies); err != nil {
+			return fmt.Errorf("Error setting resource_policies: %s", err)
+		}
+	}
+
+	if reservationAffinity := instanceProperties.ReservationAffinity; reservationAffinity != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+			return fmt.Errorf("Error setting reservation_affinity: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceComputeRegionInstanceTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}")
+	if err != nil {
+		return err
+	}
+
+	var obj map[string]interface{}
+
+	op, err := SendRequestWithTimeout(config, "DELETE", project, url, userAgent, obj, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return handleNotFoundError(err, d, "RegionInstanceTemplate")
+	}
+
+	err = ComputeOperationWaitTime(config, op, project, "Deleting Region Instance Template", userAgent, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceComputeRegionInstanceTemplateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if err := parseImportId([]string{"projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/instanceTemplates/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := replaceVars(d, config, "projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_template_test.go.erb
@@ -20,7 +20,7 @@ func TestAccRegionInstanceTemplateDatasource_name(t *testing.T) {
 			{
 				Config: testAccRegionInstanceTemplate_name(GetTestProjectFromEnv(), RandString(t, 10)),
 				Check: resource.ComposeTestCheckFunc(
-					checkDataSourceStateMatchesResourceStateWithIgnores(
+					CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_compute_region_instance_template.default",
 						"google_compute_region_instance_template.default",
 						map[string]struct{}{},
@@ -41,7 +41,7 @@ func TestAccRegionInstanceTemplateDatasource_filter(t *testing.T) {
 			{
 				Config: testAccRegionInstanceTemplate_filter(GetTestProjectFromEnv(), RandString(t, 10)),
 				Check: resource.ComposeTestCheckFunc(
-					checkDataSourceStateMatchesResourceStateWithIgnores(
+					CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_compute_region_instance_template.default",
 						"google_compute_region_instance_template.c",
 						map[string]struct{}{},
@@ -62,7 +62,7 @@ func TestAccRegionInstanceTemplateDatasource_filter_mostRecent(t *testing.T) {
 			{
 				Config: testAccRegionInstanceTemplate_filter_mostRecent(GetTestProjectFromEnv(), RandString(t, 10)),
 				Check: resource.ComposeTestCheckFunc(
-					checkDataSourceStateMatchesResourceStateWithIgnores(
+					CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_compute_region_instance_template.default",
 						"google_compute_region_instance_template.c",
 						map[string]struct{}{},

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_template_test.go.erb
@@ -14,7 +14,7 @@ func TestAccRegionInstanceTemplateDatasource_name(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -35,7 +35,7 @@ func TestAccRegionInstanceTemplateDatasource_filter(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccRegionInstanceTemplateDatasource_filter_mostRecent(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_region_instance_template_test.go.erb
@@ -1,0 +1,228 @@
+<% autogen_exception -%>
+
+package google
+
+<% unless version == 'ga' -%>
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccRegionInstanceTemplateDatasource_name(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegionInstanceTemplate_name(GetTestProjectFromEnv(), RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_compute_region_instance_template.default",
+						"google_compute_region_instance_template.default",
+						map[string]struct{}{},
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRegionInstanceTemplateDatasource_filter(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegionInstanceTemplate_filter(GetTestProjectFromEnv(), RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_compute_region_instance_template.default",
+						"google_compute_region_instance_template.c",
+						map[string]struct{}{},
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRegionInstanceTemplateDatasource_filter_mostRecent(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegionInstanceTemplate_filter_mostRecent(GetTestProjectFromEnv(), RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_compute_region_instance_template.default",
+						"google_compute_region_instance_template.c",
+						map[string]struct{}{},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccRegionInstanceTemplate_name(project, suffix string) string {
+	return Nprintf(`
+resource "google_compute_region_instance_template" "default" {
+  name        = "tf-test-template-%{suffix}"
+  description = "Example template."
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+}
+data "google_compute_region_instance_template" "default" {
+  project = "%{project}"
+  region = "us-central1"
+  name    = google_compute_region_instance_template.default.name
+}
+`, map[string]interface{}{"project": project, "suffix": suffix})
+}
+
+func testAccRegionInstanceTemplate_filter(project, suffix string) string {
+	return Nprintf(`
+resource "google_compute_region_instance_template" "a" {
+  name        = "tf-test-template-a-%{suffix}"
+  description = "Example template."
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar", "a"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+}
+resource "google_compute_region_instance_template" "b" {
+  name        = "tf-test-template-b-%{suffix}"
+  description = "Example template."
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar", "b"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+}
+resource "google_compute_region_instance_template" "c" {
+  name        = "tf-test-template-c-%{suffix}"
+  description = "Example template."
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar", "c"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+}
+data "google_compute_region_instance_template" "default" {
+  project = "%{project}"
+  region = "us-central1"
+  filter  = "name = tf-test-template-c-%{suffix}"
+  depends_on = [
+    google_compute_region_instance_template.a,
+    google_compute_region_instance_template.b,
+    google_compute_region_instance_template.c,
+  ]
+}
+`, map[string]interface{}{"project": project, "suffix": suffix})
+}
+
+func testAccRegionInstanceTemplate_filter_mostRecent(project, suffix string) string {
+	return Nprintf(`
+resource "google_compute_region_instance_template" "a" {
+  name        = "tf-test-template-%{suffix}-a"
+  description = "tf-test-instance-template"
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar", "a"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+}
+resource "google_compute_region_instance_template" "b" {
+  name        = "tf-test-template-%{suffix}-b"
+  description = "tf-test-instance-template"
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar", "b"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+  depends_on = [
+    google_compute_region_instance_template.a,
+    google_compute_region_instance_template.c,
+  ]
+}
+resource "google_compute_region_instance_template" "c" {
+  name        = "tf-test-template-%{suffix}-c"
+  description = "tf-test-instance-template"
+  region = "us-central1"
+  machine_type = "e2-small"
+  tags = ["foo", "bar", "c"]
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+  depends_on = [
+    google_compute_region_instance_template.a,
+  ]
+}
+data "google_compute_region_instance_template" "default" {
+  region = "us-central1"
+  filter      = "(name != tf-test-template-%{suffix}-b) (description = tf-test-instance-template)"
+  most_recent = true
+  depends_on = [
+    google_compute_region_instance_template.a,
+    google_compute_region_instance_template.b,
+    google_compute_region_instance_template.c,
+  ]
+}
+`, map[string]interface{}{"project": project, "suffix": suffix})
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_from_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_from_template_test.go.erb
@@ -83,7 +83,7 @@ func TestAccComputeInstanceFromRegionTemplate_basic(t *testing.T) {
 	resourceName := "google_compute_instance_from_template.foobar"
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeInstanceFromTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_from_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_from_template_test.go.erb
@@ -72,6 +72,38 @@ func TestAccComputeInstanceFromTemplate_self_link_unique(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+
+func TestAccComputeInstanceFromRegionTemplate_basic(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", RandString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", RandString(t, 10))
+	resourceName := "google_compute_instance_from_template.foobar"
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeInstanceFromTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceFromRegionTemplate_basic(instanceName, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+
+					// Check that fields were set based on the template
+					resource.TestCheckResourceAttr(resourceName, "machine_type", "n1-standard-1"),
+					resource.TestCheckResourceAttr(resourceName, "attached_disk.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.automatic_restart", "false"),
+				),
+			},
+		},
+	})
+}
+
+<% end -%>
+
 func TestAccComputeInstanceFromTemplate_overrideBootDisk(t *testing.T) {
 	t.Parallel()
 
@@ -342,6 +374,85 @@ resource "google_compute_instance_from_template" "foobar" {
 }
 `, template, template, instance)
 }
+
+<% unless version == 'ga' -%>
+
+func testAccComputeInstanceFromRegionTemplate_basic(instance, template string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_disk" "foobar" {
+  name          = "%s"
+  size          = 10
+  type          = "pd-ssd"
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%s"
+  region = "us-central1"
+  machine_type = "n1-standard-1"  // can't be e2 because of local-ssd
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 100
+    boot         = true
+    disk_type    = "pd-ssd"
+    type         = "PERSISTENT"
+  }
+
+  disk {
+    source      = google_compute_region_disk.foobar.self_link
+    auto_delete = false
+    boot        = false
+  }
+
+  disk {
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  scheduling {
+    automatic_restart = true
+  }
+
+  can_ip_forward = true
+}
+
+resource "google_compute_instance_from_template" "foobar" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  source_instance_template = google_compute_region_instance_template.foobar.id
+
+  // Overrides
+  can_ip_forward = false
+  labels = {
+    my_key = "my_value"
+  }
+  scheduling {
+    automatic_restart = false
+  }
+}
+`, template, template, instance)
+}
+
+<% end -%>
 
 func testAccComputeInstanceFromTemplate_self_link_unique(instance, template string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
@@ -1230,6 +1230,75 @@ func TestAccComputeRegionInstanceTemplate_spot_maxRunDuration(t *testing.T) {
 }
 <% end -%>
 
+func TestAccComputeRegionInstanceTemplate_sourceSnapshotEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	kmsKey := BootstrapKMSKeyInLocation(t, "us-central1")
+
+	context := map[string]interface{}{
+		"kms_ring_name": GetResourceNameFromSelfLink(kmsKey.KeyRing.Name),
+		"kms_key_name":  GetResourceNameFromSelfLink(kmsKey.CryptoKey.Name),
+		"random_suffix": RandString(t, 10),
+	}
+
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_sourceSnapshotEncryptionKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.template", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.template",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk.0.source_snapshot", "disk.0.source_snapshot_encryption_key"},
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_sourceImageEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	kmsKey := BootstrapKMSKeyInLocation(t, "us-central1")
+
+	context := map[string]interface{}{
+		"kms_ring_name": GetResourceNameFromSelfLink(kmsKey.KeyRing.Name),
+		"kms_key_name":  GetResourceNameFromSelfLink(kmsKey.CryptoKey.Name),
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_sourceImageEncryptionKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.template", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.template",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk.0.source_image_encryption_key"},
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRegionInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := GoogleProviderConfig(t)
@@ -3203,6 +3272,134 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 }
 `, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_sourceSnapshotEncryptionKey(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_kms_key_ring" "ring" {
+  name     = "%{kms_ring_name}"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "key" {
+  name     = "%{kms_key_name}"
+  key_ring = data.google_kms_key_ring.ring.id
+}
+
+resource "google_service_account" "test" {
+  account_id   = "tf-test-sa-%{random_suffix}"
+  display_name = "KMS Ops Account"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = data.google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.test.email}"
+}
+
+data "google_compute_image" "debian" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "persistent" {
+  name  = "tf-test-debian-disk-%{random_suffix}"
+  image = data.google_compute_image.debian.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapshot" {
+  name        = "tf-test-my-snapshot-%{random_suffix}"
+  source_disk = google_compute_disk.persistent.id
+  zone        = "us-central1-a"
+  snapshot_encryption_key {
+    kms_key_self_link       = data.google_kms_crypto_key.key.id
+    kms_key_service_account = google_service_account.test.email
+  }
+}
+
+resource "google_compute_region_instance_template" "template" {
+  name           = "tf-test-instance-template-%{random_suffix}"
+  machine_type   = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_snapshot = google_compute_snapshot.snapshot.self_link
+    source_snapshot_encryption_key {
+      kms_key_self_link       = data.google_kms_crypto_key.key.id
+      kms_key_service_account = google_service_account.test.email
+    }
+    auto_delete = true
+    boot        = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
+}
+
+func testAccComputeRegionInstanceTemplate_sourceImageEncryptionKey(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_kms_key_ring" "ring" {
+  name     = "%{kms_ring_name}"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "key" {
+  name     = "%{kms_key_name}"
+  key_ring = data.google_kms_key_ring.ring.id
+}
+
+resource "google_service_account" "test" {
+  account_id   = "tf-test-sa-%{random_suffix}"
+  display_name = "KMS Ops Account"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = data.google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.test.email}"
+}
+
+data "google_compute_image" "debian" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_image" "image" {
+  name         = "debian-image"
+  source_image = data.google_compute_image.debian.self_link
+  image_encryption_key {
+    kms_key_self_link       = data.google_kms_crypto_key.key.id
+    kms_key_service_account = google_service_account.test.email
+  }
+}
+
+
+resource "google_compute_region_instance_template" "template" {
+  name           = "tf-test-instance-template-%{random_suffix}"
+  machine_type   = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = google_compute_image.image.self_link
+    source_image_encryption_key {
+      kms_key_self_link       = data.google_kms_crypto_key.key.id
+      kms_key_service_account = google_service_account.test.email
+    }
+    auto_delete = true
+    boot        = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
@@ -1,0 +1,3208 @@
+<% autogen_exception -%>
+
+package google
+
+<% unless version == 'ga' -%>
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+<% if version == "ga" -%>
+	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
+)
+
+func TestComputeRegionInstanceTemplate_reorderDisks(t *testing.T) {
+	t.Parallel()
+
+	cBoot := map[string]interface{}{
+		"source": "boot-source",
+	}
+	cFallThrough := map[string]interface{}{
+		"auto_delete": true,
+	}
+	cDeviceName := map[string]interface{}{
+		"device_name": "disk-1",
+	}
+	cScratch := map[string]interface{}{
+		"type": "SCRATCH",
+	}
+	cSource := map[string]interface{}{
+		"source": "disk-source",
+	}
+	cScratchNvme := map[string]interface{}{
+		"type":      "SCRATCH",
+		"interface": "NVME",
+	}
+
+	aBoot := map[string]interface{}{
+		"source": "boot-source",
+		"boot":   true,
+	}
+	aScratchNvme := map[string]interface{}{
+		"device_name": "scratch-1",
+		"type":        "SCRATCH",
+		"interface":   "NVME",
+	}
+	aSource := map[string]interface{}{
+		"device_name": "disk-2",
+		"source":      "disk-source",
+	}
+	aScratchScsi := map[string]interface{}{
+		"device_name": "scratch-2",
+		"type":        "SCRATCH",
+		"interface":   "SCSI",
+	}
+	aFallThrough := map[string]interface{}{
+		"device_name": "disk-3",
+		"auto_delete": true,
+		"source":      "fake-source",
+	}
+	aFallThrough2 := map[string]interface{}{
+		"device_name": "disk-4",
+		"auto_delete": true,
+		"source":      "fake-source",
+	}
+	aDeviceName := map[string]interface{}{
+		"device_name": "disk-1",
+		"auto_delete": true,
+		"source":      "fake-source-2",
+	}
+	aNoMatch := map[string]interface{}{
+		"device_name": "disk-2",
+		"source":      "disk-source-doesn't-match",
+	}
+
+	cases := map[string]struct {
+		ConfigDisks    []interface{}
+		ApiDisks       []map[string]interface{}
+		ExpectedResult []map[string]interface{}
+	}{
+		"all disks represented": {
+			ApiDisks: []map[string]interface{}{
+				aBoot, aScratchNvme, aSource, aScratchScsi, aFallThrough, aDeviceName,
+			},
+			ConfigDisks: []interface{}{
+				cBoot, cFallThrough, cDeviceName, cScratch, cSource, cScratchNvme,
+			},
+			ExpectedResult: []map[string]interface{}{
+				aBoot, aFallThrough, aDeviceName, aScratchScsi, aSource, aScratchNvme,
+			},
+		},
+		"one non-match": {
+			ApiDisks: []map[string]interface{}{
+				aBoot, aNoMatch, aScratchNvme, aScratchScsi, aFallThrough, aDeviceName,
+			},
+			ConfigDisks: []interface{}{
+				cBoot, cFallThrough, cDeviceName, cScratch, cSource, cScratchNvme,
+			},
+			ExpectedResult: []map[string]interface{}{
+				aBoot, aFallThrough, aDeviceName, aScratchScsi, aScratchNvme, aNoMatch,
+			},
+		},
+		"two fallthroughs": {
+			ApiDisks: []map[string]interface{}{
+				aBoot, aScratchNvme, aFallThrough, aSource, aScratchScsi, aFallThrough2, aDeviceName,
+			},
+			ConfigDisks: []interface{}{
+				cBoot, cFallThrough, cDeviceName, cScratch, cFallThrough, cSource, cScratchNvme,
+			},
+			ExpectedResult: []map[string]interface{}{
+				aBoot, aFallThrough, aDeviceName, aScratchScsi, aFallThrough2, aSource, aScratchNvme,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Disks read using d.Get will always have values for all keys, so set those values
+			for _, disk := range tc.ConfigDisks {
+				d := disk.(map[string]interface{})
+				for _, k := range []string{"auto_delete", "boot"} {
+					if _, ok := d[k]; !ok {
+						d[k] = false
+					}
+				}
+				for _, k := range []string{"device_name", "disk_name", "interface", "mode", "source", "type"} {
+					if _, ok := d[k]; !ok {
+						d[k] = ""
+					}
+				}
+			}
+
+			// flattened disks always set auto_delete, boot, device_name, interface, mode, source, and type
+			for _, d := range tc.ApiDisks {
+				for _, k := range []string{"auto_delete", "boot"} {
+					if _, ok := d[k]; !ok {
+						d[k] = false
+					}
+				}
+
+				for _, k := range []string{"device_name", "interface", "mode", "source"} {
+					if _, ok := d[k]; !ok {
+						d[k] = ""
+					}
+				}
+				if _, ok := d["type"]; !ok {
+					d["type"] = "PERSISTENT"
+				}
+			}
+
+			result := reorderDisks(tc.ConfigDisks, tc.ApiDisks)
+			if !reflect.DeepEqual(tc.ExpectedResult, result) {
+				t.Errorf("reordering did not match\nExpected: %+v\nActual: %+v", tc.ExpectedResult, result)
+			}
+		})
+	}
+}
+
+func TestComputeRegionInstanceTemplate_scratchDiskSizeCustomizeDiff(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Typee       string // misspelled on purpose, type is a special symbol
+		DiskType    string
+		DiskSize    int
+		Interfacee  string
+		ExpectError bool
+	}{
+		"scratch disk correct size 1": {
+			Typee:       "SCRATCH",
+			DiskType:    "local-ssd",
+			DiskSize:    375,
+			Interfacee:  "NVME",
+			ExpectError: false,
+		},
+		"scratch disk correct size 2": {
+			Typee:       "SCRATCH",
+			DiskType:    "local-ssd",
+			DiskSize:    3000,
+			Interfacee:  "NVME",
+			ExpectError: false,
+		},
+		"scratch disk incorrect size": {
+			Typee:       "SCRATCH",
+			DiskType:    "local-ssd",
+			DiskSize:    300,
+			Interfacee:  "NVME",
+			ExpectError: true,
+		},
+		"scratch disk incorrect interface": {
+			Typee:       "SCRATCH",
+			DiskType:    "local-ssd",
+			DiskSize:    3000,
+			Interfacee:  "SCSI",
+			ExpectError: true,
+		},
+		"non-scratch disk": {
+			Typee:       "PERSISTENT",
+			DiskType:    "",
+			DiskSize:    300,
+			Interfacee:  "NVME",
+			ExpectError: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		d := &ResourceDiffMock{
+			After: map[string]interface{}{
+				"disk.#":              1,
+				"disk.0.type":         tc.Typee,
+				"disk.0.disk_type":    tc.DiskType,
+				"disk.0.disk_size_gb": tc.DiskSize,
+				"disk.0.interface":    tc.Interfacee,
+			},
+		}
+		err := resourceComputeInstanceTemplateScratchDiskCustomizeDiffFunc(d)
+		if tc.ExpectError && err == nil {
+			t.Errorf("%s failed, expected error but was none", tn)
+		}
+		if !tc.ExpectError && err != nil {
+			t.Errorf("%s failed, found unexpected error: %s", tn, err)
+		}
+	}
+}
+
+func TestAccComputeRegionInstanceTemplate_basic(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_basic(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateTag(&instanceTemplate, "foo"),
+					testAccCheckComputeRegionInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
+					testAccCheckComputeRegionInstanceTemplateContainsLabel(&instanceTemplate, "my_label", "foobar"),
+					testAccCheckComputeRegionInstanceTemplateLacksShieldedVmConfig(&instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_imageShorthand(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_imageShorthand(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_preemptible(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_preemptible(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateAutomaticRestart(&instanceTemplate, false),
+					testAccCheckComputeRegionInstanceTemplatePreemptible(&instanceTemplate, true),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_IP(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_ip(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateNetwork(&instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_IPv6(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_ipv6(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_networkTier(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_networkTier(RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_networkIP(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	networkIP := "10.128.0.2"
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_networkIP(RandString(t, 10), networkIP),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateNetwork(&instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateNetworkIP(
+						"google_compute_region_instance_template.foobar", networkIP, &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_networkIPAddress(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	ipAddress := "10.128.0.2"
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_networkIPAddress(RandString(t, 10), ipAddress),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateNetwork(&instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateNetworkIPAddress(
+						"google_compute_region_instance_template.foobar", ipAddress, &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_disksInvalid(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeRegionInstanceTemplate_disksInvalid(RandString(t, 10)),
+				ExpectError: regexp.MustCompile("Cannot use `source`.*"),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_regionDisks(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_regionDisks(RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_subnet_auto(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	network := "tf-test-network-" + RandString(t, 10)
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_subnet_auto(network, RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateNetworkName(&instanceTemplate, network),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_subnet_custom(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_subnet_custom(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateSubnetwork(&instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_subnet_xpn(t *testing.T) {
+	// Randomness
+	SkipIfVcr(t)
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	org := GetTestOrgFromEnv(t)
+	billingId := GetTestBillingAccountFromEnv(t)
+	projectName := fmt.Sprintf("tf-testxpn-%d", time.Now().Unix())
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_subnet_xpn(org, billingId, projectName, RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExistsInProject(
+						t, "google_compute_region_instance_template.foobar", fmt.Sprintf("%s-service", projectName),
+						&instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateSubnetwork(&instanceTemplate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_metadata_startup_script(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_startup_script(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateStartupScript(&instanceTemplate, "echo 'Hello'"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_primaryAliasIpRange(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_primaryAliasIpRange(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasAliasIpRange(&instanceTemplate, "", "/24"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_secondaryAliasIpRange(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_secondaryAliasIpRange(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasAliasIpRange(&instanceTemplate, "inst-test-secondary", "/24"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_guestAccelerator(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_guestAccelerator(RandString(t, 10), 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasGuestAccelerator(&instanceTemplate, "nvidia-tesla-k80", 1),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func TestAccComputeRegionInstanceTemplate_guestAcceleratorSkip(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_guestAccelerator(RandString(t, 10), 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateLacksGuestAccelerator(&instanceTemplate),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccComputeRegionInstanceTemplate_minCpuPlatform(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_minCpuPlatform(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasMinCpuPlatform(&instanceTemplate, DEFAULT_MIN_CPU_TEST_VALUE),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_soleTenantNodeAffinities(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_soleTenantInstanceTemplate(RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_instanceResourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	var template compute.InstanceTemplate
+	var policyName = "tf-test-policy-" + RandString(t, 10)
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_instanceResourcePolicyCollocated(RandString(t, 10), policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &template),
+					testAccCheckComputeRegionInstanceTemplateHasInstanceResourcePolicies(&template, policyName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_reservationAffinities(t *testing.T) {
+	t.Parallel()
+
+	var template compute.InstanceTemplate
+	var templateName = RandString(t, 10)
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, "NO_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &template),
+					testAccCheckComputeRegionInstanceTemplateHasReservationAffinity(&template, "NO_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, "ANY_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &template),
+					testAccCheckComputeRegionInstanceTemplateHasReservationAffinity(&template, "ANY_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_specificReservation(templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &template),
+					testAccCheckComputeRegionInstanceTemplateHasReservationAffinity(&template, "SPECIFIC_RESERVATION", templateName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_shieldedVmConfig1(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_shieldedVmConfig(RandString(t, 10), true, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasShieldedVmConfig(&instanceTemplate, true, true, true),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_shieldedVmConfig2(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_shieldedVmConfig(RandString(t, 10), true, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasShieldedVmConfig(&instanceTemplate, true, true, false),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(RandString(t, 10), true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_AdvancedMachineFeatures(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplateAdvancedMachineFeatures(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+		},
+	})
+}
+
+<% unless version == "ga" -%>
+func TestAccComputeRegionInstanceTemplate_enableDisplay(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_enableDisplay(RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+<% end -%>
+
+<% unless version == "ga" -%>
+func TestAccComputeRegionInstanceTemplate_maintenance_interval(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_maintenance_interval(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateMaintenanceInterval(&instanceTemplate, "PERIODIC"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_basic(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateMaintenanceInterval(&instanceTemplate, ""),
+				),
+			},
+		},
+	})
+}
+<% end -%>
+
+func TestAccComputeRegionInstanceTemplate_invalidDiskType(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeRegionInstanceTemplate_invalidDiskType(RandString(t, 10)),
+				ExpectError: regexp.MustCompile("SCRATCH disks must have a disk_type of local-ssd"),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_withScratchDisk(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_with375GbScratchDisk(RandString(t, 10)),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_with18TbScratchDisk(t *testing.T) {
+	t.Parallel()
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_with18TbScratchDisk(RandString(t, 10)),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_imageResourceTest(t *testing.T) {
+	// Multiple fine-grained resources
+	SkipIfVcr(t)
+	t.Parallel()
+	diskName := "tf-test-disk-" + RandString(t, 10)
+	computeImage := "tf-test-image-" + RandString(t, 10)
+	imageDesc1 := "Some description"
+	imageDesc2 := "Some other description"
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_imageResourceTest(diskName, computeImage, imageDesc1),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_imageResourceTest(diskName, computeImage, imageDesc2),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_diskResourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	policyName := "tf-test-policy-" + RandString(t, 10)
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_diskResourcePolicies(RandString(t, 10), policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasDiskResourcePolicy(&instanceTemplate, policyName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_nictype_update(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	var instanceTemplateName = fmt.Sprintf("tf-test-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_nictype(instanceTemplateName, instanceTemplateName, "GVNIC"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_nictype(instanceTemplateName, instanceTemplateName, "VIRTIO_NET"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_queueCount(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	var instanceTemplateName = fmt.Sprintf("tf-test-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_queueCount(instanceTemplateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_managedEnvoy(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_managedEnvoy(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionInstanceTemplate_spot(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_spot(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateAutomaticRestart(&instanceTemplate, false),
+					testAccCheckComputeRegionInstanceTemplatePreemptible(&instanceTemplate, true),
+					testAccCheckComputeRegionInstanceTemplateProvisioningModel(&instanceTemplate, "SPOT"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+<% unless version == 'ga' -%>
+func TestAccComputeRegionInstanceTemplate_spot_maxRunDuration(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	var expectedMaxRunDuration = compute.Duration{}
+	// Define in testAccComputeRegionInstanceTemplate_spot
+	expectedMaxRunDuration.Nanos = 123
+	expectedMaxRunDuration.Seconds = 60
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_spot_maxRunDuration(RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateAutomaticRestart(&instanceTemplate, false),
+					testAccCheckComputeRegionInstanceTemplatePreemptible(&instanceTemplate, true),
+					testAccCheckComputeRegionInstanceTemplateProvisioningModel(&instanceTemplate, "SPOT"),
+					testAccCheckComputeRegionInstanceTemplateInstanceTerminationAction(&instanceTemplate, "DELETE"),
+					testAccCheckComputeRegionInstanceTemplateMaxRunDuration(&instanceTemplate, expectedMaxRunDuration),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
+func testAccCheckComputeRegionInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		config := GoogleProviderConfig(t)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_compute_region_instance_template" {
+				continue
+			}
+
+			splits := strings.Split(rs.Primary.ID, "/")
+			name := splits[len(splits)-1]
+		
+			url, err := replaceVarsForTest(config, rs, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/"+name)
+			if err != nil {
+				return err
+			}
+
+			billingProject := ""
+
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
+
+			instanceTemplate, err := SendRequest(config, "GET", billingProject, url, config.UserAgent, nil)
+			_ = instanceTemplate
+			if err == nil {
+				return fmt.Errorf("Instance template still exists")
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateExists(t *testing.T, n string, instanceTemplate interface{}) resource.TestCheckFunc {
+	if instanceTemplate == nil {
+		panic("Attempted to check existence of Instance template that was nil.")
+	}
+
+	return testAccCheckComputeRegionInstanceTemplateExistsInProject(t, n, GetTestProjectFromEnv(), instanceTemplate.(*compute.InstanceTemplate))
+}
+
+func testAccCheckComputeRegionInstanceTemplateExistsInProject(t *testing.T, n, p string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := GoogleProviderConfig(t)
+
+		splits := strings.Split(rs.Primary.ID, "/")
+		templateName := splits[len(splits)-1]
+	
+		url, err := replaceVarsForTest(config, rs, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceTemplates/"+templateName)
+
+		billingProject := ""
+
+		if config.BillingProject != "" {
+			billingProject = config.BillingProject
+		}
+
+		found, err := SendRequest(config, "GET", billingProject, url, config.UserAgent, nil)
+		if err != nil {
+			return err
+		}
+
+		foundObj, err := json.Marshal(found)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+	
+		instanceTemplateFound := compute.InstanceTemplate{}
+	
+		if err := json.Unmarshal(foundObj, &instanceTemplateFound); err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		if instanceTemplateFound.Name != templateName {
+			return fmt.Errorf("Instance template not found")
+		}
+
+		*instanceTemplate = instanceTemplateFound
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateMetadata(
+	instanceTemplate *compute.InstanceTemplate,
+	k string, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Metadata == nil {
+			return fmt.Errorf("no metadata")
+		}
+
+		for _, item := range instanceTemplate.Properties.Metadata.Items {
+			if k != item.Key {
+				continue
+			}
+
+			if item.Value != nil && v == *item.Value {
+				return nil
+			}
+
+			return fmt.Errorf("bad value for %s: %s", k, *item.Value)
+		}
+
+		return fmt.Errorf("metadata not found: %s", k)
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateNetwork(instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
+			for _, c := range i.AccessConfigs {
+				if c.NatIP == "" {
+					return fmt.Errorf("no NAT IP")
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateNetworkName(instanceTemplate *compute.InstanceTemplate, network string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
+			if !strings.Contains(i.Network, network) {
+				return fmt.Errorf("Network doesn't match expected value, Expected: %s Actual: %s", network, i.Network[strings.LastIndex("/", i.Network)+1:])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateSubnetwork(instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
+			if i.Subnetwork == "" {
+				return fmt.Errorf("no subnet")
+			}
+		}
+
+		return nil
+	}
+}
+
+<% unless version == "ga" -%>
+func testAccCheckComputeRegionInstanceTemplateMaintenanceInterval(instanceTemplate *compute.InstanceTemplate, maintenance_interval string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Scheduling.MaintenanceInterval != maintenance_interval {
+			return fmt.Errorf("Expected maintenance interval value %v, got %v", maintenance_interval, instanceTemplate.Properties.Scheduling.MaintenanceInterval)
+		}
+		return nil
+	}
+}
+<% end -%>
+
+func testAccCheckComputeRegionInstanceTemplateTag(instanceTemplate *compute.InstanceTemplate, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Tags == nil {
+			return fmt.Errorf("no tags")
+		}
+
+		for _, k := range instanceTemplate.Properties.Tags.Items {
+			if k == n {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("tag not found: %s", n)
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplatePreemptible(instanceTemplate *compute.InstanceTemplate, preemptible bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Scheduling.Preemptible != preemptible {
+			return fmt.Errorf("Expected preemptible value %v, got %v", preemptible, instanceTemplate.Properties.Scheduling.Preemptible)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateProvisioningModel(instanceTemplate *compute.InstanceTemplate, provisioning_model string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Scheduling.ProvisioningModel != provisioning_model {
+			return fmt.Errorf("Expected provisioning_model  %v, got %v", provisioning_model, instanceTemplate.Properties.Scheduling.ProvisioningModel)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateInstanceTerminationAction(instanceTemplate *compute.InstanceTemplate, instance_termination_action string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Scheduling.InstanceTerminationAction != instance_termination_action {
+			return fmt.Errorf("Expected instance_termination_action  %v, got %v", instance_termination_action, instanceTemplate.Properties.Scheduling.InstanceTerminationAction)
+		}
+		return nil
+	}
+}
+
+<% unless version == 'ga' -%>
+func testAccCheckComputeRegionInstanceTemplateMaxRunDuration(instanceTemplate *compute.InstanceTemplate, instance_max_run_duration_want compute.Duration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !reflect.DeepEqual(*instanceTemplate.Properties.Scheduling.MaxRunDuration, instance_max_run_duration_want) {
+			return fmt.Errorf("gExpected instance_termination_action: %#v; got %#v", instance_max_run_duration_want, instanceTemplate.Properties.Scheduling.MaxRunDuration)
+		}
+
+		return nil
+	}
+}
+<% end -%>
+
+func testAccCheckComputeRegionInstanceTemplateAutomaticRestart(instanceTemplate *compute.InstanceTemplate, automaticRestart bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ar := instanceTemplate.Properties.Scheduling.AutomaticRestart
+		if ar == nil {
+			return fmt.Errorf("Expected to see a value for AutomaticRestart, but got nil")
+		}
+		if *ar != automaticRestart {
+			return fmt.Errorf("Expected automatic restart value %v, got %v", automaticRestart, ar)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateStartupScript(instanceTemplate *compute.InstanceTemplate, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.Metadata == nil && n == "" {
+			return nil
+		} else if instanceTemplate.Properties.Metadata == nil && n != "" {
+			return fmt.Errorf("Expected metadata.startup-script to be '%s', metadata wasn't set at all", n)
+		}
+		for _, item := range instanceTemplate.Properties.Metadata.Items {
+			if item.Key != "startup-script" {
+				continue
+			}
+			if item.Value != nil && *item.Value == n {
+				return nil
+			} else if item.Value == nil && n == "" {
+				return nil
+			} else if item.Value == nil && n != "" {
+				return fmt.Errorf("Expected metadata.startup-script to be '%s', wasn't set", n)
+			} else if *item.Value != n {
+				return fmt.Errorf("Expected metadata.startup-script to be '%s', got '%s'", n, *item.Value)
+			}
+		}
+		return fmt.Errorf("This should never be reached.")
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateNetworkIP(n, networkIP string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ip := instanceTemplate.Properties.NetworkInterfaces[0].NetworkIP
+		err := resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", ip)(s)
+		if err != nil {
+			return err
+		}
+		return resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", networkIP)(s)
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateNetworkIPAddress(n, ipAddress string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ip := instanceTemplate.Properties.NetworkInterfaces[0].NetworkIP
+		err := resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", ip)(s)
+		if err != nil {
+			return err
+		}
+		return resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", ipAddress)(s)
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateContainsLabel(instanceTemplate *compute.InstanceTemplate, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		v, ok := instanceTemplate.Properties.Labels[key]
+		if !ok {
+			return fmt.Errorf("Expected label with key '%s' not found", key)
+		}
+		if v != value {
+			return fmt.Errorf("Incorrect label value for key '%s': expected '%s' but found '%s'", key, value, v)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasAliasIpRange(instanceTemplate *compute.InstanceTemplate, subnetworkRangeName, iPCidrRange string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, networkInterface := range instanceTemplate.Properties.NetworkInterfaces {
+			for _, aliasIpRange := range networkInterface.AliasIpRanges {
+				if aliasIpRange.SubnetworkRangeName == subnetworkRangeName && (aliasIpRange.IpCidrRange == iPCidrRange || ipCidrRangeDiffSuppress("ip_cidr_range", aliasIpRange.IpCidrRange, iPCidrRange, nil)) {
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("Alias ip range with name %s and cidr %s not present", subnetworkRangeName, iPCidrRange)
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasGuestAccelerator(instanceTemplate *compute.InstanceTemplate, acceleratorType string, acceleratorCount int64) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(instanceTemplate.Properties.GuestAccelerators) != 1 {
+			return fmt.Errorf("Expected only one guest accelerator")
+		}
+
+		if !strings.HasSuffix(instanceTemplate.Properties.GuestAccelerators[0].AcceleratorType, acceleratorType) {
+			return fmt.Errorf("Wrong accelerator type: expected %v, got %v", acceleratorType, instanceTemplate.Properties.GuestAccelerators[0].AcceleratorType)
+		}
+
+		if instanceTemplate.Properties.GuestAccelerators[0].AcceleratorCount != acceleratorCount {
+			return fmt.Errorf("Wrong accelerator acceleratorCount: expected %d, got %d", acceleratorCount, instanceTemplate.Properties.GuestAccelerators[0].AcceleratorCount)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateLacksGuestAccelerator(instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(instanceTemplate.Properties.GuestAccelerators) > 0 {
+			return fmt.Errorf("Expected no guest accelerators")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasMinCpuPlatform(instanceTemplate *compute.InstanceTemplate, minCpuPlatform string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.MinCpuPlatform != minCpuPlatform {
+			return fmt.Errorf("Wrong minimum CPU platform: expected %s, got %s", minCpuPlatform, instanceTemplate.Properties.MinCpuPlatform)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasInstanceResourcePolicies(instanceTemplate *compute.InstanceTemplate, resourcePolicy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourcePolicyActual := instanceTemplate.Properties.ResourcePolicies[0]
+		if resourcePolicyActual != resourcePolicy {
+			return fmt.Errorf("Wrong instance resource policy: expected %s, got %s", resourcePolicy, resourcePolicyActual)
+		}
+
+		return nil
+	}
+
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasReservationAffinity(instanceTemplate *compute.InstanceTemplate, consumeReservationType string, specificReservationNames ...string) resource.TestCheckFunc {
+	if len(specificReservationNames) > 1 {
+		panic("too many specificReservationNames in test")
+	}
+
+	return func(*terraform.State) error {
+		if instanceTemplate.Properties.ReservationAffinity == nil {
+			return fmt.Errorf("expected template to have reservation affinity, but it was nil")
+		}
+
+		if actualReservationType := instanceTemplate.Properties.ReservationAffinity.ConsumeReservationType; actualReservationType != consumeReservationType {
+			return fmt.Errorf("Wrong reservationAffinity consumeReservationType: expected %s, got, %s", consumeReservationType, actualReservationType)
+		}
+
+		if len(specificReservationNames) > 0 {
+			const reservationNameKey = "compute.googleapis.com/reservation-name"
+			if actualKey := instanceTemplate.Properties.ReservationAffinity.Key; actualKey != reservationNameKey {
+				return fmt.Errorf("Wrong reservationAffinity key: expected %s, got, %s", reservationNameKey, actualKey)
+			}
+
+			reservationAffinityValues := instanceTemplate.Properties.ReservationAffinity.Values
+			if len(reservationAffinityValues) != 1 || reservationAffinityValues[0] != specificReservationNames[0] {
+				return fmt.Errorf("Wrong reservationAffinity values: expected %s, got, %s", specificReservationNames, reservationAffinityValues)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasShieldedVmConfig(instanceTemplate *compute.InstanceTemplate, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.ShieldedInstanceConfig.EnableSecureBoot != enableSecureBoot {
+			return fmt.Errorf("Wrong shieldedVmConfig enableSecureBoot: expected %t, got, %t", enableSecureBoot, instanceTemplate.Properties.ShieldedInstanceConfig.EnableSecureBoot)
+		}
+
+		if instanceTemplate.Properties.ShieldedInstanceConfig.EnableVtpm != enableVtpm {
+			return fmt.Errorf("Wrong shieldedVmConfig enableVtpm: expected %t, got, %t", enableVtpm, instanceTemplate.Properties.ShieldedInstanceConfig.EnableVtpm)
+		}
+
+		if instanceTemplate.Properties.ShieldedInstanceConfig.EnableIntegrityMonitoring != enableIntegrityMonitoring {
+			return fmt.Errorf("Wrong shieldedVmConfig enableIntegrityMonitoring: expected %t, got, %t", enableIntegrityMonitoring, instanceTemplate.Properties.ShieldedInstanceConfig.EnableIntegrityMonitoring)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(instanceTemplate *compute.InstanceTemplate, EnableConfidentialCompute bool) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
+			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateLacksShieldedVmConfig(instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instanceTemplate.Properties.ShieldedInstanceConfig != nil {
+			return fmt.Errorf("Expected no shielded vm config")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRegionInstanceTemplateHasDiskResourcePolicy(instanceTemplate *compute.InstanceTemplate, resourcePolicy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourcePolicyActual := instanceTemplate.Properties.Disks[0].InitializeParams.ResourcePolicies[0]
+		if resourcePolicyActual != resourcePolicy {
+			return fmt.Errorf("Wrong disk resource policy: expected %s, got %s", resourcePolicy, resourcePolicyActual)
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeRegionInstanceTemplate_basic(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_imageShorthand(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_image" "foobar" {
+  name        = "tf-test-%s"
+  description = "description-test"
+  family      = "family-test"
+  raw_disk {
+    source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+  }
+  labels = {
+    my-label    = "my-label-value"
+    empty-label = ""
+  }
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = google_compute_image.foobar.name
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_preemptible(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+  region      = "us-central1"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = true
+    automatic_restart = false
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_ip(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_address" "foo" {
+  name = "tf-test-instance-template-%s"
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type = "e2-medium"
+  tags         = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      nat_ip = google_compute_address.foo.address
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_ipv6(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_address" "foo" {
+  name = "tf-test-instance-template-%s"
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "foo" {
+  name                    = "tf-test-network-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork-ipv6" {
+  name          = "tf-test-subnetwork-%s"
+
+  ip_cidr_range = "10.0.0.0/22"
+  region        = "us-central1"
+
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+
+  network       = google_compute_network.foo.id
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+  tags         = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork-ipv6.name
+    stack_type = "IPV4_IPV6"
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_networkTier(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      network_tier = "STANDARD"
+    }
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_networkIP(suffix, networkIP string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type = "e2-medium"
+  tags         = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    network    = "default"
+    network_ip = "%s"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, networkIP)
+}
+
+func testAccComputeRegionInstanceTemplate_networkIPAddress(suffix, ipAddress string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type = "e2-medium"
+  tags         = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    network    = "default"
+    network_ip = "%s"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, ipAddress)
+}
+
+func testAccComputeRegionInstanceTemplate_disksInvalid(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "tf-test-instance-template-%s"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 100
+    boot         = true
+  }
+
+  disk {
+    source       = google_compute_disk.foobar.name
+    disk_size_gb = 50
+    auto_delete  = false
+    boot         = false
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_with375GbScratchDisk(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "centos-7"
+	project = "centos-cloud"
+}
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  disk {
+    source_image = data.google_compute_image.my_image.name
+    auto_delete  = true
+    boot         = true
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 375
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+  }
+  network_interface {
+    network = "default"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_with18TbScratchDisk(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "centos-7"
+	project = "centos-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "n2-standard-16"
+  region      = "us-central1"
+  can_ip_forward = false
+  disk {
+    source_image = data.google_compute_image.my_image.name
+    auto_delete  = true
+    boot         = true
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 3000
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 3000
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 3000
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 3000
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 3000
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 3000
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+  }
+  network_interface {
+    network = "default"
+  }
+}`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_regionDisks(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_disk" "foobar" {
+  name          = "tf-test-instance-template-%s"
+  size          = 10
+  type          = "pd-ssd"
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 100
+    boot         = true
+  }
+
+  disk {
+    source      = google_compute_region_disk.foobar.self_link
+    auto_delete = false
+    boot        = false
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_subnet_auto(network, suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "auto-network" {
+  name                    = "%s"
+  auto_create_subnetworks = true
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  network_interface {
+    network = google_compute_network.auto-network.name
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, network, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_subnet_custom(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "network" {
+  name                    = "tf-test-network-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "subnetwork-%s"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.network.self_link
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork.name
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_subnet_xpn(org, billingId, projectName, suffix string) string {
+	return fmt.Sprintf(`
+resource "google_project" "host_project" {
+  name            = "Test Project XPN Host"
+  project_id      = "%s-host"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "host_project" {
+  project = google_project.host_project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_shared_vpc_host_project" "host_project" {
+  project = google_project_service.host_project.project
+}
+
+resource "google_project" "service_project" {
+  name            = "Test Project XPN Service"
+  project_id      = "%s-service"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "service_project" {
+  project = google_project.service_project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_shared_vpc_service_project" "service_project" {
+  host_project    = google_compute_shared_vpc_host_project.host_project.project
+  service_project = google_project_service.service_project.project
+}
+
+resource "google_compute_network" "network" {
+  name                    = "tf-test-network-%s"
+  auto_create_subnetworks = false
+  project                 = google_compute_shared_vpc_host_project.host_project.project
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "subnetwork-%s"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.network.self_link
+  project       = google_compute_shared_vpc_host_project.host_project.project
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  network_interface {
+    subnetwork         = google_compute_subnetwork.subnetwork.name
+    subnetwork_project = google_compute_subnetwork.subnetwork.project
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+  project = google_compute_shared_vpc_service_project.service_project.service_project
+}
+`, projectName, org, billingId, projectName, org, billingId, suffix, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_startup_script(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata_startup_script = "echo 'Hello'"
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_primaryAliasIpRange(i string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  network_interface {
+    network = "default"
+    alias_ip_range {
+      ip_cidr_range = "/24"
+    }
+  }
+}
+`, i)
+}
+
+func testAccComputeRegionInstanceTemplate_secondaryAliasIpRange(i string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "inst-test-network" {
+  name = "tf-test-network-%s"
+}
+
+resource "google_compute_subnetwork" "inst-test-subnetwork" {
+  name          = "inst-test-subnetwork-%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.inst-test-network.self_link
+  secondary_ip_range {
+    range_name    = "inst-test-secondary"
+    ip_cidr_range = "172.16.0.0/20"
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.inst-test-subnetwork.self_link
+
+    // Note that unlike compute instances, instance templates seem to be
+    // only able to specify the netmask here. Trying a full CIDR string
+    // results in:
+    // Invalid value for field 'resource.properties.networkInterfaces[0].aliasIpRanges[0].ipCidrRange':
+    // '172.16.0.0/24'. Alias IP CIDR range must be a valid netmask starting with '/' (e.g. '/24')
+    alias_ip_range {
+      subnetwork_range_name = google_compute_subnetwork.inst-test-subnetwork.secondary_ip_range[0].range_name
+      ip_cidr_range         = "/24"
+    }
+  }
+}
+`, i, i, i)
+}
+
+<% unless version == 'ga' -%>
+func testAccComputeRegionInstanceTemplate_maintenance_interval(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region        = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+    maintenance_interval = "PERIODIC"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, suffix)
+}
+<% end -%>
+
+
+func testAccComputeRegionInstanceTemplate_guestAccelerator(i string, count uint8) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    # Instances with guest accelerators do not support live migration.
+    on_host_maintenance = "TERMINATE"
+  }
+
+  guest_accelerator {
+    count = %d
+    type  = "nvidia-tesla-k80"
+  }
+}
+`, i, count)
+}
+
+func testAccComputeRegionInstanceTemplate_minCpuPlatform(i string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    # Instances with guest accelerators do not support live migration.
+    on_host_maintenance = "TERMINATE"
+  }
+
+  min_cpu_platform = "%s"
+}
+`, i, DEFAULT_MIN_CPU_TEST_VALUE)
+}
+
+func testAccComputeRegionInstanceTemplate_soleTenantInstanceTemplate(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-standard-4"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+    node_affinities {
+      key      = "tfacc"
+      operator = "IN"
+      values   = ["testinstancetemplate"]
+    }
+
+    min_node_cpus = 2
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_instanceResourcePolicyCollocated(suffix string, policyName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_resource_policy" "foo" {
+  name = "%s"
+  region = "us-central1"
+  group_placement_policy {
+    vm_count  = 2
+    collocation = "COLLOCATED"
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-standard-4"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = false
+  }
+
+  resource_policies = [google_compute_resource_policy.foo.self_link]
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+`, policyName, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, consumeReservationType string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instancet-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "%s"
+  }
+}
+`, templateName, consumeReservationType)
+}
+
+func testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_specificReservation(templateName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instancet-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "SPECIFIC_RESERVATION"
+
+	specific_reservation {
+		key = "compute.googleapis.com/reservation-name"
+		values = ["%s"]
+	}
+  }
+}
+`, templateName, templateName)
+}
+
+func testAccComputeRegionInstanceTemplate_shieldedVmConfig(suffix string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "centos-7"
+  project = "centos-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = %t
+    enable_vtpm                 = %t
+    enable_integrity_monitoring = %t
+  }
+}
+`, suffix, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
+}
+
+func testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "ubuntu-2004-lts"
+  project = "ubuntu-os-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "n2d-standard-2"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  confidential_instance_config {
+    enable_confidential_compute       = %t
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+`, suffix, enableConfidentialCompute)
+}
+
+func testAccComputeRegionInstanceTemplateAdvancedMachineFeatures(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "ubuntu-2004-lts"
+  project = "ubuntu-os-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type = "n2-standard-2" // Nested Virt isn't supported on E2 and N2Ds https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#restrictions and https://cloud.google.com/compute/docs/instances/disabling-smt#limitations
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  advanced_machine_features {
+	threads_per_core = 1
+	enable_nested_virtualization = true
+	visible_core_count = 1
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+`, suffix)
+}
+
+<% unless version == "ga" -%>
+func testAccComputeRegionInstanceTemplate_enableDisplay(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "centos-7"
+  project = "centos-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+  enable_display = true
+}
+`, suffix)
+}
+
+<% end -%>
+
+func testAccComputeRegionInstanceTemplate_invalidDiskType(suffix string) string {
+	return fmt.Sprintf(`
+# Use this datasource insead of hardcoded values when https://github.com/hashicorp/terraform/issues/22679
+# is resolved.
+# data "google_compute_image" "my_image" {
+# 	family  = "centos-7"
+# 	project = "centos-cloud"
+# }
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  disk {
+    source_image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
+    auto_delete  = true
+    boot         = true
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = 375
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+  }
+  disk {
+    source_image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
+    auto_delete  = true
+    type         = "SCRATCH"
+  }
+  network_interface {
+    network = "default"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_imageResourceTest(diskName string, imageName string, imageDescription string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_disk" "my_disk" {
+	name  = "%s"
+	zone  = "us-central1-a"
+	image = data.google_compute_image.my_image.self_link
+}
+
+resource "google_compute_image" "diskimage" {
+	name = "%s"
+	description = "%s"
+	source_disk = google_compute_disk.my_disk.self_link
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+	name_prefix = "tf-test-instance-template-"
+	machine_type         = "e2-medium"
+	region      = "us-central1"
+	disk {
+		source_image = google_compute_image.diskimage.self_link
+	}
+	network_interface {
+		network = "default"
+		access_config {}
+	}
+}
+`, diskName, imageName, imageDescription)
+}
+
+func testAccComputeRegionInstanceTemplate_diskResourcePolicies(suffix string, policyName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+resource "google_compute_region_instance_template" "foobar" {
+  region      = "us-central1"
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    resource_policies = [google_compute_resource_policy.foo.id]
+  }
+  network_interface {
+    network = "default"
+  }
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+  labels = {
+    my_label = "foobar"
+  }
+}
+
+resource "google_compute_resource_policy" "foo" {
+  name   = "%s"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "04:00"
+      }
+    }
+  }
+}
+`, suffix, policyName)
+}
+
+func testAccComputeRegionInstanceTemplate_nictype(image, instance, nictype string) string {
+	return fmt.Sprintf(`
+resource "google_compute_image" "example" {
+	name = "%s"
+	raw_disk {
+		source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+	}
+
+	guest_os_features {
+		type = "SECURE_BOOT"
+	}
+
+	guest_os_features {
+		type = "MULTI_IP_SUBNET"
+	}
+
+	guest_os_features {
+		type = "GVNIC"
+	}
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+	name           = "tf-test-instance-template-%s"
+	region      = "us-central1"
+	machine_type   = "e2-medium"
+	can_ip_forward = false
+	tags           = ["foo", "bar"]
+
+	disk {
+		source_image = google_compute_image.example.name
+		auto_delete  = true
+		boot         = true
+	}
+
+	network_interface {
+		network = "default"
+		nic_type = "%s"
+	}
+
+	scheduling {
+		preemptible       = false
+		automatic_restart = true
+	}
+
+	metadata = {
+		foo = "bar"
+	}
+
+	service_account {
+		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+	}
+
+	labels = {
+		my_label = "foobar"
+	}
+}
+`, image, instance, nictype)
+}
+
+func testAccComputeRegionInstanceTemplate_queueCount(instanceTemplateName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+	name = "%s"
+	region      = "us-central1"
+	machine_type         = "e2-medium"
+	network_interface {
+		network = "default"
+		access_config {}
+		queue_count = 2
+	}
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+`, instanceTemplateName)
+}
+
+func testAccComputeRegionInstanceTemplate_managedEnvoy(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_default_service_account" "default" {
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+  region      = "us-central1"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+  }
+
+  metadata = {
+    gce-software-declaration = <<-EOF
+    {
+	  "softwareRecipes": [{
+	    "name": "install-gce-service-proxy-agent",
+	    "desired_state": "INSTALLED",
+	    "installSteps": [{
+	      "scriptRun": {
+	        "script": "#! /bin/bash\nZONE=$(curl --silent http://metadata.google.internal/computeMetadata/v1/instance/zone -H Metadata-Flavor:Google | cut -d/ -f4 )\nexport SERVICE_PROXY_AGENT_DIRECTORY=$(mktemp -d)\nsudo gsutil cp   gs://gce-service-proxy-"$ZONE"/service-proxy-agent/releases/service-proxy-agent-0.2.tgz   "$SERVICE_PROXY_AGENT_DIRECTORY"   || sudo gsutil cp     gs://gce-service-proxy/service-proxy-agent/releases/service-proxy-agent-0.2.tgz     "$SERVICE_PROXY_AGENT_DIRECTORY"\nsudo tar -xzf "$SERVICE_PROXY_AGENT_DIRECTORY"/service-proxy-agent-0.2.tgz -C "$SERVICE_PROXY_AGENT_DIRECTORY"\n"$SERVICE_PROXY_AGENT_DIRECTORY"/service-proxy-agent/service-proxy-agent-bootstrap.sh"
+	      }
+	    }]
+	  }]
+	}
+    EOF
+    gce-service-proxy        = <<-EOF
+    {
+      "api-version": "0.2",
+      "proxy-spec": {
+        "proxy-port": 15001,
+        "network": "my-network",
+        "tracing": "ON",
+        "access-log": "/var/log/envoy/access.log"
+      }
+      "service": {
+        "serving-ports": [80, 81]
+      },
+     "labels": {
+       "app_name": "bookserver_app",
+       "app_version": "STABLE"
+      }
+    }
+    EOF
+    enable-guest-attributes = "true"
+    enable-osconfig         = "true"
+
+  }
+
+  service_account {
+  	email  = data.google_compute_default_service_account.default.email
+    scopes = ["cloud-platform"]
+  }
+
+  labels = {
+    gce-service-proxy = "on"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_spot(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = true
+    automatic_restart = false
+    provisioning_model = "SPOT"
+    instance_termination_action = "STOP"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_spot_maxRunDuration(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region      = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = true
+    automatic_restart = false
+    provisioning_model = "SPOT"
+    instance_termination_action = "DELETE"
+	<% unless version == 'ga' -%>
+    max_run_duration {
+	nanos = 123
+	seconds = 60
+    }
+<% end -%>
+
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+`, suffix)
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
@@ -240,7 +240,7 @@ func TestAccComputeRegionInstanceTemplate_basic(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -270,7 +270,7 @@ func TestAccComputeRegionInstanceTemplate_imageShorthand(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -296,7 +296,7 @@ func TestAccComputeRegionInstanceTemplate_preemptible(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -324,7 +324,7 @@ func TestAccComputeRegionInstanceTemplate_IP(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -351,7 +351,7 @@ func TestAccComputeRegionInstanceTemplate_IPv6(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -375,7 +375,7 @@ func TestAccComputeRegionInstanceTemplate_networkTier(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -398,7 +398,7 @@ func TestAccComputeRegionInstanceTemplate_networkIP(t *testing.T) {
 	networkIP := "10.128.0.2"
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -428,7 +428,7 @@ func TestAccComputeRegionInstanceTemplate_networkIPAddress(t *testing.T) {
 	ipAddress := "10.128.0.2"
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -455,7 +455,7 @@ func TestAccComputeRegionInstanceTemplate_disksInvalid(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -471,7 +471,7 @@ func TestAccComputeRegionInstanceTemplate_regionDisks(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -494,7 +494,7 @@ func TestAccComputeRegionInstanceTemplate_subnet_auto(t *testing.T) {
 	network := "tf-test-network-" + RandString(t, 10)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -521,7 +521,7 @@ func TestAccComputeRegionInstanceTemplate_subnet_custom(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -553,7 +553,7 @@ func TestAccComputeRegionInstanceTemplate_subnet_xpn(t *testing.T) {
 	projectName := fmt.Sprintf("tf-testxpn-%d", time.Now().Unix())
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -576,7 +576,7 @@ func TestAccComputeRegionInstanceTemplate_metadata_startup_script(t *testing.T) 
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -598,7 +598,7 @@ func TestAccComputeRegionInstanceTemplate_primaryAliasIpRange(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -624,7 +624,7 @@ func TestAccComputeRegionInstanceTemplate_secondaryAliasIpRange(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -650,7 +650,7 @@ func TestAccComputeRegionInstanceTemplate_guestAccelerator(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -677,7 +677,7 @@ func TestAccComputeRegionInstanceTemplate_guestAcceleratorSkip(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -699,7 +699,7 @@ func TestAccComputeRegionInstanceTemplate_minCpuPlatform(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -723,7 +723,7 @@ func TestAccComputeRegionInstanceTemplate_soleTenantNodeAffinities(t *testing.T)
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -746,7 +746,7 @@ func TestAccComputeRegionInstanceTemplate_instanceResourcePolicies(t *testing.T)
 	var policyName = "tf-test-policy-" + RandString(t, 10)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -773,7 +773,7 @@ func TestAccComputeRegionInstanceTemplate_reservationAffinities(t *testing.T) {
 	var templateName = RandString(t, 10)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -823,7 +823,7 @@ func TestAccComputeRegionInstanceTemplate_shieldedVmConfig1(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -849,7 +849,7 @@ func TestAccComputeRegionInstanceTemplate_shieldedVmConfig2(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -875,7 +875,7 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -896,7 +896,7 @@ func TestAccComputeRegionInstanceTemplate_AdvancedMachineFeatures(t *testing.T) 
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -915,7 +915,7 @@ func TestAccComputeRegionInstanceTemplate_enableDisplay(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -940,7 +940,7 @@ func TestAccComputeRegionInstanceTemplate_maintenance_interval(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -974,7 +974,7 @@ func TestAccComputeRegionInstanceTemplate_invalidDiskType(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -989,7 +989,7 @@ func TestAccComputeRegionInstanceTemplate_withScratchDisk(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -1009,7 +1009,7 @@ func TestAccComputeRegionInstanceTemplate_with18TbScratchDisk(t *testing.T) {
 	t.Parallel()
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -1035,7 +1035,7 @@ func TestAccComputeRegionInstanceTemplate_imageResourceTest(t *testing.T) {
 	imageDesc2 := "Some other description"
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -1068,7 +1068,7 @@ func TestAccComputeRegionInstanceTemplate_diskResourcePolicies(t *testing.T) {
 	policyName := "tf-test-policy-" + RandString(t, 10)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -1095,7 +1095,7 @@ func TestAccComputeRegionInstanceTemplate_nictype_update(t *testing.T) {
 	var instanceTemplateName = fmt.Sprintf("tf-test-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -1124,7 +1124,7 @@ func TestAccComputeRegionInstanceTemplate_queueCount(t *testing.T) {
 	var instanceTemplateName = fmt.Sprintf("tf-test-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -1145,7 +1145,7 @@ func TestAccComputeRegionInstanceTemplate_managedEnvoy(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -1170,7 +1170,7 @@ func TestAccComputeRegionInstanceTemplate_spot(t *testing.T) {
 
 	var instanceTemplate compute.InstanceTemplate
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -1204,7 +1204,7 @@ func TestAccComputeRegionInstanceTemplate_spot_maxRunDuration(t *testing.T) {
 	expectedMaxRunDuration.Seconds = 60
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories:    ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_instance_template_test.go.erb
@@ -1529,7 +1529,7 @@ func testAccCheckComputeRegionInstanceTemplateHasAliasIpRange(instanceTemplate *
 	return func(s *terraform.State) error {
 		for _, networkInterface := range instanceTemplate.Properties.NetworkInterfaces {
 			for _, aliasIpRange := range networkInterface.AliasIpRanges {
-				if aliasIpRange.SubnetworkRangeName == subnetworkRangeName && (aliasIpRange.IpCidrRange == iPCidrRange || ipCidrRangeDiffSuppress("ip_cidr_range", aliasIpRange.IpCidrRange, iPCidrRange, nil)) {
+				if aliasIpRange.SubnetworkRangeName == subnetworkRangeName && (aliasIpRange.IpCidrRange == iPCidrRange || IpCidrRangeDiffSuppress("ip_cidr_range", aliasIpRange.IpCidrRange, iPCidrRange, nil)) {
 					return nil
 				}
 			}

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -204,6 +204,9 @@ func Provider() *schema.Provider {
 			"google_compute_regions":                           DataSourceGoogleComputeRegions(),
 			"google_compute_region_network_endpoint_group":     DataSourceGoogleComputeRegionNetworkEndpointGroup(),
 			"google_compute_region_instance_group":             DataSourceGoogleComputeRegionInstanceGroup(),
+			<% unless version == 'ga' -%>	
+			"google_compute_region_instance_template":          DataSourceGoogleComputeRegionInstanceTemplate(),
+			<% end -%>
 			"google_compute_region_ssl_certificate":            DataSourceGoogleRegionComputeSslCertificate(),
 			"google_compute_resource_policy":                   DataSourceGoogleComputeResourcePolicy(),
 			"google_compute_router":                            DataSourceGoogleComputeRouter(),
@@ -393,6 +396,9 @@ end     # products.each do
 				"google_compute_project_metadata":              ResourceComputeProjectMetadata(),
 				"google_compute_project_metadata_item":         ResourceComputeProjectMetadataItem(),
 				"google_compute_region_instance_group_manager": ResourceComputeRegionInstanceGroupManager(),
+				<% unless version == 'ga' -%>	
+				"google_compute_region_instance_template":      ResourceComputeRegionInstanceTemplate(),
+				<% end -%>
 				"google_compute_router_interface":              ResourceComputeRouterInterface(),
 				"google_compute_security_policy":               ResourceComputeSecurityPolicy(),
 				"google_compute_shared_vpc_host_project":       ResourceComputeSharedVpcHostProject(),

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
@@ -1,0 +1,305 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  Get a VM instance template within GCE.
+---
+
+# google\_compute\_region\_instance\_template
+
+Get information about a VM instance template resource within GCE. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/instance-templates)
+and
+[API](https://cloud.google.com/compute/docs/reference/rest/v1/regionInstanceTemplates).
+
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+
+## Example Usage
+
+```hcl
+# by name
+data "google_compute_region_instance_template" "generic" {
+  name    = "generic-tpl-20200107"
+}
+
+# using a filter
+data "google_compute_region_instance_template" "generic-regex" {
+  filter      = "name != generic-tpl-20200107"
+  most_recent = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Optional) The name of the instance template. One of `name` or `filter` must be provided.
+
+- `filter` - (Optional) A filter to retrieve the instance templates.
+    See [gcloud topic filters](https://cloud.google.com/sdk/gcloud/reference/topic/filters) for reference.
+    If multiple instance templates match, either adjust the filter or specify `most_recent`. One of `name` or `filter` must be provided.
+
+- `most_recent` - (Optional) If `filter` is provided, ensures the most recent template is returned when multiple instance templates match. One of `name` or `filter` must be provided.
+
+---
+
+* `project` - (Optional) The ID of the project in which the resource belongs.
+    If `project` is not provided, the provider project is used.
+
+* `region` - (Optional) The Region in which the resource belongs.
+    If `region` is not provided, the provider region is used.
+
+## Attributes Reference
+
+* `disk` - Disks to attach to instances created from this template.
+    This can be specified multiple times for multiple disks. Structure is
+    [documented below](#nested_disk).
+
+* `machine_type` - The machine type to create.
+
+    To create a machine with a [custom type][custom-vm-types] (such as extended memory), format the value like `custom-VCPUS-MEM_IN_MB` like `custom-6-20480` for 6 vCPU and 20GB of RAM.
+
+* `name` - The name of the instance template. If you leave
+  this blank, Terraform will auto-generate a unique name.
+
+* `name_prefix` - Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
+
+* `can_ip_forward` - Whether to allow sending and receiving of
+    packets with non-matching source or destination IPs. This defaults to false.
+
+* `description` - A brief description of this resource.
+
+* `instance_description` - A brief description to use for instances
+    created from this template.
+
+* `labels` - A set of key/value label pairs to assign to instances
+    created from this template,
+
+* `metadata` - Metadata key/value pairs to make available from
+    within instances created from this template.
+
+* `metadata_startup_script` - An alternative to using the
+    startup-script metadata key, mostly to match the compute_instance resource.
+    This replaces the startup-script metadata key on the created instance and
+    thus the two mechanisms are not allowed to be used simultaneously.
+
+* `network_interface` - Networks to attach to instances created from
+    this template. This can be specified multiple times for multiple networks.
+    Structure is [documented below](#nested_network_interface).
+
+* `network_performance_config` - The network performance configuration setting
+    for the instance, if set. Structure is [documented below](#nested_network_performance_config).
+
+* `project` - The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `scheduling` - The scheduling strategy to use. More details about
+    this configuration option are detailed below.
+
+* `service_account` - Service account to attach to the instance. Structure is [documented below](#nested_service_account).
+
+* `tags` - Tags to attach to the instance.
+
+* `guest_accelerator` - List of the type and count of accelerator cards attached to the instance. Structure [documented below](#nested_guest_accelerator).
+
+* `min_cpu_platform` - Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as
+`Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
+
+* `shielded_instance_config` - Enable [Shielded VM](https://cloud.google.com/security/shielded-cloud/shielded-vm) on this instance. Shielded VM provides verifiable integrity to prevent against malware and rootkits. Defaults to disabled. Structure is [documented below](#nested_shielded_instance_config).
+	**Note**: [`shielded_instance_config`](#shielded_instance_config) can only be used with boot images with shielded vm support. See the complete list [here](https://cloud.google.com/compute/docs/images#shielded-images).
+
+* `enable_display` - Enable [Virtual Displays](https://cloud.google.com/compute/docs/instances/enable-instance-virtual-display#verify_display_driver) on this instance.
+**Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
+
+* `confidential_instance_config` - Enable [Confidential Mode](https://cloud.google.com/compute/confidential-vm/docs/about-cvm) on this VM. Structure is [documented below](#nested_confidential_instance_config)
+
+<a name="nested_disk"></a>The `disk` block supports:
+
+* `auto_delete` - Whether or not the disk should be auto-deleted.
+    This defaults to true.
+
+* `boot` - Indicates that this is a boot disk.
+
+* `device_name` - A unique device name that is reflected into the
+    /dev/  tree of a Linux operating system running within the instance. If not
+    specified, the server chooses a default device name to apply to this disk.
+
+* `disk_name` - Name of the disk. When not provided, this defaults
+    to the name of the instance.
+
+* `source_image` - The image from which to
+    initialize this disk. This can be one of: the image's `self_link`,
+    `projects/{project}/global/images/{image}`,
+    `projects/{project}/global/images/family/{family}`, `global/images/{image}`,
+    `global/images/family/{family}`, `family/{family}`, `{project}/{family}`,
+    `{project}/{image}`, `{family}`, or `{image}`.
+~> **Note:** Either `source` or `source_image` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `interface` - Specifies the disk interface to use for attaching this disk,
+    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI
+    and the request will fail if you attempt to attach a persistent disk in any other format
+    than SCSI. Local SSDs can use either NVME or SCSI.
+
+* `mode` - The mode in which to attach this disk, either READ_WRITE
+    or READ_ONLY. If you are attaching or creating a boot disk, this must
+    read-write mode.
+
+* `source` - The name (**not self_link**)
+    of the disk (such as those managed by `google_compute_disk`) to attach.
+~> **Note:** Either `source` or `source_image` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `disk_type` - The GCE disk type. Such as `"pd-ssd"`, `"local-ssd"`,
+    `"pd-balanced"` or `"pd-standard"`.
+
+* `disk_size_gb` - The size of the image in gigabytes. If not
+    specified, it will inherit the size of its base image. For SCRATCH disks,
+    the size must be exactly 375GB.
+
+* `labels` - (Optional) A set of ket/value label pairs to assign to disk created from
+    this template
+
+* `type` - The type of GCE disk, can be either `"SCRATCH"` or
+    `"PERSISTENT"`.
+
+* `disk_encryption_key` - Encrypts or decrypts a disk using a customer-supplied encryption key.
+
+    If you are creating a new disk, this field encrypts the new disk using an encryption key that you provide. If you are attaching an existing disk that is already encrypted, this field decrypts the disk using the customer-supplied encryption key.
+
+    If you encrypt a disk using a customer-supplied key, you must provide the same key again when you attempt to use this resource at a later time. For example, you must provide the key when you create a snapshot or an image from the disk or when you attach the disk to a virtual machine instance.
+
+    If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
+
+    Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
+
+* `resource_policies` (Optional) -- A list of short names of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
+
+The `disk_encryption_key` block supports:
+
+* `kms_key_self_link` - The self link of the encryption key that is stored in Google Cloud KMS
+
+<a name="nested_network_interface"></a>The `network_interface` block supports:
+
+* `network` - The name or self_link of the network to attach this interface to.
+    Use `network` attribute for Legacy or Auto subnetted networks and
+    `subnetwork` for custom subnetted networks.
+
+* `subnetwork` - the name of the subnetwork to attach this interface
+    to. The subnetwork must exist in the same `region` this instance will be
+    created in. Either `network` or `subnetwork` must be provided.
+
+* `subnetwork_project` - The ID of the project in which the subnetwork belongs.
+    If it is not provided, the provider project is used.
+
+* `network_ip` - The private IP address to assign to the instance. If
+    empty, the address will be automatically assigned.
+
+* `access_config` - Access configurations, i.e. IPs via which this
+    instance can be accessed via the Internet. Omit to ensure that the instance
+    is not accessible from the Internet (this means that ssh provisioners will
+    not work unless you are running Terraform can send traffic to the instance's
+    network (e.g. via tunnel or because it is running on another cloud instance
+    on that network). This block can be repeated multiple times. Structure [documented below](#nested_access_config).
+
+* `alias_ip_range` - An
+    array of alias IP ranges for this network interface. Can only be specified for network
+    interfaces on subnet-mode networks. Structure [documented below](#nested_alias_ip_range).
+
+<a name="nested_access_config"></a>The `access_config` block supports:
+
+* `nat_ip` - The IP address that will be 1:1 mapped to the instance's
+    network ip. If not given, one will be generated.
+
+* `network_tier` - The [networking tier][network-tier] used for configuring
+    this instance template. This field can take the following values: PREMIUM or
+    STANDARD. If this field is not specified, it is assumed to be PREMIUM.
+
+<a name="nested_alias_ip_range"></a>The `alias_ip_range` block supports:
+
+* `ip_cidr_range` - The IP CIDR range represented by this alias IP range. This IP CIDR range
+    must belong to the specified subnetwork and cannot contain IP addresses reserved by
+    system or used by other network interfaces. At the time of writing only a
+    netmask (e.g. /24) may be supplied, with a CIDR format resulting in an API
+    error.
+
+* `subnetwork_range_name` - The subnetwork secondary range name specifying
+    the secondary range from which to allocate the IP CIDR range for this alias IP
+    range. If left unspecified, the primary range of the subnetwork will be used.
+
+<a name="nested_service_account"></a>The `service_account` block supports:
+
+* `email` - The service account e-mail address. If not given, the
+    default Google Compute Engine service account is used.
+
+* `scopes` - A list of service scopes. Both OAuth2 URLs and gcloud
+    short names are supported. To allow full access to all Cloud APIs, use the
+    `cloud-platform` scope. See a complete list of scopes [here](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes).
+
+    The [service accounts documentation](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
+    explains that access scopes are the legacy method of specifying permissions for your instance.
+    If you are following best practices and using IAM roles to grant permissions to service accounts,
+    then you can define this field as an empty list.
+
+<a name="nested_scheduling"></a>The `scheduling` block supports:
+
+* `automatic_restart` - Specifies whether the instance should be
+    automatically restarted if it is terminated by Compute Engine (not
+    terminated by a user). This defaults to true.
+
+* `on_host_maintenance` - Defines the maintenance behavior for this
+    instance.
+
+* `preemptible` - Allows instance to be preempted. This defaults to
+    false. Read more on this
+    [here](https://cloud.google.com/compute/docs/instances/preemptible).
+
+* `node_affinities` - Specifies node affinities or anti-affinities
+   to determine which sole-tenant nodes your instances and managed instance
+   groups will use as host systems. Read more on sole-tenant node creation
+   [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
+   Structure [documented below](#nested_node_affinities).
+   
+* `provisioning_model` - Describe the type of preemptible VM. 
+
+* `instance_termination_action` - Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot) 
+
+<a name="nested_guest_accelerator"></a>The `guest_accelerator` block supports:
+
+* `type` - The accelerator type resource to expose to this instance. E.g. `nvidia-tesla-k80`.
+
+* `count` - The number of the guest accelerator cards exposed to this instance.
+
+<a name="nested_node_affinities"></a>The `node_affinities` block supports:
+
+* `key` - The key for the node affinity label.
+
+* `operator` - The operator. Can be `IN` for node-affinities
+    or `NOT_IN` for anti-affinities.
+
+* `value` - The values for the node affinity label.
+
+<a name="nested_shielded_instance_config"></a>The `shielded_instance_config` block supports:
+
+* `enable_secure_boot` -- Verify the digital signature of all boot components, and halt the boot process if signature verification fails. Defaults to false.
+
+* `enable_vtpm` -- Use a virtualized trusted platform module, which is a specialized computer chip you can use to encrypt objects like keys and certificates. Defaults to true.
+
+* `enable_integrity_monitoring` -- Compare the most recent boot measurements to the integrity policy baseline and return a pair of pass/fail results depending on whether they match or not. Defaults to true.
+
+<a name="nested_confidential_instance_config"></a>The `confidential_instance_config` block supports:
+
+* `enable_confidential_compute` Defines whether the instance should have confidential compute enabled. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+
+<a name="nested_network_performance_config"></a>The `network_performance_config` block supports:
+
+* `total_egress_bandwidth_tier` - The egress bandwidth tier for the instance.
+
+---
+
+* `id` - an identifier for the resource with format `projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}`
+
+* `metadata_fingerprint` - The unique fingerprint of the metadata.
+
+* `self_link` - The URI of the created resource.
+
+* `tags_fingerprint` - The unique fingerprint of the tags.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -1,0 +1,681 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  Manages a VM instance template resource within GCE.
+---
+
+# google\_compute\_region\_instance\_template
+
+Manages a VM instance template resource within GCE. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/instance-templates)
+and
+[API](https://cloud.google.com/compute/docs/reference/rest/v1/regionInstanceTemplates).
+
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+
+## Example Usage
+
+```hcl
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
+resource "google_compute_region_instance_template" "default" {
+  name        = "appserver-template"
+  description = "This template is used to create app server instances."
+
+  tags = ["foo", "bar"]
+
+  labels = {
+    environment = "dev"
+  }
+
+  instance_description = "description assigned to instances"
+  machine_type         = "e2-medium"
+  can_ip_forward       = false
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  // Create a new boot disk from an image
+  disk {
+    source_image      = "debian-cloud/debian-11"
+    auto_delete       = true
+    boot              = true
+    // backup the disk every day
+    resource_policies = [google_compute_resource_policy.daily_backup.id]
+  }
+
+  // Use an existing disk resource
+  disk {
+    source      = google_compute_region_disk.foobar.self_link
+    auto_delete = false
+    boot        = false
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    email  = google_service_account.default.email
+    scopes = ["cloud-platform"]
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_disk" "foobar" {
+  name  = "existing-disk"
+  snapshot                  = google_compute_snapshot.snap_disk.id
+  type                      = "pd-ssd"
+  region                    = "us-central1"
+  physical_block_size_bytes = 4096
+ 
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "foo"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+ 
+resource "google_compute_snapshot" "snap_disk" {
+  name        = "snapDisk"
+  source_disk = google_compute_disk.disk.name
+  zone        = "us-central1-a"
+}
+
+resource "google_compute_resource_policy" "daily_backup" {
+  name   = "every-day-4am"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "04:00"
+      }
+    }
+  }
+}
+```
+
+## Example Usage - Automatic Envoy deployment
+
+```hcl
+data "google_compute_default_service_account" "default" {
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "appserver-template"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+  }
+
+  metadata = {
+    gce-software-declaration = <<-EOF
+    {
+      "softwareRecipes": [{
+        "name": "install-gce-service-proxy-agent",
+        "desired_state": "INSTALLED",
+        "installSteps": [{
+          "scriptRun": {
+            "script": "#! /bin/bash\nZONE=$(curl --silent http://metadata.google.internal/computeMetadata/v1/instance/zone -H Metadata-Flavor:Google | cut -d/ -f4 )\nexport SERVICE_PROXY_AGENT_DIRECTORY=$(mktemp -d)\nsudo gsutil cp   gs://gce-service-proxy-"$ZONE"/service-proxy-agent/releases/service-proxy-agent-0.2.tgz   "$SERVICE_PROXY_AGENT_DIRECTORY"   || sudo gsutil cp     gs://gce-service-proxy/service-proxy-agent/releases/service-proxy-agent-0.2.tgz     "$SERVICE_PROXY_AGENT_DIRECTORY"\nsudo tar -xzf "$SERVICE_PROXY_AGENT_DIRECTORY"/service-proxy-agent-0.2.tgz -C "$SERVICE_PROXY_AGENT_DIRECTORY"\n"$SERVICE_PROXY_AGENT_DIRECTORY"/service-proxy-agent/service-proxy-agent-bootstrap.sh"
+          }
+        }]
+      }]
+    }
+    EOF
+    gce-service-proxy        = <<-EOF
+    {
+      "api-version": "0.2",
+      "proxy-spec": {
+        "proxy-port": 15001,
+        "network": "my-network",
+        "tracing": "ON",
+        "access-log": "/var/log/envoy/access.log"
+      }
+      "service": {
+        "serving-ports": [80, 81]
+      },
+     "labels": {
+       "app_name": "bookserver_app",
+       "app_version": "STABLE"
+      }
+    }
+    EOF
+    enable-guest-attributes = "true"
+    enable-osconfig         = "true"
+
+  }
+
+  service_account {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["cloud-platform"]
+  }
+
+  labels = {
+    gce-service-proxy = "on"
+  }
+}
+```
+
+## Using with Instance Group Manager
+
+Instance Templates cannot be updated after creation with the Google
+Cloud Platform API. In order to update an Instance Template, Terraform will
+destroy the existing resource and create a replacement. In order to effectively
+use an Instance Template resource with an [Instance Group Manager resource][1],
+it's recommended to specify `create_before_destroy` in a [lifecycle][2] block.
+Either omit the Instance Template `name` attribute, or specify a partial name
+with `name_prefix`.  Example:
+
+```hcl
+resource "google_compute_region_instance_template" "instance_template" {
+  name_prefix  = "instance-template-"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  // boot disk
+  disk {
+    # ...
+  }
+
+  // networking
+  network_interface {
+    # ...
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "instance_group_manager" {
+  name               = "instance-group-manager"
+  instance_template  = google_compute_region_instance_template.instance_template.id
+  base_instance_name = "instance-group-manager"
+  zone               = "us-central1-f"
+  target_size        = "1"
+}
+```
+
+With this setup Terraform generates a unique name for your Instance
+Template and can then update the Instance Group manager without conflict before
+destroying the previous Instance Template.
+
+## Deploying the Latest Image
+
+A common way to use instance templates and managed instance groups is to deploy the
+latest image in a family, usually the latest build of your application. There are two
+ways to do this in Terraform, and they have their pros and cons. The difference ends
+up being in how "latest" is interpreted. You can either deploy the latest image available
+when Terraform runs, or you can have each instance check what the latest image is when
+it's being created, either as part of a scaling event or being rebuilt by the instance
+group manager.
+
+If you're not sure, we recommend deploying the latest image available when Terraform runs,
+because this means all the instances in your group will be based on the same image, always,
+and means that no upgrades or changes to your instances happen outside of a `terraform apply`.
+You can achieve this by using the [`google_compute_image`](../d/compute_image.html)
+data source, which will retrieve the latest image on every `terraform apply`, and will update
+the template to use that specific image:
+
+```tf
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "instance_template" {
+  name_prefix  = "instance-template-"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  // boot disk
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+}
+```
+
+To have instances update to the latest on every scaling event or instance re-creation,
+use the family as the image for the disk, and it will use GCP's default behavior, setting
+the image for the template to the family:
+
+```tf
+resource "google_compute_region_instance_template" "instance_template" {
+  name_prefix  = "instance-template-"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  // boot disk
+  disk {
+    source_image = "debian-cloud/debian-11"
+  }
+}
+```
+
+## Argument Reference
+
+Note that changing any field for this resource forces a new resource to be created.
+
+The following arguments are supported:
+
+* `disk` - (Required) Disks to attach to instances created from this template.
+    This can be specified multiple times for multiple disks. Structure is
+    [documented below](#nested_disk).
+
+* `machine_type` - (Required) The machine type to create.
+
+    To create a machine with a [custom type][custom-vm-types] (such as extended memory), format the value like `custom-VCPUS-MEM_IN_MB` like `custom-6-20480` for 6 vCPU and 20GB of RAM.
+
+- - -
+* `name` - (Optional) The name of the instance template. If you leave
+  this blank, Terraform will auto-generate a unique name.
+
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
+
+* `can_ip_forward` - (Optional) Whether to allow sending and receiving of
+    packets with non-matching source or destination IPs. This defaults to false.
+
+* `description` - (Optional) A brief description of this resource.
+
+* `instance_description` - (Optional) A brief description to use for instances
+    created from this template.
+
+* `labels` - (Optional) A set of key/value label pairs to assign to instances
+    created from this template.
+
+* `metadata` - (Optional) Metadata key/value pairs to make available from
+    within instances created from this template.
+
+* `metadata_startup_script` - (Optional) An alternative to using the
+    startup-script metadata key, mostly to match the compute_instance resource.
+    This replaces the startup-script metadata key on the created instance and
+    thus the two mechanisms are not allowed to be used simultaneously.
+
+* `network_interface` - (Required) Networks to attach to instances created from
+    this template. This can be specified multiple times for multiple networks.
+    Structure is [documented below](#nested_network_interface).
+
+* `network_performance_config` (Optional)
+    Configures network performance settings for the instance created from the
+    template. Structure is [documented below](#nested_network_performance_config). **Note**: [`machine_type`](#machine_type)
+    must be a [supported type](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration),
+    the [`image`](#image) used must include the [`GVNIC`](https://cloud.google.com/compute/docs/networking/using-gvnic#create-instance-gvnic-image)
+    in `guest-os-features`, and `network_interface.0.nic-type` must be `GVNIC`
+    in order for this setting to take effect.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The Region in which the resource belongs.
+    If region is not provided, the provider region is used.
+
+* `resource_policies` (Optional) -- A list of self_links of resource policies to attach to the instance. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.
+
+* `reservation_affinity` - (Optional) Specifies the reservations that this instance can consume from.
+    Structure is [documented below](#nested_reservation_affinity).
+
+* `scheduling` - (Optional) The scheduling strategy to use. More details about
+    this configuration option are [detailed below](#nested_scheduling).
+
+* `service_account` - (Optional) Service account to attach to the instance. Structure is [documented below](#nested_service_account).
+
+* `tags` - (Optional) Tags to attach to the instance.
+
+* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure [documented below](#nested_guest_accelerator).
+
+* `min_cpu_platform` - (Optional) Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as
+`Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
+
+* `shielded_instance_config` - (Optional) Enable [Shielded VM](https://cloud.google.com/security/shielded-cloud/shielded-vm) on this instance. Shielded VM provides verifiable integrity to prevent against malware and rootkits. Defaults to disabled. Structure is [documented below](#nested_shielded_instance_config).
+	**Note**: [`shielded_instance_config`](#shielded_instance_config) can only be used with boot images with shielded vm support. See the complete list [here](https://cloud.google.com/compute/docs/images#shielded-images).
+
+* `enable_display` - (Optional, ) Enable [Virtual Displays](https://cloud.google.com/compute/docs/instances/enable-instance-virtual-display#verify_display_driver) on this instance.
+**Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
+
+* `confidential_instance_config` (Optional) - Enable [Confidential Mode](https://cloud.google.com/compute/confidential-vm/docs/about-cvm) on this VM. Structure is [documented below](#nested_confidential_instance_config)
+
+* `advanced_machine_features` (Optional) - Configure Nested Virtualisation and Simultaneous Hyper Threading on this VM. Structure is [documented below](#nested_advanced_machine_features)
+
+<a name="nested_disk"></a>The `disk` block supports:
+
+* `auto_delete` - (Optional) Whether or not the disk should be auto-deleted.
+    This defaults to true.
+
+* `boot` - (Optional) Indicates that this is a boot disk.
+
+* `device_name` - (Optional) A unique device name that is reflected into the
+    /dev/  tree of a Linux operating system running within the instance. If not
+    specified, the server chooses a default device name to apply to this disk.
+
+* `disk_name` - (Optional) Name of the disk. When not provided, this defaults
+    to the name of the instance.
+
+* `source_image` - (Optional) The image from which to
+    initialize this disk. This can be one of: the image's `self_link`,
+    `projects/{project}/global/images/{image}`,
+    `projects/{project}/global/images/family/{family}`, `global/images/{image}`,
+    `global/images/family/{family}`, `family/{family}`, `{project}/{family}`,
+    `{project}/{image}`, `{family}`, or `{image}`.
+~> **Note:** Either `source`, `source_image`, or `source_snapshot` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `source_image_encryption_key` - (Optional) The customer-supplied encryption
+    key of the source image. Required if the source image is protected by a
+    customer-supplied encryption key.
+
+    Instance templates do not store customer-supplied encryption keys, so you
+    cannot create disks for instances in a managed instance group if the source
+    images are encrypted with your own keys. Structure
+    [documented below](#nested_source_image_encryption_key).
+
+* `source_snapshot` - (Optional) The source snapshot to create this disk.
+~> **Note:** Either `source`, `source_image`, or `source_snapshot` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `source_snapshot_encryption_key` - (Optional) The customer-supplied encryption
+    key of the source snapshot. Structure
+    [documented below](#nested_source_snapshot_encryption_key).
+
+* `interface` - (Optional) Specifies the disk interface to use for attaching this disk,
+    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI
+    and the request will fail if you attempt to attach a persistent disk in any other format
+    than SCSI. Local SSDs can use either NVME or SCSI.
+
+* `mode` - (Optional) The mode in which to attach this disk, either READ_WRITE
+    or READ_ONLY. If you are attaching or creating a boot disk, this must
+    read-write mode.
+
+* `source` - (Optional) The name (**not self_link**)
+    of the disk (such as those managed by `google_compute_disk`) to attach.
+~> **Note:** Either `source`, `source_image`, or `source_snapshot` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
+
+* `disk_type` - (Optional) The GCE disk type. Such as `"pd-ssd"`, `"local-ssd"`,
+    `"pd-balanced"` or `"pd-standard"`.
+
+* `disk_size_gb` - (Optional) The size of the image in gigabytes. If not
+    specified, it will inherit the size of its base image. For SCRATCH disks,
+    the size must be exactly 375GB.
+
+* `labels` - (Optional) A set of ket/value label pairs to assign to disk created from
+    this template
+
+* `type` - (Optional) The type of GCE disk, can be either `"SCRATCH"` or
+    `"PERSISTENT"`.
+
+* `disk_encryption_key` - (Optional) Encrypts or decrypts a disk using a customer-supplied encryption key.
+
+    If you are creating a new disk, this field encrypts the new disk using an encryption key that you provide. If you are attaching an existing disk that is already encrypted, this field decrypts the disk using the customer-supplied encryption key.
+
+    If you encrypt a disk using a customer-supplied key, you must provide the same key again when you attempt to use this resource at a later time. For example, you must provide the key when you create a snapshot or an image from the disk or when you attach the disk to a virtual machine instance.
+
+    If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
+
+    Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group. Structure [documented below](#nested_access_config).
+
+* `resource_policies` (Optional) -- A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
+
+<a name="nested_source_image_encryption_key"></a>The `source_image_encryption_key` block supports:
+
+* `kms_key_service_account` - (Optional) The service account being used for the
+    encryption request for the given KMS key. If absent, the Compute Engine
+    default service account is used.
+
+* `kms_key_self_link` - (Required) The self link of the encryption key that is
+    stored in Google Cloud KMS.
+
+<a name="nested_source_snapshot_encryption_key"></a>The `source_snapshot_encryption_key` block supports:
+
+* `kms_key_service_account` - (Optional) The service account being used for the
+    encryption request for the given KMS key. If absent, the Compute Engine
+    default service account is used.
+
+* `kms_key_self_link` - (Required) The self link of the encryption key that is
+    stored in Google Cloud KMS.
+
+<a name="nested_disk_encryption_key"></a>The `disk_encryption_key` block supports:
+
+* `kms_key_self_link` - (Required) The self link of the encryption key that is stored in Google Cloud KMS
+
+<a name="nested_network_interface"></a>The `network_interface` block supports:
+
+* `network` - (Optional) The name or self_link of the network to attach this interface to.
+    Use `network` attribute for Legacy or Auto subnetted networks and
+    `subnetwork` for custom subnetted networks.
+
+* `subnetwork` - (Optional) the name of the subnetwork to attach this interface
+    to. The subnetwork must exist in the same `region` this instance will be
+    created in. Either `network` or `subnetwork` must be provided.
+
+* `subnetwork_project` - (Optional) The ID of the project in which the subnetwork belongs.
+    If it is not provided, the provider project is used.
+
+* `network_ip` - (Optional) The private IP address to assign to the instance. If
+    empty, the address will be automatically assigned.
+
+* `access_config` - (Optional) Access configurations, i.e. IPs via which this
+    instance can be accessed via the Internet. Omit to ensure that the instance
+    is not accessible from the Internet (this means that ssh provisioners will
+    not work unless you are running Terraform can send traffic to the instance's
+    network (e.g. via tunnel or because it is running on another cloud instance
+    on that network). This block can be repeated multiple times. Structure [documented below](#nested_access_config).
+
+* `alias_ip_range` - (Optional) An
+    array of alias IP ranges for this network interface. Can only be specified for network
+    interfaces on subnet-mode networks. Structure [documented below](#nested_alias_ip_range).
+
+* `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET.
+
+* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
+
+* `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.
+Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig
+specified, then this instance will have no external IPv6 Internet access. Structure [documented below](#nested_ipv6_access_config).
+
+* `queue_count` - (Optional) The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It will be empty if not specified.
+
+<a name="nested_access_config"></a>The `access_config` block supports:
+
+* `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
+    network ip. If not given, one will be generated.
+
+* `network_tier` - (Optional) The [networking tier][network-tier] used for configuring
+    this instance template. This field can take the following values: PREMIUM,
+    STANDARD or FIXED_STANDARD. If this field is not specified, it is assumed to be PREMIUM.
+
+<a name="nested_ipv6_access_config"></a>The `ipv6_access_config` block supports:
+
+* `network_tier` - (Optional) The service-level to be provided for IPv6 traffic when the
+    subnet has an external subnet. Only PREMIUM and STANDARD tier is valid for IPv6.
+
+<a name="nested_alias_ip_range"></a>The `alias_ip_range` block supports:
+
+* `ip_cidr_range` - The IP CIDR range represented by this alias IP range. This IP CIDR range
+    must belong to the specified subnetwork and cannot contain IP addresses reserved by
+    system or used by other network interfaces. At the time of writing only a
+    netmask (e.g. /24) may be supplied, with a CIDR format resulting in an API
+    error.
+
+* `subnetwork_range_name` - (Optional) The subnetwork secondary range name specifying
+    the secondary range from which to allocate the IP CIDR range for this alias IP
+    range. If left unspecified, the primary range of the subnetwork will be used.
+
+<a name="nested_service_account"></a>The `service_account` block supports:
+
+* `email` - (Optional) The service account e-mail address. If not given, the
+    default Google Compute Engine service account is used.
+
+* `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
+    short names are supported. To allow full access to all Cloud APIs, use the
+    `cloud-platform` scope. See a complete list of scopes [here](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes).
+
+    The [service accounts documentation](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
+    explains that access scopes are the legacy method of specifying permissions for your instance.
+    If you are following best practices and using IAM roles to grant permissions to service accounts,
+    then you can define this field as an empty list.
+
+<a name="nested_scheduling"></a>The `scheduling` block supports:
+
+* `automatic_restart` - (Optional) Specifies whether the instance should be
+    automatically restarted if it is terminated by Compute Engine (not
+    terminated by a user). This defaults to true.
+
+* `on_host_maintenance` - (Optional) Defines the maintenance behavior for this
+    instance.
+
+* `preemptible` - (Optional) Allows instance to be preempted. This defaults to
+    false. Read more on this
+    [here](https://cloud.google.com/compute/docs/instances/preemptible).
+
+* `node_affinities` - (Optional) Specifies node affinities or anti-affinities
+   to determine which sole-tenant nodes your instances and managed instance
+   groups will use as host systems. Read more on sole-tenant node creation
+   [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
+   Structure [documented below](#nested_node_affinities).
+   
+* `provisioning_model` - (Optional) Describe the type of preemptible VM. This field accepts the value `STANDARD` or `SPOT`. If the value is `STANDARD`, there will be no discount. If this   is set to `SPOT`, 
+    `preemptible` should be `true` and `auto_restart` should be
+    `false`. For more info about
+    `SPOT`, read [here](https://cloud.google.com/compute/docs/instances/spot)
+    
+* `instance_termination_action` - (Optional) Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot) 
+
+* `max_run_duration` -  (Optional)  The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Only support `DELETE` `instance_termination_action` at this point. Structure is [documented below](#nested_max_run_duration).
+    
+<a name="nested_max_run_duration"></a>The `max_run_duration` block supports:
+
+* `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond
+	resolution. Durations less than one second are represented with a 0
+	`seconds` field and a positive `nanos` field. Must be from 0 to
+	 999,999,999 inclusive.
+
+* `seconds` - (Required) Span of time at a resolution of a second. Must be from 0 to
+   315,576,000,000 inclusive. Note: these bounds are computed from: 60
+   sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years.
+
+* `maintenance_interval` - (Optional)  Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.   
+<a name="nested_guest_accelerator"></a>The `guest_accelerator` block supports:
+
+* `type` (Required) - The accelerator type resource to expose to this instance. E.g. `nvidia-tesla-k80`.
+
+* `count` (Required) - The number of the guest accelerator cards exposed to this instance.
+
+<a name="nested_node_affinities"></a>The `node_affinities` block supports:
+
+* `key` (Required) - The key for the node affinity label.
+
+* `operator` (Required) - The operator. Can be `IN` for node-affinities
+    or `NOT_IN` for anti-affinities.
+
+* `value` (Required) - The values for the node affinity label.
+
+<a name="nested_reservation_affinity"></a>The `reservation_affinity` block supports:
+
+* `type` - (Required) The type of reservation from which this instance can consume resources.
+
+* `specific_reservation` - (Optional) Specifies the label selector for the reservation to use..
+    Structure is documented below.
+
+The `specific_reservation` block supports:
+
+* `key` - (Required) Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify compute.googleapis.com/reservation-name as the key and specify the name of your reservation as the only value.
+
+* `values` - (Required) Corresponds to the label values of a reservation resource.
+
+<a name="nested_shielded_instance_config"></a>The `shielded_instance_config` block supports:
+
+* `enable_secure_boot` (Optional) -- Verify the digital signature of all boot components, and halt the boot process if signature verification fails. Defaults to false.
+
+* `enable_vtpm` (Optional) -- Use a virtualized trusted platform module, which is a specialized computer chip you can use to encrypt objects like keys and certificates. Defaults to true.
+
+* `enable_integrity_monitoring` (Optional) -- Compare the most recent boot measurements to the integrity policy baseline and return a pair of pass/fail results depending on whether they match or not. Defaults to true.
+
+<a name="nested_confidential_instance_config"></a>The `confidential_instance_config` block supports:
+
+* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+
+<a name="nested_network_performance_config"></a>The `network_performance_config` block supports:
+
+* `total_egress_bandwidth_tier` - (Optional) The egress bandwidth tier to enable. Possible values: TIER_1, DEFAULT
+
+<a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
+
+* `enable_nested_virtualization` (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance) enabled. Defaults to false.
+
+* `threads_per_core` (Optional) The number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
+
+* `visible_core_count` (Optional, ) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}`
+
+* `metadata_fingerprint` - The unique fingerprint of the metadata.
+
+* `self_link` - The URI of the created resource.
+
+* `tags_fingerprint` - The unique fingerprint of the tags.
+
+[1]: /docs/providers/google/r/compute_instance_group_manager.html
+[2]: /docs/language/meta-arguments/lifecycle.html
+
+## Timeouts
+
+This resource provides the following
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
+
+- `create` - Default is 4 minutes.
+- `delete` - Default is 4 minutes.
+
+## Import
+
+Instance templates can be imported using any of these accepted formats:
+
+```
+$ terraform import google_compute_region_instance_template.default projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}
+$ terraform import google_compute_region_instance_template.default {{project}}/{{name}}
+$ terraform import google_compute_region_instance_template.default {{name}}
+```
+
+[custom-vm-types]: https://cloud.google.com/dataproc/docs/concepts/compute/custom-machine-types
+[network-tier]: https://cloud.google.com/network-tiers/docs/overview


### PR DESCRIPTION
Note: Resubmit the changes for RIT resource and ds, the original changes are reverted in [PR](https://github.com/GoogleCloudPlatform/magic-modules/commit/11f9ba6c6165242c92b77d79e52b66d51b70298d) due to breaking changes in API. This PR wraps previous changes in the beta guard and this time we are going to release to beta provider.

Background

Regional Instance Template (later: RIT) is a new regional resource, implementing the functionality of [Instance Templates](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates) existing before only in the global scope. More details can be found: [go/rit-support-in-terraform](https://goto.google.com/rit-support-in-terraform).

There is already a handwritten global scope [google_compute_instance_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) Terraform resource and as we implement the new RIT resource, we want to give customers a smooth migration experience from GIT to RIT, the decision is to hand write RIT as GIT to keep the resource representation consistent. More info can be found: [go/rit-resource-inconsistency](https://goto.google.com/rit-resource-inconsistency)

Changes include:

1. Add Region Instance Template datasource, acceptance tests and document.
2. Add Region Instance Template resource, acceptance tests and document.
3. Modify existing google_compute_instance_from_template resource to consume RIT as source instance template.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_region_instance_template`
```
```release-note:new-datasource
`google_compute_region_instance_template`
```
```release-note:enhancement
compute: supported region instance template in`source_instance_template` field of `google_compute_instance_from_template` resource
```