### PR TITLE
Update `ProtoV5ProviderFactories` for GKE hub acceptance tests

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_backup_backup_plan_test.go.erb
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccGKEBackupBackupPlan_update(t *testing.T) {
+func TestAccGkeBackupBackupPlan_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -21,7 +21,7 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 		CheckDestroy:             testAccCheckGKEBackupBackupPlanDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGKEBackupBackupPlan_basic(context),
+				Config: testAccGkeBackupBackupPlan_basic(context),
 			},
 			{
 				ResourceName:      "google_gke_backup_backup_plan.backupplan",
@@ -29,7 +29,7 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGKEBackupBackupPlan_full(context),
+				Config: testAccGkeBackupBackupPlan_full(context),
 			},
 			{
 				ResourceName:      "google_gke_backup_backup_plan.backupplan",
@@ -40,7 +40,7 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 	})
 }
 
-func testAccGKEBackupBackupPlan_basic(context map[string]interface{}) string {
+func testAccGkeBackupBackupPlan_basic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_container_cluster" "primary" {
   name               = "tf-test-testcluster%{random_suffix}"
@@ -69,7 +69,7 @@ resource "google_gke_backup_backup_plan" "backupplan" {
 `, context)
 }
 
-func testAccGKEBackupBackupPlan_full(context map[string]interface{}) string {
+func testAccGkeBackupBackupPlan_full(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_container_cluster" "primary" {
   name               = "tf-test-testcluster%{random_suffix}"

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_membership_test.go.erb
@@ -336,7 +336,7 @@ func TestAccGkeHubFeatureMembership_gkehubFeatureAcmAllFields(t *testing.T) {
 
   VcrTest(t, resource.TestCase{
     PreCheck:                 func() { AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+    ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
     Steps: []resource.TestStep{
       {
@@ -595,7 +595,7 @@ func TestAccGkeHubFeatureMembership_gkehubFeatureAcmOci(t *testing.T) {
 
   VcrTest(t, resource.TestCase{
     PreCheck:                 func() { AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+    ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
     Steps: []resource.TestStep{
       {
@@ -793,7 +793,7 @@ func TestAccGkeHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
+func TestAccGkeHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
   // VCR fails to handle batched project services
   SkipIfVcr(t)
   t.Parallel()
@@ -28,7 +28,7 @@ func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
     CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccGKEHubFeature_gkehubFeatureMciUpdateStart(context),
+        Config: testAccGkeHubFeature_gkehubFeatureMciUpdateStart(context),
       },
       {
         ResourceName:      "google_gke_hub_feature.feature",
@@ -36,7 +36,7 @@ func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
         ImportStateVerify: true,
       },
       {
-        Config: testAccGKEHubFeature_gkehubFeatureMciChangeMembership(context),
+        Config: testAccGkeHubFeature_gkehubFeatureMciChangeMembership(context),
       },
       {
         ResourceName:      "google_gke_hub_feature.feature",
@@ -47,7 +47,7 @@ func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
   })
 }
 
-func testAccGKEHubFeature_gkehubFeatureMciUpdateStart(context map[string]interface{}) string {
+func testAccGkeHubFeature_gkehubFeatureMciUpdateStart(context map[string]interface{}) string {
   return gkeHubFeatureProjectSetup(context) + Nprintf(`
 
 resource "google_container_cluster" "primary" {
@@ -106,7 +106,7 @@ resource "google_gke_hub_feature" "feature" {
 `, context)
 }
 
-func testAccGKEHubFeature_gkehubFeatureMciChangeMembership(context map[string]interface{}) string {
+func testAccGkeHubFeature_gkehubFeatureMciChangeMembership(context map[string]interface{}) string {
   return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "google_container_cluster" "primary" {
   name               = "tf-test%{random_suffix}"
@@ -167,7 +167,7 @@ resource "google_gke_hub_feature" "feature" {
 `, context)
 }
 
-func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
+func TestAccGkeHubFeature_gkehubFeatureMcsd(t *testing.T) {
   // VCR fails to handle batched project services
   SkipIfVcr(t)
   t.Parallel()
@@ -184,7 +184,7 @@ func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
     CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccGKEHubFeature_gkehubFeatureMcsd(context),
+        Config: testAccGkeHubFeature_gkehubFeatureMcsd(context),
       },
       {
         ResourceName:      "google_gke_hub_feature.feature",
@@ -192,7 +192,7 @@ func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
         ImportStateVerify: true,
       },
       {
-        Config: testAccGKEHubFeature_gkehubFeatureMcsdUpdate(context),
+        Config: testAccGkeHubFeature_gkehubFeatureMcsdUpdate(context),
       },
       {
         ResourceName:      "google_gke_hub_feature.feature",
@@ -203,7 +203,7 @@ func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
   })
 }
 
-func testAccGKEHubFeature_gkehubFeatureMcsd(context map[string]interface{}) string {
+func testAccGkeHubFeature_gkehubFeatureMcsd(context map[string]interface{}) string {
   return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "google_gke_hub_feature" "feature" {
   name = "multiclusterservicediscovery"
@@ -218,7 +218,7 @@ resource "google_gke_hub_feature" "feature" {
 `, context)
 }
 
-func testAccGKEHubFeature_gkehubFeatureMcsdUpdate(context map[string]interface{}) string {
+func testAccGkeHubFeature_gkehubFeatureMcsdUpdate(context map[string]interface{}) string {
   return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "google_gke_hub_feature" "feature" {
   name = "multiclusterservicediscovery"

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
@@ -180,7 +180,7 @@ func TestAccGkeHubFeature_gkehubFeatureMcsd(t *testing.T) {
 
   VcrTest(t, resource.TestCase{
     PreCheck:                 func() { AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+    ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
     Steps: []resource.TestStep{
       {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/14393

These tests are broken because the google-beta provider isn't made available in the test. When the `ProtoV5ProviderFactories` value was `ProtoV5ProviderFactories(t)` it only had access to a provider called `google`. The `ProtoV5ProviderBetaFactories` function allows access to `google-beta`.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
