### PR TITLE
Add hybrid_options to google_data_loss_prevention_job_trigger

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -77,6 +77,10 @@ examples:
       project: :PROJECT_NAME
     test_vars_overrides:
       name: '"tf_test_" + RandString(t, 10)'
+    name: "dlp_job_trigger_hybrid"
+    primary_resource_id: "hybrid_trigger"
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/wrap_object.go.erb
   custom_import: templates/terraform/custom_import/dlp_import.go.erb
@@ -139,6 +143,13 @@ properties:
                 This value must be set to a time duration greater than or equal to 1 day and can be no longer than 60 days.
 
                 A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+        - !ruby/object:Api::Type::NestedObject
+          name: 'manual'
+          allow_empty_object: true
+          send_empty_value: true
+          properties: []
+          description: |
+            For use with hybrid jobs. Jobs must be manually created and finished.
   - !ruby/object:Api::Type::NestedObject
     name: 'inspectJob'
     description: Controls what and how to inspect for findings.
@@ -371,6 +382,59 @@ properties:
                       required: true
                       description: |
                         Name of a BigQuery field to be returned with the findings.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'hybridOptions'
+            allow_empty_object: true
+            send_empty_value: true
+            description: |
+              Configuration to control jobs where the content being inspected is outside of Google Cloud Platform.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'description'
+                description: |
+                  A short description of where the data is coming from. Will be stored once in the job. 256 max length.
+              - !ruby/object:Api::Type::Array
+                name: 'requiredFindingLabelKeys'
+                item_type: Api::Type::String
+                description: |
+                  These are labels that each inspection request must include within their 'finding_labels' map. Request
+                  may contain others, but any missing one of these will be rejected.
+
+                  Label keys must be between 1 and 63 characters long and must conform to the following regular expression: `[a-z]([-a-z0-9]*[a-z0-9])?`.
+
+                  No more than 10 keys can be required.
+              - !ruby/object:Api::Type::NestedObject
+                name: 'tableOptions'
+                description: |
+                  If the container is a table, additional information to make findings meaningful such as the columns that are primary keys.
+                properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'identifyingFields'
+                    description: |
+                      The columns that are the primary keys for table objects included in ContentItem. A copy of this
+                      cell's value will stored alongside alongside each finding so that the finding can be traced to
+                      the specific row it came from. No more than 3 may be provided.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'name'
+                          required: true
+                          description: |
+                            Name describing the field.
+              - !ruby/object:Api::Type::KeyValuePairs
+                name: 'labels'
+                description: |
+                  To organize findings, these labels will be added to each finding.
+
+                  Label keys must be between 1 and 63 characters long and must conform to the following regular expression: `[a-z]([-a-z0-9]*[a-z0-9])?`.
+
+                  Label values must be between 0 and 63 characters long and must conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
+
+                  No more than 10 labels can be associated with a given finding.
+
+                  Examples:
+                  * `"environment" : "production"`
+                  * `"pipeline" : "etl"`
       - !ruby/object:Api::Type::Array
         name: 'actions'
         required: true

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_hybrid.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_hybrid.tf.erb
@@ -1,0 +1,37 @@
+resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id] %>" {
+  parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+
+  triggers {
+    manual {}
+  }
+
+  inspect_job {
+    inspect_template_name = "fake"
+    actions {
+      save_findings {
+        output_config {
+          table {
+            project_id = "project"
+            dataset_id = "dataset"
+          }
+        }
+      }
+    }
+    storage_config {
+      hybrid_options {
+        description = "Hybrid job trigger for data from the comments field of a table that contains customer appointment bookings"
+        required_finding_label_keys = [
+          "appointment-bookings-comments"
+        ]
+        labels = {
+          env = "prod"
+        }
+        table_options {
+          identifying_fields {
+            name = "booking_id"
+          }
+        }
+      }
+    }
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -321,7 +321,11 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 			}
 		}
 		storage_config {
-			cloud_storage_options {}
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+			}
 		}
 	}
 }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -188,7 +188,7 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerHybridUpdate(t *testing.T)
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -180,6 +180,40 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerChangingActions(t *testing
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerHybridUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project": GetTestProjectFromEnv(),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerHybrid(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.hybrid",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerHybridUpdated(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.hybrid",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -287,11 +321,7 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 			}
 		}
 		storage_config {
-			cloud_storage_options {
-				file_set {
-					url = "gs://mybucket/directory/"
-				}
-			}
+			cloud_storage_options {}
 		}
 	}
 }
@@ -574,6 +604,77 @@ resource "google_data_loss_prevention_job_trigger" "actions" {
 					url = "gs://mybucket/directory/"
 				}
 			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerHybrid(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "hybrid" {
+	parent = "projects/%{project}"
+
+	triggers {
+		manual {}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			hybrid_options {
+				description = "Hybrid job trigger"
+				required_finding_label_keys = [
+					"test-key"
+				]
+				labels = {
+					env = "prod"
+				}
+				table_options {
+					identifying_fields {
+						name = "primary_id"
+					}
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerHybridUpdated(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "hybrid" {
+	parent = "projects/%{project}"
+
+	triggers {
+		manual {}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			hybrid_options {}
 		}
 	}
 }


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/9756

This adds functionality to allow DLP inspection to be done on data from outside of GCP (called hybrid). This guide explains the manual setup: https://cloud.google.com/dlp/docs/how-to-hybrid-jobs#create-job-or-trigger

API reference: https://cloud.google.com/dlp/docs/reference/rest/v2/projects.jobTriggers

To support the new hybrid fields, we also needed to add the `manual` option for the trigger, because this type of job is triggered manually when a `hybridInspect` API call is made externally by the user.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `triggers.manual` and `inspect_job.storage_config.hybrid_options` to `google_data_loss_prevention_job_trigger`
```
