### PR TITLE
Add plugin framework-compatible location getter functions

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -124,12 +124,12 @@ func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.
 	}
 
 	locationInfo := data.GetLocationDescription(d.providerConfig)
-	region, err := locationInfo.getRegion()
+	region, err := locationInfo.GetRegion()
 	if err != nil {
 		diags.AddError("Error getting region value", err.Error())
 		return
 	}
-	zone, err := locationInfo.getZone()
+	zone, err := locationInfo.GetZone()
 	if err != nil {
 		diags.AddError("Error getting zone value", err.Error())
 		return

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -35,7 +35,7 @@ type GoogleClientConfigModel struct {
 	AccessToken types.String `tfsdk:"access_token"`
 }
 
-func (m *GoogleClientConfigModel) getLocationDescription(providerConfig *frameworkProvider) LocationDescription {
+func (m *GoogleClientConfigModel) GetLocationDescription(providerConfig *frameworkProvider) LocationDescription {
 	return LocationDescription{
 		RegionSchemaField: types.StringValue("region"),
 		ZoneSchemaField:   types.StringValue("zone"),
@@ -123,7 +123,7 @@ func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	locationInfo := data.getLocationDescription(d.providerConfig)
+	locationInfo := data.GetLocationDescription(d.providerConfig)
 	region, err := locationInfo.getRegion()
 	if err != nil {
 		diags.AddError("Error getting region value", err.Error())

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -123,10 +123,22 @@ func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	data.Id = types.StringValue(fmt.Sprintf("projects/%s/regions/%s/zones/%s", d.providerConfig.project.String(), d.providerConfig.region.String(), d.providerConfig.zone.String()))
+	locationInfo := data.getLocationDescription(d.providerConfig)
+	region, err := locationInfo.getRegion()
+	if err != nil {
+		diags.AddError("Error getting region value", err.Error())
+		return
+	}
+	zone, err := locationInfo.getZone()
+	if err != nil {
+		diags.AddError("Error getting zone value", err.Error())
+		return
+	}
+
+	data.Id = types.StringValue(fmt.Sprintf("projects/%s/regions/%s/zones/%s", d.providerConfig.project.String(), region.String(), zone.String()))
 	data.Project = d.providerConfig.project
-	data.Region = d.providerConfig.region
-	data.Zone = d.providerConfig.zone
+	data.Region = region
+	data.Zone = zone
 
 	token, err := d.providerConfig.tokenSource.Token()
 	if err != nil {

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -14,6 +14,7 @@ import (
 var (
 	_ datasource.DataSource              = &GoogleClientConfigDataSource{}
 	_ datasource.DataSourceWithConfigure = &GoogleClientConfigDataSource{}
+	_ LocationDescriber                  = &GoogleClientConfigModel{}
 )
 
 func NewGoogleClientConfigDataSource() datasource.DataSource {
@@ -32,6 +33,17 @@ type GoogleClientConfigModel struct {
 	Region      types.String `tfsdk:"region"`
 	Zone        types.String `tfsdk:"zone"`
 	AccessToken types.String `tfsdk:"access_token"`
+}
+
+func (m *GoogleClientConfigModel) getLocationDescription(providerConfig *frameworkProvider) LocationDescription {
+	return LocationDescription{
+		RegionSchemaField: types.ValueString("region"),
+		ZoneSchemaField:   types.ValueString("zone"),
+		ResourceRegion:    m.Region,
+		ResourceZone:      m.Zone,
+		ProviderRegion:    providerConfig.region,
+		ProviderZone:      providerConfig.zone,
+	}
 }
 
 func (d *GoogleClientConfigDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -37,8 +37,8 @@ type GoogleClientConfigModel struct {
 
 func (m *GoogleClientConfigModel) getLocationDescription(providerConfig *frameworkProvider) LocationDescription {
 	return LocationDescription{
-		RegionSchemaField: types.ValueString("region"),
-		ZoneSchemaField:   types.ValueString("zone"),
+		RegionSchemaField: types.StringValue("region"),
+		ZoneSchemaField:   types.StringValue("zone"),
 		ResourceRegion:    m.Region,
 		ResourceZone:      m.Zone,
 		ProviderRegion:    providerConfig.region,

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -46,7 +46,13 @@ func (ld *LocationDescription) getLocation() (types.String, error) {
 		return ld.ProviderZone, nil
 	}
 
-	return types.StringNull(), nil
+	var err error
+	if !ld.LocationSchemaField.IsNull() {
+		err = fmt.Errorf("location could not be identified, please add `%s` in your resource or set `region` in your provider configuration block", ld.LocationSchemaField.ValueString())
+	} else {
+		err = errors.New("location could not be identified, please add `location` in your resource or `region` in your provider configuration block")
+	}
+	return types.StringNull(), err
 }
 
 func (ld *LocationDescription) getRegion() (types.String, error) {

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -90,12 +90,14 @@ func (ld *LocationDescription) getRegion() (types.String, error) {
 
 func (ld *LocationDescription) getZone() (types.String, error) {
 	// TODO(SarahFrench): Make empty strings not ignored, see https://github.com/hashicorp/terraform-provider-google/issues/14447
+	// For all checks in this function body
+
 	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
 		// Zone could be a self link
 		zone := GetResourceNameFromSelfLink(ld.ResourceZone.ValueString())
 		return types.StringValue(zone), nil
 	}
-	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
 		return ld.ProviderZone, nil
 	}
 

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -50,22 +50,25 @@ func (ld *LocationDescription) getLocation() (types.String, error) {
 }
 
 func (ld *LocationDescription) getRegion() (types.String, error) {
+	// TODO(SarahFrench): Make empty strings not ignored, see https://github.com/hashicorp/terraform-provider-google/issues/14447
+	// For all checks in this function body
+
 	// Region from resource config
-	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {
+	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() && !ld.ResourceRegion.Equal(types.StringValue("")) {
 		region := GetResourceNameFromSelfLink(ld.ResourceRegion.ValueString()) // Region could be a self link
 		return types.StringValue(region), nil
 	}
 	// Region from zone in resource config
-	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
 		region := getRegionFromZone(ld.ResourceZone.ValueString())
 		return types.StringValue(region), nil
 	}
 	// Region from provider config
-	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() {
+	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
 		return ld.ProviderRegion, nil
 	}
 	// Region from zone in provider config
-	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
 		region := getRegionFromZone(ld.ProviderZone.ValueString())
 		return types.StringValue(region), nil
 	}

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -72,7 +72,7 @@ func (ld *LocationDescription) getRegion() (types.String, error) {
 
 	var err error
 	if !ld.RegionSchemaField.IsNull() {
-		err = fmt.Errorf("region could not be identified, please add `%s` in your resource or set `region` in your provider configuration block", ld.ZoneSchemaField.ValueString())
+		err = fmt.Errorf("region could not be identified, please add `%s` in your resource or set `region` in your provider configuration block", ld.RegionSchemaField.ValueString())
 	} else {
 		err = errors.New("region could not be identified, please add `region` in your resource or provider configuration block")
 	}

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -42,7 +42,7 @@ func (ld *LocationDescription) getLocation() (types.String, error) {
 	}
 
 	// Location from zone in provider config
-	if !ld.ProviderZone.IsNull() {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
 		return ld.ProviderZone, nil
 	}
 
@@ -61,11 +61,11 @@ func (ld *LocationDescription) getRegion() (types.String, error) {
 		return types.StringValue(region), nil
 	}
 	// Region from provider config
-	if !ld.ProviderRegion.IsNull() {
+	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() {
 		return ld.ProviderRegion, nil
 	}
 	// Region from zone in provider config
-	if !ld.ProviderZone.IsNull() {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
 		region := getRegionFromZone(ld.ProviderZone.ValueString())
 		return types.StringValue(region), nil
 	}
@@ -85,7 +85,7 @@ func (ld *LocationDescription) getZone() (types.String, error) {
 		zone := GetResourceNameFromSelfLink(ld.ResourceZone.ValueString())
 		return types.StringValue(zone), nil
 	}
-	if !ld.ProviderZone.IsNull() {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
 		return ld.ProviderZone, nil
 	}
 

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -26,23 +26,23 @@ type LocationDescription struct {
 
 func (ld *LocationDescription) getLocation() (types.String, error) {
 	// Location from resource config
-	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() {
+	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() && !ld.ResourceLocation.Equal(types.StringValue("")) {
 		return ld.ResourceLocation, nil
 	}
 
 	// Location from region in resource config
-	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {
+	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() && !ld.ResourceRegion.Equal(types.StringValue("")) {
 		return ld.ResourceRegion, nil
 	}
 
 	// Location from zone in resource config
-	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
 		location := GetResourceNameFromSelfLink(ld.ResourceZone.ValueString()) // Zone could be a self link
 		return types.StringValue(location), nil
 	}
 
 	// Location from zone in provider config
-	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
 		return ld.ProviderZone, nil
 	}
 

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -1,0 +1,74 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type LocationDescriber interface {
+	getLocationDescription(providerConfig *frameworkProvider) LocationDescription
+}
+
+type LocationDescription struct {
+	LocationSchemaField types.String
+	RegionSchemaField   types.String
+	ZoneSchemaField     types.String
+
+	ResourceLocation types.String
+	ResourceRegion   types.String
+	ResourceZone     types.String
+
+	ProviderRegion types.String
+	ProviderZone   types.String
+}
+
+func (ld *LocationDescription) getRegion() (types.String, error) {
+	// Region from resource config
+	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {
+		region := GetResourceNameFromSelfLink(ld.ResourceRegion.ValueString()) // Region could be a self link
+		return types.StringValue(region), nil
+	}
+	// Region from zone in resource config
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
+		region := getRegionFromZone(ld.ResourceZone.ValueString())
+		return types.StringValue(region), nil
+	}
+	// Region from provider config
+	if !ld.ProviderRegion.IsNull() {
+		return ld.ProviderRegion, nil
+	}
+	// Region from zone in provider config
+	if !ld.ProviderZone.IsNull() {
+		region := getRegionFromZone(ld.ProviderZone.ValueString())
+		return types.StringValue(region), nil
+	}
+
+	var err error
+	if !ld.RegionSchemaField.IsNull() {
+		err = fmt.Errorf("region could not be identified, please add `%s` in your resource or set `region` in your provider configuration block", ld.ZoneSchemaField.ValueString())
+	} else {
+		err = errors.New("region could not be identified, please add `region` in your resource or provider configuration block")
+	}
+	return types.StringNull(), err
+}
+
+func (ld *LocationDescription) getZone() (types.String, error) {
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
+		// Zone could be a self link
+		zone := GetResourceNameFromSelfLink(ld.ResourceZone.ValueString())
+		return types.StringValue(zone), nil
+	}
+	if !ld.ProviderZone.IsNull() {
+		return ld.ProviderZone, nil
+	}
+
+	var err error
+	if !ld.ZoneSchemaField.IsNull() {
+		err = fmt.Errorf("zone could not be identified, please add `%s` in your resource or `zone` in your provider configuration block", ld.ZoneSchemaField.ValueString())
+	} else {
+		err = errors.New("zone could not be identified, please add `zone` in your resource or provider configuration block")
+	}
+	return types.StringNull(), err
+}

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -80,7 +80,8 @@ func (ld *LocationDescription) getRegion() (types.String, error) {
 }
 
 func (ld *LocationDescription) getZone() (types.String, error) {
-	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
+	// TODO(SarahFrench): Make empty strings not ignored, see https://github.com/hashicorp/terraform-provider-google/issues/14447
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
 		// Zone could be a self link
 		zone := GetResourceNameFromSelfLink(ld.ResourceZone.ValueString())
 		return types.StringValue(zone), nil

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -12,16 +12,19 @@ type LocationDescriber interface {
 }
 
 type LocationDescription struct {
+	// Location - not configurable on provider
 	LocationSchemaField types.String
-	RegionSchemaField   types.String
-	ZoneSchemaField     types.String
+	ResourceLocation    types.String
 
-	ResourceLocation types.String
-	ResourceRegion   types.String
-	ResourceZone     types.String
+	// Region
+	RegionSchemaField types.String
+	ResourceRegion    types.String
+	ProviderRegion    types.String
 
-	ProviderRegion types.String
-	ProviderZone   types.String
+	// Zone
+	ZoneSchemaField types.String
+	ResourceZone    types.String
+	ProviderZone    types.String
 }
 
 func (ld *LocationDescription) getLocation() (types.String, error) {

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -24,6 +24,31 @@ type LocationDescription struct {
 	ProviderZone   types.String
 }
 
+func (ld *LocationDescription) getLocation() (types.String, error) {
+	// Location from resource config
+	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() {
+		return ld.ResourceLocation, nil
+	}
+
+	// Location from region in resource config
+	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {
+		return ld.ResourceRegion, nil
+	}
+
+	// Location from zone in resource config
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
+		location := GetResourceNameFromSelfLink(ld.ResourceZone.ValueString()) // Zone could be a self link
+		return types.StringValue(location), nil
+	}
+
+	// Location from zone in provider config
+	if !ld.ProviderZone.IsNull() {
+		return ld.ProviderZone, nil
+	}
+
+	return types.StringNull(), nil
+}
+
 func (ld *LocationDescription) getRegion() (types.String, error) {
 	// Region from resource config
 	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {

--- a/mmv1/third_party/terraform/utils/framework_location.go
+++ b/mmv1/third_party/terraform/utils/framework_location.go
@@ -8,7 +8,7 @@ import (
 )
 
 type LocationDescriber interface {
-	getLocationDescription(providerConfig *frameworkProvider) LocationDescription
+	GetLocationDescription(providerConfig *frameworkProvider) LocationDescription
 }
 
 type LocationDescription struct {
@@ -27,7 +27,7 @@ type LocationDescription struct {
 	ProviderZone    types.String
 }
 
-func (ld *LocationDescription) getLocation() (types.String, error) {
+func (ld *LocationDescription) GetLocation() (types.String, error) {
 	// Location from resource config
 	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() && !ld.ResourceLocation.Equal(types.StringValue("")) {
 		return ld.ResourceLocation, nil
@@ -58,7 +58,7 @@ func (ld *LocationDescription) getLocation() (types.String, error) {
 	return types.StringNull(), err
 }
 
-func (ld *LocationDescription) getRegion() (types.String, error) {
+func (ld *LocationDescription) GetRegion() (types.String, error) {
 	// TODO(SarahFrench): Make empty strings not ignored, see https://github.com/hashicorp/terraform-provider-google/issues/14447
 	// For all checks in this function body
 
@@ -91,7 +91,7 @@ func (ld *LocationDescription) getRegion() (types.String, error) {
 	return types.StringNull(), err
 }
 
-func (ld *LocationDescription) getZone() (types.String, error) {
+func (ld *LocationDescription) GetZone() (types.String, error) {
 	// TODO(SarahFrench): Make empty strings not ignored, see https://github.com/hashicorp/terraform-provider-google/issues/14447
 	// For all checks in this function body
 

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -215,6 +215,13 @@ func TestLocationDescription_getLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("resource-region"),
 		},
+		"returns the region value set in the resource config when location is an empty string": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue(""),
+				ResourceRegion:   types.StringValue("resource-region"),
+			},
+			ExpectedLocation: types.StringValue("resource-region"),
+		},
 		"does not shorten the region value when it is set as a self link in the resource config": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/resource-region"),
@@ -227,6 +234,14 @@ func TestLocationDescription_getLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("resource-zone"),
 		},
+		"returns the zone value set in the resource config when both location or region are empty strings": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue(""),
+				ResourceRegion:   types.StringValue(""),
+				ResourceZone:     types.StringValue("resource-zone"),
+			},
+			ExpectedLocation: types.StringValue("resource-zone"),
+		},
 		"shortens zone values set as self links in the resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/resource-zone"),
@@ -236,6 +251,15 @@ func TestLocationDescription_getLocation(t *testing.T) {
 		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("provider-zone"),
+			},
+			ExpectedLocation: types.StringValue("provider-zone"),
+		},
+		"returns the zone value from the provider config when all of location/region/zone are set as empty strings in the resource config": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue(""),
+				ResourceRegion:   types.StringValue(""),
+				ResourceZone:     types.StringValue(""),
+				ProviderZone:     types.StringValue("provider-zone"),
 			},
 			ExpectedLocation: types.StringValue("provider-zone"),
 		},

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -113,6 +113,13 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't sortened from URI to name
 		},
+		"returns a region derived from the zone field in resource config when region is set as an empty string": {
+			ld: LocationDescription{
+				ResourceRegion: types.StringValue(""),
+				ResourceZone:   types.StringValue("provider-zone-a"),
+			},
+			ExpectedRegion: types.StringValue("provider-zone"),
+		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-region"),
@@ -125,7 +132,21 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("provider-zone"),
 		},
-		"returns an error when zone values can't be found": {
+		"returns the value of the region field in provider config when region/zone set as an empty string in resource config": {
+			ld: LocationDescription{
+				ResourceRegion: types.StringValue(""),
+				ResourceZone:   types.StringValue(""),
+				ProviderRegion: types.StringValue("provider-region"),
+			},
+			ExpectedRegion: types.StringValue("provider-region"),
+		},
+		"returns an error if region and zone set as empty strings in both resource and provider configs": {
+			ld: LocationDescription{
+				ResourceRegion: types.StringValue(""),
+				ResourceZone:   types.StringValue(""),
+				ProviderRegion: types.StringValue(""),
+				ProviderZone:   types.StringValue(""),
+			},
 			ExpectedError: true,
 		},
 		"returns an error that mention non-standard schema field names when region value can't be found": {

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -37,6 +37,13 @@ func TestLocationDescription_getZone(t *testing.T) {
 			},
 			ExpectedZone: types.StringValue("provider-zone"),
 		},
+		"returns the value of the zone field in provider config when zone is set to an empty string in resource config": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue(""),
+				ProviderZone: types.StringValue("provider-zone"),
+			},
+			ExpectedZone: types.StringValue("provider-zone"),
+		},
 		"returns an error when a zone value can't be found": {
 			ExpectedError: true,
 		},

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -130,7 +130,7 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
 			},
-			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't sortened from URI to name
+			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't shortened from URI to name
 		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -37,6 +37,7 @@ func TestLocationDescription_getZone(t *testing.T) {
 			},
 			ExpectedZone: types.StringValue("provider-zone"),
 		},
+		// Handling of empty strings
 		"returns the value of the zone field in provider config when zone is set to an empty string in resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue(""),
@@ -44,7 +45,15 @@ func TestLocationDescription_getZone(t *testing.T) {
 			},
 			ExpectedZone: types.StringValue("provider-zone"),
 		},
+		// Error states
 		"returns an error when a zone value can't be found": {
+			ExpectedError: true,
+		},
+		"returns an error if zone is set as an empty string in both resource and provider configs": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue(""),
+				ProviderZone: types.StringValue(""),
+			},
 			ExpectedError: true,
 		},
 		"returns an error that mention non-standard schema field names when a zone value can't be found": {
@@ -116,13 +125,6 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't sortened from URI to name
 		},
-		"returns a region derived from the zone field in resource config when region is set as an empty string": {
-			ld: LocationDescription{
-				ResourceRegion: types.StringValue(""),
-				ResourceZone:   types.StringValue("provider-zone-a"),
-			},
-			ExpectedRegion: types.StringValue("provider-zone"),
-		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-region"),
@@ -135,6 +137,14 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("provider-zone"),
 		},
+		// Handling of empty strings
+		"returns a region derived from the zone field in resource config when region is set as an empty string": {
+			ld: LocationDescription{
+				ResourceRegion: types.StringValue(""),
+				ResourceZone:   types.StringValue("provider-zone-a"),
+			},
+			ExpectedRegion: types.StringValue("provider-zone"),
+		},
 		"returns the value of the region field in provider config when region/zone set as an empty string in resource config": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue(""),
@@ -143,6 +153,7 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("provider-region"),
 		},
+		// Error states
 		"returns an error if region and zone set as empty strings in both resource and provider configs": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue(""),
@@ -215,13 +226,6 @@ func TestLocationDescription_getLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("resource-region"),
 		},
-		"returns the region value set in the resource config when location is an empty string": {
-			ld: LocationDescription{
-				ResourceLocation: types.StringValue(""),
-				ResourceRegion:   types.StringValue("resource-region"),
-			},
-			ExpectedLocation: types.StringValue("resource-region"),
-		},
 		"does not shorten the region value when it is set as a self link in the resource config": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/resource-region"),
@@ -231,14 +235,6 @@ func TestLocationDescription_getLocation(t *testing.T) {
 		"returns the zone value set in the resource config when neither location nor region in the schema": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("resource-zone"),
-			},
-			ExpectedLocation: types.StringValue("resource-zone"),
-		},
-		"returns the zone value set in the resource config when both location or region are empty strings": {
-			ld: LocationDescription{
-				ResourceLocation: types.StringValue(""),
-				ResourceRegion:   types.StringValue(""),
-				ResourceZone:     types.StringValue("resource-zone"),
 			},
 			ExpectedLocation: types.StringValue("resource-zone"),
 		},
@@ -254,6 +250,28 @@ func TestLocationDescription_getLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("provider-zone"),
 		},
+		"does not shorten the zone value when it is set as a self link in the provider config": {
+			ld: LocationDescription{
+				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone"),
+			},
+			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone"),
+		},
+		// Handling of empty strings
+		"returns the region value set in the resource config when location is an empty string": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue(""),
+				ResourceRegion:   types.StringValue("resource-region"),
+			},
+			ExpectedLocation: types.StringValue("resource-region"),
+		},
+		"returns the zone value set in the resource config when both location or region are empty strings": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue(""),
+				ResourceRegion:   types.StringValue(""),
+				ResourceZone:     types.StringValue("resource-zone"),
+			},
+			ExpectedLocation: types.StringValue("resource-zone"),
+		},
 		"returns the zone value from the provider config when all of location/region/zone are set as empty strings in the resource config": {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue(""),
@@ -263,12 +281,7 @@ func TestLocationDescription_getLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("provider-zone"),
 		},
-		"does not shorten the zone value when it is set as a self link in the provider config": {
-			ld: LocationDescription{
-				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone"),
-			},
-			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone"),
-		},
+		// Error states
 		"does not use the region value set in the provider config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-zone"),
@@ -276,6 +289,16 @@ func TestLocationDescription_getLocation(t *testing.T) {
 			ExpectedError: true,
 		},
 		"returns an error when none of location/region/zone are set on the resource, and neither region or zone is set on the provider": {
+			ExpectedError: true,
+		},
+		"returns an error if location/region/zone are set as empty strings in both resource and provider configs": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue(""),
+				ResourceRegion:   types.StringValue(""),
+				ResourceZone:     types.StringValue(""),
+				ProviderRegion:   types.StringValue(""),
+				ProviderZone:     types.StringValue(""),
+			},
 			ExpectedError: true,
 		},
 		"returns an error that mention non-standard schema field names when location value can't be found": {

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -123,7 +123,7 @@ func TestLocationDescription_getRegion(t *testing.T) {
 		},
 		"returns an error that mention non-standard schema field names when region value can't be found": {
 			ld: LocationDescription{
-				ZoneSchemaField: types.StringValue("foobar"),
+				RegionSchemaField: types.StringValue("foobar"),
 			},
 			ExpectedError: true,
 		},

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -15,8 +15,13 @@ func TestLocationDescription_getZone(t *testing.T) {
 	}{
 		"returns the value of the zone field in resource config": {
 			ld: LocationDescription{
-				ResourceZone: types.StringValue("resource-zone"),
-				ProviderZone: types.StringValue("provider-zone"),
+				// A resource would not have all 3 fields set, but if they were all present zone is used
+				ResourceZone:     types.StringValue("resource-zone"),
+				ResourceRegion:   types.StringValue("resource-region"),
+				ResourceLocation: types.StringValue("resource-location"),
+				// Provider config doesn't override resource config
+				ProviderRegion: types.StringValue("provider-region"),
+				ProviderZone:   types.StringValue("provider-zone"),
 			},
 			ExpectedZone: types.StringValue("resource-zone"),
 		},
@@ -73,8 +78,13 @@ func TestLocationDescription_getRegion(t *testing.T) {
 	}{
 		"returns the value of the region field in resource config": {
 			ld: LocationDescription{
-				ResourceRegion: types.StringValue("resource-region"),
+				// A resource would not have all 3 fields set, but if they were all present region is used first
+				ResourceRegion:   types.StringValue("resource-region"),
+				ResourceLocation: types.StringValue("resource-location"),
+				ResourceZone:     types.StringValue("resource-zone"),
+				// Provider config doesn't override resource config
 				ProviderRegion: types.StringValue("provider-region"),
+				ProviderZone:   types.StringValue("provider-zone"),
 			},
 			ExpectedRegion: types.StringValue("resource-region"),
 		},
@@ -149,7 +159,13 @@ func TestLocationDescription_getLocation(t *testing.T) {
 	}{
 		"returns the value of the location field in resource config": {
 			ld: LocationDescription{
+				// A resource would not have all 3 fields set, but if they were all present location is used first
 				ResourceLocation: types.StringValue("resource-location"),
+				ResourceRegion:   types.StringValue("resource-region"),
+				ResourceZone:     types.StringValue("resource-zone"),
+				// Provider config doesn't override resource config
+				ProviderRegion: types.StringValue("provider-region"),
+				ProviderZone:   types.StringValue("provider-zone"),
 			},
 			ExpectedLocation: types.StringValue("resource-location"),
 		},

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -16,36 +16,36 @@ func TestLocationDescription_GetZone(t *testing.T) {
 		"returns the value of the zone field in resource config": {
 			ld: LocationDescription{
 				// A resource would not have all 3 fields set, but if they were all present zone is used
-				ResourceZone:     types.StringValue("resource-zone"),
+				ResourceZone:     types.StringValue("resource-zone-a"),
 				ResourceRegion:   types.StringValue("resource-region"),
 				ResourceLocation: types.StringValue("resource-location"),
 				// Provider config doesn't override resource config
 				ProviderRegion: types.StringValue("provider-region"),
-				ProviderZone:   types.StringValue("provider-zone"),
+				ProviderZone:   types.StringValue("provider-zone-a"),
 			},
-			ExpectedZone: types.StringValue("resource-zone"),
+			ExpectedZone: types.StringValue("resource-zone-a"),
 		},
 		"shortens zone values set as self links in the resource config": {
 			ld: LocationDescription{
-				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
+				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/resource-zone-a"),
 			},
-			ExpectedZone: types.StringValue("us-central1-a"),
+			ExpectedZone: types.StringValue("resource-zone-a"),
 		},
 		"returns the value of the zone field in provider config when zone is unset in resource config": {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue("resource-location"), // unused
 				ResourceRegion:   types.StringValue("resource-region"),   // unused
-				ProviderZone:     types.StringValue("provider-zone"),
+				ProviderZone:     types.StringValue("provider-zone-a"),
 			},
-			ExpectedZone: types.StringValue("provider-zone"),
+			ExpectedZone: types.StringValue("provider-zone-a"),
 		},
 		// Handling of empty strings
 		"returns the value of the zone field in provider config when zone is set to an empty string in resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue(""),
-				ProviderZone: types.StringValue("provider-zone"),
+				ProviderZone: types.StringValue("provider-zone-a"),
 			},
-			ExpectedZone: types.StringValue("provider-zone"),
+			ExpectedZone: types.StringValue("provider-zone-a"),
 		},
 		// Error states
 		"returns an error when a zone value can't be found": {
@@ -106,10 +106,10 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 				// A resource would not have all 3 fields set, but if they were all present region is used first
 				ResourceRegion:   types.StringValue("resource-region"),
 				ResourceLocation: types.StringValue("resource-location"),
-				ResourceZone:     types.StringValue("resource-zone"),
+				ResourceZone:     types.StringValue("resource-zone-a"),
 				// Provider config doesn't override resource config
 				ProviderRegion: types.StringValue("provider-region"),
-				ProviderZone:   types.StringValue("provider-zone"),
+				ProviderZone:   types.StringValue("provider-zone-a"),
 			},
 			ExpectedRegion: types.StringValue("resource-region"),
 		},
@@ -124,7 +124,7 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 				ResourceZone:     types.StringValue("provider-zone-a"),
 				ResourceLocation: types.StringValue("resource-location"), // unused
 			},
-			ExpectedRegion: types.StringValue("provider-zone"),
+			ExpectedRegion: types.StringValue("provider-zone"), // is truncated
 		},
 		"does not shorten region values when derived from a zone self link set in the resource config": {
 			ld: LocationDescription{
@@ -143,7 +143,7 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("provider-zone-a"),
 			},
-			ExpectedRegion: types.StringValue("provider-zone"),
+			ExpectedRegion: types.StringValue("provider-zone"), // is truncated
 		},
 		// Handling of empty strings
 		"returns a region derived from the zone field in resource config when region is set as an empty string": {
@@ -151,7 +151,7 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 				ResourceRegion: types.StringValue(""),
 				ResourceZone:   types.StringValue("provider-zone-a"),
 			},
-			ExpectedRegion: types.StringValue("provider-zone"),
+			ExpectedRegion: types.StringValue("provider-zone"), // is truncated
 		},
 		"returns the value of the region field in provider config when region/zone set as an empty string in resource config": {
 			ld: LocationDescription{
@@ -221,10 +221,10 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 				// A resource would not have all 3 fields set, but if they were all present location is used first
 				ResourceLocation: types.StringValue("resource-location"),
 				ResourceRegion:   types.StringValue("resource-region"),
-				ResourceZone:     types.StringValue("resource-zone"),
+				ResourceZone:     types.StringValue("resource-zone-a"),
 				// Provider config doesn't override resource config
 				ProviderRegion: types.StringValue("provider-region"),
-				ProviderZone:   types.StringValue("provider-zone"),
+				ProviderZone:   types.StringValue("provider-zone-a"),
 			},
 			ExpectedLocation: types.StringValue("resource-location"),
 		},
@@ -237,7 +237,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 		"returns the region value set in the resource config when location is not in the schema": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("resource-region"),
-				ResourceZone:   types.StringValue("resource-zone"), // unused
+				ResourceZone:   types.StringValue("resource-zone-a"), // unused
 			},
 			ExpectedLocation: types.StringValue("resource-region"),
 		},
@@ -249,28 +249,28 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 		},
 		"returns the zone value set in the resource config when neither location nor region in the schema": {
 			ld: LocationDescription{
-				ResourceZone: types.StringValue("resource-zone"),
+				ResourceZone: types.StringValue("resource-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("resource-zone"),
+			ExpectedLocation: types.StringValue("resource-zone-a"),
 		},
 		"shortens zone values set as self links in the resource config": {
 			ld: LocationDescription{
-				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/resource-zone"),
+				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/resource-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("resource-zone"),
+			ExpectedLocation: types.StringValue("resource-zone-a"),
 		},
 		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-region"), // unused
-				ProviderZone:   types.StringValue("provider-zone"),
+				ProviderZone:   types.StringValue("provider-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("provider-zone"),
+			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
 		"does not shorten the zone value when it is set as a self link in the provider config": {
 			ld: LocationDescription{
-				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone"),
+				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone"),
+			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a"),
 		},
 		// Handling of empty strings
 		"returns the region value set in the resource config when location is an empty string": {
@@ -284,18 +284,18 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue(""),
 				ResourceRegion:   types.StringValue(""),
-				ResourceZone:     types.StringValue("resource-zone"),
+				ResourceZone:     types.StringValue("resource-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("resource-zone"),
+			ExpectedLocation: types.StringValue("resource-zone-a"),
 		},
 		"returns the zone value from the provider config when all of location/region/zone are set as empty strings in the resource config": {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue(""),
 				ResourceRegion:   types.StringValue(""),
 				ResourceZone:     types.StringValue(""),
-				ProviderZone:     types.StringValue("provider-zone"),
+				ProviderZone:     types.StringValue("provider-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("provider-zone"),
+			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
 		// Error states
 		"does not use the region value set in the provider config": {

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -1,0 +1,139 @@
+package google
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestLocationDescription_getZone(t *testing.T) {
+	cases := map[string]struct {
+		ld            LocationDescription
+		ExpectedZone  types.String
+		ExpectedError bool
+	}{
+		"zone is sourced from resource config instead of provider config": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue("resource-zone"),
+				ProviderZone: types.StringValue("provider-zone"),
+			},
+			ExpectedZone: types.StringValue("resource-zone"),
+		},
+		"zone value from resource can be a self link": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
+			},
+			ExpectedZone: types.StringValue("us-central1-a"),
+		},
+		"zone is sourced from provider config when not set on resource": {
+			ld: LocationDescription{
+				ProviderZone: types.StringValue("provider-zone"),
+			},
+			ExpectedZone: types.StringValue("provider-zone"),
+		},
+		"error returned when zone not set on either provider or resource": {
+			ExpectedError: true,
+		},
+		"error mentions a non-standard schema field name when zone value can't be sourced from provider/resource ": {
+			ld: LocationDescription{
+				ZoneSchemaField: types.StringValue("foobar"),
+			},
+			ExpectedError: true,
+		},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			zone, err := tc.ld.getZone()
+
+			if err != nil {
+				if tc.ExpectedError {
+					if !tc.ld.ZoneSchemaField.IsNull() {
+						if !strings.Contains(err.Error(), tc.ld.ZoneSchemaField.ValueString()) {
+							t.Fatalf("expected error to use provider schema field value %s, instead got: %s", tc.ld.ZoneSchemaField.ValueString(), err)
+						}
+					}
+					return
+				}
+				t.Fatalf("unexpected error using test: %s", err)
+			}
+			if zone != tc.ExpectedZone {
+				t.Fatalf("Incorrect zone: got %s, want %s", zone, tc.ExpectedZone)
+			}
+		})
+	}
+}
+
+func TestLocationDescription_getRegion(t *testing.T) {
+	cases := map[string]struct {
+		ld             LocationDescription
+		ExpectedRegion types.String
+		ExpectedError  bool
+	}{
+		"region is sourced from the region field in resource config": {
+			ld: LocationDescription{
+				ResourceRegion: types.StringValue("resource-region"),
+				ProviderRegion: types.StringValue("provider-region"),
+			},
+			ExpectedRegion: types.StringValue("resource-region"),
+		},
+		"region sourced from the region field in resource config can be a self link": {
+			ld: LocationDescription{
+				ResourceRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1"),
+			},
+			ExpectedRegion: types.StringValue("us-central1"),
+		},
+		"region is sourced from zone on resource config when region unset in resource config": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue("provider-zone-a"),
+			},
+			ExpectedRegion: types.StringValue("provider-zone"),
+		},
+		"region cannot be sourced from the zone field in resource config if it is a self link": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
+			},
+			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't sortened from URI to name
+		},
+		"region is sourced from region on provider config when region/zone unset in resource config": {
+			ld: LocationDescription{
+				ProviderRegion: types.StringValue("provider-region"),
+			},
+			ExpectedRegion: types.StringValue("provider-region"),
+		},
+		"region is sourced from zone on provider config when region unset in both resource and provider config": {
+			ld: LocationDescription{
+				ProviderZone: types.StringValue("provider-zone-a"),
+			},
+			ExpectedRegion: types.StringValue("provider-zone"),
+		},
+		"error mentions a non-standard schema field name when region value can't be sourced from provider/resource ": {
+			ld: LocationDescription{
+				ZoneSchemaField: types.StringValue("foobar"),
+			},
+			ExpectedError: true,
+		},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			region, err := tc.ld.getRegion()
+
+			if err != nil {
+				if tc.ExpectedError {
+					if !tc.ld.RegionSchemaField.IsNull() {
+						if !strings.Contains(err.Error(), tc.ld.RegionSchemaField.ValueString()) {
+							t.Fatalf("expected error to use provider schema field value %s, instead got: %s", tc.ld.RegionSchemaField.ValueString(), err)
+						}
+					}
+					return
+				}
+				t.Fatalf("unexpected error using test: %s", err)
+			}
+			if region != tc.ExpectedRegion {
+				t.Fatalf("Incorrect region: got %s, want %s", region, tc.ExpectedRegion)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -13,29 +13,29 @@ func TestLocationDescription_getZone(t *testing.T) {
 		ExpectedZone  types.String
 		ExpectedError bool
 	}{
-		"zone is sourced from resource config instead of provider config": {
+		"returns the value of the zone field in resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("resource-zone"),
 				ProviderZone: types.StringValue("provider-zone"),
 			},
 			ExpectedZone: types.StringValue("resource-zone"),
 		},
-		"zone value from resource can be a self link": {
+		"shortens zone values set as self links in the resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
 			},
 			ExpectedZone: types.StringValue("us-central1-a"),
 		},
-		"zone is sourced from provider config when not set on resource": {
+		"returns the value of the zone field in provider config when zone is unset in resource config": {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("provider-zone"),
 			},
 			ExpectedZone: types.StringValue("provider-zone"),
 		},
-		"error returned when zone not set on either provider or resource": {
+		"returns an error when a zone value can't be found": {
 			ExpectedError: true,
 		},
-		"error mentions a non-standard schema field name when zone value can't be sourced from provider/resource ": {
+		"returns an error that mention non-standard schema field names when a zone value can't be found": {
 			ld: LocationDescription{
 				ZoneSchemaField: types.StringValue("foobar"),
 			},
@@ -71,44 +71,47 @@ func TestLocationDescription_getRegion(t *testing.T) {
 		ExpectedRegion types.String
 		ExpectedError  bool
 	}{
-		"region is sourced from the region field in resource config": {
+		"returns the value of the region field in resource config": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("resource-region"),
 				ProviderRegion: types.StringValue("provider-region"),
 			},
 			ExpectedRegion: types.StringValue("resource-region"),
 		},
-		"region sourced from the region field in resource config can be a self link": {
+		"shortens region values set as self links in the resource config": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1"),
 			},
 			ExpectedRegion: types.StringValue("us-central1"),
 		},
-		"region is sourced from zone on resource config when region unset in resource config": {
+		"returns a region derived from the zone field in resource config when region is unset": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("provider-zone-a"),
 			},
 			ExpectedRegion: types.StringValue("provider-zone"),
 		},
-		"region cannot be sourced from the zone field in resource config if it is a self link": {
+		"does not shorten region values when derived from a zone self link set in the resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
 			},
 			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't sortened from URI to name
 		},
-		"region is sourced from region on provider config when region/zone unset in resource config": {
+		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-region"),
 			},
 			ExpectedRegion: types.StringValue("provider-region"),
 		},
-		"region is sourced from zone on provider config when region unset in both resource and provider config": {
+		"returns a region derived from the zone field in provider config when region unset in both resource and provider config": {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("provider-zone-a"),
 			},
 			ExpectedRegion: types.StringValue("provider-zone"),
 		},
-		"error mentions a non-standard schema field name when region value can't be sourced from provider/resource ": {
+		"returns an error when zone values can't be found": {
+			ExpectedError: true,
+		},
+		"returns an error that mention non-standard schema field names when region value can't be found": {
 			ld: LocationDescription{
 				ZoneSchemaField: types.StringValue("foobar"),
 			},

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -33,7 +33,9 @@ func TestLocationDescription_getZone(t *testing.T) {
 		},
 		"returns the value of the zone field in provider config when zone is unset in resource config": {
 			ld: LocationDescription{
-				ProviderZone: types.StringValue("provider-zone"),
+				ResourceLocation: types.StringValue("resource-location"), // unused
+				ResourceRegion:   types.StringValue("resource-region"),   // unused
+				ProviderZone:     types.StringValue("provider-zone"),
 			},
 			ExpectedZone: types.StringValue("provider-zone"),
 		},
@@ -47,6 +49,10 @@ func TestLocationDescription_getZone(t *testing.T) {
 		},
 		// Error states
 		"returns an error when a zone value can't be found": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue("resource-location"), // unused
+				ResourceRegion:   types.StringValue("resource-region"),   // unused
+			},
 			ExpectedError: true,
 		},
 		"returns an error if zone is set as an empty string in both resource and provider configs": {
@@ -115,7 +121,8 @@ func TestLocationDescription_getRegion(t *testing.T) {
 		},
 		"returns a region derived from the zone field in resource config when region is unset": {
 			ld: LocationDescription{
-				ResourceZone: types.StringValue("provider-zone-a"),
+				ResourceZone:     types.StringValue("provider-zone-a"),
+				ResourceLocation: types.StringValue("resource-location"), // unused
 			},
 			ExpectedRegion: types.StringValue("provider-zone"),
 		},
@@ -128,6 +135,7 @@ func TestLocationDescription_getRegion(t *testing.T) {
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-region"),
+				ProviderZone:   types.StringValue("provider-zone-a"), // unused
 			},
 			ExpectedRegion: types.StringValue("provider-region"),
 		},
@@ -154,6 +162,12 @@ func TestLocationDescription_getRegion(t *testing.T) {
 			ExpectedRegion: types.StringValue("provider-region"),
 		},
 		// Error states
+		"returns an error when region/zone values can't be found (location is ignored)": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue("resource-location"),
+			},
+			ExpectedError: true,
+		},
 		"returns an error if region and zone set as empty strings in both resource and provider configs": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue(""),
@@ -223,6 +237,7 @@ func TestLocationDescription_getLocation(t *testing.T) {
 		"returns the region value set in the resource config when location is not in the schema": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("resource-region"),
+				ResourceZone:   types.StringValue("resource-zone"), // unused
 			},
 			ExpectedLocation: types.StringValue("resource-region"),
 		},
@@ -246,7 +261,8 @@ func TestLocationDescription_getLocation(t *testing.T) {
 		},
 		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
 			ld: LocationDescription{
-				ProviderZone: types.StringValue("provider-zone"),
+				ProviderRegion: types.StringValue("provider-region"), // unused
+				ProviderZone:   types.StringValue("provider-zone"),
 			},
 			ExpectedLocation: types.StringValue("provider-zone"),
 		},
@@ -284,7 +300,7 @@ func TestLocationDescription_getLocation(t *testing.T) {
 		// Error states
 		"does not use the region value set in the provider config": {
 			ld: LocationDescription{
-				ProviderRegion: types.StringValue("provider-zone"),
+				ProviderRegion: types.StringValue("provider-region"),
 			},
 			ExpectedError: true,
 		},

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func TestLocationDescription_getZone(t *testing.T) {
+func TestLocationDescription_GetZone(t *testing.T) {
 	cases := map[string]struct {
 		ld            LocationDescription
 		ExpectedZone  types.String
@@ -72,7 +72,7 @@ func TestLocationDescription_getZone(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 
-			zone, err := tc.ld.getZone()
+			zone, err := tc.ld.GetZone()
 
 			if err != nil {
 				if tc.ExpectedError {
@@ -95,7 +95,7 @@ func TestLocationDescription_getZone(t *testing.T) {
 	}
 }
 
-func TestLocationDescription_getRegion(t *testing.T) {
+func TestLocationDescription_GetRegion(t *testing.T) {
 	cases := map[string]struct {
 		ld             LocationDescription
 		ExpectedRegion types.String
@@ -187,7 +187,7 @@ func TestLocationDescription_getRegion(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 
-			region, err := tc.ld.getRegion()
+			region, err := tc.ld.GetRegion()
 
 			if err != nil {
 				if tc.ExpectedError {
@@ -210,7 +210,7 @@ func TestLocationDescription_getRegion(t *testing.T) {
 	}
 }
 
-func TestLocationDescription_getLocation(t *testing.T) {
+func TestLocationDescription_GetLocation(t *testing.T) {
 	cases := map[string]struct {
 		ld               LocationDescription
 		ExpectedLocation types.String
@@ -327,7 +327,7 @@ func TestLocationDescription_getLocation(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 
-			region, err := tc.ld.getLocation()
+			region, err := tc.ld.GetLocation()
 
 			if err != nil {
 				if tc.ExpectedError {

--- a/mmv1/third_party/terraform/utils/framework_location_test.go
+++ b/mmv1/third_party/terraform/utils/framework_location_test.go
@@ -70,6 +70,9 @@ func TestLocationDescription_getZone(t *testing.T) {
 				}
 				t.Fatalf("unexpected error using test: %s", err)
 			}
+			if err == nil && tc.ExpectedError {
+				t.Fatal("expected error but got none")
+			}
 			if zone != tc.ExpectedZone {
 				t.Fatalf("Incorrect zone: got %s, want %s", zone, tc.ExpectedZone)
 			}
@@ -172,6 +175,9 @@ func TestLocationDescription_getRegion(t *testing.T) {
 				}
 				t.Fatalf("unexpected error using test: %s", err)
 			}
+			if err == nil && tc.ExpectedError {
+				t.Fatal("expected error but got none")
+			}
 			if region != tc.ExpectedRegion {
 				t.Fatalf("Incorrect region: got %s, want %s", region, tc.ExpectedRegion)
 			}
@@ -270,6 +276,9 @@ func TestLocationDescription_getLocation(t *testing.T) {
 					return
 				}
 				t.Fatalf("unexpected error using test: %s", err)
+			}
+			if err == nil && tc.ExpectedError {
+				t.Fatal("expected error but got none")
 			}
 			if region != tc.ExpectedLocation {
 				t.Fatalf("Incorrect location: got %s, want %s", region, tc.ExpectedLocation)

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -128,7 +128,7 @@ func setupTestResourceDataFromConfigMap(t *testing.T, s map[string]*schema.Schem
 // unsetProviderConfigEnvs unsets any ENVs in the test environment that
 // configure the provider.
 // The testing package will restore the original values after the test
-func unsetTestProviderConfigEnvs() {
+func unsetTestProviderConfigEnvs(t *testing.T) {
 	envs := providerConfigEnvNames()
 	if len(envs) > 0 {
 		for _, k := range envs {

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -125,6 +125,18 @@ func setupTestResourceDataFromConfigMap(t *testing.T, s map[string]*schema.Schem
 	return d
 }
 
+// unsetProviderConfigEnvs unsets any ENVs in the test environment that
+// configure the provider.
+// The testing package will restore the original values after the test
+func unsetTestProviderConfigEnvs() {
+	envs := providerConfigEnvNames()
+	if len(envs) > 0 {
+		for _, k := range envs {
+			t.Setenv(k, "")
+		}
+	}
+}
+
 func setupTestEnvs(t *testing.T, envValues map[string]string) {
 	// Set ENVs
 	if len(envValues) > 0 {
@@ -252,6 +264,7 @@ func TestProvider_providerConfigure_credentials(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
+			unsetTestProviderConfigEnvs(t)
 			setupTestEnvs(t, tc.EnvVariables)
 			p := Provider()
 			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
@@ -347,6 +360,7 @@ func TestProvider_providerConfigure_accessToken(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
+			unsetTestProviderConfigEnvs(t)
 			setupTestEnvs(t, tc.EnvVariables)
 			p := Provider()
 			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
@@ -431,6 +445,7 @@ func TestProvider_providerConfigure_impersonateServiceAccount(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
+			unsetTestProviderConfigEnvs(t)
 			setupTestEnvs(t, tc.EnvVariables)
 			p := Provider()
 			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
@@ -504,6 +519,7 @@ func TestProvider_providerConfigure_impersonateServiceAccountDelegates(t *testin
 
 			// Arrange
 			ctx := context.Background()
+			unsetTestProviderConfigEnvs(t)
 			setupTestEnvs(t, tc.EnvVariables)
 			p := Provider()
 			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
@@ -646,6 +662,7 @@ func TestProvider_providerConfigure_project(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
+			unsetTestProviderConfigEnvs(t)
 			setupTestEnvs(t, tc.EnvVariables)
 			p := Provider()
 			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -4,13 +4,14 @@ package google
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"fmt"
 	"io/ioutil"
 	"regexp"
 	"testing"
-
+	
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -102,16 +103,14 @@ func TestProvider_validateCredentials(t *testing.T) {
 	}
 }
 
-// Used for testing the `providerConfigure` function
-func setupSDKProviderConfigTest(t *testing.T, configValues map[string]interface{},
-	envValues map[string]string) (context.Context, *schema.Provider, *schema.ResourceData) {
-
-	ctx := context.Background()
-	p := Provider()
+// Used to create populated schema.ResourceData structs in tests.
+// Pass in a schema and a config map containing the fields and values you wish to set
+// The returned schema.ResourceData can represent a configured resource, data source or provider.
+func setupTestResourceDataFromConfigMap(t *testing.T, s map[string]*schema.Schema, configValues map[string]interface{}) *schema.ResourceData {
 
 	// Create empty schema.ResourceData using the SDK Provider schema
 	emptyConfigMap := map[string]interface{}{}
-	d := schema.TestResourceDataRaw(t, p.Schema, emptyConfigMap)
+	d := schema.TestResourceDataRaw(t, s, emptyConfigMap)
 
 	// Load Terraform config data
 	if len(configValues) > 0 {
@@ -123,23 +122,16 @@ func setupSDKProviderConfigTest(t *testing.T, configValues map[string]interface{
 		}
 	}
 
-	// Unset any ENVs in the test environment here
-	// The testing package restores the original values afterwards
-	envs := acctest.ProviderConfigEnvNames()
-	if len(envs) > 0 {
-		for _, k := range envs {
-			t.Setenv(k, "")
-		}
-	}
+	return d
+}
 
-	// Set ENVs for the test case
+func setupTestEnvs(t *testing.T, envValues map[string]string) {
+	// Set ENVs
 	if len(envValues) > 0 {
 		for k, v := range envValues {
 			t.Setenv(k, v)
 		}
 	}
-
-	return ctx, p, d
 }
 
 // Returns a fake credentials JSON string with the client_email set to a test-specific value
@@ -259,7 +251,10 @@ func TestProvider_providerConfigure_credentials(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 
 			// Arrange
-			ctx, p, d := setupSDKProviderConfigTest(t, tc.ConfigValues, tc.EnvVariables)
+			ctx := context.Background()
+			setupTestEnvs(t, tc.EnvVariables)
+			p := Provider()
+			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
 			// Act
 			c, diags := providerConfigure(ctx, d, p)
@@ -338,7 +333,7 @@ func TestProvider_providerConfigure_accessToken(t *testing.T) {
 		"when access_token is set as an empty string in the config, an environment variable is used but doesn't update the schema data": {
 			ConfigValues: map[string]interface{}{
 				"access_token": "",
-			},	
+			},
 			EnvVariables: map[string]string{
 				"GOOGLE_OAUTH_ACCESS_TOKEN": "value-from-GOOGLE_OAUTH_ACCESS_TOKEN",
 			},
@@ -351,7 +346,10 @@ func TestProvider_providerConfigure_accessToken(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 
 			// Arrange
-			ctx, p, d := setupSDKProviderConfigTest(t, tc.ConfigValues, tc.EnvVariables)
+			ctx := context.Background()
+			setupTestEnvs(t, tc.EnvVariables)
+			p := Provider()
+			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
 			// Act
 			c, diags := providerConfigure(ctx, d, p)
@@ -432,7 +430,10 @@ func TestProvider_providerConfigure_impersonateServiceAccount(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 
 			// Arrange
-			ctx, p, d := setupSDKProviderConfigTest(t, tc.ConfigValues, tc.EnvVariables)
+			ctx := context.Background()
+			setupTestEnvs(t, tc.EnvVariables)
+			p := Provider()
+			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
 			// Act
 			c, diags := providerConfigure(ctx, d, p)
@@ -502,7 +503,10 @@ func TestProvider_providerConfigure_impersonateServiceAccountDelegates(t *testin
 		t.Run(tn, func(t *testing.T) {
 
 			// Arrange
-			ctx, p, d := setupSDKProviderConfigTest(t, tc.ConfigValues, tc.EnvVariables)
+			ctx := context.Background()
+			setupTestEnvs(t, tc.EnvVariables)
+			p := Provider()
+			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
 			// Act
 			c, diags := providerConfigure(ctx, d, p)
@@ -641,7 +645,10 @@ func TestProvider_providerConfigure_project(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 
 			// Arrange
-			ctx, p, d := setupSDKProviderConfigTest(t, tc.ConfigValues, tc.EnvVariables)
+			ctx := context.Background()
+			setupTestEnvs(t, tc.EnvVariables)
+			p := Provider()
+			d := setupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
 			// Act
 			c, diags := providerConfigure(ctx, d, p)

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -236,6 +236,8 @@ func TestGetLocation(t *testing.T) {
 		"returns the value of the location field in resource config": {
 			ResourceConfig: map[string]interface{}{
 				"location": "resource-location",
+				"region":   "resource-region", // unused
+				"zone":     "resource-zone-a", // unused
 			},
 			ExpectedLocation: "resource-location",
 		},
@@ -248,6 +250,7 @@ func TestGetLocation(t *testing.T) {
 		"returns the region value set in the resource config when location is not in the schema": {
 			ResourceConfig: map[string]interface{}{
 				"region": "resource-region",
+				"zone":   "resource-zone-a", // unused
 			},
 			ExpectedLocation: "resource-region",
 		},
@@ -412,6 +415,13 @@ func TestGetZone(t *testing.T) {
 		},
 		// Error states
 		"returns an error when a zone value can't be found": {
+			ResourceConfig: map[string]interface{}{
+				"location": "resource-location", // unused
+				"region":   "resource-region",   // unused
+			},
+			ProviderConfig: map[string]string{
+				"region": "provider-region", //unused
+			},
 			ExpectedError: true,
 		},
 		"returns an error if zone is set as an empty string in both resource and provider configs": {
@@ -467,8 +477,9 @@ func TestGetRegion(t *testing.T) {
 	}{
 		"returns the value of the region field in resource config": {
 			ResourceConfig: map[string]interface{}{
-				"region": "resource-region",
-				"zone":   "resource-zone-a",
+				"region":   "resource-region",
+				"zone":     "resource-zone-a",
+				"location": "resource-location", // unused
 			},
 			ProviderConfig: map[string]string{
 				"region": "provider-region",
@@ -484,7 +495,8 @@ func TestGetRegion(t *testing.T) {
 		},
 		"returns a region derived from the zone field in resource config when region is unset": {
 			ResourceConfig: map[string]interface{}{
-				"zone": "resource-zone-a",
+				"zone":     "resource-zone-a",
+				"location": "resource-location", // unused
 			},
 			ExpectedRegion: "resource-zone",
 		},
@@ -497,6 +509,7 @@ func TestGetRegion(t *testing.T) {
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ProviderConfig: map[string]string{
 				"region": "provider-region",
+				"zone":   "provider-zone-a", // unused
 			},
 			ExpectedRegion: "provider-region",
 		},
@@ -525,6 +538,12 @@ func TestGetRegion(t *testing.T) {
 			ExpectedRegion: "provider-region",
 		},
 		// Error states
+		"returns an error when region values can't be found": {
+			ResourceConfig: map[string]interface{}{
+				"location": "resource-location",
+			},
+			ExpectedError: true,
+		},
 		"returns an error if region and zone set as empty strings in both resource and provider configs": {
 			ResourceConfig: map[string]interface{}{
 				"region": "",
@@ -534,9 +553,6 @@ func TestGetRegion(t *testing.T) {
 				"region": "",
 				"zone":   "",
 			},
-			ExpectedError: true,
-		},
-		"returns an error when region values can't be found": {
 			ExpectedError: true,
 		},
 	}

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -420,30 +420,32 @@ func TestGetZone(t *testing.T) {
 func TestGetRegion(t *testing.T) {
 	cases := map[string]struct {
 		ResourceRegion string
+		ResourceZone   string
 		ProviderRegion string
 		ProviderZone   string
 		ExpectedRegion string
 		ExpectedZone   string
 		ExpectedError  bool
 	}{
-		"region is pulled from resource config instead of provider config": {
-			ResourceRegion: "foo",
-			ProviderRegion: "bar",
-			ProviderZone:   "lol-a",
-			ExpectedRegion: "foo",
+		"region is sourced from the region field in resource config": {
+			ResourceRegion: "resource-region",
+			ResourceZone:   "resource-zone-a",
+			ProviderRegion: "provider-region",
+			ProviderZone:   "provider-zone-a",
+			ExpectedRegion: "resource-region",
 		},
-		"region pulled from resource config can be a self link": {
+		"region sourced from resource config can be a self link": {
 			ResourceRegion: "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1",
 			ExpectedRegion: "us-central1",
 		},
-		"region is pulled from region on provider config when region unset in resource config": {
-			ProviderRegion: "bar",
-			ProviderZone:   "lol-a",
-			ExpectedRegion: "bar",
+		"region is sourced from region on provider config when region/zone unset in resource config": {
+			ProviderRegion: "provider-region",
+			ProviderZone:   "provider-zone-a",
+			ExpectedRegion: "provider-region",
 		},
-		"region is pulled from zone on provider config when region unset in both resource and provider config": {
-			ProviderZone:   "lol-a",
-			ExpectedRegion: "lol",
+		"region is sourced from zone on provider config when region unset in both resource and provider config": {
+			ProviderZone:   "provider-zone-a",
+			ExpectedRegion: "provider-zone",
 		},
 		"error returned when region not set on resource and neither region or zone set on provider": {
 			ExpectedError: true,
@@ -485,6 +487,11 @@ func TestGetRegion(t *testing.T) {
 			if tc.ResourceRegion != "" {
 				if err := d.Set("region", tc.ResourceRegion); err != nil {
 					t.Fatalf("Cannot set region: %s", err)
+				}
+			}
+			if tc.ResourceZone != "" {
+				if err := d.Set("zone", tc.ResourceZone); err != nil {
+					t.Fatalf("Cannot set zone: %s", err)
 				}
 			}
 

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -355,6 +355,15 @@ func TestGetZone(t *testing.T) {
 			},
 			ExpectedZone: "us-central1-a",
 		},
+		"returns the value of the zone field in provider config when zone is set to an empty string in resource config": {
+			ResourceConfig: map[string]interface{}{
+				"zone": "",
+			},
+			ProviderConfig: map[string]string{
+				"zone": "provider-zone",
+			},
+			ExpectedZone: "provider-zone",
+		},
 		"returns the value of the zone field in provider config when zone is unset in resource config": {
 			ProviderConfig: map[string]string{
 				"zone": "provider-zone",

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -251,6 +251,13 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "resource-region",
 		},
+		"returns the region value set in the resource config when location is an empty string": {
+			ResourceConfig: map[string]interface{}{
+				"location": "",
+				"region":   "resource-region",
+			},
+			ExpectedLocation: "resource-region",
+		},
 		"does not shorten the region value when it is set as a self link in the resource config": {
 			ResourceConfig: map[string]interface{}{
 				"region": "https://www.googleapis.com/compute/v1/projects/my-project/region/resource-region",
@@ -263,6 +270,14 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "resource-zone",
 		},
+		"returns the zone value set in the resource config when both location or region are empty strings": {
+			ResourceConfig: map[string]interface{}{
+				"location": "",
+				"region":   "",
+				"zone":     "resource-zone",
+			},
+			ExpectedLocation: "resource-zone",
+		},
 		"shortens zone values set as self links in the resource config": {
 			// Results from getLocation using getZone internally
 			// This behaviour makes sense because APIs may return a self link as the zone value
@@ -272,6 +287,17 @@ func TestGetLocation(t *testing.T) {
 			ExpectedLocation: "resource-zone",
 		},
 		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
+			ProviderConfig: map[string]string{
+				"zone": "provider-zone",
+			},
+			ExpectedLocation: "provider-zone",
+		},
+		"returns the zone value from the provider config when all of location/region/zone are set as empty strings in the resource config": {
+			ResourceConfig: map[string]interface{}{
+				"location": "",
+				"region":   "",
+				"zone":     "",
+			},
 			ProviderConfig: map[string]string{
 				"zone": "provider-zone",
 			},

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -374,9 +374,25 @@ func TestGetZone(t *testing.T) {
 			}
 
 			// Create resource config
-			// Here use ResourceComputeDisk schema as example - because it has a zone field in schema
+			// Here use a fictional schema as example because we need to have all of
+			// location, region, and zone fields present in the schema for the test,
+			// and no real resources would contain all of these
+			fictionalSchema := map[string]*schema.Schema{
+				"location": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"region": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"zone": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 			emptyConfigMap := map[string]interface{}{}
-			d := schema.TestResourceDataRaw(t, ResourceComputeDisk().Schema, emptyConfigMap)
+			d := schema.TestResourceDataRaw(t, fictionalSchema, emptyConfigMap)
 			if tc.ResourceZone != "" {
 				if err := d.Set("zone", tc.ResourceZone); err != nil {
 					t.Fatalf("Cannot set zone: %s", err)
@@ -447,9 +463,25 @@ func TestGetRegion(t *testing.T) {
 			}
 
 			// Create resource config
-			// Here use ResourceComputeSubnetwork schema as example - because it has a region field in schema
+			// Here use a fictional schema as example because we need to have all of
+			// location, region, and zone fields present in the schema for the test,
+			// and no real resources would contain all of these
+			fictionalSchema := map[string]*schema.Schema{
+				"location": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"region": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"zone": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 			emptyConfigMap := map[string]interface{}{}
-			d := schema.TestResourceDataRaw(t, ResourceComputeSubnetwork().Schema, emptyConfigMap)
+			d := schema.TestResourceDataRaw(t, fictionalSchema, emptyConfigMap)
 			if tc.ResourceRegion != "" {
 				if err := d.Set("region", tc.ResourceRegion); err != nil {
 					t.Fatalf("Cannot set region: %s", err)

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -214,13 +214,13 @@ func TestGetLocation(t *testing.T) {
 		ExpectedLocation string
 		ExpectError      bool
 	}{
-		"returns the location value set in the resource config": {
+		"returns the value of the location field in resource config": {
 			ResourceConfig: map[string]string{
 				"location": "resource-location",
 			},
 			ExpectedLocation: "resource-location",
 		},
-		"returned location values set as self links are not shortened": {
+		"does not shorten the location value when it is set as a self link in the resource config": {
 			ResourceConfig: map[string]string{
 				"location": "https://www.googleapis.com/compute/v1/projects/my-project/locations/resource-location",
 			},
@@ -232,7 +232,7 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "resource-region",
 		},
-		"returned region values set as self links are not shortened": {
+		"does not shorten the region value when it is set as a self link in the resource config": {
 			ResourceConfig: map[string]string{
 				"region": "https://www.googleapis.com/compute/v1/projects/my-project/region/resource-region",
 			},
@@ -244,7 +244,7 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "resource-zone",
 		},
-		"returned zone values set as self links in the resource config ARE shortened": {
+		"shortens zone values set as self links in the resource config": {
 			// Results from getLocation using getZone internally
 			// This behaviour makes sense because APIs may return a self link as the zone value
 			ResourceConfig: map[string]string{
@@ -258,7 +258,7 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "provider-zone",
 		},
-		"returned zone values set as self links in the provider config are NOT shortened": {
+		"does not shorten the zone value when it is set as a self link in the provider config": {
 			// This behaviour makes sense because provider config values don't originate from APIs
 			// Users should always configure the provider with the short names of regions/zones
 			ProviderConfig: map[string]string{
@@ -346,20 +346,20 @@ func TestGetZone(t *testing.T) {
 		ExpectedZone  string
 		ExpectedError bool
 	}{
-		"zone is sourced from resource config instead of provider config": {
+		"returns the value of the zone field in resource config": {
 			ResourceZone: "resource-zone",
 			ProviderZone: "provider-zone",
 			ExpectedZone: "resource-zone",
 		},
-		"zone sourced from the resource config can be a self link": {
+		"shortens zone values set as self links in the resource config": {
 			ResourceZone: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a",
 			ExpectedZone: "us-central1-a",
 		},
-		"zone is sourced from provider config when not set in resource config": {
+		"returns the value of the zone field in provider config when zone is unset in resource config": {
 			ProviderZone: "provider-zone",
 			ExpectedZone: "provider-zone",
 		},
-		"error returned when zone not set on either provider or resource": {
+		"returns an error when a zone value can't be found": {
 			ExpectedError: true,
 		},
 	}
@@ -427,36 +427,34 @@ func TestGetRegion(t *testing.T) {
 		ExpectedZone   string
 		ExpectedError  bool
 	}{
-		"region is sourced from the region field in resource config": {
+		"returns the value of the region field in resource config": {
 			ResourceRegion: "resource-region",
 			ResourceZone:   "resource-zone-a",
 			ProviderRegion: "provider-region",
 			ProviderZone:   "provider-zone-a",
 			ExpectedRegion: "resource-region",
 		},
-		"region sourced from the region field in resource config can be a self link": {
+		"shortens region values set as self links in the resource config": {
 			ResourceRegion: "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1",
 			ExpectedRegion: "us-central1",
 		},
-		"region is sourced from zone on resource config when region unset in resource config": {
+		"returns a region derived from the zone field in resource config when region is unset": {
 			ResourceZone:   "resource-zone-a",
-			ProviderRegion: "provider-region",
 			ExpectedRegion: "resource-zone",
 		},
-		"region cannot be sourced from the zone field in resource config if it is a self link": {
+		"does not shorten region values when derived from a zone self link set in the resource config": {
 			ResourceZone:   "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a",
 			ExpectedRegion: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1", // Value is not shortenedfrom URI to name
 		},
-		"region is sourced from region on provider config when region/zone unset in resource config": {
+		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ProviderRegion: "provider-region",
-			ProviderZone:   "provider-zone-a",
 			ExpectedRegion: "provider-region",
 		},
-		"region is sourced from zone on provider config when region unset in both resource and provider config": {
+		"returns a region derived from the zone field in provider config when region unset in both resource and provider config": {
 			ProviderZone:   "provider-zone-a",
 			ExpectedRegion: "provider-zone",
 		},
-		"error returned when region not set on resource and neither region or zone set on provider": {
+		"returns an error when region values can't be found": {
 			ExpectedError: true,
 		},
 	}

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -188,7 +188,7 @@ func TestGetProject(t *testing.T) {
 			ProviderConfig: map[string]string{
 				"project": "provider-project",
 			},
-			ExpectedProject: "bar",
+			ExpectedProject: "provider-project",
 		},
 		"error returned when project not set on either provider or resource": {
 			ExpectedError: true,

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -346,18 +346,18 @@ func TestGetZone(t *testing.T) {
 		ExpectedZone  string
 		ExpectedError bool
 	}{
-		"zone is pulled from resource config instead of provider config": {
-			ResourceZone: "foo",
-			ProviderZone: "bar",
-			ExpectedZone: "foo",
+		"zone is sourced from resource config instead of provider config": {
+			ResourceZone: "resource-zone",
+			ProviderZone: "provider-zone",
+			ExpectedZone: "resource-zone",
 		},
-		"zone value from resource can be a self link": {
+		"zone sourced from the resource config can be a self link": {
 			ResourceZone: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a",
 			ExpectedZone: "us-central1-a",
 		},
-		"zone is pulled from provider config when not set on resource": {
-			ProviderZone: "bar",
-			ExpectedZone: "bar",
+		"zone is sourced from provider config when not set in resource config": {
+			ProviderZone: "provider-zone",
+			ExpectedZone: "provider-zone",
 		},
 		"error returned when zone not set on either provider or resource": {
 			ExpectedError: true,

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -444,7 +444,24 @@ func TestGetRegion(t *testing.T) {
 			},
 			ExpectedRegion: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1", // Value is not shortenedfrom URI to name
 		},
+		"returns a region derived from the zone field in resource config when region is set as an empty string": {
+			ResourceConfig: map[string]interface{}{
+				"region": "",
+				"zone":   "resource-zone-a",
+			},
+			ExpectedRegion: "resource-zone",
+		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
+			ProviderConfig: map[string]string{
+				"region": "provider-region",
+			},
+			ExpectedRegion: "provider-region",
+		},
+		"returns the value of the region field in provider config when region/zone set as an empty string in resource config": {
+			ResourceConfig: map[string]interface{}{
+				"region": "",
+				"zone":   "",
+			},
 			ProviderConfig: map[string]string{
 				"region": "provider-region",
 			},
@@ -455,6 +472,17 @@ func TestGetRegion(t *testing.T) {
 				"zone": "provider-zone-a",
 			},
 			ExpectedRegion: "provider-zone",
+		},
+		"returns an error if region and zone set as empty strings in both resource and provider configs": {
+			ResourceConfig: map[string]interface{}{
+				"region": "",
+				"zone":   "",
+			},
+			ProviderConfig: map[string]string{
+				"region": "",
+				"zone":   "",
+			},
+			ExpectedError: true,
 		},
 		"returns an error when region values can't be found": {
 			ExpectedError: true,

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -434,9 +434,18 @@ func TestGetRegion(t *testing.T) {
 			ProviderZone:   "provider-zone-a",
 			ExpectedRegion: "resource-region",
 		},
-		"region sourced from resource config can be a self link": {
+		"region sourced from the region field in resource config can be a self link": {
 			ResourceRegion: "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1",
 			ExpectedRegion: "us-central1",
+		},
+		"region is sourced from zone on resource config when region unset in resource config": {
+			ResourceZone:   "resource-zone-a",
+			ProviderRegion: "provider-region",
+			ExpectedRegion: "resource-zone",
+		},
+		"region cannot be sourced from the zone field in resource config if it is a self link": {
+			ResourceZone:   "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a",
+			ExpectedRegion: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1", // Value is not shortenedfrom URI to name
 		},
 		"region is sourced from region on provider config when region/zone unset in resource config": {
 			ProviderRegion: "provider-region",

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -262,31 +262,31 @@ func TestGetLocation(t *testing.T) {
 		},
 		"returns the zone value set in the resource config when neither location nor region in the schema": {
 			ResourceConfig: map[string]interface{}{
-				"zone": "resource-zone",
+				"zone": "resource-zone-a",
 			},
-			ExpectedLocation: "resource-zone",
+			ExpectedLocation: "resource-zone-a",
 		},
 		"shortens zone values set as self links in the resource config": {
 			// Results from getLocation using getZone internally
 			// This behaviour makes sense because APIs may return a self link as the zone value
 			ResourceConfig: map[string]interface{}{
-				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/resource-zone",
+				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/resource-zone-a",
 			},
-			ExpectedLocation: "resource-zone",
+			ExpectedLocation: "resource-zone-a",
 		},
 		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
 			ProviderConfig: map[string]string{
-				"zone": "provider-zone",
+				"zone": "provider-zone-a",
 			},
-			ExpectedLocation: "provider-zone",
+			ExpectedLocation: "provider-zone-a",
 		},
 		"does not shorten the zone value when it is set as a self link in the provider config": {
 			// This behaviour makes sense because provider config values don't originate from APIs
 			// Users should always configure the provider with the short names of regions/zones
 			ProviderConfig: map[string]string{
-				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone",
+				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a",
 			},
-			ExpectedLocation: "https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone",
+			ExpectedLocation: "https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a",
 		},
 		// Handling of empty strings
 		"returns the region value set in the resource config when location is an empty string": {
@@ -300,9 +300,9 @@ func TestGetLocation(t *testing.T) {
 			ResourceConfig: map[string]interface{}{
 				"location": "",
 				"region":   "",
-				"zone":     "resource-zone",
+				"zone":     "resource-zone-a",
 			},
-			ExpectedLocation: "resource-zone",
+			ExpectedLocation: "resource-zone-a",
 		},
 		"returns the zone value from the provider config when all of location/region/zone are set as empty strings in the resource config": {
 			ResourceConfig: map[string]interface{}{
@@ -311,9 +311,9 @@ func TestGetLocation(t *testing.T) {
 				"zone":     "",
 			},
 			ProviderConfig: map[string]string{
-				"zone": "provider-zone",
+				"zone": "provider-zone-a",
 			},
-			ExpectedLocation: "provider-zone",
+			ExpectedLocation: "provider-zone-a",
 		},
 		// Error states
 		"returns an error when only a region value is set in the the provider config and none of location/region/zone are set in the resource config": {
@@ -384,12 +384,12 @@ func TestGetZone(t *testing.T) {
 	}{
 		"returns the value of the zone field in resource config": {
 			ResourceConfig: map[string]interface{}{
-				"zone": "resource-zone",
+				"zone": "resource-zone-a",
 			},
 			ProviderConfig: map[string]string{
-				"zone": "provider-zone",
+				"zone": "provider-zone-a",
 			},
-			ExpectedZone: "resource-zone",
+			ExpectedZone: "resource-zone-a",
 		},
 		"shortens zone values set as self links in the resource config": {
 			ResourceConfig: map[string]interface{}{
@@ -399,9 +399,9 @@ func TestGetZone(t *testing.T) {
 		},
 		"returns the value of the zone field in provider config when zone is unset in resource config": {
 			ProviderConfig: map[string]string{
-				"zone": "provider-zone",
+				"zone": "provider-zone-a",
 			},
-			ExpectedZone: "provider-zone",
+			ExpectedZone: "provider-zone-a",
 		},
 		// Handling of empty strings
 		"returns the value of the zone field in provider config when zone is set to an empty string in resource config": {
@@ -409,9 +409,9 @@ func TestGetZone(t *testing.T) {
 				"zone": "",
 			},
 			ProviderConfig: map[string]string{
-				"zone": "provider-zone",
+				"zone": "provider-zone-a",
 			},
-			ExpectedZone: "provider-zone",
+			ExpectedZone: "provider-zone-a",
 		},
 		// Error states
 		"returns an error when a zone value can't be found": {
@@ -498,7 +498,7 @@ func TestGetRegion(t *testing.T) {
 				"zone":     "resource-zone-a",
 				"location": "resource-location", // unused
 			},
-			ExpectedRegion: "resource-zone",
+			ExpectedRegion: "resource-zone", // is truncated
 		},
 		"does not shorten region values when derived from a zone self link set in the resource config": {
 			ResourceConfig: map[string]interface{}{
@@ -517,7 +517,7 @@ func TestGetRegion(t *testing.T) {
 			ProviderConfig: map[string]string{
 				"zone": "provider-zone-a",
 			},
-			ExpectedRegion: "provider-zone",
+			ExpectedRegion: "provider-zone", // is truncated
 		},
 		// Handling of empty strings
 		"returns a region derived from the zone field in resource config when region is set as an empty string": {
@@ -525,7 +525,7 @@ func TestGetRegion(t *testing.T) {
 				"region": "",
 				"zone":   "resource-zone-a",
 			},
-			ExpectedRegion: "resource-zone",
+			ExpectedRegion: "resource-zone", // is truncated
 		},
 		"returns the value of the region field in provider config when region/zone set as an empty string in resource config": {
 			ResourceConfig: map[string]interface{}{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

# Background

This PR is proposing an idea for letting plugin framework code access location-type information for a resource.

## The old way of getting location information - using the SDK

When using the SDK it is possible to pass a [schema#ResourceData](https://pkg.go.dev/github.com/hashicorp/terraform/helper/schema#ResourceData) struct as an argument into a function. This struct is used to query and set the attributes of a resource, data source, or even the provider's configuration. This struct has methods like `Get`, `GetOk` and `Set` which take string arguments to identify the field in the resource's config. This means that you can write code where the field you are getting/setting can change depending on the value of the string being passed into those getter/setter functions. It also means that a function can handle a resource's configuration regardless of it's schema; there is a common interface between all resources and data sources based on the presence of `Get`/`GetOk`/`Set`/etc functions.

In the TPG/TPGB codebase there are functions that take arguments of type `schema.ResourceData` directly, or using an interface [TerraformResourceData](https://github.com/GoogleCloudPlatform/magic-modules/blob/e06e095cc480e8f82fc9ae76ebb05df7467150ca/mmv1/third_party/terraform/utils/utils.go#L30-L40), defined in the google package, that is coupled to the SDK:

```go
type TerraformResourceData interface {
	HasChange(string) bool
	GetOkExists(string) (interface{}, bool)
	GetOk(string) (interface{}, bool)
	Get(string) interface{}
	Set(string, interface{}) error
	SetId(string)
	Id() string
	GetProviderMeta(interface{}) error
	Timeout(key string) time.Duration
}
```

The util functions for getting location information for a resource relies on these features of the SDK package because it receives an argument of type `TerraformResourceData` (interface). See: [getRegion](https://github.com/hashicorp/terraform-provider-google/blob/0180090fba7e7132693aeb640bbf87d1900471c7/google/utils.go#L70), [getZone](https://github.com/hashicorp/terraform-provider-google/blob/15b2492b7192e4dcf03db4796080bf8a00239d3f/google/regional_utils.go#L36), [getLocation](https://github.com/hashicorp/terraform-provider-google/blob/15b2492b7192e4dcf03db4796080bf8a00239d3f/google/regional_utils.go#L21)

The way these functions are implemented makes them incompatible with plugin framework code, so they need to be re-written.

## How to rewrite these functions

### Option 1. Make a function that can receive data describing resources from either SDK or plugin framework code:  Not possible

The first approach could be to identify a common interface between resource/data sources/etc in the SDK and the plugin framework to make a universally used version of the function. We would also need a common way to pass the provider's configuration into the function, as we use fallback values from the provider when considering location/region/zone.

This common interface doesn't exist; the SDK was able to have a common interface because it uses getter/setter patterns but the plugin framework encourages creation of custom structs to describe each resource/data source and accessing fields directly without getter/setter functions. Even within the plugin framework there is no common way to handle resources and datasources, and instead they must be defined with types from distinct packages: [github.com/hashicorp/terraform-plugin-framework/datasource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v1.2.0/datasource) versus [github.com/hashicorp/terraform-plugin-framework/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v1.2.0/resource).

In summary, this approach is not possible unless we write a lot of custom code to impose a common getter/setter pattern between SDK and plugin framework code.

### Option 2. Make a new function, to only use in plugin framework code, but make it receive the values directly as arguments - Possible but not ideal

Instead of getting a resource's region by using a function like:

```
getRegion(<argument containing all of resource's data>, <argument containing all of provider's configuration>)
```

...why not make a function like this that could be used regardless of how a resource is implemented:

```
getRegion(<value of resource's region field>, <value of default region in provider config>)
```

The problem here is that the logic in some functions is complex and requires access to more fields of a resource's schema than you might expect. In the case of the `getLocation` function it would need to be ready to receive 5 arguments: a resource's `location`, `region`, and `zone` value and the provider's default `region` and `zone` values. This approach results in function signatures that are very long and will always need to be passed in 'zero values' to indicate that a given field is not set (no resource has all 3 fields listed above).

```
getLocation("us-central1", "", "","us-central2", "us-central2-a") # poor readability
```

There is a risk that values could be passed in the incorrect order. There would also be a lot of effort when using this function to set up null values to pass in when a given field is not present in the resource's schema.

### Option 3. Use a new approach that isn't sticking closely to the old way this logic was implemented.

This PR attempts to solve this issue by making data model structs, which describe specific resources made using plugin framework, implement an interface that returns a struct that contains all location-related information related to that resource. Instead of creating new function like `getLocation` we create methods on that location struct that allow the information to be assessed and return any possible zone/region/location values.

Implementation of how that location object is constructed and returned is different depending on the resource. When code generation in Magic Modules is updated to use the plugin framework we will need to update templates so that the function is constructed differently depending on the resource:


```erb
# pseudo code templating code
func (m *<%= resource_name -%>Model) getLocationDescription(providerConfig *frameworkProvider) LocationDescription {
	return LocationDescription{
<%  if has_location -%>
	<%  if custom_location_schema_field -%>
		LocationSchemaField: types.StringValue("<%= custom_location_schema_field -%>"),
		ResourceLocation:    m.<%= custom_location_model_field -%>,
	<%  else -%>
		LocationSchemaField: types.StringValue("location"),
		ResourceLocation:    m.Location,
	<%  end -%>
<%  end -%>
<%  if has_region -%>
	<%  if custom_region_schema_field -%>
	        // do custom
	<%  else -%>
		RegionSchemaField: types.StringValue("region"),
		ResourceRegion:    m.Region,
	<%  end -%>
<%  end -%>
<%  if has_zone -%>
	<%  if custom_zone_schema_field -%>
	        // do custom
	<%  else -%>
		ZoneSchemaField:   types.StringValue("zone"),
		ResourceZone:      m.Zone,
         <%  end -%>
<%  end -%>
		ProviderRegion:    providerConfig.region,
		ProviderZone:      providerConfig.zone,
	}
}
```

templated code for a resource that only has 'region' information in its schema, and uses a custom name for that field: 

```erb
# pseudo templated code
func (m *FoobarModel) getLocationDescription(providerConfig *frameworkProvider) LocationDescription {
	return LocationDescription{
		RegionSchemaField: types.StringValue("custom_region_field"),
		ResourceRegion:    m.CustomRegionField,
		ProviderRegion:    providerConfig.region,
		ProviderZone:      providerConfig.zone,
	}
}
```


# In this PR

This PR makes an initial version of option 3 described above.

Tests are written for the methods on the `LocationDescription` struct to assert parity with the SDK code's `getLocation`, `getRegion` and `getZone` functions.

The PR also contains some refactoring of tests for the old `getLocation`, `getRegion` and `getZone` functions in response to reviewer feedback.


----
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
