### PR TITLE
Fix KCC provider to support cloudfunctions2 and reference field names

### DIFF
--- a/mmv1/provider/terraform_kcc.rb
+++ b/mmv1/provider/terraform_kcc.rb
@@ -27,6 +27,7 @@ module Provider
                          BigqueryReservation: 'BigQueryReservation',
                          CloudIds: 'CloudIDS',
                          CloudIot: 'CloudIOT',
+                         Cloudfunctions2: 'CloudFunctions2',
                          Pubsub: 'PubSub' }.freeze
     OBJECT_NAME_MAP = { Api: 'API',
                         Dns: 'DNS',
@@ -48,13 +49,15 @@ module Provider
       compile_product_files(output_folder)
     end
 
-    def generate_product_name(product_name)
+    def product_name(product_name)
+      product_name = product_name.upcase_first
       PRODUCT_NAME_MAP.inject(product_name.dup) do |name, (old_value, new_value)|
         name.gsub(old_value.to_s, new_value)
       end
     end
 
-    def generate_object_name(object_name)
+    def object_name(object_name)
+      object_name = object_name.upcase_first
       OBJECT_NAME_MAP.inject(object_name.dup) do |name, (old_value, new_value)|
         name.gsub(old_value.to_s, new_value)
       end
@@ -64,8 +67,8 @@ module Provider
     # Filter out samples that have no test and that don't match the current
     # product version.
     def generate_resource(pwd, data, _generate_code, _generate_docs)
-      product_name = generate_product_name(data.product.name)
-      object_name = generate_object_name(data.name)
+      product_name = product_name(data.product.name)
+      object_name = object_name(data.name)
       kind = product_name + object_name
       # skip_test examples and examples with test_env_vars should also be
       # included. Whether and how to convert them into KCC examples will be

--- a/mmv1/templates/kcc/product/service_mapping.yaml.erb
+++ b/mmv1/templates/kcc/product/service_mapping.yaml.erb
@@ -16,7 +16,7 @@ autogen_exception
 # limitations under the License.
 
 <%
-  product_name = generate_product_name(product.name)
+  product_name = product_name(product.name)
 -%>
 apiVersion: core.cnrm.cloud.google.com/v1alpha1
 kind: ServiceMapping
@@ -32,7 +32,7 @@ spec:
   product.objects.reject { |r| r.exclude || r.exclude_resource || r.not_in_version?(product.version_obj_or_closest(version)) }.each do |object|
     if object.legacy_name.nil?
       if product.legacy_name.nil?
-        terraform_name = "google_" + (product.name + object.name).underscore
+        terraform_name = "google_" + (product.name + object.name.upcase_first).underscore
       else
         terraform_name = "google_" + product.legacy_name + '_' + object.name.underscore
       end
@@ -40,7 +40,7 @@ spec:
       terraform_name = object.legacy_name
     end
 
-    object_name = generate_object_name(object.name)
+    object_name = object_name(object.name)
 -%>
     - name: <%= terraform_name %>
       kind: <%= "#{product_name}#{object_name}" %>
@@ -132,7 +132,7 @@ spec:
             kind: <%= "#{product_name}#{reference.resource}" %>
             version: v1beta1
             group: <%= product_name.downcase %>.cnrm.cloud.google.com
-          targetField: <%= reference.imports %>
+          targetField: <%= reference.imports.underscore %>
 <%  if references_in_parameters.any? {|r| r.name == reference.name } -%>
           parent: true
 <%  end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixed the KCC provider for service mapping generation.
1. Mapped TF product name `Cloudfunctions2` to service name `CloudFunctions2` to be consistent with the existing `CloudFunctions` service.
2. Capitalized the first letter of the resource object name when constructing the TF type name to work around edge cases like [this](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/cloudfunctions2/Function.yaml#L15).
3. Ensured the first letter of the product name and resource object name is always capitalized.
4. Renamed methods `generate_product_name` and `generate_object_name` to `product_name` and `object_name`.
5. Converted the referenced field name from camel case to snake case.




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
