### PR TITLE
Add CMEK support for Workflows

### DIFF
--- a/mmv1/products/workflows/Workflow.yaml
+++ b/mmv1/products/workflows/Workflow.yaml
@@ -98,4 +98,9 @@ properties:
     output: true
     description: |
       The revision of the workflow. A new one is generated if the service account or source contents is changed.
-
+  - !ruby/object:Api::Type::String
+    name: 'cryptoKeyName'
+    description: |
+      The KMS key used to encrypt workflow and execution data.
+      
+      Format: projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}

--- a/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
+++ b/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
@@ -155,13 +155,13 @@ func testAccWorkflowsWorkflow_CMEK(name string) string {
 	return fmt.Sprintf(`
 resource "google_kms_key_ring" "keyring" {
   provider = google-beta
-  name     = "tf-test-ring%1s"
+  name     = "tf-test-ring%0s"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "example-key" {
   provider        = google-beta
-  name            = "tf-test-key%1s"
+  name            = "tf-test-key%0s"
   key_ring        = google_kms_key_ring.keyring.id
   rotation_period = "100000s"
 }
@@ -187,7 +187,7 @@ resource "google_project_service_identity" "ck_sa" {
 }
 
 resource "google_workflows_workflow" "example" {
-  name          = "%1s"
+  name          = "%0s"
   region        = "us-central1"
   description   = "Magic"
   crypto_key_name = google_kms_crypto_key.example-key.id

--- a/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
+++ b/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
@@ -154,7 +154,7 @@ func TestAccWorkflowsWorkflow_CMEK(t *testing.T) {
 
 	workflowName := fmt.Sprintf("tf-test-acc-workflow-%d", RandInt(t))
 	kms := BootstrapKMSKey(t)
-  if BootstrapPSARole(t, "service-", "gcp-sa-workflows", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+	if BootstrapPSARole(t, "service-", "gcp-sa-workflows", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
+++ b/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
@@ -153,7 +153,7 @@ func TestAccWorkflowsWorkflow_CMEK(t *testing.T) {
 	t.Parallel()
 
 	workflowName := fmt.Sprintf("tf-test-acc-workflow-%d", RandInt(t))
-	kms := BootstrapKMSKey(t)
+	kms := BootstrapKMSKeyInLocation(t, "us-central1")
 	if BootstrapPSARole(t, "service-", "gcp-sa-workflows", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}

--- a/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
+++ b/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
@@ -25,6 +25,9 @@ func TestAccWorkflowsWorkflow_Update(t *testing.T) {
 			{
 				Config: testAccWorkflowsWorkflow_Updated(workflowName),
 			},
+			{
+				Config: testAccWorkflowsWorkflow_CMEK(workflowName),
+			},
 		},
 	})
 }
@@ -146,4 +149,75 @@ func TestWorkflowsWorkflowStateUpgradeV0(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testAccWorkflowsWorkflow_CMEK(name string) string {
+	return fmt.Sprintf(`
+resource "google_kms_key_ring" "keyring" {
+  provider = google-beta
+  name     = "tf-test-ring%1s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "example-key" {
+  provider        = google-beta
+  name            = "tf-test-key%1s"
+  key_ring        = google_kms_key_ring.keyring.id
+  rotation_period = "100000s"
+}
+
+resource "google_kms_crypto_key_iam_binding" "crypto-key-binding" {
+  provider      = google-beta
+  crypto_key_id = google_kms_crypto_key.example-key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:${google_project_service_identity.ck_sa.email}",
+  ]
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_project_service_identity" "ck_sa" {
+  provider = google-beta
+  project  = data.google_project.project.project_id
+  service  = "workflows.googleapis.com"
+}
+
+resource "google_workflows_workflow" "example" {
+  name          = "%1s"
+  region        = "us-central1"
+  description   = "Magic"
+  crypto_key_name = google_kms_crypto_key.example-key.id
+  source_contents = <<-EOF
+  # This is a sample workflow, feel free to replace it with your source code
+  #
+  # This workflow does the following:
+  # - reads current time and date information from an external API and stores
+  #   the response in CurrentDateTime variable
+  # - retrieves a list of Wikipedia articles related to the day of the week
+  #   from CurrentDateTime
+  # - returns the list of articles as an output of the workflow
+  # FYI, In terraform you need to escape the $$ or it will cause errors.
+
+  - getCurrentTime:
+      call: http.get
+      args:
+          url: https://us-central1-workflowsample.cloudfunctions.net/datetime
+      result: CurrentDateTime
+  - readWikipedia:
+      call: http.get
+      args:
+          url: https:/fi.wikipedia.org/w/api.php
+          query:
+              action: opensearch
+              search: $${CurrentDateTime.body.dayOfTheWeek}
+      result: WikiResult
+  - returnOutput:
+      return: $${WikiResult.body[1]}
+EOF
+}
+`, name)
 }

--- a/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
+++ b/mmv1/third_party/terraform/tests/resource_workflows_workflow_test.go
@@ -155,13 +155,13 @@ func testAccWorkflowsWorkflow_CMEK(name string) string {
 	return fmt.Sprintf(`
 resource "google_kms_key_ring" "keyring" {
   provider = google-beta
-  name     = "tf-test-ring%0s"
+  name     = "tf-test-ring%[1]s"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "example-key" {
   provider        = google-beta
-  name            = "tf-test-key%0s"
+  name            = "tf-test-key%[1]s"
   key_ring        = google_kms_key_ring.keyring.id
   rotation_period = "100000s"
 }
@@ -187,7 +187,7 @@ resource "google_project_service_identity" "ck_sa" {
 }
 
 resource "google_workflows_workflow" "example" {
-  name          = "%0s"
+  name          = "%[1]s"
   region        = "us-central1"
   description   = "Magic"
   crypto_key_name = google_kms_crypto_key.example-key.id


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Workflows now supports CMEK, which uses the 'cryptoKeyName' field to provide a key.

I wan unable to build the tests because of errors unrelated to this change.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .[ci/RELEASE_NOTES_GUIDE.md](http://ci/RELEASE_NOTES_GUIDE.md) for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workflows: added `crypto_key_name` field to `google_workflows_workflow` resource
```
