### PR TITLE
add stack_type to google_compute_network_peering

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -110,9 +110,7 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateEnum([]string{"IPV4_ONLY", "IPV4_IPV6", ""}),
-				Description: `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. 
-				Default value: "IPV4_ONLY" 
-				Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
+				Description: `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
 				Default: "IPV4_ONLY",
 			},
 		},

--- a/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -109,7 +109,7 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 			"stack_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateEnum([]string{"IPV4_ONLY", "IPV4_IPV6", ""}),
+				ValidateFunc: verify.ValidateEnum([]string{"IPV4_ONLY", "IPV4_IPV6"}),
 				Description: `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
 				Default: "IPV4_ONLY",
 			},

--- a/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -104,6 +104,17 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 				Computed:    true,
 				Description: `Details about the current state of the peering.`,
 			},
+
+			"stack_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateEnum([]string{"IPV4_ONLY", "IPV4_IPV6", ""}),
+				Description: `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. 
+				Default value: "IPV4_ONLY" 
+				Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
+				Default: "IPV4_ONLY",
+			}
 		},
 		UseJSONNumber: true,
 	}
@@ -199,6 +210,9 @@ func resourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{})
 	}
 	if err := d.Set("state_details", peering.StateDetails); err != nil {
 		return fmt.Errorf("Error setting state_details: %s", err)
+	}
+	if err := d.Set("stack_type", flattenNetworkPeeringStackType(peering.StackType, d, config); err != nil {
+		return fmt.Errorf("Error setting stack_type: %s", err)
 	}
 
 	return nil
@@ -308,8 +322,18 @@ func expandNetworkPeering(d *schema.ResourceData) *compute.NetworkPeering {
 		ImportCustomRoutes:             d.Get("import_custom_routes").(bool),
 		ExportSubnetRoutesWithPublicIp: d.Get("export_subnet_routes_with_public_ip").(bool),
 		ImportSubnetRoutesWithPublicIp: d.Get("import_subnet_routes_with_public_ip").(bool),
+		StackType:                      d.Get("stack_type").(bool),
 		ForceSendFields:                []string{"ExportSubnetRoutesWithPublicIp", "ImportCustomRoutes", "ExportCustomRoutes"},
 	}
+}
+
+func flattenNetworkPeeringStackType(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	// Prevent `stackType` is omitted in API responses for older resource
+	if v == nil || isEmptyValue(reflect.ValueOf(v)) {
+		return "IPV4_ONLY"
+	}
+
+	return v
 }
 
 func sortedNetworkPeeringMutexKeys(networkName, peerNetworkName *GlobalFieldValue) []string {

--- a/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
@@ -108,13 +109,12 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 			"stack_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateEnum([]string{"IPV4_ONLY", "IPV4_IPV6", ""}),
 				Description: `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. 
 				Default value: "IPV4_ONLY" 
 				Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
 				Default: "IPV4_ONLY",
-			}
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -211,7 +211,7 @@ func resourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("state_details", peering.StateDetails); err != nil {
 		return fmt.Errorf("Error setting state_details: %s", err)
 	}
-	if err := d.Set("stack_type", flattenNetworkPeeringStackType(peering.StackType, d, config); err != nil {
+	if err := d.Set("stack_type", flattenNetworkPeeringStackType(peering.StackType, d, config)); err != nil {
 		return fmt.Errorf("Error setting stack_type: %s", err)
 	}
 
@@ -322,13 +322,13 @@ func expandNetworkPeering(d *schema.ResourceData) *compute.NetworkPeering {
 		ImportCustomRoutes:             d.Get("import_custom_routes").(bool),
 		ExportSubnetRoutesWithPublicIp: d.Get("export_subnet_routes_with_public_ip").(bool),
 		ImportSubnetRoutesWithPublicIp: d.Get("import_subnet_routes_with_public_ip").(bool),
-		StackType:                      d.Get("stack_type").(bool),
+		StackType:                      d.Get("stack_type").(string),
 		ForceSendFields:                []string{"ExportSubnetRoutesWithPublicIp", "ImportCustomRoutes", "ExportCustomRoutes"},
 	}
 }
 
-func flattenNetworkPeeringStackType(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-	// Prevent `stackType` is omitted in API responses for older resource
+func flattenNetworkPeeringStackType(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// To prevent the perma-diff caused by the absence of `stack_type` in API responses for older resource
 	if v == nil || isEmptyValue(reflect.ValueOf(v)) {
 		return "IPV4_ONLY"
 	}

--- a/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -65,6 +65,9 @@ Whether subnet routes with public IP range are exported. The default value is tr
 * `import_subnet_routes_with_public_ip` - (Optional)
 Whether subnet routes with public IP range are imported. The default value is false. The IPv4 special-use ranges (https://en.wikipedia.org/wiki/IPv4#Special_addresses) are always imported from peers and are not controlled by this field.
 
+* `stack_type` - (Optional)
+Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. Possible values: ["IPV4_ONLY", "IPV4_IPV6"].
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13970


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `stack_type` to `google_compute_network_peering`
```
