### PR TITLE
make membership-checker exit when errors occur

### DIFF
--- a/.ci/containers/membership-checker/community.go
+++ b/.ci/containers/membership-checker/community.go
@@ -61,7 +61,7 @@ func postBuildStatus(prNumber, GITHUB_TOKEN, commitSha string, body map[string]s
 		return err
 	}
 
-	fmt.Printf("Successfully posted community-checker build link to pull request %s", prNumber)
+	fmt.Printf("Successfully posted community-checker build link to pull request %s\n", prNumber)
 
 	return nil
 }

--- a/.ci/containers/membership-checker/main.go
+++ b/.ci/containers/membership-checker/main.go
@@ -51,14 +51,14 @@ func main() {
 	author, err := getPullRequestAuthor(prNumber, GITHUB_TOKEN)
 	if err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(1)
 	}
 
 	if target == "auto_run" {
 		err = requestReviewer(author, prNumber, GITHUB_TOKEN)
 		if err != nil {
 			fmt.Println(err)
-			return
+			os.Exit(1)
 		}
 	}
 
@@ -75,7 +75,7 @@ func main() {
 		err = triggerMMPresubmitRuns(projectId, repoName, commitSha, substitutions)
 		if err != nil {
 			fmt.Println(err)
-			return
+			os.Exit(1)
 		}
 	}
 
@@ -87,7 +87,7 @@ func main() {
 			err = approveCommunityChecker(prNumber, projectId, commitSha)
 			if err != nil {
 				fmt.Println(err)
-				return
+				os.Exit(1)
 			}
 		} else {
 			addAwaitingApprovalLabel(prNumber, GITHUB_TOKEN)

--- a/.ci/containers/membership-checker/reviewer_assignment.go
+++ b/.ci/containers/membership-checker/reviewer_assignment.go
@@ -132,7 +132,7 @@ func requestPullRequestReviewer(prNumber, assignee, GITHUB_TOKEN string) error {
 		return fmt.Errorf("Error adding reviewer for PR %s", prNumber)
 	}
 
-	fmt.Printf("Successfully added reviewer %s to pull request %s", assignee, prNumber)
+	fmt.Printf("Successfully added reviewer %s to pull request %s\n", assignee, prNumber)
 
 	return nil
 }
@@ -173,7 +173,7 @@ func postComment(prNumber, reviewer, GITHUB_TOKEN string) error {
 		return fmt.Errorf("Error posting reviewer assignment comment for PR %s", prNumber)
 	}
 
-	fmt.Printf("Successfully posted reviewer assignment comment to pull request %s", prNumber)
+	fmt.Printf("Successfully posted reviewer assignment comment to pull request %s\n", prNumber)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
