### PR TITLE
Update google_compute_router_interface import, acctest, docs

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_router_interface.go.erb
@@ -371,19 +371,35 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 
 func resourceComputeRouterInterfaceImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("Invalid router interface specifier. Expecting {region}/{router}/{interface}")
+	switch len(parts) {
+	case 3:
+		// {{region}}/{{router}}/{{name}} import id
+		if err := d.Set("region", parts[0]); err != nil {
+			return nil, fmt.Errorf("error setting region: %s", err)
+		}
+		if err := d.Set("router", parts[1]); err != nil {
+			return nil, fmt.Errorf("error setting router: %s", err)
+		}
+		if err := d.Set("name", parts[2]); err != nil {
+			return nil, fmt.Errorf("error setting name: %s", err)
+		}
+		return []*schema.ResourceData{d}, nil
+	case 4:
+		// {{project}}/{{region}}/{{router}}/{{name}} import id
+		if err := d.Set("project", parts[0]); err != nil {
+			return nil, fmt.Errorf("error setting project: %s", err)
+		}
+		if err := d.Set("region", parts[1]); err != nil {
+			return nil, fmt.Errorf("error setting region: %s", err)
+		}
+		if err := d.Set("router", parts[2]); err != nil {
+			return nil, fmt.Errorf("error setting router: %s", err)
+		}
+		if err := d.Set("name", parts[3]); err != nil {
+			return nil, fmt.Errorf("error setting name: %s", err)
+		}
+		return []*schema.ResourceData{d}, nil
 	}
 
-	if err := d.Set("region", parts[0]); err != nil {
-		return nil, fmt.Errorf("Error setting region: %s", err)
-	}
-	if err := d.Set("router", parts[1]); err != nil {
-		return nil, fmt.Errorf("Error setting router: %s", err)
-	}
-	if err := d.Set("name", parts[2]); err != nil {
-		return nil, fmt.Errorf("Error setting name: %s", err)
-	}
-
-	return []*schema.ResourceData{d}, nil
+	return nil, fmt.Errorf("invalid router interface specifier. Expecting either {region}/{router}/{interface} or {project}/{region}/{router}/{interface} import id format")
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_router_interface_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_interface_test.go
@@ -11,24 +11,36 @@ import (
 func TestAccComputeRouterInterface_basic(t *testing.T) {
 	t.Parallel()
 
-	routerName := fmt.Sprintf("tf-test-router-%s", RandString(t, 10))
+	name := fmt.Sprintf("tf-test-router-%s", RandString(t, 10))
+	context := map[string]interface{}{
+		"name":   name,
+		"region": "us-central1",
+	}
+	importIdFourPart := fmt.Sprintf("%s/%s/%s/%s", GetTestProjectFromEnv(), context["region"], context["name"], context["name"]) // name reused in config
+
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRouterInterfaceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterInterfaceBasic(routerName),
+				Config: testAccComputeRouterInterfaceBasic(context),
 				Check: testAccCheckComputeRouterInterfaceExists(
 					t, "google_compute_router_interface.foobar"),
 			},
 			{
 				ResourceName:      "google_compute_router_interface.foobar",
-				ImportState:       true,
+				ImportState:       true, // Will use the 3 part {{region}}/{{router}}/{{name}} import id by default as it's the id in state
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterInterfaceKeepRouter(routerName),
+				ResourceName:      "google_compute_router_interface.foobar",
+				ImportState:       true,
+				ImportStateId:     importIdFourPart, // Make test step use 4 part {{project}}/{{region}}/{{router}}/{{name}} import id
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterInterfaceKeepRouter(name),
 				Check: testAccCheckComputeRouterInterfaceDelete(
 					t, "google_compute_router_interface.foobar"),
 			},
@@ -227,32 +239,32 @@ func testAccCheckComputeRouterInterfaceExists(t *testing.T, n string) resource.T
 	}
 }
 
-func testAccComputeRouterInterfaceBasic(routerName string) string {
-	return fmt.Sprintf(`
+func testAccComputeRouterInterfaceBasic(context map[string]interface{}) string {
+	return Nprintf(`
 resource "google_compute_network" "foobar" {
-  name = "%s-net"
+  name = "%{name}-net"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
+  name          = "%{name}-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
+  region        = "%{region}"
 }
 
 resource "google_compute_address" "foobar" {
-  name   = "%s-addr"
+  name   = "%{name}-addr"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_vpn_gateway" "foobar" {
-  name    = "%s-gateway"
+  name    = "%{name}-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_forwarding_rule" "foobar_esp" {
-  name        = "%s-fr1"
+  name        = "%{name}-fr1"
   region      = google_compute_vpn_gateway.foobar.region
   ip_protocol = "ESP"
   ip_address  = google_compute_address.foobar.address
@@ -260,7 +272,7 @@ resource "google_compute_forwarding_rule" "foobar_esp" {
 }
 
 resource "google_compute_forwarding_rule" "foobar_udp500" {
-  name        = "%s-fr2"
+  name        = "%{name}-fr2"
   region      = google_compute_forwarding_rule.foobar_esp.region
   ip_protocol = "UDP"
   port_range  = "500-500"
@@ -269,7 +281,7 @@ resource "google_compute_forwarding_rule" "foobar_udp500" {
 }
 
 resource "google_compute_forwarding_rule" "foobar_udp4500" {
-  name        = "%s-fr3"
+  name        = "%{name}-fr3"
   region      = google_compute_forwarding_rule.foobar_udp500.region
   ip_protocol = "UDP"
   port_range  = "4500-4500"
@@ -278,7 +290,7 @@ resource "google_compute_forwarding_rule" "foobar_udp4500" {
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "%s"
+  name    = "%{name}"
   region  = google_compute_forwarding_rule.foobar_udp500.region
   network = google_compute_network.foobar.self_link
   bgp {
@@ -287,12 +299,12 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_router_interface" "foobar" {
-  name     = "%s"
+  name     = "%{name}"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
   ip_range = "169.254.3.1/30"
 }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, context)
 }
 
 func testAccComputeRouterInterfaceRedundant(routerName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -82,8 +82,9 @@ This resource provides the following
 
 ## Import
 
-Router interfaces can be imported using the `region`, `router`, and `name`, e.g.
+Router interfaces can be imported using the `project` (optional), `region`, `router`, and `name`, e.g.
 
 ```
+$ terraform import google_compute_router_interface.foobar my-project/us-central1/router-1/interface-1
 $ terraform import google_compute_router_interface.foobar us-central1/router-1/interface-1
 ```


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14331

This PR:
- Adds a 4-part import format for the `google_compute_router_interface` resource to allow passing in project information.
- Updates an existing acceptance test to test import with the 4-part import id
- Update the docs

The resource is handwritten.

Router interfaces are not independent entities in the Compute API, they're [info attached to Router entities](https://cloud.google.com/compute/docs/reference/rest/v1/routers#Router.FIELDS.interface). This means they don't have self links/GET-able URIs specific to the interface that the resource represents, and instead the provider makes up a {{region}}/{{router}}/{{name}} identifier for the interface. As this lacks project info the (old) import functionality relies on project being set in the provider configuration/ENVs.

I've left the `id` of the resource as the old 3-part identifier as I didn't want to introduce breaking changes.


---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: fixed an import bug for `google_compute_router_interface` that happened when project was not set in the provider configuration or via environment variable
```
