### PR TITLE
Added missing fields in the google_data_loss_prevention_deidentify_template resource

### DIFF
--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -1830,5 +1830,5 @@ properties:
                                           - :FRIDAY
                                           - :SATURDAY
                                           - :SUNDAY
-                        
-                                          
+
+                              

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -1830,3 +1830,5 @@ properties:
                                           - :FRIDAY
                                           - :SATURDAY
                                           - :SUNDAY
+                        
+                                          

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -126,13 +126,10 @@ properties:
                 - !ruby/object:Api::Type::NestedObject
                   name: 'selectedInfoTypes'
                   description: Apply transformation to the selected infoTypes.
-                  exactly_one_of:
-                    - transforms.0.selected_info_types
-                    - transforms.0.all_info_types
-                    - transforms.0.all_text
                   properties:
                   - !ruby/object:Api::Type::Array
                     name: 'infoTypes'
+                    required: true
                     description: |
                       InfoTypes to apply the transformation to. Leaving this empty will apply the transformation to apply to
                       all findings that correspond to infoTypes that were requested in InspectConfig.
@@ -150,10 +147,6 @@ properties:
                 - !ruby/object:Api::Type::NestedObject
                   name: 'allInfoTypes'
                   description: Apply transformation to all findings not specified in other ImageTransformation's selectedInfoTypes.
-                  exactly_one_of:
-                    - transforms.0.selected_info_types
-                    - transforms.0.all_info_types
-                    - transforms.0.all_text
                   properties: [] # Meant to be an empty object with no properties - see here : https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#allinfotypes
                     # The fields below are necessary to include the "allInfoTypes" transformation in the payload
                   send_empty_value: true
@@ -161,10 +154,6 @@ properties:
                 - !ruby/object:Api::Type::NestedObject
                   name: 'allText'
                   description: Apply transformation to all text that doesn't match an infoType.
-                  exactly_one_of:
-                    - transforms.0.selected_info_types
-                    - transforms.0.all_info_types
-                    - transforms.0.all_text
                   properties: [] # Meant to be an empty object with no properties - see here : https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#alltext
                     # The fields below are necessary to include the "allText" transformation in the payload
                   send_empty_value: true

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -37,6 +37,11 @@ examples:
     test_env_vars:
       project: :PROJECT_NAME
     skip_docs: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: "dlp_deidentify_template_image_transformations"
+    primary_resource_id: "basic"
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/wrap_object.go.erb
   custom_import: templates/terraform/custom_import/dlp_import.go.erb
@@ -68,11 +73,102 @@ properties:
     name: 'displayName'
     description: |
       User set display name of the template.
+  - !ruby/object:Api::Type::String
+    name: 'createTime'
+    description: |
+      The creation timestamp of an deidentifyTemplate. Set by the server.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'updateTime'
+    description: |
+      The last update timestamp of an deidentifyTemplate. Set by the server.
+    output: true
   - !ruby/object:Api::Type::NestedObject
     name: 'deidentifyConfig'
     required: true
     description: Configuration of the deidentify template
     properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'imageTransformations'
+        description: Treat the dataset as an image and redact.
+        exactly_one_of:
+          - deidentify_config.0.info_type_transformations
+          - deidentify_config.0.record_transformations
+          - deidentify_config.0.image_transformations
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'transforms'
+            required: true
+            description: |
+              For determination of how redaction of images should occur.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'redactionColor'
+                  description: |
+                    The color to use when redacting content from an image. If not specified, the default is black.
+                  properties:
+                    - !ruby/object:Api::Type::Double
+                      name: red
+                      description: |
+                        The amount of red in the color as a value in the interval [0, 1].
+                      default_value: 0.0
+                    - !ruby/object:Api::Type::Double
+                      name: blue
+                      description: |
+                        The amount of blue in the color as a value in the interval [0, 1].
+                      default_value: 0.0
+                    - !ruby/object:Api::Type::Double
+                      name: green
+                      description: |
+                        The amount of green in the color as a value in the interval [0, 1].
+                      default_value: 0.0
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'selectedInfoTypes'
+                  description: Apply transformation to the selected infoTypes.
+                  exactly_one_of:
+                    - transforms.0.selected_info_types
+                    - transforms.0.all_info_types
+                    - transforms.0.all_text
+                  properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'infoTypes'
+                    description: |
+                      InfoTypes to apply the transformation to. Leaving this empty will apply the transformation to apply to
+                      all findings that correspond to infoTypes that were requested in InspectConfig.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'name'
+                          required: true
+                          description: |
+                            Name of the information type.
+                        - !ruby/object:Api::Type::String
+                          name: 'version'
+                          description: |
+                            Version of the information type to use. By default, the version is set to stable
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'allInfoTypes'
+                  description: Apply transformation to all findings not specified in other ImageTransformation's selectedInfoTypes.
+                  exactly_one_of:
+                    - transforms.0.selected_info_types
+                    - transforms.0.all_info_types
+                    - transforms.0.all_text
+                  properties: [] # Meant to be an empty object with no properties - see here : https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#allinfotypes
+                    # The fields below are necessary to include the "allInfoTypes" transformation in the payload
+                  send_empty_value: true
+                  allow_empty_object: true
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'allText'
+                  description: Apply transformation to all text that doesn't match an infoType.
+                  exactly_one_of:
+                    - transforms.0.selected_info_types
+                    - transforms.0.all_info_types
+                    - transforms.0.all_text
+                  properties: [] # Meant to be an empty object with no properties - see here : https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#alltext
+                    # The fields below are necessary to include the "allText" transformation in the payload
+                  send_empty_value: true
+                  allow_empty_object: true
       - !ruby/object:Api::Type::NestedObject
         name: 'infoTypeTransformations'
         description: Treat the dataset as free-form text and apply the same free text
@@ -80,6 +176,7 @@ properties:
         exactly_one_of:
           - deidentify_config.0.info_type_transformations
           - deidentify_config.0.record_transformations
+          - deidentify_config.0.image_transformations
         properties:
           - !ruby/object:Api::Type::Array
             name: 'transformations'
@@ -100,6 +197,10 @@ properties:
                         required: true
                         description: |
                           Name of the information type.
+                      - !ruby/object:Api::Type::String
+                        name: 'version'
+                        description: |
+                          Version of the information type to use. By default, the version is set to stable
                 - !ruby/object:Api::Type::NestedObject
                   name: 'primitiveTransformation'
                   required: true
@@ -450,6 +551,22 @@ properties:
                           name: 'radix'
                           description: |
                             The native way to select the alphabet. Must be in the range \[2, 95\].
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'replaceDictionaryConfig'
+                      description: Replace with a value randomly drawn (with replacement)
+                        from a dictionary.
+                      properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'wordList'
+                          required: true
+                          description: |
+                            A list of words to select from for random replacement. The [limits](https://cloud.google.com/dlp/limits) page contains details about the size limits of dictionaries.
+                          properties:
+                            - !ruby/object:Api::Type::Array
+                              name: 'words'
+                              required: true
+                              description: |
+                                Words or phrases defining the dictionary. The dictionary must contain at least one phrase and every phrase must contain at least 2 characters that are letters or digits.
       - !ruby/object:Api::Type::NestedObject
         name: 'recordTransformations'
         description: Treat the dataset as structured. Transformations can be applied
@@ -458,6 +575,7 @@ properties:
         exactly_one_of:
           - deidentify_config.0.info_type_transformations
           - deidentify_config.0.record_transformations
+          - deidentify_config.0.image_transformations
         properties:
           - !ruby/object:Api::Type::Array
             name: 'fieldTransformations'
@@ -1573,6 +1691,12 @@ properties:
                               description: |
                                 Words or phrases defining the dictionary. The dictionary must contain at least one phrase and every phrase must contain at least 2 characters that are letters or digits.
                               item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Boolean
+                      name: 'replaceWithInfoTypeConfig'
+                      description: |
+                        Replace each matching finding with the name of the info type.
+                      custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
+                      custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
           - !ruby/object:Api::Type::Array
             name: 'recordSuppressions'
             description: Configuration defining which records get suppressed entirely.
@@ -1706,4 +1830,3 @@ properties:
                                           - :FRIDAY
                                           - :SATURDAY
                                           - :SUNDAY
-

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -1825,3 +1825,4 @@ properties:
                                           - :FRIDAY
                                           - :SATURDAY
                                           - :SUNDAY
+

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -1692,12 +1692,6 @@ properties:
                               description: |
                                 Words or phrases defining the dictionary. The dictionary must contain at least one phrase and every phrase must contain at least 2 characters that are letters or digits.
                               item_type: Api::Type::String
-                    - !ruby/object:Api::Type::Boolean
-                      name: 'replaceWithInfoTypeConfig'
-                      description: |
-                        Replace each matching finding with the name of the info type.
-                      custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
-                      custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
           - !ruby/object:Api::Type::Array
             name: 'recordSuppressions'
             description: Configuration defining which records get suppressed entirely.

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -146,7 +146,7 @@ properties:
                         - !ruby/object:Api::Type::String
                           name: 'version'
                           description: |
-                            Version of the information type to use. By default, the version is set to stable
+                            Version name for this InfoType.
                 - !ruby/object:Api::Type::NestedObject
                   name: 'allInfoTypes'
                   description: Apply transformation to all findings not specified in other ImageTransformation's selectedInfoTypes.
@@ -200,7 +200,7 @@ properties:
                       - !ruby/object:Api::Type::String
                         name: 'version'
                         description: |
-                          Version of the information type to use. By default, the version is set to stable
+                          Version name for this InfoType.
                 - !ruby/object:Api::Type::NestedObject
                   name: 'primitiveTransformation'
                   required: true
@@ -567,6 +567,7 @@ properties:
                               required: true
                               description: |
                                 Words or phrases defining the dictionary. The dictionary must contain at least one phrase and every phrase must contain at least 2 characters that are letters or digits.
+                              item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'recordTransformations'
         description: Treat the dataset as structured. Transformations can be applied
@@ -1830,5 +1831,4 @@ properties:
                                           - :FRIDAY
                                           - :SATURDAY
                                           - :SUNDAY
-
-                              
+                

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -1831,4 +1831,3 @@ properties:
                                           - :FRIDAY
                                           - :SATURDAY
                                           - :SUNDAY
-                

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_image_transformations.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_image_transformations.tf.erb
@@ -1,36 +1,35 @@
 resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_resource_id] %>" {
-    parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
-    description = "Description"
-    display_name = "Displayname"
+  parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+  description = "Description"
+  display_name = "Displayname"
   
-    deidentify_config {
-      image_transformations {
-        transforms {
-          redaction_color {
-            red = 0.5
-            blue = 1
-            green = 0.2
-          }
-          selected_info_types {
-            info_types {
-              name = "COLOR_INFO"
-              version = "0.1"
-            }
-          }
+  deidentify_config {
+    image_transformations {
+      transforms {
+        redaction_color {
+          red = 0.5
+          blue = 1
+          green = 0.2
         }
-      }
-  
-      image_transformations {
-        transforms {
-          all_info_types {}
-        }
-      }
-  
-      image_transformations {
-        transforms {
-          all_text {}
+        selected_info_types {
+          info_types {
+            name = "COLOR_INFO"
+            version = "0.1"
+          }
         }
       }
     }
-  }
   
+    image_transformations {
+      transforms {
+        all_info_types {}
+      }
+    }
+  
+    image_transformations {
+      transforms {
+        all_text {}
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_image_transformations.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_image_transformations.tf.erb
@@ -1,0 +1,36 @@
+resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_resource_id] %>" {
+    parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+    description = "Description"
+    display_name = "Displayname"
+  
+    deidentify_config {
+      image_transformations {
+        transforms {
+          redaction_color {
+            red = 0.5
+            blue = 1
+            green = 0.2
+          }
+          selected_info_types {
+            info_types {
+              name = "COLOR_INFO"
+              version = "0.1"
+            }
+          }
+        }
+      }
+  
+      image_transformations {
+        transforms {
+          all_info_types {}
+        }
+      }
+  
+      image_transformations {
+        transforms {
+          all_text {}
+        }
+      }
+    }
+  }
+  

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_image_transformations.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_image_transformations.tf.erb
@@ -14,19 +14,15 @@ resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_res
         selected_info_types {
           info_types {
             name = "COLOR_INFO"
-            version = "0.1"
+            version = "latest"
           }
         }
       }
-    }
-  
-    image_transformations {
+
       transforms {
         all_info_types {}
       }
-    }
-  
-    image_transformations {
+
       transforms {
         all_text {}
       }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -559,14 +559,6 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
       }
       field_transformations {
         fields {
-          name = "unconditionally-replace-field"
-        }
-        primitive_transformation {
-          replace_with_info_type_config = false
-        }
-      }
-      field_transformations {
-        fields {
           name = "unconditionally-char-masked-field"
         }
         primitive_transformation {
@@ -816,16 +808,6 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
               string_value = "dude.born.after.shrek2@example.com"
             }
           }
-        }
-      }
-
-      field_transformations {
-        fields {
-          name = "unconditionally-replace-field"
-        }
-        primitive_transformation {
-          # update values of replace_with_info_type_config
-          replace_with_info_type_config = true
         }
       }
 

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -1102,7 +1102,6 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
           }
         }
       }
-
       # Update allInfoTypes and allText by removing the block
     }
   }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -1080,18 +1080,15 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
         selected_info_types {
           info_types {
             name = "COLOR_INFO"
+            version = "latest"
           }
         }
       }
-    }
 
-    image_transformations {
       transforms {
         all_info_types {}
       }
-    }
 
-    image_transformations {
       transforms {
         all_text {}
       }
@@ -1118,33 +1115,13 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
         }
         selected_info_types {
           info_types {
-            name = "COLOR_INFO"
+            name = "COLOR_EXAMPLE"
             version = "0.1"
           }
         }
       }
-    }
 
-    image_transformations {
-      transforms {
-        redaction_color {
-          red = 0.1
-          blue = 0.2
-          green = 0.9
-        }
-        all_info_types {}
-      }
-    }
-
-    image_transformations {
-      transforms {
-        redaction_color {
-          red = 0.1
-          blue = 0.2
-          green = 0.3
-        }
-        all_text {}
-      }
+      # Update allInfoTypes and allText by removing the block
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added `image_transformations`, `replace_dictionary_config`, `version`, `create_time` and `update_time` to `data_loss_prevention_deidentify_template`
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `image_transformations` field to `google_data_loss_prevention_deidentify_template` resource
```
```release-note:enhancement
dlp: added `replace_dictionary_config` field to `info_type_transformations` in `google_data_loss_prevention_deidentify_template` resource
```
