### PR TITLE
Fix environment vars for tests (`make test` command)

### DIFF
--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -122,7 +122,33 @@ func setupSDKProviderConfigTest(t *testing.T, configValues map[string]interface{
 		}
 	}
 
-	// Set ENVs
+	// Unset any ENVs in the test environment here
+	// The testing package restores the original values afterwards
+	envVarsSets := [][]string{
+		CredsEnvVars,
+		projectNumberEnvVars,
+		ProjectEnvVars,
+		firestoreProjectEnvVars,
+		regionEnvVars,
+		zoneEnvVars,
+		orgEnvVars,
+		custIdEnvVars,
+		identityUserEnvVars,
+		orgEnvDomainVars,
+		serviceAccountEnvVars,
+		billingAccountEnvVars,
+	}
+	unsetEnvs := []string{}
+	for _, set := range envVarsSets {
+		unsetEnvs = append(unsetEnvs, set...)
+	}
+	if len(unsetEnvs) > 0 {
+		for _, env := range unsetEnvs {
+			t.Setenv(env, "") // set to an empty string to 'unset' in the test run environment
+		}
+	}
+
+	// Set ENVs for the test case
 	if len(envValues) > 0 {
 		for k, v := range envValues {
 			t.Setenv(k, v)

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -124,27 +124,10 @@ func setupSDKProviderConfigTest(t *testing.T, configValues map[string]interface{
 
 	// Unset any ENVs in the test environment here
 	// The testing package restores the original values afterwards
-	envVarsSets := [][]string{
-		CredsEnvVars,
-		projectNumberEnvVars,
-		ProjectEnvVars,
-		firestoreProjectEnvVars,
-		regionEnvVars,
-		zoneEnvVars,
-		orgEnvVars,
-		custIdEnvVars,
-		identityUserEnvVars,
-		orgEnvDomainVars,
-		serviceAccountEnvVars,
-		billingAccountEnvVars,
-	}
-	unsetEnvs := []string{}
-	for _, set := range envVarsSets {
-		unsetEnvs = append(unsetEnvs, set...)
-	}
-	if len(unsetEnvs) > 0 {
-		for _, env := range unsetEnvs {
-			t.Setenv(env, "") // set to an empty string to 'unset' in the test run environment
+	envs := providerConfigEnvNames()
+	if len(envs) > 0 {
+		for _, k := range envs {
+			t.Setenv(k, "")
 		}
 	}
 

--- a/mmv1/third_party/terraform/utils/provider_test_utils.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test_utils.go.erb
@@ -26,6 +26,32 @@ const TestEnvVar = "TF_ACC"
 var TestAccProviders map[string]*schema.Provider
 var testAccProvider *schema.Provider
 
+// providerConfigEnvNames returns a list of all the environment variables that could be set by a user to configure the provider
+func providerConfigEnvNames() []string {
+
+	envs := []string{}
+
+	// Use existing collections of ENV names
+	envVarsSets := [][]string{
+		CredsEnvVars,   // credentials field
+		ProjectEnvVars, // project field
+		regionEnvVars,  //region field
+		zoneEnvVars,    // zone field
+	}
+	for _, set := range envVarsSets {
+		envs = append(envs, set...)
+	}
+
+	// Add remaining ENVs
+	envs = append(envs, "GOOGLE_OAUTH_ACCESS_TOKEN")          // access_token field 
+	envs = append(envs, "GOOGLE_BILLING_PROJECT")             // billing_project field 
+	envs = append(envs, "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT") // impersonate_service_account field
+	envs = append(envs, "USER_PROJECT_OVERRIDE")              // user_project_override field
+	envs = append(envs, "CLOUDSDK_CORE_REQUEST_REASON")       // request_reason field
+
+	return envs
+}
+
 var CredsEnvVars = []string{
 	"GOOGLE_CREDENTIALS",
 	"GOOGLE_CLOUD_KEYFILE_JSON",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The PR allows people to run `make test` in an environment where ENVs used with the Google provider are set (i.e. developers' laptops during provider development).

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
