### PR TITLE
Add google_gkeonprem_vmware_node_pool resource

### DIFF
--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -1,0 +1,288 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Resource
+name: "VmwareNodePool"
+min_version: beta
+base_url: "projects/{{project}}/locations/{{location}}/vmwareClusters/{{vmware_cluster}}/vmwareNodePools"
+create_url: "projects/{{project}}/locations/{{location}}/vmwareClusters/{{vmware_cluster}}/vmwareNodePools?vmware_node_pool_id={{name}}"
+update_url: "projects/{{project}}/locations/{{location}}/vmwareClusters/{{vmware_cluster}}/vmwareNodePools/{{name}}"
+self_link: "projects/{{project}}/locations/{{location}}/vmwareClusters/{{vmware_cluster}}/vmwareNodePools/{{name}}"
+update_verb: :PATCH
+update_mask: true
+description: "A Google Vmware Node Pool."
+autogen_async: false
+id_format: "projects/{{project}}/locations/{{location}}/vmwareClusters/{{vmware_cluster}}/vmwareNodePools/{{name}}"
+import_format: ["projects/{{project}}/locations/{{location}}/vmwareClusters/{{vmware_cluster}}/vmwareNodePools/{{name}}"]
+taint_resource_on_failed_create: true
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 55
+  delete_minutes: 50
+  update_minutes: 60
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "gkeonprem_vmware_node_pool_basic"
+    min_version: beta
+    primary_resource_id: "nodepool-basic"
+    vars:
+      name: "nodepool"
+      cluster_name: "cluster"
+    test_env_vars:
+      project: "fake-backend-360322"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "gkeonprem_vmware_node_pool_full"
+    min_version: beta
+    primary_resource_id: "nodepool-full"
+    vars:
+      name: "nodepool"
+      cluster_name: "cluster"
+    test_env_vars:
+      project: "fake-backend-360322"
+skip_sweeper: true
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "name"
+    description: The vmware node pool name.
+    immutable: true
+    url_param_only: true
+    required: true
+  - !ruby/object:Api::Type::ResourceRef
+    name: "vmwareCluster"
+    resource: "VmwareCluster"
+    imports: "name"
+    description: "The cluster this node pool belongs to."
+    url_param_only: true
+    required: true
+  - !ruby/object:Api::Type::String
+    name: "location"
+    description: The location of the resource.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: "displayName"
+    description: The display name for the node pool.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: "annotations"
+    description: |
+      Annotations on the node Pool.
+      This field has the same restrictions as Kubernetes annotations.
+      The total size of all keys and values combined is limited to 256k.
+      Key can have 2 segments: prefix (optional) and name (required),
+      separated by a slash (/).
+      Prefix must be a DNS subdomain.
+      Name must be 63 characters or less, begin and end with alphanumerics,
+      with dashes (-), underscores (_), dots (.), and alphanumerics between.
+    default_from_api: true
+  - !ruby/object:Api::Type::NestedObject
+    name: "nodePoolAutoscaling"
+    description: Node Pool autoscaling config for the node pool.
+    properties:
+      - !ruby/object:Api::Type::Integer
+        name: "minReplicas"
+        description: Minimum number of replicas in the NodePool.
+      - !ruby/object:Api::Type::Integer
+        name: "maxReplicas"
+        description: Maximum number of replicas in the NodePool.
+  - !ruby/object:Api::Type::NestedObject
+    name: "config"
+    description: The node configuration of the node pool.
+    required: true
+    properties:
+      - !ruby/object:Api::Type::Integer
+        name: "cpus"
+        description: The number of CPUs for each node in the node pool.
+        default_value: 4
+      - !ruby/object:Api::Type::Integer
+        name: "memoryMb"
+        description: The megabytes of memory for each node in the node pool.
+        default_value: 8192
+      - !ruby/object:Api::Type::Integer
+        name: "replicas"
+        description: The number of nodes in the node pool.
+        default_value: 1
+      - !ruby/object:Api::Type::String
+        name: "imageType"
+        required: true
+        description: |
+          The OS image to be used for each node in a node pool.
+          Currently `cos`, `ubuntu`, `ubuntu_containerd` and `windows` are supported.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: "image"
+        description: The OS image name in vCenter, only valid when using Windows.
+      - !ruby/object:Api::Type::Integer
+        name: "bootDiskSizeGb"
+        description: VMware disk size to be used during creation.
+      - !ruby/object:Api::Type::Array
+        name: "taints"
+        description: The initial taints assigned to nodes of this node pool.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: "key"
+              description: |
+                Key associated with the effect.
+            - !ruby/object:Api::Type::String
+              name: "value"
+              description: |
+                Value associated with the effect.
+            - !ruby/object:Api::Type::Enum
+              name: "effect"
+              description: |
+                Specifies the nodes operating system (default: LINUX).
+              values:
+                - EFFECT_UNSPECIFIED
+                - NO_SCHEDULE
+                - PREFER_NO_SCHEDULE
+                - NO_EXECUTE
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: "labels"
+        description: |
+          The map of Kubernetes labels (key/value pairs) to be applied to each node.
+          These will added in addition to any default label(s) that
+          Kubernetes may apply to the node.
+          In case of conflict in label keys, the applied set may differ depending on
+          the Kubernetes version -- it's best to assume the behavior is undefined
+          and conflicts should be avoided.
+        default_from_api: true
+      - !ruby/object:Api::Type::NestedObject
+        name: "vsphereConfig"
+        description: Specifies the vSphere config for node pool.
+        output: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: datastore
+            description: The name of the vCenter datastore. Inherited from the user
+              cluster.
+            output: true
+          - !ruby/object:Api::Type::Array
+            name: "tags"
+            description: Tags to apply to VMs.
+            output: true
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: "category"
+                  description: The Vsphere tag category.
+                  output: true
+                - !ruby/object:Api::Type::String
+                  name: "tag"
+                  description: The Vsphere tag name.
+                  output: true
+      - !ruby/object:Api::Type::Boolean
+        name: "enableLoadBalancer"
+        description: |
+          Allow node pool traffic to be load balanced. Only works for clusters with
+          MetalLB load balancers.
+  - !ruby/object:Api::Type::NestedObject
+    name: status
+    description: ResourceStatus representing detailed cluster state.
+    output: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: "errorMessage"
+        description: |
+          Human-friendly representation of the error message from the user cluster
+          controller. The error message can be temporary as the user cluster
+          controller creates a cluster or node pool. If the error message persists
+          for a longer period of time, it can be used to surface error message to
+          indicate real problems requiring user intervention.
+        output: true
+      - !ruby/object:Api::Type::Array
+        name: "conditions"
+        description: |
+          ResourceConditions provide a standard mechanism for higher-level status reporting from user cluster controller.
+        output: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: "type"
+              description: |
+                Type of the condition.
+                (e.g., ClusterRunning, NodePoolRunning or ServerSidePreflightReady)
+              output: true
+            - !ruby/object:Api::Type::String
+              name: "reason"
+              description: |
+                Machine-readable message indicating details about last transition.
+              output: true
+            - !ruby/object:Api::Type::String
+              name: "message"
+              description: |
+                Human-readable message indicating details about last transition.
+              output: true
+            - !ruby/object:Api::Type::Time
+              name: "lastTransitionTime"
+              description: |
+                Last time the condition transit from one status to another.
+              output: true
+            - !ruby/object:Api::Type::Enum
+              name: "state"
+              description: The lifecycle state of the condition.
+              output: true
+              values:
+                - STATE_UNSPECIFIED
+                - STATE_TRUE
+                - STATE_FALSE
+                - STATE_UNKNOWN
+  - !ruby/object:Api::Type::String
+    name: "uid"
+    description: The unique identifier of the node pool.
+    output: true
+  - !ruby/object:Api::Type::Enum
+    name: "state"
+    description: The current state of this cluster.
+    output: true
+    values:
+      - STATE_UNSPECIFIED
+      - PROVISIONING
+      - RUNNING
+      - RECONCILING
+      - STOPPING
+      - ERROR
+      - DEGRADED
+  - !ruby/object:Api::Type::Boolean
+    name: "reconciling"
+    description: |
+      If set, there are currently changes in flight to the node pool.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: "createTime"
+    description: |
+      The time the cluster was created, in RFC3339 text format.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: "updateTime"
+    description: |
+      The time the cluster was last updated, in RFC3339 text format.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: "deleteTime"
+    description: |
+      The time the cluster was deleted, in RFC3339 text format.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: "etag"
+    description: |
+      This checksum is computed by the server based on the value of other
+      fields, and may be sent on update and delete requests to ensure the
+      client has an up-to-date value before proceeding.
+      Allows clients to perform consistent read-modify-writes
+      through optimistic concurrency control.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: "onPremVersion"
+    description: |
+      Anthos version for the node pool. Defaults to the user cluster version.
+    output: true

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_basic.tf.erb
@@ -1,0 +1,50 @@
+resource "google_gkeonprem_vmware_cluster" "<%= ctx[:vars]['cluster_name'] %>" {
+  provider = google-beta
+  location = "us-west1"
+  name = "<%= ctx[:vars]['cluster_name'] %>"
+  admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
+  description = "test cluster"
+  on_prem_version = "1.13.1-gke.35"
+  network_config {
+    service_address_cidr_blocks = ["10.96.0.0/12"]
+    pod_address_cidr_blocks = ["192.168.0.0/16"]
+    dhcp_ip_config {
+      enabled = true
+    }
+  }
+  control_plane_node {
+     cpus = 4
+     memory = 8192
+     replicas = 1
+  }
+  load_balancer {
+    vip_config {
+      control_plane_vip = "10.251.133.5"
+      ingress_vip = "10.251.135.19"
+    }
+    metal_lb_config {
+      address_pools {
+        pool = "ingress-ip"
+        manual_assign = "true"
+        addresses = ["10.251.135.19"]
+      }
+      address_pools {
+        pool = "lb-test-ip"
+        manual_assign = "true"
+        addresses = ["10.251.135.19"]
+      }
+    }
+  }
+}
+
+resource "google_gkeonprem_vmware_node_pool" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  location = "us-west1"
+  name = "np-<%= ctx[:vars]['name'] %>"
+  vmware_cluster = google_gkeonprem_vmware_cluster.<%= ctx[:vars]['cluster_name'] %>.name
+  config {
+    replicas = 3
+    image_type = "ubuntu_containerd"
+    enable_load_balancer = true
+  }
+}

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.erb
@@ -1,0 +1,64 @@
+resource "google_gkeonprem_vmware_cluster" "<%= ctx[:vars]['cluster_name'] %>" {
+  provider = google-beta
+  location = "us-west1"
+  name = "<%= ctx[:vars]['cluster_name'] %>"
+  admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
+  description = "test cluster"
+  on_prem_version = "1.13.1-gke.35"
+  network_config {
+    service_address_cidr_blocks = ["10.96.0.0/12"]
+    pod_address_cidr_blocks = ["192.168.0.0/16"]
+    dhcp_ip_config {
+      enabled = true
+    }
+  }
+  control_plane_node {
+     cpus = 4
+     memory = 8192
+     replicas = 1
+  }
+  load_balancer {
+    vip_config {
+      control_plane_vip = "10.251.133.5"
+      ingress_vip = "10.251.135.19"
+    }
+    metal_lb_config {
+      address_pools {
+        pool = "ingress-ip"
+        manual_assign = "true"
+        addresses = ["10.251.135.19"]
+      }
+      address_pools {
+        pool = "lb-test-ip"
+        manual_assign = "true"
+        addresses = ["10.251.135.19"]
+      }
+    }
+  }
+}
+
+resource "google_gkeonprem_vmware_node_pool" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  location = "us-west1"
+  name = "np-<%= ctx[:vars]['name'] %>"
+  vmware_cluster = google_gkeonprem_vmware_cluster.<%= ctx[:vars]['cluster_name'] %>.name
+  annotations = {}
+  config {
+    cpus = 4
+    memory_mb = 8196
+    replicas = 3
+    image_type = "ubuntu_containerd"
+    image = "image"
+    boot_disk_size_gb = 10
+    taints {
+        key = "key"
+        value = "value"
+    }
+    labels = {}
+    enable_load_balancer = true
+  }
+  node_pool_autoscaling {
+    min_replicas = 1
+    max_replicas = 5
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_node_pool_test.go.erb
@@ -1,0 +1,188 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(t *testing.T) {
+  // VCR fails to handle batched project services
+  SkipIfVcr(t)
+  t.Parallel()
+
+  context := map[string]interface{}{}
+
+  VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+    CheckDestroy:             testAccCheckGkeonpremVmwareNodePoolDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context),
+      },
+      {
+        ResourceName:      "google_gkeonprem_vmware_node_pool.nodepool",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context),
+      },
+      {
+        ResourceName:      "google_gkeonprem_vmware_node_pool.nodepool",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+    },
+  })
+}
+
+func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context map[string]interface{}) string {
+  return Nprintf(`
+
+  resource "google_gkeonprem_vmware_cluster" "cluster" {
+    provider = google-beta  
+    name = "cluster"
+    location = "us-west1"
+    admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
+    description = "test cluster"
+    on_prem_version = "1.13.1-gke.35"
+    annotations = {}
+    network_config {
+      service_address_cidr_blocks = ["10.96.0.0/12"]
+      pod_address_cidr_blocks = ["192.168.0.0/16"]
+      dhcp_ip_config {
+        enabled = true
+      }
+    }
+    control_plane_node {
+       cpus = 4
+       memory = 8192
+       replicas = 1
+    }
+    load_balancer {
+      vip_config {
+        control_plane_vip = "10.251.133.5"
+        ingress_vip = "10.251.135.19"
+      }
+      metal_lb_config {
+        address_pools {
+          pool = "ingress-ip"
+          manual_assign = "true"
+          addresses = ["10.251.135.19"]
+          avoid_buggy_ips = true
+        }
+        address_pools {
+          pool = "lb-test-ip"
+          manual_assign = "true"
+          addresses = ["10.251.135.19"]
+          avoid_buggy_ips = true
+        }
+      }
+    }
+  }
+
+  resource "google_gkeonprem_vmware_node_pool" "nodepool" {
+    provider = google-beta
+    location = "us-west1"
+    name = "nodepool"
+    vmware_cluster = google_gkeonprem_vmware_cluster.cluster.name
+    annotations = {}
+    config {
+        cpus = 4
+        memory_mb = 8196
+        replicas = 3
+        image_type = "ubuntu_containerd"
+        image = "image"
+        boot_disk_size_gb = 10
+        taints {
+            key = "key"
+            value = "value"
+        }
+        labels = {}
+        enable_load_balancer = true
+    }
+    node_pool_autoscaling {
+        min_replicas = 1
+        max_replicas = 5
+    }
+  }
+`, context)
+}
+
+func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context map[string]interface{}) string {
+  return Nprintf(`
+
+  resource "google_gkeonprem_vmware_cluster" "cluster" {
+    provider = google-beta  
+    name = "cluster"
+    location = "us-west1"
+    admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
+    description = "test cluster"
+    on_prem_version = "1.13.1-gke.35"
+    annotations = {}
+    network_config {
+      service_address_cidr_blocks = ["10.96.0.0/12"]
+      pod_address_cidr_blocks = ["192.168.0.0/16"]
+      dhcp_ip_config {
+        enabled = true
+      }
+    }
+    control_plane_node {
+       cpus = 4
+       memory = 8192
+       replicas = 1
+    }
+    load_balancer {
+      vip_config {
+        control_plane_vip = "10.251.133.5"
+        ingress_vip = "10.251.135.19"
+      }
+      metal_lb_config {
+        address_pools {
+          pool = "ingress-ip"
+          manual_assign = "true"
+          addresses = ["10.251.135.19"]
+          avoid_buggy_ips = true
+        }
+        address_pools {
+          pool = "lb-test-ip"
+          manual_assign = "true"
+          addresses = ["10.251.135.19"]
+          avoid_buggy_ips = true
+        }
+      }
+    }
+  }
+
+  resource "google_gkeonprem_vmware_node_pool" "nodepool" {
+    provider = google-beta
+    location = "us-west1"
+    name = "nodepool"
+    vmware_cluster = google_gkeonprem_vmware_cluster.cluster.name
+    annotations = {}
+    config {
+        cpus = 5
+        memory_mb = 4096
+        replicas = 3
+        image_type = "windows"
+        image = "image-updated"
+        boot_disk_size_gb = 12
+        taints {
+            key = "key-updated"
+            value = "value-updated"
+        }
+        labels = {}
+        enable_load_balancer = false
+    }
+    node_pool_autoscaling {
+        min_replicas = 2
+        max_replicas = 6
+    }
+  }
+`, context)
+}
+
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_gkeonprem_vmware_node_pool`
```
