### PR TITLE
Gcb allow build step failure

### DIFF
--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -978,6 +978,23 @@ properties:
               description: |
                 A shell script to be executed in the step.
                 When script is provided, the user cannot specify the entrypoint or args.
+            - !ruby/object:Api::Type::Boolean
+              name: 'allowFailure'
+              description: |
+                Allow this build step to fail without failing the entire build.
+                If false, the entire build will fail if this step fails. Otherwise, the
+                build will succeed, but this step will still have a failure status.
+                Error information will be reported in the `failureDetail` field.
+
+                `allowExitCodes` takes precedence over this field.
+            - !ruby/object:Api:Type::Array
+              name: 'allowExitCodes'
+              item_type: Api::Type::Integer
+              description: |
+                Allow this build step to fail without failing the entire build if and
+                only if the exit code is one of the specified codes.
+
+                If `allowFailure` is also specified, this field will take precedence.
       - !ruby/object:Api::Type::NestedObject
         name: 'artifacts'
         description: |

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -81,6 +81,12 @@ examples:
     name: 'cloudbuild_trigger_github_enterprise'
     primary_resource_id: 'ghe-trigger'
     skip_test: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudbuild_trigger_allow_failure'
+    primary_resource_id: 'allow-failure-trigger'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudbuild_trigger_allow_exit_codes'
+    primary_resource_id: 'allow-exit-codes-trigger'
 
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_read: templates/terraform/pre_read/cloudbuild_trigger.go.erb

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -987,7 +987,7 @@ properties:
                 Error information will be reported in the `failureDetail` field.
 
                 `allowExitCodes` takes precedence over this field.
-            - !ruby/object:Api:Type::Array
+            - !ruby/object:Api::Type::Array
               name: 'allowExitCodes'
               item_type: Api::Type::Integer
               description: |

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_exit_codes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_exit_codes.tf.erb
@@ -10,7 +10,7 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
     step {
       name = "ubuntu"
       args = ["-c", "exit 1"]
-      allowExitCodes = [1] # using allowExitCodes field
+      allow_exit_codes = [1,3]
     }
 
     source {

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_exit_codes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_exit_codes.tf.erb
@@ -1,0 +1,66 @@
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location = "global"
+
+  trigger_template {
+    branch_name = "main"
+    repo_name   = "my-repo"
+  }
+
+  build {
+    step {
+      name = "ubuntu"
+      args = ["-c", "exit 1"]
+      allowExitCodes = [1] # using allowExitCodes field
+    }
+
+    source {
+      storage_source {
+        bucket = "mybucket"
+        object = "source_code.tar.gz"
+      }
+    }
+    tags = ["build", "newFeature"]
+    substitutions = {
+      _FOO = "bar"
+      _BAZ = "qux"
+    }
+    queue_ttl = "20s"
+    logs_bucket = "gs://mybucket/logs"
+    secret {
+      kms_key_name = "projects/myProject/locations/global/keyRings/keyring-name/cryptoKeys/key-name"
+      secret_env = {
+        PASSWORD = "ZW5jcnlwdGVkLXBhc3N3b3JkCg=="
+      }
+    }
+    available_secrets {
+      secret_manager {
+        env          = "MY_SECRET"
+        version_name = "projects/myProject/secrets/mySecret/versions/latest"
+      }
+    }
+    artifacts {
+      images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"]
+      objects {
+        location = "gs://bucket/path/to/somewhere/"
+        paths = ["path"]
+      }
+    }
+    options {
+      source_provenance_hash = ["MD5"]
+      requested_verify_option = "VERIFIED"
+      machine_type = "N1_HIGHCPU_8"
+      disk_size_gb = 100
+      substitution_option = "ALLOW_LOOSE"
+      dynamic_substitutions = true
+      log_streaming_option = "STREAM_OFF"
+      worker_pool = "pool"
+      logging = "LEGACY"
+      env = ["ekey = evalue"]
+      secret_env = ["secretenv = svalue"]
+      volumes {
+        name = "v1"
+        path = "v1"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_failure.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_failure.tf.erb
@@ -1,0 +1,66 @@
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  location = "global"
+
+  trigger_template {
+    branch_name = "main"
+    repo_name   = "my-repo"
+  }
+
+  build {
+    step {
+      name = "ubuntu"
+      args = ["-c", "exit 1"]
+      allowFailure = true # using allowFailure field
+    }
+
+    source {
+      storage_source {
+        bucket = "mybucket"
+        object = "source_code.tar.gz"
+      }
+    }
+    tags = ["build", "newFeature"]
+    substitutions = {
+      _FOO = "bar"
+      _BAZ = "qux"
+    }
+    queue_ttl = "20s"
+    logs_bucket = "gs://mybucket/logs"
+    secret {
+      kms_key_name = "projects/myProject/locations/global/keyRings/keyring-name/cryptoKeys/key-name"
+      secret_env = {
+        PASSWORD = "ZW5jcnlwdGVkLXBhc3N3b3JkCg=="
+      }
+    }
+    available_secrets {
+      secret_manager {
+        env          = "MY_SECRET"
+        version_name = "projects/myProject/secrets/mySecret/versions/latest"
+      }
+    }
+    artifacts {
+      images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"]
+      objects {
+        location = "gs://bucket/path/to/somewhere/"
+        paths = ["path"]
+      }
+    }
+    options {
+      source_provenance_hash = ["MD5"]
+      requested_verify_option = "VERIFIED"
+      machine_type = "N1_HIGHCPU_8"
+      disk_size_gb = 100
+      substitution_option = "ALLOW_LOOSE"
+      dynamic_substitutions = true
+      log_streaming_option = "STREAM_OFF"
+      worker_pool = "pool"
+      logging = "LEGACY"
+      env = ["ekey = evalue"]
+      secret_env = ["secretenv = svalue"]
+      volumes {
+        name = "v1"
+        path = "v1"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_failure.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_allow_failure.tf.erb
@@ -10,7 +10,7 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
     step {
       name = "ubuntu"
       args = ["-c", "exit 1"]
-      allowFailure = true # using allowFailure field
+      allow_failure = true
     }
 
     source {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add allowFailure and allowExitCodes to CloudBuild Trigger.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: Added `allow_failure` and `allow_exit_codes` to `build.step` in `google_cloudbuild_trigger` resource
```
