### PR TITLE
Update list implementation in `google_dns_keys` data source

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_dns_key_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_key_test.go.erb
@@ -29,7 +29,7 @@ func TestAccDataSourceDNSKeys_basic(t *testing.T) {
 						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
 					},
 				},
-				Config: testAccDataSourceDNSKeysConfig(dnsZoneName, "on"),
+				Config: testAccDataSourceDNSKeysConfigWithOutputs(dnsZoneName, "on"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceDNSKeysDSRecordCheck("data.google_dns_keys.foo_dns_key"),
 					resource.TestCheckResourceAttr("data.google_dns_keys.foo_dns_key", "key_signing_keys.#", "1"),
@@ -43,7 +43,7 @@ func TestAccDataSourceDNSKeys_basic(t *testing.T) {
 			},
 			{
 				ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-				Config:                   testAccDataSourceDNSKeysConfig(dnsZoneName, "on"),
+				Config:                   testAccDataSourceDNSKeysConfigWithOutputs(dnsZoneName, "on"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceDNSKeysDSRecordCheck("data.google_dns_keys.foo_dns_key"),
 					resource.TestCheckResourceAttr("data.google_dns_keys.foo_dns_key", "key_signing_keys.#", "1"),
@@ -131,4 +131,26 @@ data "google_dns_keys" "foo_dns_key_id" {
   managed_zone = google_dns_managed_zone.foo.id
 }
 `, dnsZoneName, dnsZoneName, dnssecStatus)
+}
+
+// This function extends the config returned from the `testAccDataSourceDNSKeysConfig` function
+// to include output blocks that access the `key_signing_keys` and `zone_signing_keys` attributes.
+// These are null if DNSSEC is not enabled.
+func testAccDataSourceDNSKeysConfigWithOutputs(dnsZoneName, dnssecStatus string) string {
+
+	config := testAccDataSourceDNSKeysConfig(dnsZoneName, dnssecStatus)
+	config = config + `
+# These outputs will cause an error if google_dns_managed_zone.foo.dnssec_config.state == "off"
+
+output "test_access_google_dns_keys_key_signing_keys" {
+  description = "Testing that we can access a value in key_signing_keys ok as a computed block"
+  value       = data.google_dns_keys.foo_dns_key_id.key_signing_keys[0].ds_record
+}
+
+output "test_access_google_dns_keys_zone_signing_keys" {
+  description = "Testing that we can access a value in zone_signing_keys ok as a computed block"
+  value       = data.google_dns_keys.foo_dns_key_id.zone_signing_keys[0].id
+}
+`
+	return config
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/14298

`google_dns_keys` was recently migrated to the plugin framework. Currently the Google provider is **muxed and uses protocol 5.**

Computed blocks have issues when protocol 5 is in use, which result in the problem seen in https://github.com/hashicorp/terraform-provider-google/issues/14298

In this PR I

1. change the DNS keys data source to follow the recommended approach for avoiding this issue
2. update acceptance tests to access these attributes, showing that these code changes fix the issue



---

Useful links:

- https://github.com/hashicorp/terraform-plugin-framework/issues/214#issuecomment-1194666110
- [Official documentation's guidance for this issue](https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks-computed#framework) when using Computed blocks in a muxed provider

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dns: fixed bug in `google_dns_keys` data source where list attributes could not be used at plan-time
```
