### PR TITLE
Adds repository field to git_file_source and source_to_build of googl…

### DIFF
--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -91,6 +91,18 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_trigger_allow_exit_codes'
     primary_resource_id: 'allow-exit-codes-trigger'
+  - !ruby/object:Provider::Terraform::Examples
+    name: "cloudbuild_trigger_pubsub_with_repo"
+    min_version: beta
+    primary_resource_id: "pubsub-with-repo-trigger"
+    vars:
+      installation_id: "123123"
+      pat_secret: "projects/my-project/secrets/github-pat-secret/versions/latest"
+      repo_uri: "https://github.com/myuser/my-repo.git"
+    test_vars_overrides:
+      installation_id: 31300675
+      pat_secret: '"projects/gcb-terraform-creds/secrets/github-pat/versions/latest"'
+      repo_uri: '"https://github.com/gcb-repos-robot/tf-demo.git"'
 
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_read: templates/terraform/pre_read/cloudbuild_trigger.go.erb
@@ -194,6 +206,12 @@ properties:
         description: |
           The URI of the repo (optional). If unspecified, the repo from which the trigger
           invocation originated is assumed to be the repo from which to read the specified path.
+      - !ruby/object:Api::Type::String
+        name: 'repository'
+        min_version: beta
+        description: |
+          The fully qualified resource name of the Repo API repository. The fully qualified resource name of the Repo API repository.
+          If unspecified, the repo from which the trigger invocation originated is assumed to be the repo from which to read the specified path.
       - !ruby/object:Api::Type::Enum
         name: 'repoType'
         required: true
@@ -315,9 +333,14 @@ properties:
     properties:
       - !ruby/object:Api::Type::String
         name: 'uri'
-        required: true
         description: |
-          The URI of the repo (required).
+          The URI of the repo.
+      - !ruby/object:Api::Type::String
+        name: 'repository'
+        min_version: beta
+        description: |
+          The qualified resource name of the Repo API repository. 
+          Either uri or repository can be specified and is required.
       - !ruby/object:Api::Type::String
         name: 'ref'
         required: true

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_pubsub_with_repo.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_pubsub_with_repo.tf.erb
@@ -1,0 +1,45 @@
+resource "google_cloudbuildv2_connection" "my-connection" {
+  provider = google-beta
+  location = "us-central1"
+  name = "my-connection"
+
+  github_config {
+    app_installation_id = <%= ctx[:vars]['installation_id'] %>
+    authorizer_credential {
+      oauth_token_secret_version = "<%= ctx[:vars]['pat_secret'] %>"
+    }
+  }
+}
+
+resource "google_cloudbuildv2_repository" "my-repository" {
+  provider = google-beta
+  name = "my-repo"
+  parent_connection = google_cloudbuildv2_connection.my-connection.id
+  remote_uri = "<%= ctx[:vars]['repo_uri'] %>"
+}
+
+resource "google_pubsub_topic" "mytopic" {
+  provider = google-beta
+  name = "mytopic"
+}
+
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name = "pubsub-with-repo-trigger"
+  location = "us-central1"
+
+  pubsub_config {
+    topic = google_pubsub_topic.mytopic.id
+  }
+  source_to_build {
+    repository = google_cloudbuildv2_repository.my-repository.id
+    ref = "refs/heads/main"
+    repo_type = "GITHUB"
+  }
+  git_file_source {
+    path = "cloudbuild.yaml"
+    repository = google_cloudbuildv2_repository.my-repository.id
+    revision = "refs/heads/main"
+    repo_type = "GITHUB"
+  }
+}


### PR DESCRIPTION
…e_cloudbuild_trigger resource

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds repository field to git_file_source and source_to_build of google_cloudbuild_trigger resource



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
cloudbuild: added `git_file_source.repository` and `source_to_build.repository` fields to `google_cloudbuild_trigger` resource (beta)
```
