### PR TITLE
Adds `port` field to `http_get` in `google_cloud_run_service` and `google_cloud_run_v2_service` resources

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -566,6 +566,7 @@ properties:
                               name: port
                               description: |-
                                 Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
                               default_from_api: true
                         - !ruby/object:Api::Type::NestedObject
                           name: httpGet
@@ -583,6 +584,12 @@ properties:
                               description: |-
                                 Path to access on the HTTP server. If set, it should not be empty string.
                               default_value: "/"
+                            - !ruby/object:Api::Type::Integer
+                              name: port
+                              description: |-
+                                Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
+                              default_from_api: true
                             - !ruby/object:Api::Type::Array
                               name: httpHeaders
                               description: |-
@@ -615,6 +622,7 @@ properties:
                               name: port
                               description: |-
                                 Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
                               default_from_api: true
                             - !ruby/object:Api::Type::String
                               name: service
@@ -669,6 +677,12 @@ properties:
                               description: |-
                                 Path to access on the HTTP server. If set, it should not be empty string.
                               default_value: "/"
+                            - !ruby/object:Api::Type::Integer
+                              name: port
+                              description: |-
+                                Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
+                              default_from_api: true
                             - !ruby/object:Api::Type::Array
                               name: httpHeaders
                               description: |-
@@ -700,6 +714,7 @@ properties:
                               name: port
                               description: |-
                                 Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
                               default_from_api: true
                             - !ruby/object:Api::Type::String
                               name: service

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -395,6 +395,12 @@ properties:
                       default_value: "/"
                       description: |-
                         Path to access on the HTTP server. Defaults to '/'.
+                    - !ruby/object:Api::Type::Integer
+                      name: port
+                      description: |-
+                        Port number to access on the container. Number must be in the range 1 to 65535.
+                        If not specified, defaults to the same value as container.ports[0].containerPort.
+                      default_from_api: true
                     - !ruby/object:Api::Type::Array
                       name: "httpHeaders"
                       description: |-
@@ -436,7 +442,8 @@ properties:
                     - !ruby/object:Api::Type::Integer
                       name: port
                       description: |-
-                        Port number to access on the container. Number must be in the range 1 to 65535. If not specified, defaults to the same value as container.ports[0].containerPort.
+                        Port number to access on the container. Number must be in the range 1 to 65535.
+                        If not specified, defaults to the same value as container.ports[0].containerPort.
                       default_from_api: true
                     - !ruby/object:Api::Type::String
                       name: service
@@ -486,6 +493,12 @@ properties:
                       default_value: "/"
                       description: |-
                         Path to access on the HTTP server. Defaults to '/'.
+                    - !ruby/object:Api::Type::Integer
+                      name: port
+                      description: |-
+                        Port number to access on the container. Must be in the range 1 to 65535.
+                        If not specified, defaults to the same value as container.ports[0].containerPort.
+                      default_from_api: true
                     - !ruby/object:Api::Type::Array
                       name: "httpHeaders"
                       description: |-
@@ -517,7 +530,8 @@ properties:
                     - !ruby/object:Api::Type::Integer
                       name: port
                       description: |-
-                        Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to 8080.
+                        Port number to access on the container. Must be in the range 1 to 65535.
+                        If not specified, defaults to the same value as container.ports[0].containerPort.
                       default_from_api: true
                 - !ruby/object:Api::Type::NestedObject
                   name: grpc
@@ -533,7 +547,8 @@ properties:
                     - !ruby/object:Api::Type::Integer
                       name: port
                       description: |-
-                        Port number to access on the container. Number must be in the range 1 to 65535. If not specified, defaults to the same value as container.ports[0].containerPort.
+                        Port number to access on the container. Number must be in the range 1 to 65535.
+                        If not specified, defaults to the same value as container.ports[0].containerPort.
                       default_from_api: true
                     - !ruby/object:Api::Type::String
                       name: service

--- a/mmv1/templates/terraform/examples/cloud_run_service_probes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_probes.tf.erb
@@ -3,11 +3,6 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
 
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
   location = "us-central1"
-  metadata {
-    annotations = {
-      "run.googleapis.com/launch-stage" = "BETA"
-    }
-  }
 
   template {
     spec {

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -440,7 +440,6 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
     }
   }
 
@@ -480,7 +479,6 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
     }
   }
 
@@ -507,6 +505,7 @@ resource "google_cloud_run_service" "default" {
           failure_threshold = %s
           http_get {
             path = "/some-path"
+            port = 8080
             http_headers {
               name = "User-Agent"
               value = "magic-modules"
@@ -539,7 +538,6 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
     }
   }
 
@@ -573,7 +571,6 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
     }
   }
 
@@ -584,6 +581,7 @@ resource "google_cloud_run_service" "default" {
         startup_probe {
           http_get {
             path = "/some-path"
+            port = 8080
             http_headers {
               name = "User-Agent"
               value = "magic-modules"
@@ -616,7 +614,6 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
     }
   }
 
@@ -650,7 +647,6 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
     }
   }
 

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
@@ -399,6 +399,7 @@ resource "google_cloud_run_v2_service" "default" {
         failure_threshold = 2
         http_get {
           path = "/some-path"
+          port = 8080
           http_headers {
             name = "User-Agent"
             value = "magic-modules"
@@ -448,6 +449,7 @@ resource "google_cloud_run_v2_service" "default" {
         failure_threshold = 3
         http_get {
           path = "/some-path"
+          port = 8080
           http_headers {
             name = "User-Agent"
             value = "magic-modules"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

* Adds port support for `liveness_probe.http_get` and `startup_probe.http_get`
* Removes the beta launch stage annotation
* Updates the description for port of probes to reflect the default value.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: added field `port` to `http_get` to resource `google_cloud_run_service` (beta)
```

```release-note:enhancement
cloudrunv2: added field `port` to `http_get` to resource `google_cloud_run_v2_service`
```
