### PR TITLE
Add tests for `HandleSDKDefaults` function; test "defaultable" SDK provider config fields

### DIFF
--- a/mmv1/third_party/terraform/utils/config_test.go
+++ b/mmv1/third_party/terraform/utils/config_test.go
@@ -93,9 +93,9 @@ func TestHandleSDKDefaults_UserProjectOverride(t *testing.T) {
 	cases := map[string]struct {
 		SetViaConfig     bool // Awkward, but necessary as zero value of ConfigValue could be intended
 		ConfigValue      bool
+		ValueNotProvided bool
 		EnvVariables     map[string]string
 		ExpectedValue    bool
-		ValueNotProvided bool
 		ExpectError      bool
 	}{
 		"user_project_override value set in the provider schema is not overridden by ENVs": {
@@ -136,7 +136,7 @@ func TestHandleSDKDefaults_UserProjectOverride(t *testing.T) {
 			},
 			ExpectError: true,
 		},
-		"when no values are provided via config or environment variables, the field remains unset": {
+		"when no values are provided via config or environment variables, the field remains unset without error": {
 			ValueNotProvided: true,
 		},
 	}

--- a/mmv1/third_party/terraform/utils/config_test.go
+++ b/mmv1/third_party/terraform/utils/config_test.go
@@ -366,6 +366,103 @@ func TestHandleSDKDefaults_Region(t *testing.T) {
 	}
 }
 
+func TestHandleSDKDefaults_Zone(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue      string
+		EnvVariables     map[string]string
+		ExpectedValue    string
+		ValueNotProvided bool
+		ExpectError      bool
+	}{
+		"region value set in the provider config is not overridden by ENVs": {
+			ConfigValue: "zone-from-config",
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE": "zone-from-env",
+			},
+			ExpectedValue: "zone-from-config",
+		},
+		"zone can be set by environment variable, when no value supplied via the config": {
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE": "zone-from-env",
+			},
+			ExpectedValue: "zone-from-env",
+		},
+		"when multiple zone environment variables are provided, `GOOGLE_ZONE` is used first": {
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE":           "zone-from-GOOGLE_ZONE",
+				"GCLOUD_ZONE":           "zone-from-GCLOUD_ZONE",
+				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			},
+			ExpectedValue: "zone-from-GOOGLE_ZONE",
+		},
+		"when multiple zone environment variables are provided, `GCLOUD_ZONE` is used second": {
+			EnvVariables: map[string]string{
+				// GOOGLE_ZONE unset
+				"GCLOUD_ZONE":           "zone-from-GCLOUD_ZONE",
+				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			},
+			ExpectedValue: "zone-from-GCLOUD_ZONE",
+		},
+		"when multiple zone environment variables are provided, `CLOUDSDK_COMPUTE_ZONE` is the last-used ENV": {
+			EnvVariables: map[string]string{
+				// GOOGLE_ZONE unset
+				// GCLOUD_ZONE unset
+				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			},
+			ExpectedValue: "zone-from-CLOUDSDK_COMPUTE_ZONE",
+		},
+		"when no values are provided via config or environment variables, the field remains unset without error": {
+			ValueNotProvided: true,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			// Create empty schema.ResourceData using the SDK Provider schema
+			emptyConfigMap := map[string]interface{}{}
+			d := schema.TestResourceDataRaw(t, Provider().Schema, emptyConfigMap)
+
+			// Set config value(s)
+			if tc.ConfigValue != "" {
+				d.Set("zone", tc.ConfigValue)
+			}
+
+			// Set ENVs
+			if len(tc.EnvVariables) > 0 {
+				for k, v := range tc.EnvVariables {
+					t.Setenv(k, v)
+				}
+			}
+
+			// Act
+			err := HandleSDKDefaults(d)
+
+			// Assert
+			if err != nil {
+				if !tc.ExpectError {
+					t.Fatalf("error: %v", err)
+				}
+				return
+			}
+
+			// Assert
+			v, ok := d.GetOk("zone")
+			if !ok && !tc.ValueNotProvided {
+				t.Fatal("expected zone to be set in the provider data")
+			}
+			if ok && tc.ValueNotProvided {
+				t.Fatal("expected zone to not be set in the provider data")
+			}
+
+			if v != tc.ExpectedValue {
+				t.Fatalf("unexpected value: wanted %v, got, %v", tc.ExpectedValue, v)
+			}
+		})
+	}
+}
+
 // The `user_project_override` field is an odd one out, as other provider schema fields tend to be strings
 // and `user_project_override` is a boolean
 func TestHandleSDKDefaults_UserProjectOverride(t *testing.T) {

--- a/mmv1/third_party/terraform/utils/config_test.go
+++ b/mmv1/third_party/terraform/utils/config_test.go
@@ -87,6 +87,115 @@ func TestHandleSDKDefaults_ImpersonateServiceAccount(t *testing.T) {
 	}
 }
 
+func TestHandleSDKDefaults_Project(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue      string
+		EnvVariables     map[string]string
+		ExpectedValue    string
+		ValueNotProvided bool
+		ExpectError      bool
+	}{
+		"project value set in the provider config is not overridden by ENVs": {
+			ConfigValue: "my-project-from-config",
+			EnvVariables: map[string]string{
+				"GOOGLE_PROJECT": "my-project-from-env",
+			},
+			ExpectedValue: "my-project-from-config",
+		},
+		"project can be set by environment variable, when no value supplied via the config": {
+			EnvVariables: map[string]string{
+				"GOOGLE_PROJECT": "my-project-from-env",
+			},
+			ExpectedValue: "my-project-from-env",
+		},
+		"when multiple project environment variables are provided, `GOOGLE_PROJECT` is used first": {
+			EnvVariables: map[string]string{
+				"GOOGLE_PROJECT":        "project-from-GOOGLE_PROJECT",
+				"GOOGLE_CLOUD_PROJECT":  "project-from-GOOGLE_CLOUD_PROJECT",
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: "project-from-GOOGLE_PROJECT",
+		},
+		"when multiple project environment variables are provided, `GOOGLE_CLOUD_PROJECT` is used second": {
+			EnvVariables: map[string]string{
+				// GOOGLE_PROJECT unset
+				"GOOGLE_CLOUD_PROJECT":  "project-from-GOOGLE_CLOUD_PROJECT",
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: "project-from-GOOGLE_CLOUD_PROJECT",
+		},
+		"when multiple project environment variables are provided, `GCLOUD_PROJECT` is used third": {
+			EnvVariables: map[string]string{
+				// GOOGLE_PROJECT unset
+				// GOOGLE_CLOUD_PROJECT unset
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: "project-from-GCLOUD_PROJECT",
+		},
+		"when multiple project environment variables are provided, `CLOUDSDK_CORE_PROJECT` is the last-used ENV": {
+			EnvVariables: map[string]string{
+				// GOOGLE_PROJECT unset
+				// GOOGLE_CLOUD_PROJECT unset
+				// GCLOUD_PROJECT unset
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: "project-from-CLOUDSDK_CORE_PROJECT",
+		},
+		"when no values are provided via config or environment variables, the field remains unset": {
+			ValueNotProvided: true,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			// Create empty schema.ResourceData using the SDK Provider schema
+			emptyConfigMap := map[string]interface{}{}
+			d := schema.TestResourceDataRaw(t, Provider().Schema, emptyConfigMap)
+
+			// Set config value(s)
+			if tc.ConfigValue != "" {
+				d.Set("project", tc.ConfigValue)
+			}
+
+			// Set ENVs
+			if len(tc.EnvVariables) > 0 {
+				for k, v := range tc.EnvVariables {
+					t.Setenv(k, v)
+				}
+			}
+
+			// Act
+			err := HandleSDKDefaults(d)
+
+			// Assert
+			if err != nil {
+				if !tc.ExpectError {
+					t.Fatalf("error: %v", err)
+				}
+				return
+			}
+
+			// Assert
+			v, ok := d.GetOk("project")
+			if !ok && !tc.ValueNotProvided {
+				t.Fatal("expected project to be set in the provider data")
+			}
+			if ok && tc.ValueNotProvided {
+				t.Fatal("expected project to not be set in the provider data")
+			}
+
+			if v != tc.ExpectedValue {
+				t.Fatalf("unexpected value: wanted %v, got, %v", tc.ExpectedValue, v)
+			}
+		})
+	}
+}
+
 // The `user_project_override` field is an odd one out, as other provider schema fields tend to be strings
 // and `user_project_override` is a boolean
 func TestHandleSDKDefaults_UserProjectOverride(t *testing.T) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds tests defining how some of the the SDK provider's fields can be configured, using the `HandleSDKDefaults` function. It doesn't include the generated custom endpoint fields in the schema.

Below is a list of all the fields a user can include in the provider block, and ones included in this PR are in bold:

- credentials
- access_token
- **_impersonate_service_account_**
- impersonate_service_account_delegates
- **_project_**
- **_billing_project_**
- **_region_**
- **_zone_**
- scopes
- batching
 	- send_after
	- enable_batching
- user_project_override
- request_timeout
- **_request_reason_**




Note: the branch is called hashicorp:add-framework-provider-config-tests but only tests SDK code

---


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

-->

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
