### PR TITLE
Fix empty string credentials validation issue, increase test coverage of credential validation

### DIFF
--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -85,11 +85,11 @@ func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
 				return string(contents)
 			},
 		},
-		// "configuring credentials as an empty string is valid": {
-		// 	ConfigValue: func(t *testing.T) string {
-		// 		return ""
-		// 	},
-		// },
+		"configuring credentials as an empty string is valid": {
+			ConfigValue: func(t *testing.T) string {
+				return ""
+			},
+		},
 		// "leaving credentials unconfigured is valid": {
 		// 	ValueNotProvided: true,
 		// },

--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -60,48 +60,48 @@ func TestFrameworkProvider_impl(t *testing.T) {
 
 func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
 	cases := map[string]struct {
-		ConfigValue          func(t *testing.T) string
-		ValueNotProvided     bool
+		ConfigValue          func(t *testing.T) types.String
 		ExpectedWarningCount int
 		ExpectedErrorCount   int
 	}{
 		"configuring credentials as a path to a credentials JSON file is valid": {
-			ConfigValue: func(t *testing.T) string {
-				return testFakeCredentialsPath // Path to a test fixture
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue(testFakeCredentialsPath) // Path to a test fixture
 			},
 		},
 		"configuring credentials as a path to a non-existant file is NOT valid": {
-			ConfigValue: func(t *testing.T) string {
-				return "./this/path/doesnt/exist.json" // Doesn't exist
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
 			},
 			ExpectedErrorCount: 1,
 		},
 		"configuring credentials as a credentials JSON string is valid": {
-			ConfigValue: func(t *testing.T) string {
+			ConfigValue: func(t *testing.T) types.String {
 				contents, err := ioutil.ReadFile(testFakeCredentialsPath)
 				if err != nil {
 					t.Fatalf("Unexpected error: %s", err)
 				}
-				return string(contents)
+				stringContents := string(contents)
+				return types.StringValue(stringContents)
 			},
 		},
 		"configuring credentials as an empty string is valid": {
-			ConfigValue: func(t *testing.T) string {
-				return ""
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue("")
 			},
 		},
-		// "leaving credentials unconfigured is valid": {
-		// 	ValueNotProvided: true,
-		// },
+		"leaving credentials unconfigured is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringNull()
+			},
+		},
 	}
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 			// Arrange
-			configValue := tc.ConfigValue(t)
-
 			req := validator.StringRequest{
-				ConfigValue: types.StringValue(configValue),
+				ConfigValue: tc.ConfigValue(t),
 			}
 
 			resp := validator.StringResponse{

--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -58,48 +58,69 @@ func TestFrameworkProvider_impl(t *testing.T) {
 	var _ provider.ProviderWithMetaSchema = New("test")
 }
 
-func TestFrameworkProvider_loadCredentialsFromFile(t *testing.T) {
-	cv := CredentialsValidator()
-
-	req := validator.StringRequest{
-		ConfigValue: types.StringValue(testFakeCredentialsPath),
+func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue          func(t *testing.T) string
+		ValueNotProvided     bool
+		ExpectedWarningCount int
+		ExpectedErrorCount   int
+	}{
+		"configuring credentials as a path to a credentials JSON file is valid": {
+			ConfigValue: func(t *testing.T) string {
+				return testFakeCredentialsPath // Path to a test fixture
+			},
+		},
+		"configuring credentials as a path to a non-existant file is NOT valid": {
+			ConfigValue: func(t *testing.T) string {
+				return "./this/path/doesnt/exist.json" // Doesn't exist
+			},
+			ExpectedErrorCount: 1,
+		},
+		"configuring credentials as a credentials JSON string is valid": {
+			ConfigValue: func(t *testing.T) string {
+				contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				return string(contents)
+			},
+		},
+		// "configuring credentials as an empty string is valid": {
+		// 	ConfigValue: func(t *testing.T) string {
+		// 		return ""
+		// 	},
+		// },
+		// "leaving credentials unconfigured is valid": {
+		// 	ValueNotProvided: true,
+		// },
 	}
 
-	resp := validator.StringResponse{
-		Diagnostics: diag.Diagnostics{},
-	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			configValue := tc.ConfigValue(t)
 
-	cv.ValidateString(context.Background(), req, &resp)
+			req := validator.StringRequest{
+				ConfigValue: types.StringValue(configValue),
+			}
 
-	if resp.Diagnostics.WarningsCount() > 0 {
-		t.Errorf("Expected 0 warnings, got %d", resp.Diagnostics.WarningsCount())
-	}
-	if resp.Diagnostics.HasError() {
-		t.Errorf("Expected 0 errors, got %d", resp.Diagnostics.ErrorsCount())
-	}
-}
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
 
-func TestFrameworkProvider_loadCredentialsFromJSON(t *testing.T) {
-	contents, err := ioutil.ReadFile(testFakeCredentialsPath)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-	cv := CredentialsValidator()
+			cv := CredentialsValidator()
 
-	req := validator.StringRequest{
-		ConfigValue: types.StringValue(string(contents)),
-	}
+			// Act
+			cv.ValidateString(context.Background(), req, &resp)
 
-	resp := validator.StringResponse{
-		Diagnostics: diag.Diagnostics{},
-	}
-
-	cv.ValidateString(context.Background(), req, &resp)
-	if resp.Diagnostics.WarningsCount() > 0 {
-		t.Errorf("Expected 0 warnings, got %d", resp.Diagnostics.WarningsCount())
-	}
-	if resp.Diagnostics.HasError() {
-		t.Errorf("Expected 0 errors, got %d", resp.Diagnostics.ErrorsCount())
+			// Assert
+			if resp.Diagnostics.WarningsCount() > tc.ExpectedWarningCount {
+				t.Errorf("Expected %d warnings, got %d", tc.ExpectedWarningCount, resp.Diagnostics.WarningsCount())
+			}
+			if resp.Diagnostics.ErrorsCount() > tc.ExpectedErrorCount {
+				t.Errorf("Expected %d errors, got %d", tc.ExpectedErrorCount, resp.Diagnostics.ErrorsCount())
+			}
+		})
 	}
 }
 

--- a/mmv1/third_party/terraform/framework_utils/framework_validators.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_validators.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	googleoauth "golang.org/x/oauth2/google"
 )
@@ -36,7 +37,7 @@ func (v credentialsValidator) MarkdownDescription(ctx context.Context) string {
 
 // ValidateString performs the validation.
 func (v credentialsValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
-	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() || request.ConfigValue.Equal(types.StringValue("")) {
 		return
 	}
 

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -3,6 +3,7 @@ package google
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -166,27 +166,72 @@ func AccTestPreCheck(t *testing.T) {
 	}
 }
 
-func TestProvider_loadCredentialsFromFile(t *testing.T) {
-	ws, es := validateCredentials(testFakeCredentialsPath, "")
-	if len(ws) != 0 {
-		t.Errorf("Expected %d warnings, got %v", len(ws), ws)
+func TestProvider_validateCredentials(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue      func(t *testing.T) interface{}
+		ValueNotProvided bool
+		ExpectedWarnings []string
+		ExpectedErrors   []error
+	}{
+		"configuring credentials as a path to a credentials JSON file is valid": {
+			ConfigValue: func(t *testing.T) interface{} {
+				return testFakeCredentialsPath // Path to a test fixture
+			},
+		},
+		"configuring credentials as a path to a non-existant file is NOT valid": {
+			ConfigValue: func(t *testing.T) interface{} {
+				return "./this/path/doesnt/exist.json" // Doesn't exist
+			},
+			ExpectedErrors: []error{
+				// As the file doesn't exist, so the function attempts to parse it as a JSON
+				errors.New("JSON credentials are not valid: invalid character '.' looking for beginning of value"),
+			},
+		},
+		"configuring credentials as a credentials JSON string is valid": {
+			ConfigValue: func(t *testing.T) interface{} {
+				contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				return string(contents)
+			},
+		},
+		"configuring credentials as an empty string is valid": {
+			ConfigValue: func(t *testing.T) interface{} {
+				return ""
+			},
+		},
+		"leaving credentials unconfigured is valid": {
+			ValueNotProvided: true,
+		},
 	}
-	if len(es) != 0 {
-		t.Errorf("Expected %d errors, got %v", len(es), es)
-	}
-}
 
-func TestProvider_loadCredentialsFromJSON(t *testing.T) {
-	contents, err := ioutil.ReadFile(testFakeCredentialsPath)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-	ws, es := validateCredentials(string(contents), "")
-	if len(ws) != 0 {
-		t.Errorf("Expected %d warnings, got %v", len(ws), ws)
-	}
-	if len(es) != 0 {
-		t.Errorf("Expected %d errors, got %v", len(es), es)
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			var configValue interface{}
+			if !tc.ValueNotProvided {
+				configValue = tc.ConfigValue(t)
+			}
+
+			// Act
+			// Note: second argument is currently unused by the function but is necessary to fulfill the SchemaValidateFunc type's function signature
+			ws, es := validateCredentials(configValue, "")
+
+			// Assert
+			if len(ws) != len(tc.ExpectedWarnings) {
+				t.Errorf("Expected %d warnings, got %d: %v", len(tc.ExpectedWarnings), len(ws), ws)
+			}
+			if len(es) != len(tc.ExpectedErrors) {
+				t.Errorf("Expected %d errors, got %d: %v", len(tc.ExpectedErrors), len(es), es)
+			}
+
+			if len(tc.ExpectedErrors) > 0 {
+				if es[0].Error() != tc.ExpectedErrors[0].Error() {
+					t.Errorf("Expected first error to be \"%s\", got \"%s\"", tc.ExpectedErrors[0], es[0])
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14255

This PR:

- Improves testing for credential validation in the SDK provider config code
- Makes the tests for the plugin framework provider's config code match the new SDK tests
- Changes the new credential validator to allow empty strings as values of `credentials` in the provider config

Here are details of old tests that I replaced with test cases in a table-driven test

| Removed test | Equivalent test case in new test |
|---------------|--------------------------------|
|`TestProvider_loadCredentialsFromFile`  (SDK version) | `TestProvider_validateCredentials`'s "configuring credentials as a path to a credentials JSON file is valid" |
|`TestProvider_loadCredentialsFromJSON `  (SDK version) | `TestProvider_validateCredentials`'s "configuring credentials as a credentials JSON string is valid" |
| `TestFrameworkProvider_loadCredentialsFromFile` | `TestFrameworkProvider_CredentialsValidator`'s "configuring credentials as a path to a credentials JSON file is valid"  |
| `TestFrameworkProvider_loadCredentialsFromJSON` | `TestFrameworkProvider_CredentialsValidator`'s "configuring credentials as a credentials JSON string is valid" |


---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed bug where `credentials` field could not be set as an empty string
```
