### PR TITLE
Fix spacing of resource template

### DIFF
--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -18,33 +18,33 @@ package google
 
 import (
 
- "fmt"
- "log"
- "reflect"
-<% if updatable?(object, object.root_properties) && object.update_mask -%>
- "strings"
-<% end -%>
- "time"
+    "fmt"
+    "log"
+    "reflect"
+<%  if updatable?(object, object.root_properties) && object.update_mask -%>
+    "strings"
+<%  end -%>
+    "time"
 
 <%- # We list all the v2 imports here, because we run 'goimports' to guess the correct
     # set of imports, which will never guess the major version correctly. -%>
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 
-  "<%= import_path() -%>/tpgresource"
-  transport_tpg "<%= import_path() -%>/transport"
-  "<%= import_path() -%>/verify"
+    "<%= import_path() -%>/tpgresource"
+    transport_tpg "<%= import_path() -%>/transport"
+    "<%= import_path() -%>/verify"
 
-<% if object.gettable_properties.reject { |p| p.ignore_read }.any? { |prop| prop.flatten_object } -%>
-  "google.golang.org/api/googleapi"
-<% end -%>
+<%  if object.gettable_properties.reject { |p| p.ignore_read }.any? { |prop| prop.flatten_object } -%>
+    "google.golang.org/api/googleapi"
+<%  end -%>
 )
 
 <%= lines(compile(pwd + '/' + object.custom_code.constants)) if object.custom_code.constants -%>
@@ -72,90 +72,90 @@ func Resource<%= resource_name -%>() *schema.Resource {
     return &schema.Resource{
         Create: resource<%= resource_name -%>Create,
         Read: resource<%= resource_name -%>Read,
-<%      if updatable?(object, properties) -%>
+<%  if updatable?(object, properties) -%>
         Update: resource<%= resource_name -%>Update,
-<%      end -%>
+<%  end -%>
         Delete: resource<%= resource_name -%>Delete,
-<%      if object.settable_properties.any? {|p| p.unordered_list} && !object.custom_code.resource_definition -%>
+<%  if object.settable_properties.any? {|p| p.unordered_list} && !object.custom_code.resource_definition -%>
         CustomizeDiff: customdiff.All(
 <%=
-            object.settable_properties.select { |p| p.unordered_list }
-                               .map { |p| "resource#{resource_name}#{p.name.camelize(:upper)}SetStyleDiff"}
-                               .join(",\n")
+  object.settable_properties.select { |p| p.unordered_list }
+    .map { |p| "resource#{resource_name}#{p.name.camelize(:upper)}SetStyleDiff"}
+    .join(",\n")
 -%>
         ),
-<%      end -%>
+<%  end -%>
 
-<%      unless object.exclude_import -%>
+<%  unless object.exclude_import -%>
         Importer: &schema.ResourceImporter{
             State: resource<%= resource_name -%>Import,
         },
-<%      end -%>
+<%  end -%>
 
         Timeouts: &schema.ResourceTimeout {
             Create: schema.DefaultTimeout(<%= timeouts.insert_minutes -%> * time.Minute),
-<%      if updatable?(object, properties) -%>
+<%  if updatable?(object, properties) -%>
             Update: schema.DefaultTimeout(<%= timeouts.update_minutes -%> * time.Minute),
-<%      end -%>
+<%  end -%>
             Delete: schema.DefaultTimeout(<%= timeouts.delete_minutes -%> * time.Minute),
         },
 
-<%      if object.schema_version -%>
+<%  if object.schema_version -%>
         SchemaVersion: <%= object.schema_version -%>,
         StateUpgraders: []schema.StateUpgrader{
-<%        for v in 0..object.schema_version-1 -%>
+<%    for v in 0..object.schema_version-1 -%>
             {
                 Type: resource<%= "#{resource_name}ResourceV#{v}" -%>().CoreConfigSchema().ImpliedType(),
                 Upgrade: Resource<%= "#{resource_name}UpgradeV#{v}" -%>,
                 Version: <%= v -%>,
             },
-<%        end -%>
+<%    end -%>
         },
-<%      end -%>
+<%  end -%>
 
-<%=     lines(compile(pwd + '/' + object.custom_code.resource_definition)) if object.custom_code.resource_definition -%>
+<%= lines(compile(pwd + '/' + object.custom_code.resource_definition)) if object.custom_code.resource_definition -%>
 
         Schema: map[string]*schema.Schema{
-<%      order_properties(properties).each do |prop| -%>
+<%  order_properties(properties).each do |prop| -%>
 <%=       lines(build_schema_property(prop, object, pwd)) -%>
-<%      end -%>
-<%-     unless object.virtual_fields.empty? -%>
-<%-       object.virtual_fields.each do |field| -%>
+<%  end -%>
+<%- unless object.virtual_fields.empty? -%>
+<%-   object.virtual_fields.each do |field| -%>
             "<%= field.name -%>": {
-              Type: <%= tf_type(field) -%>,
-              Optional: true,
-            <% unless field.default_value.nil? -%>
-              Default:  <%= go_literal(field.default_value) -%>,
-            <% end -%>
-              Description: `<%= field.description.strip.gsub("`", "'") -%>`,
+                Type: <%= tf_type(field) -%>,
+                Optional: true,
+<%       unless field.default_value.nil? -%>
+                Default:  <%= go_literal(field.default_value) -%>,
+<%       end -%>
+                Description: `<%= field.description.strip.gsub("`", "'") -%>`,
             },
-<%        end -%>
-<%      end -%>
-<%=     lines(compile(pwd + '/' + object.custom_code.extra_schema_entry)) if object.custom_code.extra_schema_entry -%>
-<%      if has_project -%>
+<%     end -%>
+<%   end -%>
+<%= lines(compile(pwd + '/' + object.custom_code.extra_schema_entry)) if object.custom_code.extra_schema_entry -%>
+<%  if has_project -%>
             "project": {
                 Type:     schema.TypeString,
                 Optional: true,
                 Computed: true,
                 ForceNew: true,
             },
-<%      end -%>
-<%      if object.has_self_link -%>
+<%  end -%>
+<%  if object.has_self_link -%>
             "self_link": {
                 Type:     schema.TypeString,
                 Computed: true,
             },
-<%      end -%>
+<%  end -%>
         },
         UseJSONNumber: true,
     }
 }
 
-<% properties.each do |prop| -%>
+<%  properties.each do |prop| -%>
 <%= lines(build_subresource_schema(prop, object, pwd), 1) -%>
-<% end -%>
+<%  end -%>
 
-<% object.settable_properties.select {|p| p.unordered_list}.each do |prop| -%>
+<%  object.settable_properties.select {|p| p.unordered_list}.each do |prop| -%>
 func resource<%= resource_name -%><%= prop.name.camelize(:upper) -%>SetStyleDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 <%=
     compile_template(pwd + '/templates/terraform/unordered_list_customize_diff.erb',
@@ -163,12 +163,12 @@ func resource<%= resource_name -%><%= prop.name.camelize(:upper) -%>SetStyleDiff
                      resource_name: resource_name)
 -%>
 }
-<% end -%>
+<%  end -%>
 
 func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{}) error {
 <%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project && object.async&.allow?('create') -%>
     var project string
-<% end -%>
+<%  end -%>
     config := meta.(*transport_tpg.Config)
 <%  if object.custom_code.custom_create -%>
     <%= lines(compile(pwd + '/' + object.custom_code.custom_create))  -%>
@@ -179,37 +179,37 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     obj := make(map[string]interface{})
-<%  object.settable_properties.each do |prop| -%>
-    <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
+<%    object.settable_properties.each do |prop| -%>
+<%      schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
     <%= prop.api_name -%>Prop, err := expand<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
     if err != nil {
         return err
-<%    if prop.send_empty_value -%>
+<%      if prop.send_empty_value -%>
     } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
-<%    elsif prop.flatten_object -%>
+<%      elsif prop.flatten_object -%>
     } else if !tpgresource.IsEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
-<%    else -%>
+<%      else -%>
     } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !tpgresource.IsEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
-<%    end -%>
+<%      end -%>
         obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
     }
-<%  end -%>
+<%    end -%>
 
-<%  if object.custom_code.encoder -%>
+<%    if object.custom_code.encoder -%>
     obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
     if err != nil {
         return err
     }
-<%  end -%>
+<%    end -%>
 
-<%  if object.mutex -%>
+<%    if object.mutex -%>
     lockName, err := tpgresource.ReplaceVars(d, config, "<%= object.mutex -%>")
     if err != nil {
         return err
     }
     transport_tpg.MutexStore.Lock(lockName)
     defer transport_tpg.MutexStore.Unlock(lockName)
-<%  end -%>
+<%    end -%>
 
     url, err := tpgresource.ReplaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.create_uri}" -%>")
     if err != nil {
@@ -217,34 +217,34 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
-<%  if object.nested_query&.modify_by_patch -%>
+<%    if object.nested_query&.modify_by_patch -%>
 <%# Keep this after mutex - patch request data relies on current resource state %>
     obj, err = resource<%= resource_name -%>PatchCreateEncoder(d, meta, obj)
     if err != nil {
         return err
     }
-<%    if object.update_mask -%>
+<%      if object.update_mask -%>
     url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": "<%= object.nested_query.keys.join('.') -%>"})
     if err != nil {
         return err
     }
+<%      end -%>
 <%    end -%>
-<%  end -%>
     billingProject := ""
 
-<%  if has_project -%>
+<%    if has_project -%>
     project, err := tpgresource.GetProject(d, config)
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
     billingProject = project
-<%  end -%>
+<%    end -%>
 
-<%  if object.supports_indirect_user_project_override -%>
+<%    if object.supports_indirect_user_project_override -%>
     if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
         billingProject = parts[1]
     }
-<%  end -%>
+<%    end -%>
 
     // err == nil indicates that the billing_project value was found
     if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
@@ -254,21 +254,21 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%= lines(compile(pwd + '/' + object.custom_code.pre_create)) if object.custom_code.pre_create -%>
     res, err := transport_tpg.SendRequestWithTimeout(config, "<%= object.create_verb.to_s.upcase -%>", billingProject, url, userAgent, obj, d.Timeout(schema.TimeoutCreate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
     if err != nil {
-<%  if object.custom_code.post_create_failure && object.async.nil? # Only add if not handled by async error handling -%>
+<%    if object.custom_code.post_create_failure && object.async.nil? # Only add if not handled by async error handling -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%  end -%>
+<%    end -%>
         return fmt.Errorf("Error creating <%= object.name -%>: %s", err)
     }
 <% # Set resource properties from create API response (unless it returns an Operation) -%>
-<%  unless object.async&.is_a? Api::OpAsync -%>
-    <% object.gettable_properties.each do |prop| -%>
-        <% if object.identity.include?(prop) && prop.output -%>
+<%    unless object.async&.is_a? Api::OpAsync -%>
+<%      object.gettable_properties.each do |prop| -%>
+<%        if object.identity.include?(prop) && prop.output -%>
     if err := d.Set("<%= prop.name.underscore -%>", flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
         return fmt.Errorf(`Error setting computed identity field "<%=prop.name.underscore%>": %s`, err)
     }
-        <% end -%>
-    <% end -%>
-<% end -%>
+<%        end -%>
+<%      end -%>
+<%    end -%>
 
     // Store the ID now
     id, err := tpgresource.ReplaceVars(d, config, "<%= id_format(object) -%>")
@@ -277,9 +277,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
     d.SetId(id)
 
-<%  if object.async&.allow?('create') -%>
-<%    if object.async.is_a? Api::OpAsync -%>
-<%      if object.async.result.resource_inside_response and not object.identity.empty? -%>
+<%    if object.async&.allow?('create') -%>
+<%      if object.async.is_a? Api::OpAsync -%>
+<%        if object.async.result.resource_inside_response and not object.identity.empty? -%>
     // Use the resource in the operation response to populate
     // identity fields and d.Id() before read
     var opRes map[string]interface{}
@@ -287,17 +287,17 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     config, res, &opRes, <% if has_project || object.async.include_project -%> project, <% end -%> "Creating <%= object.name -%>", userAgent,
         d.Timeout(schema.TimeoutCreate))
     if err != nil {
-<%        if object.custom_code.post_create_failure -%>
+<%          if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%        end -%>
-<% unless object.taint_resource_on_failed_create -%>
+<%          end -%>
+<%          unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
-<%  end -%>         
+<%          end -%>         
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 
-<%      if object.custom_code.decoder -%>
+<%          if object.custom_code.decoder -%>
     opRes, err = resource<%= resource_name -%>Decoder(d, meta, opRes)
     if err != nil {
         return fmt.Errorf("Error decoding response from operation: %s", err)
@@ -305,9 +305,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if opRes == nil {
         return fmt.Errorf("Error decoding response from operation, could not find object")
     }
-<%      end -%>
+<%          end -%>
 
-<%      if object.nested_query -%>
+<%          if object.nested_query -%>
     if _, ok := opRes["<%=object.nested_query.keys[0]-%>"]; ok {
         opRes, err = flattenNested<%= resource_name -%>(d, meta, opRes)
         if err != nil {
@@ -318,14 +318,14 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
             return fmt.Errorf("Error decoding response from operation, could not find nested object")
         }
     }
-<%      end -%>
-    <% object.gettable_properties.each do |prop| -%>
-    <% if object.identity.include?(prop) -%>
+<%          end -%>
+<%          object.gettable_properties.each do |prop| -%>
+<%            if object.identity.include?(prop) -%>
     if err := d.Set("<%= prop.name.underscore -%>", flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(opRes["<%= prop.api_name -%>"], d, config)); err != nil {
         return err
     }
-    <% end -%>
-    <% end -%>
+<%            end -%>
+<%          end -%>
 
     // This may have caused the ID to update - update it if so.
     id, err = tpgresource.ReplaceVars(d, config, "<%= id_format(object) -%>")
@@ -334,49 +334,49 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
     d.SetId(id)
 
-    <% else -%>
+<%        else # if object.async.is_a? Api::OpAsync -%>
     err = <%= client_name_pascal -%>OperationWaitTime(
     config, res, <% if has_project || object.async.include_project -%> project, <% end -%> "Creating <%= object.name -%>", userAgent,
         d.Timeout(schema.TimeoutCreate))
 
     if err != nil {
-<%      if object.custom_code.post_create_failure -%>
+<%          if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%      end -%>
-<% unless object.taint_resource_on_failed_create -%>
+<%          end -%>
+<%          unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
-<%      end -%>
+<%          end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 
-<%    end -%>
-<%  end -%>
-<%  end -%>
+<%        end # object.async.result.resource_inside_response and not object.identity.empty? -%>
+<%      end # if object.async.is_a? Api::OpAsync -%>
+<%    end # if object.async&.allow?('create') -%>
 
 <%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
 
-<%  if object.async&.allow?('create') -%>
-<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
+<%    if object.async&.allow?('create') -%>
+<%      if object.async.is_a? Provider::Terraform::PollAsync -%>
     err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_existence -%>, "Creating <%= object.name -%>", d.Timeout(schema.TimeoutCreate), <%= object.async.target_occurrences -%>)
     if err != nil {
-<%      if object.async.suppress_error -%>
+<%        if object.async.suppress_error -%>
         log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
-<%      else -%>
-<%        if object.custom_code.post_create_failure -%>
+<%        else -%>
+<%          if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%        end -%>
+<%          end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
-<%      end -%>
+<%        end -%>
     }
 
+<%      end -%>
 <%    end -%>
-<% end -%>
 
     log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
     return resource<%= resource_name -%>Read(d, meta)
-<%  end # if custom_create  -%>
+<%  end # if custom_create -%>
 }
 
 <%  if object.async&.is_a? Provider::Terraform::PollAsync -%>
@@ -394,19 +394,19 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
 
         billingProject := ""
 
-<%  if has_project -%>
+<%      if has_project -%>
         project, err := tpgresource.GetProject(d, config)
         if err != nil {
             return nil, fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
         }
         billingProject = project
-<%  end -%>
+<%      end -%>
 
-<%  if object.supports_indirect_user_project_override -%>
+<%      if object.supports_indirect_user_project_override -%>
         if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
             billingProject = parts[1]
         }
-<%  end -%>
+<%      end -%>
 
         // err == nil indicates that the billing_project value was found
         if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
@@ -422,7 +422,7 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
         if err != nil {
             return res, err
         }
-    <%  if object.nested_query -%>
+<%      if object.nested_query -%>
         res, err = flattenNested<%= resource_name -%>(d, meta, res)
         if err != nil {
             return nil, err
@@ -432,8 +432,8 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
             return nil, fake404("nested", "<%= resource_name%>")
         }
 
-    <%  end -%>
-    <%  if object.custom_code.decoder -%>
+<%      end -%>
+<%      if object.custom_code.decoder -%>
         res, err = resource<%= resource_name -%>Decoder(d, meta, res)
         if err != nil {
             return nil, err
@@ -442,12 +442,12 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
             return nil, fake404("decoded", "<%= resource_name%>")
         }
 
-    <%  end -%>
+<%      end -%>
         return res, nil
 <%    end # ifelse object.async.custom_poll_read -%>
     }
 }
-<%  end -%>
+<%  end # if object.async&.is_a? Provider::Terraform::PollAsync -%>
 
 func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*transport_tpg.Config)
@@ -524,13 +524,13 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 <%- unless object.virtual_fields.empty? -%>
   // Explicitly set virtual fields to default values if unset
 <%-   object.virtual_fields.each do |field| -%>
-    <% unless field.default_value.nil? -%>
+<%      unless field.default_value.nil? -%>
     if _, ok := d.GetOkExists("<%= field.name -%>"); !ok {
-      if err := d.Set("<%= field.name -%>", <%= go_literal(field.default_value) -%>); err != nil {
-      	return fmt.Errorf("Error setting <%= field.name -%>: %s", err)
-      }
+        if err := d.Set("<%= field.name -%>", <%= go_literal(field.default_value) -%>); err != nil {
+            return fmt.Errorf("Error setting <%= field.name -%>: %s", err)
+        }
     }
-    <% end -%>
+<%      end -%>
 <%    end -%>
 <%  end -%>
 <%  if has_project -%>
@@ -555,13 +555,13 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 // it's difficult to know what the top level should be. Instead we just loop over the map returned from flatten.
     if flattenedProp := flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config); flattenedProp != nil {
         if gerr, ok := flattenedProp.(*googleapi.Error); ok {
-			return fmt.Errorf("Error reading <%= object.name -%>: %s", gerr)
-		}
+            return fmt.Errorf("Error reading <%= object.name -%>: %s", gerr)
+        }
         casted := flattenedProp.([]interface{})[0]
         if casted != nil {
             for k, v := range casted.(map[string]interface{}) {
                 if err := d.Set(k, v); err != nil {
-                	return fmt.Errorf("Error setting %s: %s", k, err)
+                    return fmt.Errorf("Error setting %s: %s", k, err)
                 }
             }
         }
@@ -581,68 +581,68 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
     return nil
 }
 
-<% if updatable?(object, object.root_properties) -%>
+<%  if updatable?(object, object.root_properties) -%>
 func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{}) error {
-<%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project && object.async&.allow?('update') -%>
+<%    if object.async&.is_a?(Api::OpAsync) && object.async.include_project && object.async&.allow?('update') -%>
     var project string
-<% end -%>
+<%    end -%>
     config := meta.(*transport_tpg.Config)
     userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
-    	return err
+        return err
     }
 
     billingProject := ""
 
-<%  if has_project -%>
+<%    if has_project -%>
     project, err := tpgresource.GetProject(d, config)
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
     billingProject = project
-<%  end -%>
+<%    end -%>
 
 
-<%  if !object.immutable -%>
+<%    if !object.immutable -%>
     obj := make(map[string]interface{})
-<%  update_body_properties.each do |prop| -%>
+<%      update_body_properties.each do |prop| -%>
     <%# flattened objects won't have something stored in state so instead nil is passed to the next expander. -%>
-    <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
+<%        schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
     <%= prop.api_name -%>Prop, err := expand<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
     if err != nil {
         return err
-<%      if prop.send_empty_value -%>
+<%        if prop.send_empty_value -%>
     } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
-<%      elsif prop.flatten_object -%>
+<%        elsif prop.flatten_object -%>
     } else if !tpgresource.IsEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
-<%      else -%>
+<%        else -%>
     } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
-<%      end -%>
+<%        end -%>
         obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
     }
-<%  end -%>
+<%      end -%>
 
-<%# We need to decide what encoder to use here - if there's an update encoder, use that! -%>
-<%  if object.custom_code.update_encoder -%>
+<%#     We need to decide what encoder to use here - if there's an update encoder, use that! -%>
+<%      if object.custom_code.update_encoder -%>
     obj, err = resource<%= resource_name -%>UpdateEncoder(d, meta, obj)
     if err != nil {
         return err
     }
-<%  elsif object.custom_code.encoder -%>
+<%      elsif object.custom_code.encoder -%>
     obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
     if err != nil {
         return err
     }
-<%  end -%>
+<%      end -%>
 
-<%  if object.mutex -%>
+<%      if object.mutex -%>
     lockName, err := tpgresource.ReplaceVars(d, config, "<%= object.mutex -%>")
     if err != nil {
         return err
     }
     transport_tpg.MutexStore.Lock(lockName)
     defer transport_tpg.MutexStore.Unlock(lockName)
-<%  end -%>
+<%      end -%>
 
     url, err := tpgresource.ReplaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{update_uri(object, object.update_url)}" -%>")
     if err != nil {
@@ -652,38 +652,38 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     log.Printf("[DEBUG] Updating <%= object.name -%> %q: %#v", d.Id(), obj)
 <%= lines(compile(pwd + '/templates/terraform/update_mask.erb')) if object.update_mask -%>
 <%= lines(compile(pwd + '/' + object.custom_code.pre_update)) if object.custom_code.pre_update -%>
-<%  if object.nested_query&.modify_by_patch -%>
-<%# Keep this after mutex - patch request data relies on current resource state %>
+<%      if object.nested_query&.modify_by_patch -%>
+<%#       Keep this after mutex - patch request data relies on current resource state %>
     obj, err = resource<%= resource_name -%>PatchUpdateEncoder(d, meta, obj)
     if err != nil {
         return err
     }
-<%  end -%>
-<%  if object.supports_indirect_user_project_override -%>
-     if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
+<%      end -%>
+<%      if object.supports_indirect_user_project_override -%>
+    if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
         billingProject = parts[1]
     }
-<%  end -%>
+<%      end -%>
 
     // err == nil indicates that the billing_project value was found
     if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
       billingProject = bp
     }
 
-<% if object.update_mask && field_specific_update_methods(object.root_properties) -%>
+<%      if object.update_mask && field_specific_update_methods(object.root_properties) -%>
 // if updateMask is empty we are not updating anything so skip the post
 if len(updateMask) > 0 {
-<% end -%>
+<%      end -%>
     res, err := transport_tpg.SendRequestWithTimeout(config, "<%= object.update_verb -%>", billingProject, url, userAgent, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 
     if err != nil {
         return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
     } else {
-	log.Printf("[DEBUG] Finished updating <%= object.name -%> %q: %#v", d.Id(), res)
+        log.Printf("[DEBUG] Finished updating <%= object.name -%> %q: %#v", d.Id(), res)
     }
 
-<%  if object.async&.allow?('update') -%>
-<%    if object.async.is_a? Api::OpAsync -%>
+<%      if object.async&.allow?('update') -%>
+<%        if object.async.is_a? Api::OpAsync -%>
     err = <%= client_name_pascal -%>OperationWaitTime(
         config, res, <% if has_project || object.async.include_project -%> project, <% end -%> "Updating <%= object.name -%>", userAgent,
         d.Timeout(schema.TimeoutUpdate))
@@ -691,41 +691,41 @@ if len(updateMask) > 0 {
     if err != nil {
         return err
     }
-<%    elsif object.async.is_a? Provider::Terraform::PollAsync -%>
+<%        elsif object.async.is_a? Provider::Terraform::PollAsync -%>
     err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_existence -%>, "Updating <%= object.name -%>", d.Timeout(schema.TimeoutUpdate), <%= object.async.target_occurrences -%>)
     if err != nil {
-<%      if object.async.suppress_error-%>
+<%          if object.async.suppress_error-%>
         log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
-<%      else -%>
+<%          else -%>
         return err
-<%      end -%>
+<%          end -%>
     }
-<%    end -%>
-<%  end -%>
-<% if object.update_mask && field_specific_update_methods(object.root_properties) -%>
+<%        end -%>
+<%      end -%>
+<%      if object.update_mask && field_specific_update_methods(object.root_properties) -%>
   }
-<% end -%>
-<%  end # if !object.immutable -%>
+<%      end -%>
+<%    end # if !object.immutable -%>
 <%    if field_specific_update_methods(object.root_properties) -%>
     d.Partial(true)
 
-<% properties_by_custom_update(object.root_properties)
-    .sort_by {|k, _| k.nil? ? "" : k[:update_id].to_s}
-    .each do |key, props|
+<%      properties_by_custom_update(object.root_properties)
+          .sort_by {|k, _| k.nil? ? "" : k[:update_id].to_s}
+          .each do |key, props|
 -%>
-if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' || ' -%> {
+    if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' || ' -%> {
         obj := make(map[string]interface{})
 
-<%-      unless key[:fingerprint_name] == nil -%>
+<%-       unless key[:fingerprint_name] == nil -%>
         getUrl, err := tpgresource.ReplaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
         if err != nil {
             return err
         }
-<%         if object.supports_indirect_user_project_override -%>
+<%          if object.supports_indirect_user_project_override -%>
         if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
             billingProject = parts[1]
         }
-<%         end -%>
+<%          end -%>
 
         // err == nil indicates that the billing_project value was found
         if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
@@ -739,11 +739,11 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 
         obj["<%= key[:fingerprint_name] %>"] = getRes["<%= key[:fingerprint_name] %>"]
 
-<%       end # unless key[:fingerprint_name] -%>
-<%      custom_update_properties_by_key(properties, key)
-          .reject(&:url_param_only)
-          .each do |prop| -%>
-        <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
+<%      end # unless key[:fingerprint_name] -%>
+<%        custom_update_properties_by_key(properties, key)
+            .reject(&:url_param_only)
+            .each do |prop| -%>
+<%          schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
         <%= prop.api_name -%>Prop, err := expand<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
         if err != nil {
             return err
@@ -773,24 +773,24 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <%          end -%>
             obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
         }
-<%    end # props.each -%>
+<%        end # props.each -%>
 
-<%# We need to decide what encoder to use here - if there's an update encoder, use that! -%>
-<%  if object.custom_code.update_encoder -%>
+<%#     We need to decide what encoder to use here - if there's an update encoder, use that! -%>
+<%        if object.custom_code.update_encoder -%>
     obj, err = resource<%= resource_name -%>UpdateEncoder(d, meta, obj)
     if err != nil {
         return err
     }
-<%  end -%>
+<%        end -%>
 
-<%      if object.mutex -%>
+<%        if object.mutex -%>
         lockName, err := tpgresource.ReplaceVars(d, config, "<%= object.mutex -%>")
         if err != nil {
             return err
         }
         transport_tpg.MutexStore.Lock(lockName)
         defer transport_tpg.MutexStore.Unlock(lockName)
-<%      end -%>
+<%        end -%>
 
         url, err := tpgresource.ReplaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{update_uri(object, key[:update_url])}" -%>")
         if err != nil {
@@ -798,11 +798,11 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         }
 
 <%= lines(compile(pwd + '/' + object.custom_code.pre_update)) if object.custom_code.pre_update -%>
-<%      if object.supports_indirect_user_project_override -%>
+<%        if object.supports_indirect_user_project_override -%>
         if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
             billingProject = parts[1]
         }
-<%      end -%>
+<%        end -%>
 
         // err == nil indicates that the billing_project value was found
         if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
@@ -813,10 +813,10 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         if err != nil {
             return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
         } else {
-	    log.Printf("[DEBUG] Finished updating <%= object.name -%> %q: %#v", d.Id(), res)
-	}
+        log.Printf("[DEBUG] Finished updating <%= object.name -%> %q: %#v", d.Id(), res)
+    }
 
-<%      if object.async&.allow?('update') -%>
+<%        if object.async&.allow?('update') -%>
 <%          if object.async.is_a? Api::OpAsync-%>
         err = <%= client_name_pascal -%>OperationWaitTime(
             config, res, <% if has_project || object.async.include_project -%> project, <% end -%> "Updating <%= object.name -%>", userAgent,
@@ -827,65 +827,65 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <%          elsif object.async.is_a? Provider::Terraform::PollAsync -%>
         err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_existence -%>, "Updating <%= object.name -%>", d.Timeout(schema.TimeoutUpdate), <%= object.async.target_occurrences -%>)
         if err != nil {
-<%              if object.async.suppress_error-%>
+<%            if object.async.suppress_error-%>
         log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
-<%              else -%>
+<%            else -%>
         return err
-<%              end -%>
+<%            end -%>
         }
 <%          end -%>
-<%      end -%>
+<%        end -%>
     }
-<%  end -%>
+<%      end -%>
 
   d.Partial(false)
-<% end -%>
+<%    end -%>
 
 <%= lines(compile(pwd + '/' + object.custom_code.post_update)) if object.custom_code.post_update -%>
     return resource<%= resource_name -%>Read(d, meta)
 }
-<% end # if updatable? -%>
+<%  end # if updatable? -%>
 
 func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{}) error {
-<%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project && object.async&.allow?('delete')  -%>
+<%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project && object.async&.allow?('delete') -%>
     var project string
-<% end -%>
-<% if object.skip_delete -%>
+<%  end -%>
+<%  if object.skip_delete -%>
     log.Printf("[WARNING] <%= object.__product.name + " " + object.name %> resources" +
     " cannot be deleted from Google Cloud. The resource %s will be removed from Terraform" +
     " state, but will still be present on Google Cloud.", d.Id())
     d.SetId("")
 
     return nil
-<% else -%>
+<%  else -%>
     config := meta.(*transport_tpg.Config)
     userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
-    	return err
+        return err
     }
 
-<% if object.custom_code.custom_delete -%>
+<%    if object.custom_code.custom_delete -%>
 <%= lines(compile(pwd + '/' + object.custom_code.custom_delete)) -%>
-<% else -%>
+<%    else -%>
 
     billingProject := ""
 
-<%  if has_project -%>
+<%      if has_project -%>
     project, err := tpgresource.GetProject(d, config)
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
     billingProject = project
-<%  end -%>
+<%      end -%>
 
-<%  if object.mutex -%>
+<%      if object.mutex -%>
     lockName, err := tpgresource.ReplaceVars(d, config, "<%= object.mutex -%>")
     if err != nil {
         return err
     }
     transport_tpg.MutexStore.Lock(lockName)
     defer transport_tpg.MutexStore.Unlock(lockName)
-<%  end -%>
+<%      end -%>
 
     url, err := tpgresource.ReplaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.delete_uri}" -%>")
     if err != nil {
@@ -895,26 +895,26 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 <%# If the deletion of the object requires sending a request body, the custom code will set 'obj' -%>
     var obj map[string]interface{}
 <%= lines(compile(pwd + '/' + object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
-<%  if object.nested_query&.modify_by_patch -%>
+<%      if object.nested_query&.modify_by_patch -%>
 <%# Keep this after mutex - patch request data relies on current resource state %>
     obj, err = resource<%= resource_name -%>PatchDeleteEncoder(d, meta, obj)
     if err != nil {
         return transport_tpg.HandleNotFoundError(err, d, "<%= object.name -%>")
     }
-<%    if object.update_mask -%>
+<%        if object.update_mask -%>
     url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": "<%= object.nested_query.keys.join('.') -%>"})
     if err != nil {
         return err
     }
-<%    end -%>
-<%  end -%>
-<%  if object.supports_indirect_user_project_override -%>
+<%        end -%>
+<%      end -%>
+<%      if object.supports_indirect_user_project_override -%>
 
     if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
         billingProject = parts[1]
     }
 
-<%  end -%>
+<%      end -%>
     log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
 
     // err == nil indicates that the billing_project value was found
@@ -927,17 +927,17 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
         return transport_tpg.HandleNotFoundError(err, d, "<%= object.name -%>")
     }
 
-<%  if object.async&.allow?('delete') -%>
-<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
+<%      if object.async&.allow?('delete') -%>
+<%        if object.async.is_a? Provider::Terraform::PollAsync -%>
     err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_absence -%>, "Deleting <%= object.name -%>", d.Timeout(schema.TimeoutCreate), <%= object.async.target_occurrences -%>)
     if err != nil {
-<%      if object.async.suppress_error -%>
+<%          if object.async.suppress_error -%>
         log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
-<%      else -%>
+<%          else -%>
         return fmt.Errorf("Error waiting to delete <%= object.name -%>: %s", err)
-<%      end -%>
+<%          end -%>
     }
-<%    else -%>
+<%        else -%>
     err = <%= client_name_pascal -%>OperationWaitTime(
         config, res, <% if has_project || object.async.include_project-%> project, <% end -%> "Deleting <%= object.name -%>", userAgent,
         d.Timeout(schema.TimeoutDelete))
@@ -945,26 +945,26 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
-<%    end -%>
-<%  end -%>
+<%        end -%>
+<%      end -%>
 <%= lines(compile(pwd + '/' + object.custom_code.post_delete)) if object.custom_code.post_delete -%>
 
     log.Printf("[DEBUG] Finished deleting <%= object.name -%> %q: %#v", d.Id(), res)
     return nil
-<% end # custom code -%>
-<% end # skip_delete -%>
+<%    end # custom code -%>
+<%  end # skip_delete -%>
 }
 
-<% unless object.exclude_import -%>
+<%  unless object.exclude_import -%>
 func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-<% if object.custom_code.custom_import -%>
+<%    if object.custom_code.custom_import -%>
 <%= lines(compile(pwd + '/' + object.custom_code.custom_import)) -%>
-<% else -%>
+<%    else -%>
     config := meta.(*transport_tpg.Config)
     if err := tpgresource.ParseImportId([]string{
-<%   for import_id in import_id_formats_from_resource(object) -%>
+<%      for import_id in import_id_formats_from_resource(object) -%>
         "<%= format2regex(import_id) %>",
-<%   end -%>
+<%      end -%>
     }, d, config); err != nil {
       return nil, err
     }
@@ -976,64 +976,63 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     }
     d.SetId(id)
 
-<%-  unless object.virtual_fields.empty? -%>
+<%-     unless object.virtual_fields.empty? -%>
     // Explicitly set virtual fields to default values on import
-  <%-  object.virtual_fields.each do |field| -%>
-    <% unless field.default_value.nil? -%>
+<%-       object.virtual_fields.each do |field| -%>
+<%          unless field.default_value.nil? -%>
     if err := d.Set("<%= field.name %>", <%= go_literal(field.default_value) -%>); err != nil {
-    	return nil, fmt.Errorf("Error setting <%= field.name %>: %s", err)
+        return nil, fmt.Errorf("Error setting <%= field.name %>: %s", err)
     }
-    <% end -%>
-  <%   end -%>
-<%   end -%>
+<%          end -%>
+<%        end -%>
+<%      end -%>
 <%= lines(compile(pwd + '/' + object.custom_code.post_import)) if object.custom_code.post_import -%>
 
     return []*schema.ResourceData{d}, nil
-<% end -%>
+<%    end -%>
 }
-<% end -%>
+<%  end -%>
 
 <%- nested_prefix = object.nested_query ? "Nested" : "" -%>
-<% object.gettable_properties.reject(&:ignore_read).each do |prop| -%>
+<%  object.gettable_properties.reject(&:ignore_read).each do |prop| -%>
 <%= lines(build_flatten_method(nested_prefix+resource_name, prop, object, pwd), 1) -%>
-<% end -%>
+<%  end -%>
 
-<% object.settable_properties.each do |prop| -%>
+<%  object.settable_properties.each do |prop| -%>
 <%= lines(build_expand_method(nested_prefix+resource_name, prop, object, pwd), 1) -%>
-<% end -%>
+<%  end -%>
 
-<% if object.custom_code.encoder -%>
+<%  if object.custom_code.encoder -%>
 func resource<%= resource_name -%>Encoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-<%= lines(compile(pwd + '/' + object.custom_code.encoder)) -%>
+    <%= lines(compile(pwd + '/' + object.custom_code.encoder)) -%>
 }
-<% end -%>
+<%  end -%>
 
-<% if object.custom_code.update_encoder-%>
+<%  if object.custom_code.update_encoder-%>
 func resource<%= resource_name -%>UpdateEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-<%= lines(compile(pwd + '/' + object.custom_code.update_encoder)) -%>
+    <%= lines(compile(pwd + '/' + object.custom_code.update_encoder)) -%>
 }
-<% end -%>
+<%  end -%>
 
 <%  if object.nested_query -%>
 <%= compile_template(pwd + '/templates/terraform/nested_query.go.erb',
-                 object: object,
-                 settable_properties: object.settable_properties,
-                 resource_name: resource_name) -%>
-<% end -%>
-
-<% if object.custom_code.decoder -%>
-func resource<%= resource_name -%>Decoder(d *schema.ResourceData, meta interface{}, res map[string]interface{}) (map[string]interface{}, error) {
-<%= lines(compile(pwd + '/' + object.custom_code.decoder)) -%>
-}
-<% end -%>
-
-<% if object.custom_code.post_create_failure -%>
-func resource<%= resource_name -%>PostCreateFailure(d *schema.ResourceData, meta interface{}) {
-<%= lines(compile(pwd + '/' + object.custom_code.post_create_failure)) -%>
-}
-<% end -%>
-
-<% if object.schema_version -%>
-<%= lines(compile(pwd + "/templates/terraform/state_migrations/#{product_ns.underscore}_#{object.name.underscore}.go.erb")) -%>
+                     object: object,
+                     settable_properties: object.settable_properties,
+                     resource_name: resource_name) -%>
 <%  end -%>
 
+<%  if object.custom_code.decoder -%>
+func resource<%= resource_name -%>Decoder(d *schema.ResourceData, meta interface{}, res map[string]interface{}) (map[string]interface{}, error) {
+    <%= lines(compile(pwd + '/' + object.custom_code.decoder)) -%>
+}
+<%  end -%>
+
+<%  if object.custom_code.post_create_failure -%>
+func resource<%= resource_name -%>PostCreateFailure(d *schema.ResourceData, meta interface{}) {
+    <%= lines(compile(pwd + '/' + object.custom_code.post_create_failure)) -%>
+}
+<%  end -%>
+
+<%  if object.schema_version -%>
+<%= lines(compile(pwd + "/templates/terraform/state_migrations/#{product_ns.underscore}_#{object.name.underscore}.go.erb")) -%>
+<%  end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
