### PR TITLE
Make weeklySchedule (under automatedBackupPolicy) optional for AlloyDB cluster

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -145,7 +145,6 @@
           description: "Labels to apply to backups created using this configuration."
         - !ruby/object:Api::Type::NestedObject
           name: "weeklySchedule"
-          required: true
           description: "Weekly schedule for the Backup."
           default_from_api: true
           properties:

--- a/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
@@ -255,3 +255,53 @@ resource "google_compute_network" "default" {
 }
 `, context)
 }
+
+// The cluster creation should work fine even without a weekly schedule.
+func TestAccAlloydbCluster_missingWeeklySchedule(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbCluster_missingWeeklySchedule(context),
+			},
+			{
+				ResourceName:      "google_alloydb_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAlloydbCluster_missingWeeklySchedule(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+  automated_backup_policy {
+    location      = "us-central1"
+    backup_window = "1800s"
+    enabled       = true
+    quantity_based_retention {
+	  count = 1
+	}
+    labels = {
+	  test = "tf-test-alloydb-cluster%{random_suffix}"
+	}
+  }
+}
+data "google_project" "project" {}
+resource "google_compute_network" "default" {
+  name = "tf-test-alloydb-cluster%{random_suffix}"
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

### Make weeklySchedule (under automatedBackupPolicy) optional for AlloyDB cluster
`weeklySchedule` is marked [required](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/alloydb/Cluster.yaml#L147) but is optional as per REST API [documentation](https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters#automatedbackuppolicy). ("All fields in the automated backup policy are optional. Defaults for each field are provided if they are not set.")



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
alloydb: made field `weeklySchedule` (under `automatedBackupPolicy`) `optional` for `google_alloydb_cluster`

```
