### PR TITLE
[#14100] Add compute_instance tag binding example to google_tags_location_tag_binding resource docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
@@ -15,8 +15,9 @@ To get more information about TagBinding, see:
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing)
 
-## Example Usage - Location Tag Binding Basic
+## Example Usage
 
+To bind a tag to a Cloud Run instance:
 
 ```hcl
 resource "google_project" "project" {
@@ -26,21 +27,49 @@ resource "google_project" "project" {
 }
 
 resource "google_tags_tag_key" "key" {
-	parent = "organizations/123456789"
-	short_name = "keyname"
+	parent      = "organizations/123456789"
+	short_name  = "keyname"
 	description = "For keyname resources."
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "valuename"
+	parent      = "tagKeys/${google_tags_tag_key.key.name}"
+	short_name  = "valuename"
 	description = "For valuename resources."
 }
 
 resource "google_tags_location_tag_binding" "binding" {
-	parent = "//run.googleapis.com/projects/${data.google_project.project.number}/locations/${google_cloud_run_service.default.location}/services/${google_cloud_run_service.default.name}"
+	parent    = "//run.googleapis.com/projects/${data.google_project.project.number}/locations/${google_cloud_run_service.default.location}/services/${google_cloud_run_service.default.name}"
 	tag_value = "tagValues/${google_tags_tag_value.value.name}"
-    location = "us-central1"
+	location  = "us-central1"
+}
+```
+
+To bind a (firewall) tag to compute instance:
+
+```hcl
+resource "google_project" "project" {
+	project_id = "project_id"
+	name       = "project_id"
+	org_id     = "123456789"
+}
+
+resource "google_tags_tag_key" "key" {
+	parent      = "organizations/123456789"
+	short_name  = "keyname"
+	description = "For keyname resources."
+}
+
+resource "google_tags_tag_value" "value" {
+	parent      = "tagKeys/${google_tags_tag_key.key.name}"
+	short_name  = "valuename"
+	description = "For valuename resources."
+}
+
+resource "google_tags_location_tag_binding" "binding" {
+	parent    = "//compute.googleapis.com/projects/${google_project.project.number}/zones/us-central1-a/instances/${google_compute_instance.instance.instance_id}"
+	tag_value = "tagValues/${google_tags_tag_value.value.name}"
+	location  = "us-central1"
 }
 ```
 


### PR DESCRIPTION
Adds location tag binging example for compute_instance in google_tags_location_tag_binding docs.

Fixes [#14100](https://github.com/hashicorp/terraform-provider-google/issues/14100) and [#14210](https://github.com/hashicorp/terraform-provider-google/issues/14210).

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


Note: I removed the release note as this PR is a docs-only change

```release-note:none
```

