### PR TITLE
Fix breaking-change-detector

### DIFF
--- a/.ci/containers/github-differ/Dockerfile
+++ b/.ci/containers/github-differ/Dockerfile
@@ -6,4 +6,5 @@ RUN apt-get install -y curl jq
 ADD generate_comment.sh /generate_comment.sh
 ADD compare_breaking_changes.sh /compare_breaking_changes.sh
 ADD test_tools.sh /test_tools.sh
+ADD utils.sh /utils.sh
 ENTRYPOINT ["/generate_comment.sh"]

--- a/.ci/containers/github-differ/utils.sh
+++ b/.ci/containers/github-differ/utils.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+update_package_name() {
+  old_package_name="$1"
+  new_package_name="$2"
+
+  # Update import statements and references within files
+  find . -type f -name "*.go" -exec sed -i.bak "s~$old_package_name~$new_package_name~g" {} +
+
+  # Update go.mod file
+  sed -i.bak "s|$old_package_name|$new_package_name|g" go.mod
+
+  # Optional: Update go.sum file
+  sed -i.bak "s|$old_package_name|$new_package_name|g" go.sum
+}


### PR DESCRIPTION
Fix breaking change detector to account for nest packages.. also fail unit tests in case of build failures


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
