### PR TITLE
Docs: Fix a broken-link in getting-started/provider-documentation

### DIFF
--- a/docs/content/docs/getting-started/provider-documentation.md
+++ b/docs/content/docs/getting-started/provider-documentation.md
@@ -87,4 +87,4 @@ Terraform Provider Google (TPG) contains handwritten documentation for handwritt
 ### Generated documentation (mmv1)
 
 The majority of resources in TPG are generated, and the information used to generate provider code is also used to generate documentation. For information about how documentation is generated, see:
-- [Update MMv1 resource documentation](/magic-modules/docs/how-to/update-mmv1-resource-documentation)
+- [Update MMv1 resource documentation](/magic-modules/docs/how-to/mmv1-resource-documentation)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Update a document for fixing a broken link in getting-started/provider-documentation
Info: This Pull request only fixed a tiny change about  a broken link

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [-] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [-] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [-] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [-] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [-] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

```release-note:none
```