### PR TITLE
Add OS_INVENTORY to CloudAsset feed contentTypes

### DIFF
--- a/mmv1/products/cloudasset/FolderFeed.yaml
+++ b/mmv1/products/cloudasset/FolderFeed.yaml
@@ -103,6 +103,7 @@ properties:
       - :RESOURCE
       - :IAM_POLICY
       - :ORG_POLICY
+      - :OS_INVENTORY
       - :ACCESS_POLICY
   - !ruby/object:Api::Type::NestedObject
     name: feedOutputConfig

--- a/mmv1/products/cloudasset/OrganizationFeed.yaml
+++ b/mmv1/products/cloudasset/OrganizationFeed.yaml
@@ -96,6 +96,7 @@ properties:
       - :RESOURCE
       - :IAM_POLICY
       - :ORG_POLICY
+      - :OS_INVENTORY
       - :ACCESS_POLICY
   - !ruby/object:Api::Type::NestedObject
     name: feedOutputConfig

--- a/mmv1/products/cloudasset/ProjectFeed.yaml
+++ b/mmv1/products/cloudasset/ProjectFeed.yaml
@@ -86,6 +86,7 @@ properties:
       - :RESOURCE
       - :IAM_POLICY
       - :ORG_POLICY
+      - :OS_INVENTORY
       - :ACCESS_POLICY
   - !ruby/object:Api::Type::NestedObject
     name: feedOutputConfig


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This adds `OS_INVENTORY` to `contentType` for cloud asset feeds like `google_cloud_asset_project_feed`.
The option is specified here: https://cloud.google.com/asset-inventory/docs/overview#content_types but not present in the current provider.

_Note: as this is a very small change -- I did not open an issue (i did search though!) or run the acceptance tests._

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudasset: added `OS_INVENTORY` value to `content_type` for `google_cloud_asset_*_feed`
```
