### PR TITLE
Add google_datastream_static_ips data source

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_datastream_static_ips.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_datastream_static_ips.go
@@ -1,0 +1,77 @@
+package google
+
+import (
+	"fmt"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceGoogleDatastreamStaticIps() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleDatastreamStaticIpsRead,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"static_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleDatastreamStaticIpsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	url, err := ReplaceVars(d, config, "{{DatastreamBasePath}}projects/{{project}}/locations/{{location}}:fetchStaticIps")
+	if err != nil {
+		return err
+	}
+
+	staticIps, err := paginatedListRequest(project, url, userAgent, config, flattenStaticIpsList)
+	if err != nil {
+		return fmt.Errorf("Error retrieving monitoring uptime check ips: %s", err)
+	}
+
+	if err := d.Set("static_ips", staticIps); err != nil {
+		return fmt.Errorf("Error retrieving monitoring uptime check ips: %s", err)
+	}
+
+	// Store the ID now
+	id, err := ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}:fetchStaticIps")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return nil
+}
+
+func flattenStaticIpsList(resp map[string]interface{}) []interface{} {
+	ipList := resp["staticIps"].([]interface{})
+	staticIps := make([]interface{}, len(ipList))
+	for i, u := range ipList {
+		staticIps[i] = u
+	}
+	return staticIps
+}

--- a/mmv1/third_party/terraform/data_sources/data_source_google_datastream_static_ips_test.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_datastream_static_ips_test.go
@@ -1,0 +1,40 @@
+package google
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGoogleDatastreamStaticIps_basic(t *testing.T) {
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleDatastreamStaticIps_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.google_datastream_static_ips.foobar",
+						"static_ips.0", regexp.MustCompile("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")),
+					resource.TestMatchResourceAttr("data.google_datastream_static_ips.foobarbaz",
+						"static_ips.0", regexp.MustCompile("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceGoogleDatastreamStaticIps_basic = `
+data "google_project" "project" {
+}
+
+data "google_datastream_static_ips" "foobar" {
+	location       = "us-west1"
+}
+
+data "google_datastream_static_ips" "foobarbaz" {
+	location       = "us-central1"
+	project        = data.google_project.project.project_id
+}
+`

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -228,6 +228,7 @@ func Provider() *schema.Provider {
 			"google_container_registry_image":                  DataSourceGoogleContainerImage(),
 			"google_container_registry_repository":             DataSourceGoogleContainerRepo(),
 			"google_dataproc_metastore_service":                DataSourceDataprocMetastoreService(),
+			"google_datastream_static_ips":                     DataSourceGoogleDatastreamStaticIps(),
 			"google_game_services_game_server_deployment_rollout":  DataSourceGameServicesGameServerDeploymentRollout(),
 			"google_iam_policy":                                DataSourceGoogleIamPolicy(),
 			"google_iam_role":                                  DataSourceGoogleIamRole(),

--- a/mmv1/third_party/terraform/website/docs/d/datastream_static_ips.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/datastream_static_ips.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Datastream"
+description: |-
+  Returns the list of IP addresses that Datastream connects from.
+---
+
+# google\_datastream\_static\_ips
+
+Returns the list of IP addresses that Datastream connects from. For more information see
+the [official documentation](https://cloud.google.com/datastream/docs/ip-allowlists-and-regions).
+
+## Example Usage
+
+```hcl
+data "google_datastream_static_ips" "datastream_ips" {
+  location       = "us-west1"
+  project        = "my-project"
+}
+
+
+output "ip_list" {
+  value = data.google_datastream_static_ips.datastream_ips.static_ips
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (required) The location to list Datastream IPs for. For example: `us-east1`.
+
+* `project` (Optional) - Project from which to list static IP addresses. Defaults to project declared in the provider.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `static_ips` - A list of static IP addresses that Datastream will connect from.


### PR DESCRIPTION
This PR introduces a `google_datastream_static_ips` data source, enabling automated access to the [Datastream IP allowlists](https://cloud.google.com/datastream/docs/ip-allowlists-and-regions) via the [projects.locations.fetchStaticIps](https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations/fetchStaticIps) API method.

This is similar to the `google_monitoring_uptime_check_ips` data source (#3320), except that the API method requires a `name` parameter passing to it, which is constructed from `project` and `location` (`projects/{project}/locations/{location}`).

The data source therefore accepts `project` and `location` as inputs. `project` is optional, as that can be inferred from the provider configuration. `location` is required however as, whilst it could be inferred through [`getLocation`](https://github.com/hashicorp/terraform-provider-google/blob/e520fc30aaa4141dc037ad345a444c607f009770/google/regional_utils.go#L21), it's not appropriate to infer it because:

- `getLocation` can fall back to a zone argument, whereas the _fetchStaticIps_ method only supports regions.
- Passing `{{location}}` into `ReplaceVars` doesn't invoke the fallback behaviour from `getLocation`, so even if it was useful & appropriate to use it would actually just construct an invalid name of `project/my-project/:fetchStaticIps`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12928

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_datastream_static_ips`
```
