### PR TITLE
Fix patch behavior of Cloud Workstations resources in beta provider.

### DIFF
--- a/mmv1/products/workstations/Workstation.yaml
+++ b/mmv1/products/workstations/Workstation.yaml
@@ -87,32 +87,32 @@ parameters:
     immutable: true
     url_param_only: true
     description: |
-      The ID of the workstation cluster config.
+      The ID of the parent workstation cluster config.
   - !ruby/object:Api::Type::String
     name: 'workstationClusterId'
     required: true
     immutable: true
     url_param_only: true
     description: |
-      The name of the workstation cluster.
+      The ID of the parent workstation cluster.
   - !ruby/object:Api::Type::String
     name: 'location'
     immutable: true
     required: true
     url_param_only: true
     description: |
-      The location where the workstation cluster config should reside.
+      The location where the workstation parent resources reside.
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'
     output: true
     description: |
-      The name of the cluster resource.
+      Full name of this resource.
   - !ruby/object:Api::Type::String
     name: 'uid'
     output: true
     description: |
-      The system-generated UID of the resource.
+      A system-assigned unique identified for this resource.
   - !ruby/object:Api::Type::String
     name: 'displayName'
     description: |
@@ -128,7 +128,7 @@ properties:
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: |
-      Time the Instance was created in UTC.
+      Time when this resource was created.
     output: true
   - !ruby/object:Api::Type::String
     name: 'host'

--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -19,7 +19,7 @@ create_url: 'projects/{{project}}/locations/{{location}}/workstationClusters?wor
 update_verb: :PATCH
 update_mask: true
 min_version: beta
-description: 'A managed workstation cluster.'
+description: 'A grouping of workstation configurations and the associated workstations in that region.'
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Workstations': 'https://cloud.google.com/workstations/docs/'
@@ -69,9 +69,10 @@ parameters:
     immutable: true
     url_param_only: true
     description: |
-      The ID of the workstation cluster.
+      ID to use for the workstation cluster.
   - !ruby/object:Api::Type::String
     name: 'location'
+    # TODO(esu): Change to required, as it's not possible for this field to be omitted on the API side.
     immutable: true
     url_param_only: true
     description: |
@@ -127,7 +128,7 @@ properties:
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: |
-      Time the Instance was created in UTC.
+      Time when this resource was created.
     output: true
   - !ruby/object:Api::Type::NestedObject
     name: 'privateClusterConfig'
@@ -151,7 +152,7 @@ properties:
         name: 'serviceAttachmentUri'
         description: |
           Service attachment URI for the workstation cluster.
-          The service attachemnt is created when private endpoint is enabled.
+          The service attachment is created when private endpoint is enabled.
           To access workstations in the cluster, configure access to the managed service using (Private Service Connect)[https://cloud.google.com/vpc/docs/configure-private-service-connect-services].
         output: true
   - !ruby/object:Api::Type::Array

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -109,14 +109,14 @@ parameters:
     immutable: true
     url_param_only: true
     description: |
-      The ID of the workstation cluster config.
+      The ID to be assigned to the workstation cluster config.
   - !ruby/object:Api::Type::String
     name: 'workstationClusterId'
     required: true
     immutable: true
     url_param_only: true
     description: |
-      The name of the workstation cluster.
+      The ID of the parent workstation cluster.
   - !ruby/object:Api::Type::String
     name: 'location'
     immutable: true
@@ -155,25 +155,31 @@ properties:
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: |
-      Time the Instance was created in UTC.
+      Time when this resource was created.
     output: true
   - !ruby/object:Api::Type::NestedObject
     name: 'host'
     description: |
       Runtime host for a workstation.
-    immutable: true
     default_from_api: true
+    update_mask_fields:
+      - 'host.gceInstance.machineType'
+      - 'host.gceInstance.poolSize'
+      - 'host.gceInstance.tags'
+      - 'host.gceInstance.disablePublicIpAddresses'
+      - 'host.gceInstance.shieldedInstanceConfig.enableSecureBoot'
+      - 'host.gceInstance.shieldedInstanceConfig.enableVtpm'
+      - 'host.gceInstance.shieldedInstanceConfig.enableIntegrityMonitoring'
+      - 'host.gceInstance.confidentialInstanceConfig.enableConfidentialCompute'
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'gceInstance'
         description: |
-          Specifies a Compute Engine instance as the host.
-        immutable: true
+          A runtime using a Compute Engine instance.
         default_from_api: true
         properties:
           - !ruby/object:Api::Type::String
             name: 'machineType'
-            immutable: true
             description: |-
               The name of a Compute Engine machine type.
             default_from_api: true
@@ -185,7 +191,6 @@ properties:
             default_from_api: true
           - !ruby/object:Api::Type::Integer
             name: 'poolSize'
-            immutable: true
             description: |-
               Number of instances to pool for faster workstation startup.
             default_from_api: true
@@ -198,84 +203,92 @@ properties:
           - !ruby/object:Api::Type::Array
             name: 'tags'
             item_type: Api::Type::String
-            immutable: true
             description: |
               Network tags to add to the Compute Engine machines backing the Workstations.
           - !ruby/object:Api::Type::Boolean
             name: 'disablePublicIpAddresses'
-            immutable: true
             description: |
               Whether instances have no public IP address.
           - !ruby/object:Api::Type::NestedObject
             name: 'shieldedInstanceConfig'
             description: |
               A set of Compute Engine Shielded instance options.
-            immutable: true
+            default_from_api: true
+            custom_flatten: 'templates/terraform/custom_flatten/workstations_config_shielded_instance.go.erb'
             properties:
               - !ruby/object:Api::Type::Boolean
                 name: 'enableSecureBoot'
-                immutable: true
                 description: |
                   Whether the instance has Secure Boot enabled.
+                send_empty_value: true
               - !ruby/object:Api::Type::Boolean
                 name: 'enableVtpm'
-                immutable: true
                 description: |
                   Whether the instance has the vTPM enabled.
+                send_empty_value: true
               - !ruby/object:Api::Type::Boolean
                 name: 'enableIntegrityMonitoring'
-                immutable: true
                 description: |
                   Whether the instance has integrity monitoring enabled.
+                send_empty_value: true
           - !ruby/object:Api::Type::NestedObject
             name: 'confidentialInstanceConfig'
             description: |
               A set of Compute Engine Confidential VM instance options.
-            immutable: true
+            default_from_api: true
+            custom_flatten: 'templates/terraform/custom_flatten/workstations_config_confidential_instance.go.erb'
             properties:
               - !ruby/object:Api::Type::Boolean
                 name: 'enableConfidentialCompute'
-                immutable: true
+                # TODO(esu): Change this to required in next breaking release.
                 description: |
                   Whether the instance has confidential compute enabled.
+                send_empty_value: true
   - !ruby/object:Api::Type::Array
     name: 'persistentDirectories'
     description: |
       Directories to persist across workstation sessions.
     default_from_api: true
+    immutable: true
     item_type: !ruby/object:Api::Type::NestedObject
       properties:
         - !ruby/object:Api::Type::String
           name: 'mountPath'
           description: |
             Location of this directory in the running workstation.
+          default_from_api: true
+          immutable: true
         - !ruby/object:Api::Type::NestedObject
           name: 'gcePd'
           description: |
             PersistentDirectory backed by a Compute Engine regional persistent disk.
           default_from_api: true
+          immutable: true
           properties:
             - !ruby/object:Api::Type::String
               name: 'fsType'
               description: |
                 Type of file system that the disk should be formatted with. The workstation image must support this file system type. Must be empty if sourceSnapshot is set.
               default_from_api: true
+              immutable: true
             - !ruby/object:Api::Type::String
               name: 'diskType'
               description: |
                 Type of the disk to use.
               default_from_api: true
+              immutable: true
             - !ruby/object:Api::Type::Integer
               name: 'sizeGb'
               description: |-
                 Size of the disk in GB. Must be empty if sourceSnapshot is set.
               default_from_api: true
+              immutable: true
             - !ruby/object:Api::Type::Enum
               name: 'reclaimPolicy'
               description: |
                 What should happen to the disk after the workstation is deleted. Defaults to DELETE.
+              immutable: true
               values:
-                - :RECLAIM_POLICY_UNSPECIFIED
                 - :DELETE
                 - :RETAIN
   - !ruby/object:Api::Type::NestedObject
@@ -283,11 +296,19 @@ properties:
     description: |
       Container that will be run for each workstation using this configuration when that workstation is started.
     default_from_api: true
+    # Mask fields must be sent as distinct keys, else some fields will upsert rather than be replaced.
+    update_mask_fields:
+      - 'container.image'
+      - 'container.command'
+      - 'container.args'
+      - 'container.workingDir'
+      - 'container.env'
+      - 'container.runAsUser'
     properties:
       - !ruby/object:Api::Type::String
         name: 'image'
         description: |
-          Docker image defining the container. This image must be accessible by the config"s service account.
+          Docker image defining the container. This image must be accessible by the config's service account.
         default_from_api: true
       - !ruby/object:Api::Type::Array
         name: 'command'
@@ -303,6 +324,8 @@ properties:
         name: 'workingDir'
         description: |
           If set, overrides the default DIR specified by the image.
+        # Allow unsetting to revert to container default.
+        send_empty_value: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'env'
         description: |
@@ -314,6 +337,7 @@ properties:
           If set, overrides the USER specified in the image with the given uid.
   - !ruby/object:Api::Type::NestedObject
     name: 'encryptionKey'
+    immutable: true
     description: |
       Encrypts resources of this workstation configuration using a customer-managed encryption key.
 

--- a/mmv1/products/workstations/product.yaml
+++ b/mmv1/products/workstations/product.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Workstations
-display_name: Workstations
+display_name: Cloud Workstations
 versions:
   - !ruby/object:Api::Product::Version
     name: beta
@@ -22,5 +22,5 @@ scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:
   - !ruby/object:Api::Product::ApiReference
-    name: Workstations API
+    name: Cloud Workstations API
     url: https://console.cloud.google.com/apis/library/workstations.googleapis.com

--- a/mmv1/templates/terraform/custom_flatten/workstations_config_confidential_instance.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/workstations_config_confidential_instance.go.erb
@@ -1,0 +1,31 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	transformed := make(map[string]interface{})
+
+	// Defaults for when no value is provided by API.
+	transformed["enable_confidential_compute"] = false
+
+	if v == nil {
+		return []interface{}{transformed}
+	}
+
+	original := v.(map[string]interface{})
+	if original["enableConfidentialCompute"] != nil {
+		transformed["enable_confidential_compute"] = original["enableConfidentialCompute"]
+	}
+
+	return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/custom_flatten/workstations_config_shielded_instance.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/workstations_config_shielded_instance.go.erb
@@ -1,0 +1,39 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	transformed := make(map[string]interface{})
+
+	// Defaults for when no value is provided by API.
+	transformed["enable_secure_boot"] = false
+	transformed["enable_vtpm"] = false
+	transformed["enable_integrity_monitoring"] = false
+
+	if v == nil {
+		return []interface{}{transformed}
+	}
+
+	original := v.(map[string]interface{})
+	if original["enableSecureBoot"] != nil {
+		transformed["enable_secure_boot"] = original["enableSecureBoot"]
+	}
+	if original["enableVtpm"] != nil {
+		transformed["enable_vtpm"] = original["enableVtpm"]
+	}
+	if original["enableIntegrityMonitoring"] != nil {
+		transformed["enable_integrity_monitoring"] = original["enableIntegrityMonitoring"]
+	}
+
+	return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -33,7 +33,7 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
   workstation_config_id  = "<%= ctx[:vars]['workstation_config_name'] %>"
   workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
   location   		         = "us-central1"
-  
+
   host {
     gce_instance {
       machine_type                = "e2-standard-4"

--- a/mmv1/third_party/terraform/tests/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_workstations_workstation_config_test.go.erb
@@ -305,4 +305,310 @@ resource "google_workstations_workstation_config" "default" {
 }
 `, context)
 }
+
+func TestAccWorkstationsWorkstationConfig_updateHostDetails(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_updateHostDetailsDefault(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+			{
+				Config: testAccWorkstationsWorkstationConfig_updateHostDetailsUpdated(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+			{
+				Config: testAccWorkstationsWorkstationConfig_updateHostDetailsUnsetInstanceConfigs(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_updateHostDetailsDefault(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "e2-standard-2"
+      boot_disk_size_gb           = 35
+      pool_size                   = 0
+
+      disable_public_ip_addresses = false
+
+      shielded_instance_config {
+        enable_secure_boot          = false
+        enable_vtpm                 = false
+        enable_integrity_monitoring = false
+      }
+
+      confidential_instance_config {
+        enable_confidential_compute = false
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccWorkstationsWorkstationConfig_updateHostDetailsUpdated(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "n2d-standard-2"
+      boot_disk_size_gb           = 35
+      pool_size                   = 1
+
+      disable_public_ip_addresses = true
+      tags = ["foo", "bar"]
+
+      shielded_instance_config {
+        enable_secure_boot          = true
+        enable_vtpm                 = true
+        enable_integrity_monitoring = true
+      }
+
+      confidential_instance_config {
+        enable_confidential_compute = true
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccWorkstationsWorkstationConfig_updateHostDetailsUnsetInstanceConfigs(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "n2d-standard-2"
+      boot_disk_size_gb           = 35
+      pool_size                   = 1
+
+      disable_public_ip_addresses = true
+      tags = ["foo", "bar"]
+
+      shielded_instance_config {}
+      confidential_instance_config {}
+    }
+  }
+}
+`, context)
+}
+
+func TestAccWorkstationsWorkstationConfig_updateWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_withCustomWorkingDir(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+			{
+				Config: testAccWorkstationsWorkstationConfig_unsetWorkingDir(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_withCustomWorkingDir(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  container {
+    image       = "us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest"
+    working_dir = "/test"
+  }
+}
+`, context)
+}
+
+func testAccWorkstationsWorkstationConfig_unsetWorkingDir(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  container {
+    image       = "us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest"
+  }
+}
+`, context)
+}
 <% end -%>


### PR DESCRIPTION
This change adds support for timeout-related fields to the Cloud Workstations config resource, and also updates several others so they can be updated via `PATCH` to avoid re-creating the underlying resource.

This provides fixes for the following issues:
* https://github.com/hashicorp/terraform-provider-google/issues/14072

This is a copy of #7629 to try to unblock it.

---

This PR is for Terraform. I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: supported in-place update for `host` and `container` in `google_workstations_workstation_config` (beta)
```

```release-note:bug
workstations: fixed an issue where unsetting the container working directory in `google_workstations_workstations_config` was not propagated to the underlying resource (beta)
```

```release-note:bug
workstations: fixed an issue where modifying `persistent_directories` and `encryption_key` would fail with API errors; now updating them will recreate the resource (beta)
```