### PR TITLE
Add Fine Grained Resource IngressPolicy

### DIFF
--- a/mmv1/products/accesscontextmanager/IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/IngressPolicy.yaml
@@ -1,0 +1,65 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Resource
+  name: 'IngressPolicy'
+  create_url: "{{ingress_policy_name}}"
+  base_url: ""
+  self_link: "{{ingress_policy_name}}"
+  create_verb: :PATCH
+  delete_verb: :PATCH
+  immutable: true
+  update_mask: true
+  identity:
+    - resource
+  nested_query: !ruby/object:Api::Resource::NestedQuery
+    modify_by_patch: true
+    is_list_of_ids: true
+    keys:
+      - status
+      - resources
+  references: !ruby/object:Api::Resource::ReferenceLinks
+    api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#ingresspolicy'
+  description: |
+    IngressPolicies match requests based on ingressFrom and ingressTo stanzas. For an ingress policy to match, 
+    both the ingressFrom and ingressTo stanzas must be matched. If an IngressPolicy matches a request, 
+    the request is allowed through the perimeter boundary from outside the perimeter.
+    For example, access from the internet can be allowed either based on an AccessLevel or, 
+    for traffic hosted on Google Cloud, the project of the source network. 
+    For access from private networks, using the project of the hosting network is required.
+    Individual ingress policies can be limited by restricting which services and/
+    or actions they match using the ingressTo field.
+  autogen_async: true
+  exclude_validator: true
+  # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter/IngressPolicy
+  skip_sweeper: true
+  id_format: "{{ingress_policy_name}}{{resource}}"
+  import_format: ["{{ingress_policy_name}}{{resource}}"]
+  custom_code: !ruby/object:Provider::Terraform::CustomCode
+    custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
+  parameters:
+    - !ruby/object:Api::Type::ResourceRef
+      name: 'ingressPolicyName'
+      resource: 'ServicePerimeter'
+      imports: 'name'
+      description: |
+        The name of the Service Perimeter to add this resource to.
+      required: true
+      immutable: true
+      url_param_only: true
+  properties:
+    - !ruby/object:Api::Type::String
+      name: 'resource'
+      description: |
+            A GCP resource that is inside of the service perimeter.
+      required: true
+      immutable: true

--- a/mmv1/templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
+++ b/mmv1/templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
@@ -1,0 +1,29 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+	config := meta.(*Config)
+
+	// current import_formats can't import fields with forward slashes in their value
+	parts, err := getImportIdQualifiers([]string{"accessPolicies/(?P<accessPolicy>[^/]+)/servicePerimeters/(?P<perimeter>[^/]+)/(?P<resource>.+)"}, d, config, d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("ingress_policy_name", fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", parts["accessPolicy"], parts["perimeter"])); err != nil {
+		return nil, fmt.Errorf("Error setting ingress_policy_name: %s", err)
+	}
+	if err := d.Set("resource", parts["resource"]); err != nil {
+		return nil, fmt.Errorf("Error setting resource: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -89,6 +89,7 @@ func TestAccAccessContextManager(t *testing.T) {
 		"access_level_custom":        testAccAccessContextManagerAccessLevel_customTest,
 		"access_levels":              testAccAccessContextManagerAccessLevels_basicTest,
 		"access_level_condition":     testAccAccessContextManagerAccessLevelCondition_basicTest,
+		"ingress_policy":             testAccAccessContextManagerIngressPolicy_basicTest,
 		"service_perimeters":         testAccAccessContextManagerServicePerimeters_basicTest,
 		"gcp_user_access_binding":    testAccAccessContextManagerGcpUserAccessBinding_basicTest,
 		"authorized_orgs_desc":       testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_ingress_policy_test.go
@@ -1,0 +1,158 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Since each test here is acting on the same organization and only one AccessPolicy
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
+
+func testAccAccessContextManagerIngressPolicy_basicTest(t *testing.T) {
+	// Multiple fine-grained resources
+	SkipIfVcr(t)
+	org := GetTestOrgFromEnv(t)
+	projects := BootstrapServicePerimeterProjects(t, 2)
+	policyTitle := RandString(t, 10)
+	perimeterTitle := RandString(t, 10)
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterTitle, projects[0].ProjectNumber, projects[1].ProjectNumber),
+			},
+			{
+				ResourceName:      "google_access_context_manager_ingress_policy.test-access1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_access_context_manager_ingress_policy.test-access2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAccessContextManagerIngressPolicy_destroy(org, policyTitle, perimeterTitle),
+				Check:  testAccCheckAccessContextManagerIngressPolicyDestroyProducer(t),
+			},
+		},
+	})
+}
+
+func testAccCheckAccessContextManagerIngressPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_access_context_manager_ingress_policy" {
+				continue
+			}
+
+			config := GoogleProviderConfig(t)
+
+			url, err := replaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{ingress_policy_name}}")
+			if err != nil {
+				return err
+			}
+
+			res, err := SendRequest(config, "GET", "", url, config.UserAgent, nil)
+			if err != nil {
+				return err
+			}
+
+			v, ok := res["status"]
+			if !ok || v == nil {
+				return nil
+			}
+
+			res = v.(map[string]interface{})
+			v, ok = res["resources"]
+			if !ok || v == nil {
+				return nil
+			}
+
+			resources := v.([]interface{})
+			if len(resources) == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("expected 0 resources in perimeter, found %d: %v", len(resources), resources)
+		}
+
+		return nil
+	}
+}
+
+func testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterTitleName string, projectNumber1, projectNumber2 int64) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_access_context_manager_ingress_policy" "test-access1" {
+  ingress_policy_name = google_access_context_manager_service_perimeter.test-access.name
+  resource            = "projects/%d"
+}
+
+resource "google_access_context_manager_ingress_policy" "test-access2" {
+  ingress_policy_name = google_access_context_manager_service_perimeter.test-access.name
+  resource            = "projects/%d"
+}
+
+`, testAccAccessContextManagerIngressPolicy_destroy(org, policyTitle, perimeterTitleName), projectNumber1, projectNumber2)
+}
+
+func testAccAccessContextManagerIngressPolicy_destroy(org, policyTitle, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+}
+
+resource "google_access_context_manager_service_perimeter" "test-access" {
+  parent         = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  title          = "%s"
+  status {
+    restricted_services = ["storage.googleapis.com"]
+	ingress_policies {
+		ingress_from {
+			identity_type = "ANY_IDENTITY"
+		}
+
+		ingress_to {
+			resources = [ "*" ]
+			operations {
+				service_name = "bigquery.googleapis.com"
+
+				method_selectors {
+					method = "BigQueryStorage.ReadRows"
+				}
+
+				method_selectors {
+					method = "TableService.ListTables"
+				}
+
+				method_selectors {
+					permission = "bigquery.jobs.get"
+				}
+			}
+
+			operations {
+				service_name = "storage.googleapis.com"
+
+				method_selectors {
+					method = "google.storage.objects.create"
+				}
+			}
+		}
+	}
+  }
+
+  lifecycle {
+  	ignore_changes = [status[0].resources]
+  }
+}
+`, org, policyTitle, perimeterTitleName, perimeterTitleName)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add Fine Grained Resource IngressPolicy

For Access Context Policy Product, only one access policy can exist, so we have to run all the tests under this product within a single function `TestAccAccessContextManager`. That test did not pass locally, reason why I drafted this PR. Once the test passes, I will open the PR and add the fine grained resource for `EgressPolicy`.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
accessContextManager: added fine grained resource `google_access_context_manager_ingress_policy`
```
