### PR TITLE
Add PubSub subscription detach support

### DIFF
--- a/mmv1/products/activedirectory/Domain.yaml
+++ b/mmv1/products/activedirectory/Domain.yaml
@@ -71,7 +71,7 @@
       url_param_only: true
       immutable: true
       description: |
-        The fully qualified domain name. e.g. mydomain.myorganization.com, with the restrictions, 
+        The fully qualified domain name. e.g. mydomain.myorganization.com, with the restrictions,
         https://cloud.google.com/managed-microsoft-ad/reference/rest/v1/projects.locations.global.domains.
       validation: !ruby/object:Provider::Terraform::Validation
         function: 'validateADDomainName()'
@@ -95,26 +95,26 @@
       required: true
       immutable: true
       description: |
-        The CIDR range of internal addresses that are reserved for this domain. Reserved networks must be /24 or larger. 
+        The CIDR range of internal addresses that are reserved for this domain. Reserved networks must be /24 or larger.
         Ranges must be unique and non-overlapping with existing subnets in authorizedNetworks
     - !ruby/object:Api::Type::Array
       name: 'locations'
       required: true
       item_type: Api::Type::String
       description: |
-        Locations where domain needs to be provisioned. [regions][compute/docs/regions-zones/] 
+        Locations where domain needs to be provisioned. [regions][compute/docs/regions-zones/]
         e.g. us-west1 or us-east4 Service supports up to 4 locations at once. Each location will use a /26 block.
     - !ruby/object:Api::Type::String
       name: 'admin'
       default_value: 'setupadmin'
       immutable: true
       description: |
-        The name of delegated administrator account used to perform Active Directory operations. 
+        The name of delegated administrator account used to perform Active Directory operations.
         If not specified, setupadmin will be used.
     - !ruby/object:Api::Type::String
       name: 'fqdn'
       output: true
       description: |
-        The fully-qualified domain name of the exposed domain used by clients to connect to the service. 
+        The fully-qualified domain name of the exposed domain used by clients to connect to the service.
         Similar to what would be chosen for an Active Directory set up on an internal network.
-  
+

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -199,26 +199,26 @@ properties:
   - !ruby/object:Api::Type::Integer
     name: 'mtu'
     description: |
-      Maximum Transmission Unit in bytes. The default value is 1460 bytes. 
+      Maximum Transmission Unit in bytes. The default value is 1460 bytes.
       The minimum value for this field is 1300 and the maximum value is 8896 bytes (jumbo frames).
       Note that packets larger than 1500 bytes (standard Ethernet) can be subject to TCP-MSS clamping or dropped
-      with an ICMP `Fragmentation-Needed` message if the packets are routed to the Internet or other VPCs 
+      with an ICMP `Fragmentation-Needed` message if the packets are routed to the Internet or other VPCs
       with varying MTUs.
     immutable: true
     default_from_api: true
   - !ruby/object:Api::Type::Boolean
     name: 'enableUlaInternalIpv6'
     description: |
-      Enable ULA internal ipv6 on this network. Enabling this feature will assign 
+      Enable ULA internal ipv6 on this network. Enabling this feature will assign
       a /48 from google defined ULA prefix fd20::/20.
     immutable: true
   - !ruby/object:Api::Type::String
     name: 'internalIpv6Range'
     description: |
-      When enabling ula internal ipv6, caller optionally can specify the /48 range 
-      they want from the google defined ULA prefix fd20::/20. The input must be a 
-      valid /48 ULA IPv6 address and must be within the fd20::/20. Operation will 
-      fail if the speficied /48 is already in used by another resource. 
+      When enabling ula internal ipv6, caller optionally can specify the /48 range
+      they want from the google defined ULA prefix fd20::/20. The input must be a
+      valid /48 ULA IPv6 address and must be within the fd20::/20. Operation will
+      fail if the speficied /48 is already in used by another resource.
       If the field is not speficied, then a /48 range will be randomly allocated from fd20::/20 and returned via this field.
     immutable: true
     default_from_api: true

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -70,7 +70,7 @@ examples:
       table_id: "example_table"
 docs: !ruby/object:Provider::Terraform::Docs
   note: |
-    You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding 
+    You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding
     by using the `google_project_service_identity` resource.
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/subscription.go.erb
@@ -264,9 +264,9 @@ properties:
     name: 'filter'
     required: false
     description: |
-      The subscription only delivers the messages that match the filter. 
+      The subscription only delivers the messages that match the filter.
       Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages
-      by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription, 
+      by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription,
       you can't modify the filter.
     immutable: true
   - !ruby/object:Api::Type::NestedObject
@@ -289,7 +289,7 @@ properties:
           Format is `projects/{project}/topics/{topic}`.
 
           The Cloud Pub/Sub service account associated with the enclosing subscription's
-          parent project (i.e., 
+          parent project (i.e.,
           service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
           permission to Publish() to this topic.
 
@@ -302,7 +302,7 @@ properties:
           The maximum number of delivery attempts for any message. The value must be
           between 5 and 100.
 
-          The number of delivery attempts is defined as 1 + (the sum of number of 
+          The number of delivery attempts is defined as 1 + (the sum of number of
           NACKs and number of times the acknowledgement deadline has been exceeded for the message).
 
           A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that
@@ -316,7 +316,7 @@ properties:
     description: |
       A policy that specifies how Pub/Sub retries message delivery for this subscription.
 
-      If not set, the default retry policy is applied. This generally implies that messages will be retried as soon as possible for healthy subscribers. 
+      If not set, the default retry policy is applied. This generally implies that messages will be retried as soon as possible for healthy subscribers.
       RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message
     properties:
       - !ruby/object:Api::Type::String
@@ -329,7 +329,7 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'maximumBackoff'
         description: |
-          The maximum delay between consecutive deliveries of a given message. Value should be between 0 and 600 seconds. Defaults to 600 seconds. 
+          The maximum delay between consecutive deliveries of a given message. Value should be between 0 and 600 seconds. Defaults to 600 seconds.
           A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
         default_from_api: true
         diff_suppress_func: 'DurationDiffSuppress'
@@ -352,3 +352,12 @@ properties:
 
       Note that subscribers may still receive multiple copies of a message when `enable_exactly_once_delivery`
       is true if the message was published multiple times by a publisher client. These copies are considered distinct by Pub/Sub and have distinct messageId values
+  - !ruby/object:Api::Type::Boolean
+    name: 'detached'
+    description: |
+      Indicates whether the subscription is detached from its topic.
+      Detached subscriptions don't receive messages from their topic and don't retain any backlog.
+      `subscriptions.pull` and `StreamingPull` requests will return `FAILED_PRECONDITION`.
+      If the subscription is a push subscription, pushes to the endpoint will not be made.
+    update_url: 'projects/{{project}}/subscriptions/{{name}}:detach'
+    update_verb: :POST

--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -29,7 +29,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   method_name_separator: ':'
 docs: !ruby/object:Provider::Terraform::Docs
   note: |
-    You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding 
+    You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding
     by using the `google_project_service_identity` resource.
    # PubSub resources don't have operations but are negatively cached
     # and eventually consistent.

--- a/mmv1/products/spanner/Database.yaml
+++ b/mmv1/products/spanner/Database.yaml
@@ -111,7 +111,7 @@ properties:
       and 7 days, and can be specified in days, hours, minutes, or seconds. For example,
       the values 1d, 24h, 1440m, and 86400s are equivalent. Default value is 1h.
       If this property is used, you must avoid adding new DDL statements to `ddl` that
-      update the database's version_retention_period. 
+      update the database's version_retention_period.
     validation: !ruby/object:Provider::Terraform::Validation
       function: ValidateDatabaseRetentionPeriod
     default_from_api: true
@@ -152,7 +152,7 @@ properties:
     name: 'databaseDialect'
     description: |
       The dialect of the Cloud Spanner Database.
-      If it is not provided, "GOOGLE_STANDARD_SQL" will be used. 
+      If it is not provided, "GOOGLE_STANDARD_SQL" will be used.
     values:
       - :GOOGLE_STANDARD_SQL
       - :POSTGRESQL

--- a/mmv1/templates/terraform.yaml
+++ b/mmv1/templates/terraform.yaml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Base terraform.yaml for product folders that have been converted over to the 
+# Base terraform.yaml for product folders that have been converted over to the
 # per-resource format.
 --- !ruby/object:Provider::Terraform::Config
 # This is for copying files over

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -288,7 +288,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <% unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
-<%  end -%>         
+<%  end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 
@@ -522,7 +522,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
     <% unless field.default_value.nil? -%>
     if _, ok := d.GetOkExists("<%= field.name -%>"); !ok {
       if err := d.Set("<%= field.name -%>", <%= go_literal(field.default_value) -%>); err != nil {
-      	return fmt.Errorf("Error setting <%= field.name -%>: %s", err)
+        return fmt.Errorf("Error setting <%= field.name -%>: %s", err)
       }
     }
     <% end -%>
@@ -556,7 +556,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
         if casted != nil {
             for k, v := range casted.(map[string]interface{}) {
                 if err := d.Set(k, v); err != nil {
-                	return fmt.Errorf("Error setting %s: %s", k, err)
+                return fmt.Errorf("Error setting %s: %s", k, err)
                 }
             }
         }
@@ -584,7 +584,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     config := meta.(*Config)
     userAgent, err := generateUserAgentString(d, config.UserAgent)
     if err != nil {
-    	return err
+      return err
     }
 
     billingProject := ""
@@ -856,7 +856,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     config := meta.(*Config)
     userAgent, err := generateUserAgentString(d, config.UserAgent)
     if err != nil {
-    	return err
+      return err
     }
 
 <% if object.custom_code.custom_delete -%>
@@ -976,7 +976,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
   <%-  object.virtual_fields.each do |field| -%>
     <% unless field.default_value.nil? -%>
     if err := d.Set("<%= field.name %>", <%= go_literal(field.default_value) -%>); err != nil {
-    	return nil, fmt.Errorf("Error setting <%= field.name %>: %s", err)
+      return nil, fmt.Errorf("Error setting <%= field.name %>: %s", err)
     }
     <% end -%>
   <%   end -%>

--- a/mmv1/templates/terraform/update_encoder/pubsub_subscription.erb
+++ b/mmv1/templates/terraform/update_encoder/pubsub_subscription.erb
@@ -12,6 +12,10 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-	newObj := make(map[string]interface{})
-	newObj["subscription"] = obj
+  newObj := make(map[string]interface{})
+  if d.HasChange("detached") {
+    newObj = nil
+  } else {
+    newObj["subscription"] = obj
+  }
 return newObj, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for detaching Pub/Sub subscriptions.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14215

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: Added `detached` field to `google_pubsub_subscription`
```
