### PR TITLE
Added general field `load.parquet_options ` to `google_bigquery_job`

### DIFF
--- a/mmv1/products/bigquery/Job.yaml
+++ b/mmv1/products/bigquery/Job.yaml
@@ -77,6 +77,14 @@ examples:
       - 'etag'
       - 'status.0.state'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_job_load_parquet'
+    primary_resource_id: 'job'
+    vars:
+      job_id: "job_load"
+    ignore_read_extra:
+      - 'etag'
+      - 'status.0.state'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_job_load_table_reference'
     primary_resource_id: 'job'
     vars:
@@ -600,6 +608,22 @@ properties:
                 description: |
                   Describes the Cloud KMS encryption key version used to protect destination BigQuery table.
                 output: true
+          - !ruby/object:Api::Type::NestedObject
+            name: 'parquetOptions'
+            description: |
+              Parquet Options for load and make external tables.
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'enumAsString'
+                description: |
+                  If sourceFormat is set to PARQUET, indicates whether to infer Parquet ENUM logical type as STRING instead of BYTES by default.
+              - !ruby/object:Api::Type::Boolean
+                name: 'enableListInference'
+                description: |
+                  If sourceFormat is set to PARQUET, indicates whether to use schema inference specifically for Parquet LIST logical type.
+                at_least_one_of:
+                  - configuration.0.load.0.parquet_options.0.enum_as_string
+                  - configuration.0.load.0.parquet_options.0.enable_list_inference
       - !ruby/object:Api::Type::NestedObject
         name: 'copy'
         description: 'Copies a table.'

--- a/mmv1/templates/terraform/examples/bigquery_job_load_parquet.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_parquet.tf.erb
@@ -1,0 +1,54 @@
+resource "google_storage_bucket" "test" {
+  name                        = "<%= ctx[:vars]['job_id'] %>_bucket"
+  location                    = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "test" {
+  name   =  "<%= ctx[:vars]['job_id'] %>_bucket_object"
+  source = "./test-fixtures/bigquerytable/test.parquet.gzip"
+  bucket = google_storage_bucket.test.name
+}
+
+resource "google_bigquery_dataset" "test" {
+  dataset_id                  = "<%= ctx[:vars]['job_id'] %>_dataset"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
+resource "google_bigquery_table" "test" {
+  deletion_protection = false
+  table_id            = "<%= ctx[:vars]['job_id'] %>_table"
+  dataset_id          = google_bigquery_dataset.test.dataset_id
+}
+
+resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
+  job_id = "<%= ctx[:vars]['job_id'] %>"
+
+  labels = {
+    "my_job" ="load"
+  }
+
+  load {
+    source_uris = [
+      "gs://${google_storage_bucket_object.test.bucket}/${google_storage_bucket_object.test.name}"
+    ]
+
+    destination_table {
+      project_id = google_bigquery_table.test.project
+      dataset_id = google_bigquery_table.test.dataset_id
+      table_id   = google_bigquery_table.test.table_id
+    }
+
+    schema_update_options = ["ALLOW_FIELD_RELAXATION", "ALLOW_FIELD_ADDITION"]
+    write_disposition     = "WRITE_APPEND"
+    source_format         = "PARQUET"
+    autodetect            = true
+
+    parquet_options {
+      enum_as_string        = true
+      enable_list_inference = true
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://b.corp.google.com/issues/268201164

API: https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
bigquery: Added general field `load.parquet_options ` to `google_bigquery_job`
```
