### PR TITLE
fix: Update config.go and framework_config.go to use transport.Creds for all cases

### DIFF
--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -601,7 +601,7 @@ func GetCredentials(ctx context.Context, data ProviderModel, initialCredentialsO
 			return *creds
 		}
 
-		creds, err := googleoauth.CredentialsFromJSON(ctx, []byte(contents), clientScopes...)
+		creds, err := transport.Creds(ctx, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
 		if err != nil {
 			diags.AddError("unable to parse credentials", err.Error())
 			return googleoauth.Credentials{}
@@ -625,14 +625,12 @@ func GetCredentials(ctx context.Context, data ProviderModel, initialCredentialsO
 
 	tflog.Info(ctx, "Authenticating using DefaultClient...")
 	tflog.Info(ctx, fmt.Sprintf("  -- Scopes: %s", clientScopes))
-	defaultTS, err := googleoauth.DefaultTokenSource(context.Background(), clientScopes...)
+	creds, err := transport.Creds(context.Background(), option.WithScopes(clientScopes...))
 	if err != nil {
 		diags.AddError(fmt.Sprintf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  "+
 			"No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'"), err.Error())
 		return googleoauth.Credentials{}
 	}
 
-	return googleoauth.Credentials{
-		TokenSource: defaultTS,
-	}
+	return *creds
 }

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -1189,6 +1189,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 	}
 
 	return *creds, nil
+}
 
 // Remove the `/{{version}}/` from a base path if present.
 func RemoveBasePathVersion(url string) string {

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -1161,7 +1161,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 			return *creds, nil
 		}
 
-		creds, err := transport.Creds(c.context, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
+		creds, err := transport.Creds(c.Context, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
 		if err != nil {
 			return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials from '%s': %s", contents, err)
 		}

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -1161,7 +1161,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 			return *creds, nil
 		}
 
-		creds, err := googleoauth.CredentialsFromJSON(c.Context, []byte(contents), clientScopes...)
+		creds, err := transport.Creds(c.context, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
 		if err != nil {
 			return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials from '%s': %s", contents, err)
 		}
@@ -1183,15 +1183,12 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 
 	log.Printf("[INFO] Authenticating using DefaultClient...")
 	log.Printf("[INFO]   -- Scopes: %s", clientScopes)
-	defaultTS, err := googleoauth.DefaultTokenSource(context.Background(), clientScopes...)
+	creds, err := transport.Creds(context.Background(), option.WithScopes(clientScopes...))
 	if err != nil {
 		return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
 	}
 
-	return googleoauth.Credentials{
-		TokenSource: defaultTS,
-	}, err
-}
+	return *creds, nil
 
 // Remove the `/{{version}}/` from a base path if present.
 func RemoveBasePathVersion(url string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR fixes the issue in https://github.com/hashicorp/terraform-provider-google/issues/14411 by ensuring we use transport.Creds for initializing the credentials/tokenSource in all applicable code-path. Using transport.Creds ensures that the underlying OAuth2 HTTPClient used for token exchange is properly configured for mTLS - the current version of the code in terraform bypasses this logic when calling the oauth2 google package APIs directly.

What is not included in this PR:
1. Removing the custom tokenSource override logic - this is because Terraform persists the custom tokenSource for use in other locations such as for initializing big table grpc client as well as populating data source config for GKE clusters. The transport API for creating HTTPClient does not export the underlying tokenSource for re-use. (This support may be added in a future version of the API, which is currently being re-designed.)
2. Simplifying the duplicated ADC logic in terraform. We will revisit this in the future.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Update config.go and framework_config.go to use transport.Creds for all cases
```
