### PR TITLE
Rework batching

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_dns_keys.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_keys.go
@@ -351,23 +351,3 @@ func generateDSRecord(signingKey *dns.DnsKey) (string, error) {
 		digestType,
 		signingKey.Digests[0].Digest), nil
 }
-
-func getDnsKeyAttrs(keyType string) map[string]attr.Type {
-	dnsKeyAttrs := map[string]attr.Type{
-		"algorithm":     types.StringType,
-		"creation_time": types.StringType,
-		"description":   types.StringType,
-		"id":            types.StringType,
-		"is_active":     types.BoolType,
-		"key_length":    types.Int64Type,
-		"key_tag":       types.Int64Type,
-		"public_key":    types.StringType,
-		"digests":       types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(digestAttrTypes)),
-	}
-
-	if keyType == "keySigning" {
-		dnsKeyAttrs["ds_record"] = types.StringType
-	}
-
-	return dnsKeyAttrs
-}

--- a/mmv1/third_party/terraform/framework_models/provider_model.go.erb
+++ b/mmv1/third_party/terraform/framework_models/provider_model.go.erb
@@ -16,7 +16,7 @@ type ProviderModel struct {
 	Region                             types.String `tfsdk:"region"`
 	Zone                               types.String `tfsdk:"zone"`
 	Scopes                             types.List   `tfsdk:"scopes"`
-	Batching                           types.Object `tfsdk:"batching"`
+	Batching                           types.List   `tfsdk:"batching"`
 	UserProjectOverride                types.Bool   `tfsdk:"user_project_override"`
 	RequestTimeout                     types.String `tfsdk:"request_timeout"`
 	RequestReason                      types.String `tfsdk:"request_reason"`

--- a/mmv1/third_party/terraform/framework_models/provider_model.go.erb
+++ b/mmv1/third_party/terraform/framework_models/provider_model.go.erb
@@ -2,7 +2,6 @@
 package google
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -17,7 +16,7 @@ type ProviderModel struct {
 	Region                             types.String `tfsdk:"region"`
 	Zone                               types.String `tfsdk:"zone"`
 	Scopes                             types.List   `tfsdk:"scopes"`
-	Batching                           types.List   `tfsdk:"batching"`
+	Batching                           types.Object `tfsdk:"batching"`
 	UserProjectOverride                types.Bool   `tfsdk:"user_project_override"`
 	RequestTimeout                     types.String `tfsdk:"request_timeout"`
 	RequestReason                      types.String `tfsdk:"request_reason"`
@@ -67,11 +66,6 @@ type ProviderModel struct {
 	// internal definition is removed.
 	RunCustomEndpoint                  types.String `tfsdk:"run_custom_endpoint"`
 <% end -%>
-}
-
-var ProviderBatchingAttributes = map[string]attr.Type{
-	"send_after":      types.StringType,
-	"enable_batching": types.BoolType,
 }
 
 // ProviderMetaModel describes the provider meta model

--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -153,23 +153,25 @@ func (p *frameworkProvider) HandleDefaults(ctx context.Context, data *ProviderMo
 		}
 	}
 
-	if !data.Batching.IsNull() {
-		var pbConfigs []transport_tpg.ProviderBatching
-		d := data.Batching.ElementsAs(ctx, &pbConfigs, true)
-		diags.Append(d...)
-		if diags.HasError() {
-			return
-		}
+	var pbConfig transport_tpg.ProviderBatching
+	d := data.Batching.As(ctx, &pbConfig, unhandledAsEmpty)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
 
-		if pbConfigs[0].SendAfter.IsNull() {
-			pbConfigs[0].SendAfter = types.StringValue("10s")
-		}
+	if pbConfig.SendAfter.IsNull() {
+		pbConfig.SendAfter = types.StringValue("10s")
+	}
 
-		if pbConfigs[0].EnableBatching.IsNull() {
-			pbConfigs[0].EnableBatching = types.BoolValue(true)
-		}
+	if pbConfig.EnableBatching.IsNull() {
+		pbConfig.EnableBatching = types.BoolValue(true)
+	}
 
-		data.Batching, d = types.ListValueFrom(ctx, types.ObjectType{}.WithAttributeTypes(ProviderBatchingAttributes), pbConfigs)
+	data.Batching, d = types.ObjectValueFrom(ctx, data.Batching.AttributeTypes(ctx), pbConfig)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
 	}
 
 	if data.UserProjectOverride.IsNull() && os.Getenv("USER_PROJECT_OVERRIDE") != "" {
@@ -635,4 +637,40 @@ func GetCredentials(ctx context.Context, data ProviderModel, initialCredentialsO
 	return googleoauth.Credentials{
 		TokenSource: defaultTS,
 	}
+}
+
+// GetBatchingConfig returns the batching config object given the
+// provider configuration set for batching
+func GetBatchingConfig(ctx context.Context, data types.Object, diags *diag.Diagnostics) *batchingConfig {
+	bc := &batchingConfig{
+		SendAfter:      time.Second * DefaultBatchSendIntervalSec,
+		EnableBatching: true,
+	}
+
+	if data.IsNull() {
+		return bc
+	}
+
+	var pbConfig transport_tpg.ProviderBatching
+	d := data.As(ctx, &pbConfig, unhandledAsEmpty)
+	diags.Append(d...)
+	if diags.HasError() {
+		return bc
+	}
+
+	if !pbConfig.SendAfter.IsNull() {
+		sendAfter, err := time.ParseDuration(pbConfig.SendAfter.ValueString())
+		if err != nil {
+			diags.AddError("error parsing send after time duration", err.Error())
+			return bc
+		}
+
+		bc.SendAfter = sendAfter
+	}
+
+	if !pbConfig.EnableBatching.IsNull() {
+		bc.EnableBatching = pbConfig.EnableBatching.ValueBool()
+	}
+
+	return bc
 }

--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -153,25 +153,27 @@ func (p *frameworkProvider) HandleDefaults(ctx context.Context, data *ProviderMo
 		}
 	}
 
-	var pbConfig transport_tpg.ProviderBatching
-	d := data.Batching.As(ctx, &pbConfig, unhandledAsEmpty)
-	diags.Append(d...)
-	if diags.HasError() {
-		return
-	}
+	if !data.Batching.IsNull() {
+		var pbConfig transport_tpg.ProviderBatching
+		d := data.Batching.As(ctx, &pbConfig, unhandledAsEmpty)
+		diags.Append(d...)
+		if diags.HasError() {
+			return
+		}
 
-	if pbConfig.SendAfter.IsNull() {
-		pbConfig.SendAfter = types.StringValue("10s")
-	}
+		if pbConfig.SendAfter.IsNull() {
+			pbConfig.SendAfter = types.StringValue("10s")
+		}
 
-	if pbConfig.EnableBatching.IsNull() {
-		pbConfig.EnableBatching = types.BoolValue(true)
-	}
+		if pbConfig.EnableBatching.IsNull() {
+			pbConfig.EnableBatching = types.BoolValue(true)
+		}
 
-	data.Batching, d = types.ObjectValueFrom(ctx, data.Batching.AttributeTypes(ctx), pbConfig)
-	diags.Append(d...)
-	if diags.HasError() {
-		return
+		data.Batching, d = types.ObjectValueFrom(ctx, data.Batching.AttributeTypes(ctx), pbConfig)
+		diags.Append(d...)
+		if diags.HasError() {
+			return
+		}
 	}
 
 	if data.UserProjectOverride.IsNull() && os.Getenv("USER_PROJECT_OVERRIDE") != "" {

--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -154,22 +154,22 @@ func (p *frameworkProvider) HandleDefaults(ctx context.Context, data *ProviderMo
 	}
 
 	if !data.Batching.IsNull() {
-		var pbConfig transport_tpg.ProviderBatching
-		d := data.Batching.As(ctx, &pbConfig, unhandledAsEmpty)
+		var pbConfigs []transport_tpg.ProviderBatching
+		d := data.Batching.ElementsAs(ctx, &pbConfigs, true)
 		diags.Append(d...)
 		if diags.HasError() {
 			return
 		}
 
-		if pbConfig.SendAfter.IsNull() {
-			pbConfig.SendAfter = types.StringValue("10s")
+		if pbConfigs[0].SendAfter.IsNull() {
+			pbConfigs[0].SendAfter = types.StringValue("10s")
 		}
 
-		if pbConfig.EnableBatching.IsNull() {
-			pbConfig.EnableBatching = types.BoolValue(true)
+		if pbConfigs[0].EnableBatching.IsNull() {
+			pbConfigs[0].EnableBatching = types.BoolValue(true)
 		}
 
-		data.Batching, d = types.ObjectValueFrom(ctx, data.Batching.AttributeTypes(ctx), pbConfig)
+		data.Batching, d = types.ListValueFrom(ctx, data.Batching.ElementType(ctx), pbConfigs)
 		diags.Append(d...)
 		if diags.HasError() {
 			return
@@ -639,40 +639,4 @@ func GetCredentials(ctx context.Context, data ProviderModel, initialCredentialsO
 	return googleoauth.Credentials{
 		TokenSource: defaultTS,
 	}
-}
-
-// GetBatchingConfig returns the batching config object given the
-// provider configuration set for batching
-func GetBatchingConfig(ctx context.Context, data types.Object, diags *diag.Diagnostics) *batchingConfig {
-	bc := &batchingConfig{
-		SendAfter:      time.Second * DefaultBatchSendIntervalSec,
-		EnableBatching: true,
-	}
-
-	if data.IsNull() {
-		return bc
-	}
-
-	var pbConfig transport_tpg.ProviderBatching
-	d := data.As(ctx, &pbConfig, unhandledAsEmpty)
-	diags.Append(d...)
-	if diags.HasError() {
-		return bc
-	}
-
-	if !pbConfig.SendAfter.IsNull() {
-		sendAfter, err := time.ParseDuration(pbConfig.SendAfter.ValueString())
-		if err != nil {
-			diags.AddError("error parsing send after time duration", err.Error())
-			return bc
-		}
-
-		bc.SendAfter = sendAfter
-	}
-
-	if !pbConfig.EnableBatching.IsNull() {
-		bc.EnableBatching = pbConfig.EnableBatching.ValueBool()
-	}
-
-	return bc
 }

--- a/mmv1/third_party/terraform/framework_utils/framework_utils.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils.go
@@ -18,8 +18,8 @@ import (
 const uaEnvVar = "TF_APPEND_USER_AGENT"
 
 var (
-	unhandledAsEmpty = basetypes.ObjectAsOptions {
-		UnhandledNullAsEmpty: true,
+	unhandledAsEmpty = basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
 		UnhandledUnknownAsEmpty: true,
 	}
 )

--- a/mmv1/third_party/terraform/framework_utils/framework_utils.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils.go
@@ -10,11 +10,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 const uaEnvVar = "TF_APPEND_USER_AGENT"
+
+var (
+	unhandledAsEmpty = basetypes.ObjectAsOptions {
+		UnhandledNullAsEmpty: true,
+		UnhandledUnknownAsEmpty: true,
+	}
+)
 
 func CompileUserAgentString(ctx context.Context, name, tfVersion, provVersion string) string {
 	ua := fmt.Sprintf("Terraform/%s (+https://www.terraform.io) Terraform-Plugin-SDK/%s %s/%s", tfVersion, "terraform-plugin-framework", name, provVersion)

--- a/mmv1/third_party/terraform/utils/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/utils/framework_provider.go.erb
@@ -222,18 +222,16 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
             },
         },
         Blocks: map[string]schema.Block{
-            "batching": schema.ListNestedBlock{
-                NestedObject: schema.NestedBlockObject{
-                    Attributes: map[string]schema.Attribute{
-                        "send_after": schema.StringAttribute{
-                            Optional: true,
-                            Validators: []validator.String{
-                                NonNegativeDurationValidator(),
-                            },
+            "batching": schema.SingleNestedBlock{
+                Attributes: map[string]schema.Attribute{
+                    "send_after": schema.StringAttribute{
+                        Optional: true,
+                        Validators: []validator.String{
+                            NonNegativeDurationValidator(),
                         },
-                        "enable_batching": schema.BoolAttribute{
-                            Optional: true,
-                        },
+                    },
+                    "enable_batching": schema.BoolAttribute{
+                        Optional: true,
                     },
                 },
             },

--- a/mmv1/third_party/terraform/utils/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/utils/framework_provider.go.erb
@@ -222,16 +222,18 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
             },
         },
         Blocks: map[string]schema.Block{
-            "batching": schema.SingleNestedBlock{
-                Attributes: map[string]schema.Attribute{
-                    "send_after": schema.StringAttribute{
-                        Optional: true,
-                        Validators: []validator.String{
-                            NonNegativeDurationValidator(),
+            "batching": schema.ListNestedBlock{
+                NestedObject: schema.NestedBlockObject{
+                    Attributes: map[string]schema.Attribute{
+                        "send_after": schema.StringAttribute{
+                            Optional: true,
+                            Validators: []validator.String{
+                                NonNegativeDurationValidator(),
+                            },
                         },
-                    },
-                    "enable_batching": schema.BoolAttribute{
-                        Optional: true,
+                        "enable_batching": schema.BoolAttribute{
+                            Optional: true,
+                        },
                     },
                 },
             },


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

~~A couple things going on here - first, I originally had batching as a List (this is what was used in the SDK, but you could set max-items 1 there, we want it to be a SingleNestedBlock in the new framework).~~
(Can't do this, it'd be a breaking change)

Also, I wanted to figure out an easier way than to always make these redundant maps for finding attribute types, after talking to DevEx there is a method that you can get that on the models (`.AttributeTypes`), there's also a way to get Element types, so I reworked that in the dns keys as well since that's what the batching solution was based off of.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
