### PR TITLE
Added support for Postgres in `google_sql_source_representation_instance`

### DIFF
--- a/mmv1/products/sql/SourceRepresentationInstance.yaml
+++ b/mmv1/products/sql/SourceRepresentationInstance.yaml
@@ -30,6 +30,13 @@ examples:
       name: "my-instance"
     ignore_read_extra:
       - "password"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "sql_source_representation_instance_postgres"
+    primary_resource_id: "instance"
+    vars:
+      name: "my-instance"
+    ignore_read_extra:
+    - "password"
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: 'templates/terraform/encoders/sql_source_representation_instance.go.erb'
   decoder: 'templates/terraform/decoders/sql_source_representation_instance.go.erb'

--- a/mmv1/products/sql/SourceRepresentationInstance.yaml
+++ b/mmv1/products/sql/SourceRepresentationInstance.yaml
@@ -52,10 +52,15 @@ properties:
       The MySQL version running on your source database server.
     required: true
     values:
-      - :MYSQL_5_5
       - :MYSQL_5_6
       - :MYSQL_5_7
       - :MYSQL_8_0
+      - :POSTGRES_9_6
+      - :POSTGRES_10
+      - :POSTGRES_11
+      - :POSTGRES_12
+      - :POSTGRES_13
+      - :POSTGRES_14
   - !ruby/object:Api::Type::NestedObject
     name: 'onPremisesConfiguration'
     description: |

--- a/mmv1/templates/terraform/examples/sql_source_representation_instance_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_source_representation_instance_postgres.tf.erb
@@ -1,0 +1,10 @@
+resource "google_sql_source_representation_instance" "<%= ctx[:primary_resource_id] %>" {
+  name               = "<%= ctx[:vars]['name'] %>"
+  region             = "us-central1"
+  database_version   = "POSTGRES_9_6"
+  host               = "10.20.30.40"
+  port               = 3306
+  username           = "some-user"
+  password           = "password-for-the-user"
+  dump_file_path     = "gs://replica-bucket/source-database.sql.gz"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Updated validation for supported DatabaseVersions by Source Representation Instance, which now supports Postgres as well. Fixes b/272549903.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: Added support for Postgres in `google_sql_source_representation_instance`
```
