### PR TITLE
Promotes `startupProbe` and `livenessProbe` field to GA in resource `google_cloud_run_service`

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -112,7 +112,6 @@ examples:
     skip_docs: true
   - !ruby/object:Provider::Terraform::Examples
     name: "cloud_run_service_probes"
-    min_version: beta
     primary_resource_id: "default"
     vars:
       cloud_run_service_name: "cloudrun-srv"
@@ -518,7 +517,6 @@ properties:
                               This must match the Name of a Volume.
                     - !ruby/object:Api::Type::NestedObject
                       name: startupProbe
-                      min_version: beta
                       description: |-
                         Startup probe of application within the container.
                         All other probes are disabled if a startup probe is provided, until it
@@ -632,7 +630,6 @@ properties:
                                 If this is not specified, the default behavior is defined by gRPC.
                     - !ruby/object:Api::Type::NestedObject
                       name: livenessProbe
-                      min_version: beta
                       description: |-
                         Periodic probe of container liveness. Container will be restarted if the probe fails.
                       properties:

--- a/mmv1/templates/terraform/examples/cloud_run_service_probes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_probes.tf.erb
@@ -1,6 +1,4 @@
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
   location = "us-central1"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13310



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: promoted `startup_probe` and `liveness_probe` in resource `google_cloud_run_service` to GA.
```
