### PR TITLE
Create draft to run tpg unit tests in github actions

### DIFF
--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -1,5 +1,7 @@
 name: Build and Unit Test GA Provider
 
+permissions: read-all
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       owner:
-        description: 'The owner the fork'
+        description: 'The owner of the fork'
         required: false
         default: 'modular-magician'
       repo:

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -1,0 +1,47 @@
+name: Build and Unit Test GA Provider
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: 'The owner the fork'
+        required: false
+        default: 'modular-magician'
+      repo:
+        description: 'The Base Repository to pull from'
+        required: false
+        default: 'terraform-provider-google'
+      branch:
+        description: 'The branch or sha to execute against'
+        required: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.client_payload.owner }}/${{ github.event.client_payload.repo }}
+        ref: ${{ github.event.client_payload.branch }}
+        path: provider
+    - name: Set up Go
+      uses: golang/setup-go@v2
+      with:
+        go-version: '1.19.x'
+    - name: Build
+      run: |
+        cd provider
+        go build
+    - name: Lint
+      run: |
+        cd provider
+        make lint
+      if: ${{ always() }} # This step will always run, even if the previous fails
+    - name: Test
+      run: |
+        cd provider
+        make test
+      if: ${{ always() }} # This step will always run, even if the previous fails
+
+


### PR DESCRIPTION
This is a test to see whether its possible to trigger unit and build tests directly on github api... More work to follow after sequential testing is done... NOTE: [initial workflow will /not/ show up unless committed on main](https://stackoverflow.com/questions/67523882/workflow-is-not-shown-so-i-cannot-run-it-manually-github-actions). Thus I cannot iterate before an initial workflow is present.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
