### PR TITLE
Add supported system annotations to google_cloud_run_service

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -269,11 +269,46 @@ properties:
                 name: annotations
                 description: |-
                   Annotations is a key value map stored with a resource that
-                  may be set by external tools to store and retrieve arbitrary metadata.
+                  may be set by external tools to store and retrieve arbitrary metadata. More
+                  info: http://kubernetes.io/docs/user-guide/annotations
 
                   **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
                   If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
                   or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+
+                  Annotations with `run.googleapis.com/` and `autoscaling.knative.dev` are restricted. Use the following annotation
+                  keys to configure features on a Revision template:
+
+                  - `autoscaling.knative.dev/maxScale` sets the [maximum number of container
+                    instances](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--max-instances) of the Revision to run.
+                  - `autoscaling.knative.dev/minScale` sets the [minimum number of container
+                    instances](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--min-instances) of the Revision to run.
+                  - `run.googleapis.com/client-name` sets the client name calling the Cloud Run API.
+                  - `run.googleapis.com/cloudsql-instances` sets the [Cloud SQL
+                    instances](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--add-cloudsql-instances) the Revision connects to.
+                  - `run.googleapis.com/cpu-throttling` sets whether to throttle the CPU when the container is not actively serving
+                    requests. See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--[no-]cpu-throttling.
+                  - `run.googleapis.com/encryption-key-shutdown-hours` sets the number of hours to wait before an automatic shutdown
+                    server after CMEK key revocation is detected.
+                  - `run.googleapis.com/encryption-key` sets the [CMEK key](https://cloud.google.com/run/docs/securing/using-cmek)
+                    reference to encrypt the container with.
+                  - `run.googleapis.com/execution-environment` sets the [execution
+                    environment](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--execution-environment)
+                    where the application will run.
+                  - `run.googleapis.com/post-key-revocation-action-type` sets the
+                    [action type](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--post-key-revocation-action-type)
+                    after CMEK key revocation.
+                  - `run.googleapis.com/secrets` sets a list of key-value pairs to set as
+                    [secrets](https://cloud.google.com/run/docs/configuring/secrets#yaml).
+                  - `run.googleapis.com/sessionAffinity` sets whether to enable
+                    [session affinity](https://cloud.google.com/sdk/gcloud/reference/beta/run/deploy#--[no-]session-affinity)
+                    for connections to the Revision.
+                  - `run.googleapis.com/startup-cpu-boost` sets whether to allocate extra CPU to containers on startup.
+                    See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--[no-]cpu-boost.
+                  - `run.googleapis.com/vpc-access-connector` sets a [VPC connector](https://cloud.google.com/run/docs/configuring/connecting-vpc#terraform_1)
+                    for the Revision.
+                  - `run.googleapis.com/vpc-access-egress` sets the outbound traffic to send through the VPC connector for this resource.
+                    See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--vpc-egress.
                 default_from_api: true
                 diff_suppress_func: 'cloudrunTemplateAnnotationDiffSuppress'
               - !ruby/object:Api::Type::String
@@ -902,10 +937,19 @@ properties:
           If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
           or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
 
-          Cloud Run (fully managed) uses the following annotation keys to configure features on a Service:
+          Annotations with `run.googleapis.com/` and `autoscaling.knative.dev` are restricted. Use the following annotation
+          keys to configure features on a Service:
 
+          - `run.googleapis.com/binary-authorization-breakglass` sets the [Binary Authorization breakglass](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--breakglass).
+          - `run.googleapis.com/binary-authorization` sets the [Binary Authorization](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--binary-authorization).
+          - `run.googleapis.com/client-name` sets the client name calling the Cloud Run API.
+          - `run.googleapis.com/custom-audiences` sets the [custom audiences](https://cloud.google.com/sdk/gcloud/reference/alpha/run/deploy#--add-custom-audiences)
+            that can be used in the audience field of ID token for authenticated requests.
+          - `run.googleapis.com/description` sets a user defined description for the Service.
           - `run.googleapis.com/ingress` sets the [ingress settings](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--ingress)
             for the Service. For example, `"run.googleapis.com/ingress" = "all"`.
+          - `run.googleapis.com/launch-stage` sets the [launch stage](https://cloud.google.com/run/docs/troubleshooting#launch-stage-validation)
+            when a preview feature is used. For example, `"run.googleapis.com/launch-stage": "BETA"`
         default_from_api: true
         diff_suppress_func: 'cloudrunAnnotationDiffSuppress'
       - !ruby/object:Api::Type::String


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10589.

Add supported system annotations to `google_cloud_run_service` for Cloud Run Service and RevisionTemplate.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
N/A
```
