### PR TITLE
Add Fine Grained Resources acm_service_perimeter_ingress_policy and egress_policy

### DIFF
--- a/mmv1/products/accesscontextmanager/IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/IngressPolicy.yaml
@@ -12,12 +12,11 @@
 # limitations under the License.
 --- !ruby/object:Api::Resource
 name: 'IngressPolicy'
-create_url: '{{ingress_policy_name}}'
+create_url: '{{perimeter}}'
 base_url: ''
-self_link: '{{ingress_policy_name}}'
+self_link: '{{perimeter}}'
 create_verb: :PATCH
 delete_verb: :PATCH
-immutable: true
 update_mask: true
 identity:
   - resource
@@ -42,13 +41,13 @@ autogen_async: true
 exclude_validator: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter/IngressPolicy
 skip_sweeper: true
-id_format: '{{ingress_policy_name}}/{{resource}}'
-import_format: ['{{ingress_policy_name}}/{{resource}}']
+id_format: '{{perimeter}}/{{resource}}'
+import_format: ['{{perimeter}}/{{resource}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
 parameters:
   - !ruby/object:Api::Type::ResourceRef
-    name: 'ingressPolicyName'
+    name: 'perimeter'
     resource: 'ServicePerimeter'
     imports: 'name'
     description: |
@@ -61,5 +60,106 @@ properties:
     name: 'resource'
     description: |
       A GCP resource that is inside of the service perimeter.
-    required: true
+    required: false
     immutable: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'ingressFrom'
+    description: |
+      Defines the conditions on the source of a request causing this `IngressPolicy`
+      to apply.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'identityType'
+        description: |
+          Specifies the type of identities that are allowed access from outside the
+          perimeter. If left unspecified, then members of `identities` field will be
+          allowed access.
+        values:
+          - :IDENTITY_TYPE_UNSPECIFIED
+          - :ANY_IDENTITY
+          - :ANY_USER_ACCOUNT
+          - :ANY_SERVICE_ACCOUNT
+      - !ruby/object:Api::Type::Array
+        name: 'identities'
+        item_type: Api::Type::String
+        description: |
+          A list of identities that are allowed access through this ingress policy.
+          Should be in the format of email address. The email address should represent
+          individual user or service account only.
+      - !ruby/object:Api::Type::Array
+        name: 'sources'
+        description: |
+          Sources that this `IngressPolicy` authorizes access from.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'accessLevel'
+              description: |
+                An `AccessLevel` resource name that allow resources within the
+                `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
+                must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
+                `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
+                resources within the perimeter can only be accessed via Google Cloud calls
+                with request origins within the perimeter.
+                Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
+                If * is specified, then all IngressSources will be allowed.
+            - !ruby/object:Api::Type::String
+              name: 'resource'
+              description: |
+                A Google Cloud resource that is allowed to ingress the perimeter.
+                Requests from these resources will be allowed to access perimeter data.
+                Currently only projects are allowed. Format `projects/{project_number}`
+                The project may be in any Google Cloud organization, not just the
+                organization that the perimeter is defined in. `*` is not allowed, the case
+                of allowing all Google Cloud resources only is not supported.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'ingressTo'
+    description: |
+      Defines the conditions on the `ApiOperation` and request destination that cause
+      this `IngressPolicy` to apply.
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'resources'
+        item_type: Api::Type::String
+        description: |
+          A list of resources, currently only projects in the form
+          `projects/<projectnumber>`, protected by this `ServicePerimeter`
+          that are allowed to be accessed by sources defined in the
+          corresponding `IngressFrom`. A request matches if it contains
+          a resource in this list. If `*` is specified for resources,
+          then this `IngressTo` rule will authorize access to all
+          resources inside the perimeter, provided that the request
+          also matches the `operations` field.
+      - !ruby/object:Api::Type::Array
+        name: 'operations'
+        description: |
+          A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
+          are allowed to perform in this `ServicePerimeter`.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'serviceName'
+              description: |
+                The name of the API whose methods or permissions the `IngressPolicy` or
+                `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
+                field set to `*` will allow all methods AND permissions for all services.
+            - !ruby/object:Api::Type::Array
+              name: 'methodSelectors'
+              description: |
+                API methods or permissions to allow. Method or permission must belong to
+                the service specified by serviceName field. A single `MethodSelector` entry
+                with `*` specified for the method field will allow all methods AND
+                permissions for the service specified in `serviceName`.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'method'
+                    description: |
+                      Value for method should be a valid method name for the corresponding
+                      serviceName in `ApiOperation`. If `*` used as value for `method`, then
+                      ALL methods and permissions are allowed.
+                  - !ruby/object:Api::Type::String
+                    name: 'permission'
+                    description: |
+                      Value for permission should be a valid Cloud IAM permission for the
+                      corresponding `serviceName` in `ApiOperation`.

--- a/mmv1/products/accesscontextmanager/IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/IngressPolicy.yaml
@@ -19,13 +19,13 @@ create_verb: :PATCH
 delete_verb: :PATCH
 update_mask: true
 identity:
-  - resource
+  - ingressPolicy
 nested_query: !ruby/object:Api::Resource::NestedQuery
   modify_by_patch: true
   is_list_of_ids: true
   keys:
     - status
-    - resources
+    - ingressPolicies
 references: !ruby/object:Api::Resource::ReferenceLinks
   api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#ingresspolicy'
 description: |
@@ -57,109 +57,118 @@ parameters:
     url_param_only: true
 properties:
   - !ruby/object:Api::Type::String
-    name: 'resource'
+    name: 'ingressPolicy'
     description: |
       A GCP resource that is inside of the service perimeter.
     required: false
     immutable: true
-  - !ruby/object:Api::Type::NestedObject
-    name: 'ingressFrom'
+  - !ruby/object:Api::Type::Array
+    name: 'ingressPolicies'
     description: |
-      Defines the conditions on the source of a request causing this `IngressPolicy`
-      to apply.
-    properties:
-      - !ruby/object:Api::Type::Enum
-        name: 'identityType'
-        description: |
-          Specifies the type of identities that are allowed access from outside the
-          perimeter. If left unspecified, then members of `identities` field will be
-          allowed access.
-        values:
-          - :IDENTITY_TYPE_UNSPECIFIED
-          - :ANY_IDENTITY
-          - :ANY_USER_ACCOUNT
-          - :ANY_SERVICE_ACCOUNT
-      - !ruby/object:Api::Type::Array
-        name: 'identities'
-        item_type: Api::Type::String
-        description: |
-          A list of identities that are allowed access through this ingress policy.
-          Should be in the format of email address. The email address should represent
-          individual user or service account only.
-      - !ruby/object:Api::Type::Array
-        name: 'sources'
-        description: |
-          Sources that this `IngressPolicy` authorizes access from.
-        item_type: !ruby/object:Api::Type::NestedObject
+      List of `IngressPolicies` to apply to the perimeter. A perimeter may
+      have multiple `IngressPolicies`, each of which is evaluated
+      separately. Access is granted if any `Ingress Policy` grants it.
+      Must be empty for a perimeter bridge.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::NestedObject
+          name: 'ingressFrom'
+          description: |
+            Defines the conditions on the source of a request causing this `IngressPolicy`
+            to apply.
           properties:
-            - !ruby/object:Api::Type::String
-              name: 'accessLevel'
+            - !ruby/object:Api::Type::Enum
+              name: 'identityType'
               description: |
-                An `AccessLevel` resource name that allow resources within the
-                `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
-                must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
-                `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
-                resources within the perimeter can only be accessed via Google Cloud calls
-                with request origins within the perimeter.
-                Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
-                If * is specified, then all IngressSources will be allowed.
-            - !ruby/object:Api::Type::String
-              name: 'resource'
-              description: |
-                A Google Cloud resource that is allowed to ingress the perimeter.
-                Requests from these resources will be allowed to access perimeter data.
-                Currently only projects are allowed. Format `projects/{project_number}`
-                The project may be in any Google Cloud organization, not just the
-                organization that the perimeter is defined in. `*` is not allowed, the case
-                of allowing all Google Cloud resources only is not supported.
-  - !ruby/object:Api::Type::NestedObject
-    name: 'ingressTo'
-    description: |
-      Defines the conditions on the `ApiOperation` and request destination that cause
-      this `IngressPolicy` to apply.
-    properties:
-      - !ruby/object:Api::Type::Array
-        name: 'resources'
-        item_type: Api::Type::String
-        description: |
-          A list of resources, currently only projects in the form
-          `projects/<projectnumber>`, protected by this `ServicePerimeter`
-          that are allowed to be accessed by sources defined in the
-          corresponding `IngressFrom`. A request matches if it contains
-          a resource in this list. If `*` is specified for resources,
-          then this `IngressTo` rule will authorize access to all
-          resources inside the perimeter, provided that the request
-          also matches the `operations` field.
-      - !ruby/object:Api::Type::Array
-        name: 'operations'
-        description: |
-          A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
-          are allowed to perform in this `ServicePerimeter`.
-        item_type: !ruby/object:Api::Type::NestedObject
-          properties:
-            - !ruby/object:Api::Type::String
-              name: 'serviceName'
-              description: |
-                The name of the API whose methods or permissions the `IngressPolicy` or
-                `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
-                field set to `*` will allow all methods AND permissions for all services.
+                Specifies the type of identities that are allowed access from outside the
+                perimeter. If left unspecified, then members of `identities` field will be
+                allowed access.
+              values:
+                - :IDENTITY_TYPE_UNSPECIFIED
+                - :ANY_IDENTITY
+                - :ANY_USER_ACCOUNT
+                - :ANY_SERVICE_ACCOUNT
             - !ruby/object:Api::Type::Array
-              name: 'methodSelectors'
+              name: 'identities'
+              item_type: Api::Type::String
               description: |
-                API methods or permissions to allow. Method or permission must belong to
-                the service specified by serviceName field. A single `MethodSelector` entry
-                with `*` specified for the method field will allow all methods AND
-                permissions for the service specified in `serviceName`.
+                A list of identities that are allowed access through this ingress policy.
+                Should be in the format of email address. The email address should represent
+                individual user or service account only.
+            - !ruby/object:Api::Type::Array
+              name: 'sources'
+              description: |
+                Sources that this `IngressPolicy` authorizes access from.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   - !ruby/object:Api::Type::String
-                    name: 'method'
+                    name: 'accessLevel'
                     description: |
-                      Value for method should be a valid method name for the corresponding
-                      serviceName in `ApiOperation`. If `*` used as value for `method`, then
-                      ALL methods and permissions are allowed.
+                      An `AccessLevel` resource name that allow resources within the
+                      `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
+                      must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
+                      `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
+                      resources within the perimeter can only be accessed via Google Cloud calls
+                      with request origins within the perimeter.
+                      Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
+                      If * is specified, then all IngressSources will be allowed.
                   - !ruby/object:Api::Type::String
-                    name: 'permission'
+                    name: 'resource'
                     description: |
-                      Value for permission should be a valid Cloud IAM permission for the
-                      corresponding `serviceName` in `ApiOperation`.
+                      A Google Cloud resource that is allowed to ingress the perimeter.
+                      Requests from these resources will be allowed to access perimeter data.
+                      Currently only projects are allowed. Format `projects/{project_number}`
+                      The project may be in any Google Cloud organization, not just the
+                      organization that the perimeter is defined in. `*` is not allowed, the case
+                      of allowing all Google Cloud resources only is not supported.
+        - !ruby/object:Api::Type::NestedObject
+          name: 'ingressTo'
+          description: |
+            Defines the conditions on the `ApiOperation` and request destination that cause
+            this `IngressPolicy` to apply.
+          properties:
+            - !ruby/object:Api::Type::Array
+              name: 'resources'
+              item_type: Api::Type::String
+              description: |
+                A list of resources, currently only projects in the form
+                `projects/<projectnumber>`, protected by this `ServicePerimeter`
+                that are allowed to be accessed by sources defined in the
+                corresponding `IngressFrom`. A request matches if it contains
+                a resource in this list. If `*` is specified for resources,
+                then this `IngressTo` rule will authorize access to all
+                resources inside the perimeter, provided that the request
+                also matches the `operations` field.
+            - !ruby/object:Api::Type::Array
+              name: 'operations'
+              description: |
+                A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
+                are allowed to perform in this `ServicePerimeter`.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'serviceName'
+                    description: |
+                      The name of the API whose methods or permissions the `IngressPolicy` or
+                      `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
+                      field set to `*` will allow all methods AND permissions for all services.
+                  - !ruby/object:Api::Type::Array
+                    name: 'methodSelectors'
+                    description: |
+                      API methods or permissions to allow. Method or permission must belong to
+                      the service specified by serviceName field. A single `MethodSelector` entry
+                      with `*` specified for the method field will allow all methods AND
+                      permissions for the service specified in `serviceName`.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'method'
+                          description: |
+                            Value for method should be a valid method name for the corresponding
+                            serviceName in `ApiOperation`. If `*` used as value for `method`, then
+                            ALL methods and permissions are allowed.
+                        - !ruby/object:Api::Type::String
+                          name: 'permission'
+                          description: |
+                            Value for permission should be a valid Cloud IAM permission for the
+                            corresponding `serviceName` in `ApiOperation`.

--- a/mmv1/products/accesscontextmanager/IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/IngressPolicy.yaml
@@ -41,8 +41,8 @@ autogen_async: true
 exclude_validator: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter/IngressPolicy
 skip_sweeper: true
-id_format: '{{perimeter}}/{{resource}}'
-import_format: ['{{perimeter}}/{{resource}}']
+id_format: '{{perimeter}}'
+import_format: ['{{perimeter}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
 parameters:

--- a/mmv1/products/accesscontextmanager/IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/IngressPolicy.yaml
@@ -56,119 +56,112 @@ parameters:
     immutable: true
     url_param_only: true
 properties:
-  - !ruby/object:Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
     name: 'ingressPolicy'
-    description: |
-      A GCP resource that is inside of the service perimeter.
-    required: false
-    immutable: true
-  - !ruby/object:Api::Type::Array
-    name: 'ingressPolicies'
     description: |
       List of `IngressPolicies` to apply to the perimeter. A perimeter may
       have multiple `IngressPolicies`, each of which is evaluated
       separately. Access is granted if any `Ingress Policy` grants it.
       Must be empty for a perimeter bridge.
-    item_type: !ruby/object:Api::Type::NestedObject
-      properties:
-        - !ruby/object:Api::Type::NestedObject
-          name: 'ingressFrom'
-          description: |
-            Defines the conditions on the source of a request causing this `IngressPolicy`
-            to apply.
-          properties:
-            - !ruby/object:Api::Type::Enum
-              name: 'identityType'
-              description: |
-                Specifies the type of identities that are allowed access from outside the
-                perimeter. If left unspecified, then members of `identities` field will be
-                allowed access.
-              values:
-                - :IDENTITY_TYPE_UNSPECIFIED
-                - :ANY_IDENTITY
-                - :ANY_USER_ACCOUNT
-                - :ANY_SERVICE_ACCOUNT
-            - !ruby/object:Api::Type::Array
-              name: 'identities'
-              item_type: Api::Type::String
-              description: |
-                A list of identities that are allowed access through this ingress policy.
-                Should be in the format of email address. The email address should represent
-                individual user or service account only.
-            - !ruby/object:Api::Type::Array
-              name: 'sources'
-              description: |
-                Sources that this `IngressPolicy` authorizes access from.
-              item_type: !ruby/object:Api::Type::NestedObject
-                properties:
-                  - !ruby/object:Api::Type::String
-                    name: 'accessLevel'
-                    description: |
-                      An `AccessLevel` resource name that allow resources within the
-                      `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
-                      must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
-                      `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
-                      resources within the perimeter can only be accessed via Google Cloud calls
-                      with request origins within the perimeter.
-                      Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
-                      If * is specified, then all IngressSources will be allowed.
-                  - !ruby/object:Api::Type::String
-                    name: 'resource'
-                    description: |
-                      A Google Cloud resource that is allowed to ingress the perimeter.
-                      Requests from these resources will be allowed to access perimeter data.
-                      Currently only projects are allowed. Format `projects/{project_number}`
-                      The project may be in any Google Cloud organization, not just the
-                      organization that the perimeter is defined in. `*` is not allowed, the case
-                      of allowing all Google Cloud resources only is not supported.
-        - !ruby/object:Api::Type::NestedObject
-          name: 'ingressTo'
-          description: |
-            Defines the conditions on the `ApiOperation` and request destination that cause
-            this `IngressPolicy` to apply.
-          properties:
-            - !ruby/object:Api::Type::Array
-              name: 'resources'
-              item_type: Api::Type::String
-              description: |
-                A list of resources, currently only projects in the form
-                `projects/<projectnumber>`, protected by this `ServicePerimeter`
-                that are allowed to be accessed by sources defined in the
-                corresponding `IngressFrom`. A request matches if it contains
-                a resource in this list. If `*` is specified for resources,
-                then this `IngressTo` rule will authorize access to all
-                resources inside the perimeter, provided that the request
-                also matches the `operations` field.
-            - !ruby/object:Api::Type::Array
-              name: 'operations'
-              description: |
-                A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
-                are allowed to perform in this `ServicePerimeter`.
-              item_type: !ruby/object:Api::Type::NestedObject
-                properties:
-                  - !ruby/object:Api::Type::String
-                    name: 'serviceName'
-                    description: |
-                      The name of the API whose methods or permissions the `IngressPolicy` or
-                      `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
-                      field set to `*` will allow all methods AND permissions for all services.
-                  - !ruby/object:Api::Type::Array
-                    name: 'methodSelectors'
-                    description: |
-                      API methods or permissions to allow. Method or permission must belong to
-                      the service specified by serviceName field. A single `MethodSelector` entry
-                      with `*` specified for the method field will allow all methods AND
-                      permissions for the service specified in `serviceName`.
-                    item_type: !ruby/object:Api::Type::NestedObject
-                      properties:
-                        - !ruby/object:Api::Type::String
-                          name: 'method'
-                          description: |
-                            Value for method should be a valid method name for the corresponding
-                            serviceName in `ApiOperation`. If `*` used as value for `method`, then
-                            ALL methods and permissions are allowed.
-                        - !ruby/object:Api::Type::String
-                          name: 'permission'
-                          description: |
-                            Value for permission should be a valid Cloud IAM permission for the
-                            corresponding `serviceName` in `ApiOperation`.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'ingressFrom'
+        description: |
+          Defines the conditions on the source of a request causing this `IngressPolicy`
+          to apply.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'identityType'
+            description: |
+              Specifies the type of identities that are allowed access from outside the
+              perimeter. If left unspecified, then members of `identities` field will be
+              allowed access.
+            values:
+              - :IDENTITY_TYPE_UNSPECIFIED
+              - :ANY_IDENTITY
+              - :ANY_USER_ACCOUNT
+              - :ANY_SERVICE_ACCOUNT
+          - !ruby/object:Api::Type::Array
+            name: 'identities'
+            item_type: Api::Type::String
+            description: |
+              A list of identities that are allowed access through this ingress policy.
+              Should be in the format of email address. The email address should represent
+              individual user or service account only.
+          - !ruby/object:Api::Type::Array
+            name: 'sources'
+            description: |
+              Sources that this `IngressPolicy` authorizes access from.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'accessLevel'
+                  description: |
+                    An `AccessLevel` resource name that allow resources within the
+                    `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
+                    must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
+                    `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
+                    resources within the perimeter can only be accessed via Google Cloud calls
+                    with request origins within the perimeter.
+                    Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
+                    If * is specified, then all IngressSources will be allowed.
+                - !ruby/object:Api::Type::String
+                  name: 'resource'
+                  description: |
+                    A Google Cloud resource that is allowed to ingress the perimeter.
+                    Requests from these resources will be allowed to access perimeter data.
+                    Currently only projects are allowed. Format `projects/{project_number}`
+                    The project may be in any Google Cloud organization, not just the
+                    organization that the perimeter is defined in. `*` is not allowed, the case
+                    of allowing all Google Cloud resources only is not supported.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'ingressTo'
+        description: |
+          Defines the conditions on the `ApiOperation` and request destination that cause
+          this `IngressPolicy` to apply.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'resources'
+            item_type: Api::Type::String
+            description: |
+              A list of resources, currently only projects in the form
+              `projects/<projectnumber>`, protected by this `ServicePerimeter`
+              that are allowed to be accessed by sources defined in the
+              corresponding `IngressFrom`. A request matches if it contains
+              a resource in this list. If `*` is specified for resources,
+              then this `IngressTo` rule will authorize access to all
+              resources inside the perimeter, provided that the request
+              also matches the `operations` field.
+          - !ruby/object:Api::Type::Array
+            name: 'operations'
+            description: |
+              A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
+              are allowed to perform in this `ServicePerimeter`.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'serviceName'
+                  description: |
+                    The name of the API whose methods or permissions the `IngressPolicy` or
+                    `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
+                    field set to `*` will allow all methods AND permissions for all services.
+                - !ruby/object:Api::Type::Array
+                  name: 'methodSelectors'
+                  description: |
+                    API methods or permissions to allow. Method or permission must belong to
+                    the service specified by serviceName field. A single `MethodSelector` entry
+                    with `*` specified for the method field will allow all methods AND
+                    permissions for the service specified in `serviceName`.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'method'
+                        description: |
+                          Value for method should be a valid method name for the corresponding
+                          serviceName in `ApiOperation`. If `*` used as value for `method`, then
+                          ALL methods and permissions are allowed.
+                      - !ruby/object:Api::Type::String
+                        name: 'permission'
+                        description: |
+                          Value for permission should be a valid Cloud IAM permission for the
+                          corresponding `serviceName` in `ApiOperation`.

--- a/mmv1/products/accesscontextmanager/IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/IngressPolicy.yaml
@@ -10,22 +10,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 --- !ruby/object:Api::Resource
 name: 'IngressPolicy'
-create_url: '{{perimeter}}'
+create_url: '{{ingress_policy_name}}'
 base_url: ''
-self_link: '{{perimeter}}'
+self_link: '{{ingress_policy_name}}'
 create_verb: :PATCH
 delete_verb: :PATCH
+immutable: true
 update_mask: true
 identity:
-  - ingressPolicy
+  - resource
 nested_query: !ruby/object:Api::Resource::NestedQuery
   modify_by_patch: true
   is_list_of_ids: true
   keys:
     - status
-    - ingressPolicies
+    - resources
 references: !ruby/object:Api::Resource::ReferenceLinks
   api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#ingresspolicy'
 description: |
@@ -41,13 +43,13 @@ autogen_async: true
 exclude_validator: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter/IngressPolicy
 skip_sweeper: true
-id_format: '{{perimeter}}'
-import_format: ['{{perimeter}}']
+id_format: '{{ingress_policy_name}}/{{resource}}'
+import_format: ['{{ingress_policy_name}}/{{resource}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
 parameters:
   - !ruby/object:Api::Type::ResourceRef
-    name: 'perimeter'
+    name: 'ingressPolicyName'
     resource: 'ServicePerimeter'
     imports: 'name'
     description: |
@@ -56,112 +58,9 @@ parameters:
     immutable: true
     url_param_only: true
 properties:
-  - !ruby/object:Api::Type::NestedObject
-    name: 'ingressPolicy'
+  - !ruby/object:Api::Type::String
+    name: 'resource'
     description: |
-      List of `IngressPolicies` to apply to the perimeter. A perimeter may
-      have multiple `IngressPolicies`, each of which is evaluated
-      separately. Access is granted if any `Ingress Policy` grants it.
-      Must be empty for a perimeter bridge.
-    properties:
-      - !ruby/object:Api::Type::NestedObject
-        name: 'ingressFrom'
-        description: |
-          Defines the conditions on the source of a request causing this `IngressPolicy`
-          to apply.
-        properties:
-          - !ruby/object:Api::Type::Enum
-            name: 'identityType'
-            description: |
-              Specifies the type of identities that are allowed access from outside the
-              perimeter. If left unspecified, then members of `identities` field will be
-              allowed access.
-            values:
-              - :IDENTITY_TYPE_UNSPECIFIED
-              - :ANY_IDENTITY
-              - :ANY_USER_ACCOUNT
-              - :ANY_SERVICE_ACCOUNT
-          - !ruby/object:Api::Type::Array
-            name: 'identities'
-            item_type: Api::Type::String
-            description: |
-              A list of identities that are allowed access through this ingress policy.
-              Should be in the format of email address. The email address should represent
-              individual user or service account only.
-          - !ruby/object:Api::Type::Array
-            name: 'sources'
-            description: |
-              Sources that this `IngressPolicy` authorizes access from.
-            item_type: !ruby/object:Api::Type::NestedObject
-              properties:
-                - !ruby/object:Api::Type::String
-                  name: 'accessLevel'
-                  description: |
-                    An `AccessLevel` resource name that allow resources within the
-                    `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
-                    must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
-                    `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
-                    resources within the perimeter can only be accessed via Google Cloud calls
-                    with request origins within the perimeter.
-                    Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
-                    If * is specified, then all IngressSources will be allowed.
-                - !ruby/object:Api::Type::String
-                  name: 'resource'
-                  description: |
-                    A Google Cloud resource that is allowed to ingress the perimeter.
-                    Requests from these resources will be allowed to access perimeter data.
-                    Currently only projects are allowed. Format `projects/{project_number}`
-                    The project may be in any Google Cloud organization, not just the
-                    organization that the perimeter is defined in. `*` is not allowed, the case
-                    of allowing all Google Cloud resources only is not supported.
-      - !ruby/object:Api::Type::NestedObject
-        name: 'ingressTo'
-        description: |
-          Defines the conditions on the `ApiOperation` and request destination that cause
-          this `IngressPolicy` to apply.
-        properties:
-          - !ruby/object:Api::Type::Array
-            name: 'resources'
-            item_type: Api::Type::String
-            description: |
-              A list of resources, currently only projects in the form
-              `projects/<projectnumber>`, protected by this `ServicePerimeter`
-              that are allowed to be accessed by sources defined in the
-              corresponding `IngressFrom`. A request matches if it contains
-              a resource in this list. If `*` is specified for resources,
-              then this `IngressTo` rule will authorize access to all
-              resources inside the perimeter, provided that the request
-              also matches the `operations` field.
-          - !ruby/object:Api::Type::Array
-            name: 'operations'
-            description: |
-              A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
-              are allowed to perform in this `ServicePerimeter`.
-            item_type: !ruby/object:Api::Type::NestedObject
-              properties:
-                - !ruby/object:Api::Type::String
-                  name: 'serviceName'
-                  description: |
-                    The name of the API whose methods or permissions the `IngressPolicy` or
-                    `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
-                    field set to `*` will allow all methods AND permissions for all services.
-                - !ruby/object:Api::Type::Array
-                  name: 'methodSelectors'
-                  description: |
-                    API methods or permissions to allow. Method or permission must belong to
-                    the service specified by serviceName field. A single `MethodSelector` entry
-                    with `*` specified for the method field will allow all methods AND
-                    permissions for the service specified in `serviceName`.
-                  item_type: !ruby/object:Api::Type::NestedObject
-                    properties:
-                      - !ruby/object:Api::Type::String
-                        name: 'method'
-                        description: |
-                          Value for method should be a valid method name for the corresponding
-                          serviceName in `ApiOperation`. If `*` used as value for `method`, then
-                          ALL methods and permissions are allowed.
-                      - !ruby/object:Api::Type::String
-                        name: 'permission'
-                        description: |
-                          Value for permission should be a valid Cloud IAM permission for the
-                          corresponding `serviceName` in `ApiOperation`.
+      A GCP resource that is inside of the service perimeter.
+    required: true
+    immutable: true

--- a/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
@@ -1,0 +1,143 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Resource
+name: 'ServicePerimeterEgressPolicy'
+create_url: '{{perimeter}}'
+base_url: ''
+self_link: '{{perimeter}}'
+create_verb: :PATCH
+delete_verb: :PATCH
+update_mask: true
+identity:
+  - egressPolicy
+nested_query: !ruby/object:Api::Resource::NestedQuery
+  modify_by_patch: true
+  is_list_of_ids: true
+  keys:
+    - status
+    - egressPolicies
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#egresspolicy'
+description: |
+  EgressPolicies match requests based on egressFrom and egressTo stanzas. 
+  For an EgressPolicy to match, both egressFrom and egressTo stanzas must be matched. 
+  If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter 
+  boundary. For example, an EgressPolicy can be used to allow VMs on networks 
+  within the ServicePerimeter to access a defined set of projects outside the 
+  perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket 
+  or query against a BigQuery dataset).
+autogen_async: true
+exclude_validator: true
+# Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter/IngressPolicy
+skip_sweeper: true
+id_format: '{{perimeter}}'
+import_format: ['{{perimeter}}']
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
+parameters:
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'perimeter'
+    resource: 'ServicePerimeter'
+    imports: 'name'
+    description: |
+      The name of the Service Perimeter to add this resource to.
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::NestedObject
+    name: 'egressPolicy'
+    description: |
+      List of EgressPolicies to apply to the perimeter. A perimeter may
+      have multiple EgressPolicies, each of which is evaluated separately.
+      Access is granted if any EgressPolicy grants it. Must be empty for
+      a perimeter bridge.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'egressFrom'
+        description: |
+          Defines conditions on the source of a request causing this `EgressPolicy` to apply.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'identityType'
+            description: |
+              Specifies the type of identities that are allowed access to outside the
+              perimeter. If left unspecified, then members of `identities` field will
+              be allowed access.
+            values:
+              - :IDENTITY_TYPE_UNSPECIFIED
+              - :ANY_IDENTITY
+              - :ANY_USER_ACCOUNT
+              - :ANY_SERVICE_ACCOUNT
+          - !ruby/object:Api::Type::Array
+            name: 'identities'
+            description: |
+              A list of identities that are allowed access through this `EgressPolicy`.
+              Should be in the format of email address. The email address should
+              represent individual user or service account only.
+            item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'egressTo'
+        description: |
+          Defines the conditions on the `ApiOperation` and destination resources that
+          cause this `EgressPolicy` to apply.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'resources'
+            item_type: Api::Type::String
+            description: |
+              A list of resources, currently only projects in the form
+              `projects/<projectnumber>`, that match this to stanza. A request matches
+              if it contains a resource in this list. If * is specified for resources,
+              then this `EgressTo` rule will authorize access to all resources outside
+              the perimeter.
+          - !ruby/object:Api::Type::Array
+            name: 'externalResources'
+            item_type: Api::Type::String
+            description: |
+              A list of external resources that are allowed to be accessed. A request
+              matches if it contains an external resource in this list (Example:
+              s3://bucket/path). Currently '*' is not allowed.
+          - !ruby/object:Api::Type::Array
+            name: 'operations'
+            description: |
+              A list of `ApiOperations` that this egress rule applies to. A request matches
+              if it contains an operation/service in this list.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'serviceName'
+                  description: |
+                    The name of the API whose methods or permissions the `IngressPolicy` or
+                    `EgressPolicy` want to allow. A single `ApiOperation` with serviceName
+                    field set to `*` will allow all methods AND permissions for all services.
+                - !ruby/object:Api::Type::Array
+                  name: 'methodSelectors'
+                  description: |
+                    API methods or permissions to allow. Method or permission must belong
+                    to the service specified by `serviceName` field. A single MethodSelector
+                    entry with `*` specified for the `method` field will allow all methods
+                    AND permissions for the service specified in `serviceName`.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'method'
+                        description: |
+                          Value for `method` should be a valid method name for the corresponding
+                          `serviceName` in `ApiOperation`. If `*` used as value for method,
+                          then ALL methods and permissions are allowed.
+                      - !ruby/object:Api::Type::String
+                        name: 'permission'
+                        description: |
+                          Value for permission should be a valid Cloud IAM permission for the
+                          corresponding `serviceName` in `ApiOperation`.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -1,0 +1,167 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Resource
+name: 'ServicePerimeterIngressPolicy'
+create_url: '{{perimeter}}'
+base_url: ''
+self_link: '{{perimeter}}'
+create_verb: :PATCH
+delete_verb: :PATCH
+update_mask: true
+identity:
+  - ingressPolicy
+nested_query: !ruby/object:Api::Resource::NestedQuery
+  modify_by_patch: true
+  is_list_of_ids: true
+  keys:
+    - status
+    - ingressPolicies
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#ingresspolicy'
+description: |
+  IngressPolicies match requests based on ingressFrom and ingressTo stanzas. For an ingress policy to match,
+  both the ingressFrom and ingressTo stanzas must be matched. If an IngressPolicy matches a request,
+  the request is allowed through the perimeter boundary from outside the perimeter.
+  For example, access from the internet can be allowed either based on an AccessLevel or,
+  for traffic hosted on Google Cloud, the project of the source network.
+  For access from private networks, using the project of the hosting network is required.
+  Individual ingress policies can be limited by restricting which services and/
+  or actions they match using the ingressTo field.
+autogen_async: true
+exclude_validator: true
+# Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter/IngressPolicy
+skip_sweeper: true
+id_format: '{{perimeter}}'
+import_format: ['{{perimeter}}']
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
+parameters:
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'perimeter'
+    resource: 'ServicePerimeter'
+    imports: 'name'
+    description: |
+      The name of the Service Perimeter to add this resource to.
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::NestedObject
+    name: 'ingressPolicy'
+    description: |
+      List of `IngressPolicies` to apply to the perimeter. A perimeter may
+      have multiple `IngressPolicies`, each of which is evaluated
+      separately. Access is granted if any `Ingress Policy` grants it.
+      Must be empty for a perimeter bridge.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'ingressFrom'
+        description: |
+          Defines the conditions on the source of a request causing this `IngressPolicy`
+          to apply.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'identityType'
+            description: |
+              Specifies the type of identities that are allowed access from outside the
+              perimeter. If left unspecified, then members of `identities` field will be
+              allowed access.
+            values:
+              - :IDENTITY_TYPE_UNSPECIFIED
+              - :ANY_IDENTITY
+              - :ANY_USER_ACCOUNT
+              - :ANY_SERVICE_ACCOUNT
+          - !ruby/object:Api::Type::Array
+            name: 'identities'
+            item_type: Api::Type::String
+            description: |
+              A list of identities that are allowed access through this ingress policy.
+              Should be in the format of email address. The email address should represent
+              individual user or service account only.
+          - !ruby/object:Api::Type::Array
+            name: 'sources'
+            description: |
+              Sources that this `IngressPolicy` authorizes access from.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'accessLevel'
+                  description: |
+                    An `AccessLevel` resource name that allow resources within the
+                    `ServicePerimeters` to be accessed from the internet. `AccessLevels` listed
+                    must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent
+                    `AccessLevel` will cause an error. If no `AccessLevel` names are listed,
+                    resources within the perimeter can only be accessed via Google Cloud calls
+                    with request origins within the perimeter.
+                    Example `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.`
+                    If * is specified, then all IngressSources will be allowed.
+                - !ruby/object:Api::Type::String
+                  name: 'resource'
+                  description: |
+                    A Google Cloud resource that is allowed to ingress the perimeter.
+                    Requests from these resources will be allowed to access perimeter data.
+                    Currently only projects are allowed. Format `projects/{project_number}`
+                    The project may be in any Google Cloud organization, not just the
+                    organization that the perimeter is defined in. `*` is not allowed, the case
+                    of allowing all Google Cloud resources only is not supported.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'ingressTo'
+        description: |
+          Defines the conditions on the `ApiOperation` and request destination that cause
+          this `IngressPolicy` to apply.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'resources'
+            item_type: Api::Type::String
+            description: |
+              A list of resources, currently only projects in the form
+              `projects/<projectnumber>`, protected by this `ServicePerimeter`
+              that are allowed to be accessed by sources defined in the
+              corresponding `IngressFrom`. A request matches if it contains
+              a resource in this list. If `*` is specified for resources,
+              then this `IngressTo` rule will authorize access to all
+              resources inside the perimeter, provided that the request
+              also matches the `operations` field.
+          - !ruby/object:Api::Type::Array
+            name: 'operations'
+            description: |
+              A list of `ApiOperations` the sources specified in corresponding `IngressFrom`
+              are allowed to perform in this `ServicePerimeter`.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'serviceName'
+                  description: |
+                    The name of the API whose methods or permissions the `IngressPolicy` or
+                    `EgressPolicy` want to allow. A single `ApiOperation` with `serviceName`
+                    field set to `*` will allow all methods AND permissions for all services.
+                - !ruby/object:Api::Type::Array
+                  name: 'methodSelectors'
+                  description: |
+                    API methods or permissions to allow. Method or permission must belong to
+                    the service specified by serviceName field. A single `MethodSelector` entry
+                    with `*` specified for the method field will allow all methods AND
+                    permissions for the service specified in `serviceName`.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'method'
+                        description: |
+                          Value for method should be a valid method name for the corresponding
+                          serviceName in `ApiOperation`. If `*` used as value for `method`, then
+                          ALL methods and permissions are allowed.
+                      - !ruby/object:Api::Type::String
+                        name: 'permission'
+                        description: |
+                          Value for permission should be a valid Cloud IAM permission for the
+                          corresponding `serviceName` in `ApiOperation`.

--- a/mmv1/templates/terraform/custom_import/access_context_manager_service_perimeter_egress_policy.go.erb
+++ b/mmv1/templates/terraform/custom_import/access_context_manager_service_perimeter_egress_policy.go.erb
@@ -15,15 +15,12 @@
 	config := meta.(*transport_tpg.Config)
 
 	// current import_formats can't import fields with forward slashes in their value
-	parts, err := getImportIdQualifiers([]string{"accessPolicies/(?P<accessPolicy>[^/]+)/servicePerimeters/(?P<perimeter>[^/]+)/(?P<resource>.+)"}, d, config, d.Id())
+	parts, err := getImportIdQualifiers([]string{"accessPolicies/(?P<accessPolicy>[^/]+)/servicePerimeters/(?P<perimeter>[^/]+)"}, d, config, d.Id())
 	if err != nil {
 		return nil, err
 	}
 
-	if err := d.Set("egress_policy_name", fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", parts["accessPolicy"], parts["perimeter"])); err != nil {
-		return nil, fmt.Errorf("Error setting egress_policy_name: %s", err)
-	}
-	if err := d.Set("resource", parts["resource"]); err != nil {
-		return nil, fmt.Errorf("Error setting resource: %s", err)
+	if err := d.Set("perimeter", fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", parts["accessPolicy"], parts["perimeter"])); err != nil {
+		return nil, fmt.Errorf("Error setting perimeter: %s", err)
 	}
 	return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
+++ b/mmv1/templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.erb
@@ -15,15 +15,12 @@
 	config := meta.(*transport_tpg.Config)
 
 	// current import_formats can't import fields with forward slashes in their value
-	parts, err := getImportIdQualifiers([]string{"accessPolicies/(?P<accessPolicy>[^/]+)/servicePerimeters/(?P<perimeter>[^/]+)/(?P<resource>.+)"}, d, config, d.Id())
+	parts, err := getImportIdQualifiers([]string{"accessPolicies/(?P<accessPolicy>[^/]+)/servicePerimeters/(?P<perimeter>[^/]+)"}, d, config, d.Id())
 	if err != nil {
 		return nil, err
 	}
 
-	if err := d.Set("ingress_policy_name", fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", parts["accessPolicy"], parts["perimeter"])); err != nil {
-		return nil, fmt.Errorf("Error setting ingress_policy_name: %s", err)
-	}
-	if err := d.Set("resource", parts["resource"]); err != nil {
-		return nil, fmt.Errorf("Error setting resource: %s", err)
+	if err := d.Set("perimeter", fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", parts["accessPolicy"], parts["perimeter"])); err != nil {
+		return nil, fmt.Errorf("Error setting perimeter: %s", err)
 	}
 	return []*schema.ResourceData{d}, nil

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -81,21 +81,21 @@ func testSweepAccessContextManagerPolicies(region string) error {
 // can exist, they need to be run serially
 func TestAccAccessContextManager(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"access_policy":              testAccAccessContextManagerAccessPolicy_basicTest,
-		"access_policy_scoped":       testAccAccessContextManagerAccessPolicy_scopedTest,
-		"service_perimeter":          testAccAccessContextManagerServicePerimeter_basicTest,
-		"service_perimeter_update":   testAccAccessContextManagerServicePerimeter_updateTest,
-		"service_perimeter_resource": testAccAccessContextManagerServicePerimeterResource_basicTest,
-		"access_level":               testAccAccessContextManagerAccessLevel_basicTest,
-		"access_level_full":          testAccAccessContextManagerAccessLevel_fullTest,
-		"access_level_custom":        testAccAccessContextManagerAccessLevel_customTest,
-		"access_levels":              testAccAccessContextManagerAccessLevels_basicTest,
-		"access_level_condition":     testAccAccessContextManagerAccessLevelCondition_basicTest,
-		"egress_policy":              testAccAccessContextManagerEgressPolicy_basicTest,
-		"ingress_policy":             TestAccAccessContextManagerServicePerimeterIngressPolicy_basicTest,
-		"service_perimeters":         testAccAccessContextManagerServicePerimeters_basicTest,
-		"gcp_user_access_binding":    testAccAccessContextManagerGcpUserAccessBinding_basicTest,
-		"authorized_orgs_desc":       testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,
+		"access_policy":                    testAccAccessContextManagerAccessPolicy_basicTest,
+		"access_policy_scoped":             testAccAccessContextManagerAccessPolicy_scopedTest,
+		"service_perimeter":                testAccAccessContextManagerServicePerimeter_basicTest,
+		"service_perimeter_update":         testAccAccessContextManagerServicePerimeter_updateTest,
+		"service_perimeter_resource":       testAccAccessContextManagerServicePerimeterResource_basicTest,
+		"access_level":                     testAccAccessContextManagerAccessLevel_basicTest,
+		"access_level_full":                testAccAccessContextManagerAccessLevel_fullTest,
+		"access_level_custom":              testAccAccessContextManagerAccessLevel_customTest,
+		"access_levels":                    testAccAccessContextManagerAccessLevels_basicTest,
+		"access_level_condition":           testAccAccessContextManagerAccessLevelCondition_basicTest,
+		"service_perimeter_egress_policy":  testAccAccessContextManagerServicePerimeterEgressPolicy_basicTest,
+		"service_perimeter_ingress_policy": testAccAccessContextManagerServicePerimeterIngressPolicy_basicTest,
+		"service_perimeters":               testAccAccessContextManagerServicePerimeters_basicTest,
+		"gcp_user_access_binding":          testAccAccessContextManagerGcpUserAccessBinding_basicTest,
+		"authorized_orgs_desc":             testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,
 	}
 
 	for name, tc := range testCases {

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -92,7 +92,7 @@ func TestAccAccessContextManager(t *testing.T) {
 		"access_levels":              testAccAccessContextManagerAccessLevels_basicTest,
 		"access_level_condition":     testAccAccessContextManagerAccessLevelCondition_basicTest,
 		"egress_policy":              testAccAccessContextManagerEgressPolicy_basicTest,
-		"ingress_policy":             testAccAccessContextManagerIngressPolicy_basicTest,
+		"ingress_policy":             TestAccAccessContextManagerIngressPolicy_basicTest,
 		"service_perimeters":         testAccAccessContextManagerServicePerimeters_basicTest,
 		"gcp_user_access_binding":    testAccAccessContextManagerGcpUserAccessBinding_basicTest,
 		"authorized_orgs_desc":       testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -92,7 +92,7 @@ func TestAccAccessContextManager(t *testing.T) {
 		"access_levels":              testAccAccessContextManagerAccessLevels_basicTest,
 		"access_level_condition":     testAccAccessContextManagerAccessLevelCondition_basicTest,
 		"egress_policy":              testAccAccessContextManagerEgressPolicy_basicTest,
-		"ingress_policy":             TestAccAccessContextManagerIngressPolicy_basicTest,
+		"ingress_policy":             TestAccAccessContextManagerServicePerimeterIngressPolicy_basicTest,
 		"service_perimeters":         testAccAccessContextManagerServicePerimeters_basicTest,
 		"gcp_user_access_binding":    testAccAccessContextManagerGcpUserAccessBinding_basicTest,
 		"authorized_orgs_desc":       testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_ingress_policy_test.go
@@ -28,7 +28,7 @@ func TestAccAccessContextManagerIngressPolicy_basicTest(t *testing.T) {
 				Config: testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterTitle),
 			},
 			{
-				ResourceName:      "google_access_context_manager_ingress_policy.test-access1",
+				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -86,7 +86,7 @@ func testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterT
 	return fmt.Sprintf(`
 %s
 
-resource "google_access_context_manager_ingress_policy" "test-access1" {
+resource "google_access_context_manager_ingress_policy" "test-access" {
   perimeter = google_access_context_manager_service_perimeter.test-access.name
   ingress_policy {
 	ingress_from {

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_ingress_policy_test.go
@@ -89,35 +89,37 @@ func testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterT
 
 resource "google_access_context_manager_ingress_policy" "test-access1" {
   perimeter = google_access_context_manager_service_perimeter.test-access.name
-  resource       = "projects/%d"
-  ingress_from {
-    identity_type = "ANY_IDENTITY"
-  }
-  ingress_to {
-	resources = [ "*" ]
-	operations {
-		service_name = "bigquery.googleapis.com"
-
-		method_selectors {
-			method = "BigQueryStorage.ReadRows"
+  ingress_policy       = "projects/%d"
+  ingress_policies {
+	ingress_from {
+		identity_type = "ANY_IDENTITY"
+	  }
+	  ingress_to {
+		resources = [ "*" ]
+		operations {
+			service_name = "bigquery.googleapis.com"
+	
+			method_selectors {
+				method = "BigQueryStorage.ReadRows"
+			}
+	
+			method_selectors {
+				method = "TableService.ListTables"
+			}
+	
+			method_selectors {
+				permission = "bigquery.jobs.get"
+			}
 		}
-
-		method_selectors {
-			method = "TableService.ListTables"
+	
+		operations {
+			service_name = "storage.googleapis.com"
+	
+			method_selectors {
+				method = "google.storage.objects.create"
+			}
 		}
-
-		method_selectors {
-			permission = "bigquery.jobs.get"
-		}
-	}
-
-	operations {
-		service_name = "storage.googleapis.com"
-
-		method_selectors {
-			method = "google.storage.objects.create"
-		}
-	}
+  	}
   }
 }
 

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_service_perimeter_egress_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_service_perimeter_egress_policy_test.go
@@ -13,11 +13,10 @@ import (
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 
-func testAccAccessContextManagerEgressPolicy_basicTest(t *testing.T) {
+func testAccAccessContextManagerServicePerimeterEgressPolicy_basicTest(t *testing.T) {
 	// Multiple fine-grained resources
 	acctest.SkipIfVcr(t)
 	org := acctest.GetTestOrgFromEnv(t)
-	projects := BootstrapServicePerimeterProjects(t, 1)
 	policyTitle := RandString(t, 10)
 	perimeterTitle := "perimeter"
 
@@ -26,31 +25,31 @@ func testAccAccessContextManagerEgressPolicy_basicTest(t *testing.T) {
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerEgressPolicy_basic(org, policyTitle, perimeterTitle, projects[0].ProjectNumber),
+				Config: testAccAccessContextManagerServicePerimeterEgressPolicy_basic(org, policyTitle, perimeterTitle),
 			},
 			{
-				ResourceName:      "google_access_context_manager_egress_policy.test-access1",
+				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAccessContextManagerEgressPolicy_destroy(org, policyTitle, perimeterTitle),
-				Check:  testAccCheckAccessContextManagerEgressPolicyDestroyProducer(t),
+				Config: testAccAccessContextManagerServicePerimeterEgressPolicy_destroy(org, policyTitle, perimeterTitle),
+				Check:  testAccCheckAccessContextManagerServicePerimeterEgressPolicyDestroyProducer(t),
 			},
 		},
 	})
 }
 
-func testAccCheckAccessContextManagerEgressPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
+func testAccCheckAccessContextManagerServicePerimeterEgressPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_access_context_manager_egress_policy" {
+			if rs.Type != "google_access_context_manager_service_perimeter_egress_policy" {
 				continue
 			}
 
 			config := GoogleProviderConfig(t)
 
-			url, err := acctest.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{egress_policy_name}}")
+			url, err := acctest.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter}}")
 			if err != nil {
 				return err
 			}
@@ -66,7 +65,7 @@ func testAccCheckAccessContextManagerEgressPolicyDestroyProducer(t *testing.T) f
 			}
 
 			res = v.(map[string]interface{})
-			v, ok = res["resources"]
+			v, ok = res["egress_policies"]
 			if !ok || v == nil {
 				return nil
 			}
@@ -83,19 +82,31 @@ func testAccCheckAccessContextManagerEgressPolicyDestroyProducer(t *testing.T) f
 	}
 }
 
-func testAccAccessContextManagerEgressPolicy_basic(org, policyTitle, perimeterTitleName string, projectNumber1 int64) string {
+func testAccAccessContextManagerServicePerimeterEgressPolicy_basic(org, policyTitle, perimeterTitleName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "google_access_context_manager_egress_policy" "test-access1" {
-  egress_policy_name = google_access_context_manager_service_perimeter.test-access.name
-  resource           = "projects/%d"
+resource "google_access_context_manager_service_perimeter_egress_policy" "test-access1" {
+  perimeter = google_access_context_manager_service_perimeter.test-access.name
+  egress_policy {
+	egress_from {
+		identity_type = "ANY_USER_ACCOUNT"
+	}
+	egress_to {
+	  operations {
+		service_name = "storage.googleapis.com"
+		method_selectors {
+		  method = "*"
+	    }
+	  }
+	}
+  }
 }
 
-`, testAccAccessContextManagerEgressPolicy_destroy(org, policyTitle, perimeterTitleName), projectNumber1)
+`, testAccAccessContextManagerServicePerimeterEgressPolicy_destroy(org, policyTitle, perimeterTitleName))
 }
 
-func testAccAccessContextManagerEgressPolicy_destroy(org, policyTitle, perimeterTitleName string) string {
+func testAccAccessContextManagerServicePerimeterEgressPolicy_destroy(org, policyTitle, perimeterTitleName string) string {
 	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
@@ -108,15 +119,10 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
   title          = "%s"
   status {
     restricted_services = ["storage.googleapis.com"]
-	egress_policies {
-		egress_from {
-			identity_type = "ANY_USER_ACCOUNT"
-		}
-	}
   }
 
   lifecycle {
-  	ignore_changes = [status[0].resources]
+  	ignore_changes = [status[0].egress_policies]
   }
 }
 `, org, policyTitle, perimeterTitleName, perimeterTitleName)

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_service_perimeter_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_service_perimeter_ingress_policy_test.go
@@ -13,7 +13,7 @@ import (
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 
-func TestAccAccessContextManagerServicePerimeterIngressPolicy_basicTest(t *testing.T) {
+func testAccAccessContextManagerServicePerimeterIngressPolicy_basicTest(t *testing.T) {
 	// Multiple fine-grained resources
 	acctest.SkipIfVcr(t)
 	org := acctest.GetTestOrgFromEnv(t)
@@ -43,7 +43,7 @@ func TestAccAccessContextManagerServicePerimeterIngressPolicy_basicTest(t *testi
 func testAccCheckAccessContextManagerServicePerimeterIngressPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_access_context_manager_ingress_policy" {
+			if rs.Type != "google_access_context_manager_service_perimeter_ingress_policy" {
 				continue
 			}
 

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_service_perimeter_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_service_perimeter_ingress_policy_test.go
@@ -13,7 +13,7 @@ import (
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 
-func TestAccAccessContextManagerIngressPolicy_basicTest(t *testing.T) {
+func TestAccAccessContextManagerServicePerimeterIngressPolicy_basicTest(t *testing.T) {
 	// Multiple fine-grained resources
 	acctest.SkipIfVcr(t)
 	org := acctest.GetTestOrgFromEnv(t)
@@ -25,7 +25,7 @@ func TestAccAccessContextManagerIngressPolicy_basicTest(t *testing.T) {
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterTitle),
+				Config: testAccAccessContextManagerServicePerimeterIngressPolicy_basic(org, policyTitle, perimeterTitle),
 			},
 			{
 				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
@@ -33,14 +33,14 @@ func TestAccAccessContextManagerIngressPolicy_basicTest(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAccessContextManagerIngressPolicy_destroy(org, policyTitle, perimeterTitle),
-				Check:  testAccCheckAccessContextManagerIngressPolicyDestroyProducer(t),
+				Config: testAccAccessContextManagerServicePerimeterIngressPolicy_destroy(org, policyTitle, perimeterTitle),
+				Check:  testAccCheckAccessContextManagerServicePerimeterIngressPolicyDestroyProducer(t),
 			},
 		},
 	})
 }
 
-func testAccCheckAccessContextManagerIngressPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
+func testAccCheckAccessContextManagerServicePerimeterIngressPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "google_access_context_manager_ingress_policy" {
@@ -82,11 +82,11 @@ func testAccCheckAccessContextManagerIngressPolicyDestroyProducer(t *testing.T) 
 	}
 }
 
-func testAccAccessContextManagerIngressPolicy_basic(org, policyTitle, perimeterTitleName string) string {
+func testAccAccessContextManagerServicePerimeterIngressPolicy_basic(org, policyTitle, perimeterTitleName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "google_access_context_manager_ingress_policy" "test-access" {
+resource "google_access_context_manager_service_perimeter_ingress_policy" "test-access" {
   perimeter = google_access_context_manager_service_perimeter.test-access.name
   ingress_policy {
 	ingress_from {
@@ -121,10 +121,10 @@ resource "google_access_context_manager_ingress_policy" "test-access" {
   }
 }
 
-`, testAccAccessContextManagerIngressPolicy_destroy(org, policyTitle, perimeterTitleName))
+`, testAccAccessContextManagerServicePerimeterIngressPolicy_destroy(org, policyTitle, perimeterTitleName))
 }
 
-func testAccAccessContextManagerIngressPolicy_destroy(org, policyTitle, perimeterTitleName string) string {
+func testAccAccessContextManagerServicePerimeterIngressPolicy_destroy(org, policyTitle, perimeterTitleName string) string {
 	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#IngressPolicy
https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters#egresspolicy



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_access_context_manager_service_perimeter_egress_policy`
`google_access_context_manager_service_perimeter_ingress_policy`
```
