### PR TITLE
Remove ProviderBatching from provider_model.go in the google package

### DIFF
--- a/mmv1/third_party/terraform/framework_models/provider_model.go.erb
+++ b/mmv1/third_party/terraform/framework_models/provider_model.go.erb
@@ -69,11 +69,6 @@ type ProviderModel struct {
 <% end -%>
 }
 
-type ProviderBatching struct {
-	SendAfter      types.String `tfsdk:"send_after"`
-	EnableBatching types.Bool   `tfsdk:"enable_batching"`
-}
-
 var ProviderBatchingAttributes = map[string]attr.Type{
 	"send_after":      types.StringType,
 	"enable_batching": types.BoolType,

--- a/mmv1/third_party/terraform/utils/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates.go
@@ -3,8 +3,6 @@ package google
 import (
 	"fmt"
 
-	sqladmin "google.golang.org/api/sqladmin/v1beta4"
-
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -29,22 +27,6 @@ func IamMemberMissing(err error) (bool, string) {
 // See https://github.com/hashicorp/terraform-provider-google/issues/4349
 func PubsubTopicProjectNotReady(err error) (bool, string) {
 	return transport_tpg.PubsubTopicProjectNotReady(err)
-}
-
-// Retry if Cloud SQL operation returns a 429 with a specific message for
-// concurrent operations.
-func IsSqlInternalError(err error) (bool, string) {
-	if gerr, ok := err.(*SqlAdminOperationError); ok {
-		// SqlAdminOperationError is a non-interface type so we need to cast it through
-		// a layer of interface{}.  :)
-		var ierr interface{}
-		ierr = gerr
-		if serr, ok := ierr.(*sqladmin.OperationErrors); ok && serr.Errors[0].Code == "INTERNAL_ERROR" {
-			return true, "Received an internal error, which is sometimes retryable for some SQL resources.  Optimistically retrying."
-		}
-
-	}
-	return false, ""
 }
 
 // Retry if Cloud SQL operation returns a 429 with a specific message for


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

1. Remove ProviderBatching from provider_model.go in the google package, which is not used anymore. ProviderBatching is already moved to the  [transport/provider_model.go](https://github.com/GoogleCloudPlatform/magic-modules/blob/987eb9e541720cfc36061cf55967ceccdaa86efb/mmv1/third_party/terraform/transport/provider_model.go#L7)
2. Move the function IsSqlInternalError to the file mmv1/third_party/terraform/utils/sqladmin_operation.go


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
