### PR TITLE
Add eap-only DCL products to models + fix gkeonprem op

### DIFF
--- a/mmv1/third_party/terraform/framework_models/provider_model.go.erb
+++ b/mmv1/third_party/terraform/framework_models/provider_model.go.erb
@@ -61,6 +61,12 @@ type ProviderModel struct {
 <% unless version == "ga" -%>
 	GkehubFeatureCustomEndpoint        types.String `tfsdk:"gkehub_feature_custom_endpoint"`
 <% end -%>
+<% if version == "private" -%>
+	VmwareCustomEndpoint                  types.String `tfsdk:"vmware_custom_endpoint"`
+	// artifact from a private internal fork- this one can be removed when the
+	// internal definition is removed.
+	RunCustomEndpoint                  types.String `tfsdk:"run_custom_endpoint"`
+<% end -%>
 }
 
 type ProviderBatching struct {

--- a/mmv1/third_party/terraform/utils/gkeonprem_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/gkeonprem_operation.go.erb
@@ -94,7 +94,7 @@ func (w *gkeonpremOperationWaiter) QueryOp() (interface{}, error) {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
 	// Returns the proper get.
-	url := fmt.Sprintf("%s%s", w.Config.gkeonpremBasePath, w.Op.Name)
+	url := fmt.Sprintf("%s%s", w.Config.GkeonpremBasePath, w.Op.Name)
 
 	return SendRequest(w.Config, "GET", w.Project, url, w.UserAgent, nil)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

These are handwritten, but their bindings are generated. This ends up causing a runtime issue:

```
An unexpected error was encountered trying to convert tftypes.Value into google.ProviderModel. 

This is always an error in the provider. Please report the following to the provider developer: mismatch between struct and object: Object defines fields not found in struct: run_custom_endpoint, gkeonprem_custom_endpoint, and vmware_custom_endpoint.
```

(gkeonprem has a separate issue, see https://github.com/GoogleCloudPlatform/magic-modules/pull/7731)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
