### PR TITLE
Add support for insecureKubeletReadonlyPortEnabled

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -402,12 +402,14 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "100us", true, 2048),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "100us", true, true, 2048),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.cpu_cfs_quota", "true"),
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.pod_pids_limit", "2048"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
+                        "node_config.0.kubelet_config.0.insecure_kubelet_readonly_port_enabled", "true"),
 				),
 			},
 			{
@@ -416,10 +418,12 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "", "", false, 1024),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "", "", false, false, 1024),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.cpu_cfs_quota", "false"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
+                        "node_config.0.kubelet_config.0.insecure_kubelet_readonly_port_enabled", "false"),
 				),
 			},
 			{
@@ -445,7 +449,7 @@ func TestAccContainerNodePool_withInvalidKubeletCpuManagerPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "100us", true, 1024),
+				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "100us", true, true, 1024),
 				ExpectError: regexp.MustCompile(`.*to be one of \[static none \].*`),
 			},
 		},
@@ -2394,7 +2398,7 @@ resource "google_container_node_pool" "with_sandbox_config" {
 }
 <% end -%>
 
-func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, period string, quota bool, podPidsLimit int) string {
+func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, period string, quota, insecureKubeletReadonlyPortEnabled bool, podPidsLimit int) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -2420,6 +2424,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
       cpu_manager_policy   = %q
       cpu_cfs_quota        = %v
       cpu_cfs_quota_period = %q
+      insecure_kubelet_readonly_port_enabled = %v
       pod_pids_limit			 = %d
     }
     oauth_scopes = [
@@ -2428,7 +2433,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
     ]
   }
 }
-`, cluster, np, policy, quota, period, podPidsLimit)
+`, cluster, np, policy, quota, period, insecureKubeletReadonlyPortEnabled, podPidsLimit)
 }
 
 func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, maxBacklog, soMaxConn int, tcpMem string, twReuse int) string {

--- a/mmv1/third_party/terraform/utils/node_config.go.erb
+++ b/mmv1/third_party/terraform/utils/node_config.go.erb
@@ -494,6 +494,11 @@ func schemaNodeConfig() *schema.Schema {
 								Optional: true,
 								Description: `Set the CPU CFS quota period value 'cpu.cfs_period_us'.`,
 							},
+							"insecure_kubelet_readonly_port_enabled" {
+								Type:     schema.TypeBool,
+                                Optional: true,
+                                Description: `Disable the Kubelet read only API port. Default enabled.`,
+							},
 							"pod_pids_limit": {
 								Type:        schema.TypeInt,
 								Optional:    true,

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -864,10 +864,11 @@ Structure is [documented below](#nested_kubelet_config).
 
 ```
 kubelet_config {
-  cpu_manager_policy   = "static"
-  cpu_cfs_quota        = true
-  cpu_cfs_quota_period = "100us"
-  pod_pids_limit       = 1024
+  cpu_manager_policy                     = "static"
+  cpu_cfs_quota                          = true
+  cpu_cfs_quota_period                   = "100us"
+  insecure_kubelet_readonly_port_enabled = false
+  pod_pids_limit                         = 1024
 }
 ```
 


### PR DESCRIPTION
This adds support for insecureKubeletReadonlyPortEnabled documented at [1] which is referenced at [2].

[1]: https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/create#--system-config-from-file
[2]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

```
