### PR TITLE
fix: check if Bigtable cluster zones are affected by partial unavailability

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"cloud.google.com/go/bigtable"
@@ -260,7 +262,17 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 
 	clusters, err := c.Clusters(ctx, instance.Name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving instance clusters. %s", err)
+		partiallyUnavailableErr, ok := err.(bigtable.ErrPartiallyUnavailable)
+
+		if !ok {
+			return fmt.Errorf("Error retrieving instance clusters. %s", err)
+		}
+
+		unavailableClusterZones := getUnavailableClusterZones(d.Get("cluster").([]interface{}), partiallyUnavailableErr.Locations)
+
+		if len(unavailableClusterZones) > 0 {
+			return fmt.Errorf("Error retrieving instance clusters. The following zones are unavailable: %s", strings.Join(unavailableClusterZones, ", "))
+		}
 	}
 
 	clustersNewState := []map[string]interface{}{}
@@ -403,6 +415,22 @@ func flattenBigtableCluster(c *bigtable.ClusterInfo) map[string]interface{} {
 		autoscaling_config[0]["storage_target"] = c.AutoscalingConfig.StorageUtilizationPerNode
 	}
 	return cluster
+}
+
+func getUnavailableClusterZones(clusters []interface{}, unavailableZones []string) []string {
+	zones := make([]string, len(clusters))
+	for i, c := range clusters {
+		cluster := c.(map[string]interface{})
+		zone := cluster["zone"].(string)
+
+		for _, unavailableZone := range unavailableZones {
+			if zone == unavailableZone {
+				zones[i] = zone
+				break
+			}
+		}
+	}
+	return zones
 }
 
 func expandBigtableClusters(clusters []interface{}, instanceID string, config *transport_tpg.Config) ([]bigtable.ClusterConfig, error) {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_instance.go
@@ -418,14 +418,15 @@ func flattenBigtableCluster(c *bigtable.ClusterInfo) map[string]interface{} {
 }
 
 func getUnavailableClusterZones(clusters []interface{}, unavailableZones []string) []string {
-	zones := make([]string, len(clusters))
-	for i, c := range clusters {
+	var zones []string
+
+	for _, c := range clusters {
 		cluster := c.(map[string]interface{})
 		zone := cluster["zone"].(string)
 
 		for _, unavailableZone := range unavailableZones {
 			if zone == unavailableZone {
-				zones[i] = zone
+				zones = append(zones, zone)
 				break
 			}
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14424

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed plan failure because of an unused zone being unavailable
```
