### PR TITLE
Transition provider unit tests to run as a github action

### DIFF
--- a/.ci/containers/terraform-tester/Dockerfile
+++ b/.ci/containers/terraform-tester/Dockerfile
@@ -1,8 +1,5 @@
 from golang:1.19-bullseye as resource
 SHELL ["/bin/bash", "-c"]
-# Set up Github SSH cloning.
-RUN ssh-keyscan github.com >> /known_hosts
-RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
 
 RUN apt-get update
 RUN apt-get install -y git jq

--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -2,19 +2,11 @@
 
 set -e
 
-version=$1
-pr_number=$2
-mm_commit_sha=$3
-build_id=$4
-project_id=$5
-repo_name=$6
-build_step=$7
-if [ -z "$7" ]; then
-  # an old run - any time after october 15 2021 this can be removed.
-  repo_name=GoogleCloudPlatform/magic-modules
-  build_step=$6
-fi
+version=${VERSION:-$1} # fallback for old variable based declaration
+pr_number=${PR_NUMBER:-$2}
+mm_commit_sha=${COMMIT_SHA:-$3}
 github_username=modular-magician
+
 if [ "$version" == "ga" ]; then
     gh_repo=terraform-provider-google
 elif [ "$version" == "beta" ]; then
@@ -25,112 +17,25 @@ else
 fi
 
 new_branch="auto-pr-$pr_number"
-git_remote=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
-local_path=$GOPATH/src/github.com/hashicorp/$gh_repo
-mkdir -p "$(dirname $local_path)"
-git clone $git_remote $local_path --branch $new_branch --depth 2
-pushd $local_path
 
-# Only skip tests if we can tell for sure that no go files were changed
-echo "Checking for modified go files"
-# get the names of changed files and look for go files
-# (ignoring "no matches found" errors from grep)
-gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
-if [[ -z $gofiles ]]; then
-    echo "Skipping tests: No go files changed"
-    exit 0
-else
-    echo "Running tests: Go files changed"
-fi
-
-post_body=$( jq -n \
-    --arg context "${gh_repo}-test" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "pending" \
-    '{context: $context, target_url: $target_url, state: $state}')
+post_body=$(jq -n \
+  --arg owner "$github_username" \
+  --arg branch "$new_branch" \
+  --arg repo "$gh_repo" \
+  --arg sha "$mm_commit_sha" \
+  '{
+    ref: "main",
+    inputs: {
+      owner: $owner,
+      repo: $repo,
+      branch: $branch,
+      sha: $sha
+    }
+  }')
 
 curl \
   -X POST \
   -u "$github_username:$GITHUB_TOKEN" \
   -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/$repo_name/statuses/$mm_commit_sha" \
-  -d "$post_body"
-
-
-post_body=$( jq -n \
-    --arg context "${gh_repo}-lint" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "pending" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/$repo_name/statuses/$mm_commit_sha" \
-  -d "$post_body"
-
-set +e
-
-make
-lint_exit_code=$?
-test_exit_code=1
-
-# TODO: remove on 2022/08/18 or later.
-# note: maintain (degraded) backwards compatibility with the old lint rule which
-# needs tools run in advance
-# note: this will silently fail on newer makefiles, as we are in a +e block
-make tools
-
-make lint
-lint_exit_code=$(($lint_exit_code || $?))
-
-# note: test has a dependency on lint (which runs fmtcheck and vet) so it will
-# run them a second time.
-make test
-test_exit_code=$?
-
-
-make docscheck
-lint_exit_code=$(($lint_exit_code || $?))
-
-set -e
-
-if [ $test_exit_code -ne 0 ]; then
-    test_state="failure"
-else
-    test_state="success"
-fi
-
-if [ $lint_exit_code -ne 0 ]; then
-    lint_state="failure"
-else
-    lint_state="success"
-fi
-
-post_body=$( jq -n \
-    --arg context "${gh_repo}-test" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "${test_state}" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/$repo_name/statuses/$mm_commit_sha" \
-  -d "$post_body"
-
-
-post_body=$( jq -n \
-    --arg context "${gh_repo}-lint" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "${lint_state}" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/$repo_name/statuses/$mm_commit_sha" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/actions/workflows/test-tpg.yml/dispatches" \
   -d "$post_body"

--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -217,26 +217,34 @@ steps:
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["tpgb-head", "tpgb-base"]
       args:
-          - 'beta'
-          - $_PR_NUMBER
-          - $COMMIT_SHA
-          - $BUILD_ID
-          - $PROJECT_ID
-          - GoogleCloudPlatform/magic-modules
-          - "20"  # Build step
+          - 'beta'                            # remove after 07/2023
+          - $_PR_NUMBER                       # remove after 07/2023
+          - $COMMIT_SHA                       # remove after 07/2023
+          - $BUILD_ID                         # remove after 07/2023
+          - $PROJECT_ID                       # remove after 07/2023
+          - GoogleCloudPlatform/magic-modules # remove after 07/2023
+          - "20"                              # remove after 07/2023
+      env:
+        - VERSION=beta
+        - COMMIT_SHA=$COMMIT_SHA
+        - PR_NUMBER=$_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpg-test
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["tpg-head", "tpg-base"]
       args:
-          - 'ga'
-          - $_PR_NUMBER
-          - $COMMIT_SHA
-          - $BUILD_ID
-          - $PROJECT_ID
-          - GoogleCloudPlatform/magic-modules
-          - "21"  # Build step
+          - 'ga'                               # remove after 07/2023
+          - $_PR_NUMBER                        # remove after 07/2023
+          - $COMMIT_SHA                        # remove after 07/2023
+          - $BUILD_ID                          # remove after 07/2023
+          - $PROJECT_ID                        # remove after 07/2023
+          - GoogleCloudPlatform/magic-modules  # remove after 07/2023
+          - "21"                               # remove after 07/2023
+      env:
+        - VERSION=beta
+        - COMMIT_SHA=$COMMIT_SHA
+        - PR_NUMBER=$_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/gcb-terraform-vcr-tester'
       id: gcb-tpg-vcr-test

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -1,6 +1,12 @@
-name: Build and Unit Test GA Provider
+name: Terraform Build and Unit Test
 
-permissions: read-all
+permissions:
+  actions: read
+  contents: read
+  statuses: write
+
+env:
+  status_suffix: "-build-and-unit-tests"
 
 on:
   workflow_dispatch:
@@ -14,36 +20,90 @@ on:
         required: false
         default: 'terraform-provider-google'
       branch:
-        description: 'The branch or sha to execute against'
+        description: 'The branch or sha of the provider execute against'
+        required: true
+      sha:
+        description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
 
+concurrency:
+  group: test-tpg-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}
+  cancel-in-progress: true
+
 jobs:
-  build-and-test:
+  build-and-unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
       with:
-        repository: ${{ github.event.client_payload.owner }}/${{ github.event.client_payload.repo }}
-        ref: ${{ github.event.client_payload.branch }}
+        repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
+        ref: ${{ github.event.inputs.branch }}
         path: provider
+        fetch-depth: 2
+    - name: Check for Code Changes
+      id: pull_request
+      run: |
+        cd provider
+        gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
+        echo "url=${html_url}" >> $GITHUB_OUTPUT
+        if [ -z "$gofiles" ]; then
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+        fi
+    - name: Get Job URL
+      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
+      id: get_job
+      run: |
+        response=$(curl --get -Ss -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs")
+        html_url=$(echo "$response" | jq -r --arg job_name "${{ github.job }}" '.jobs | map(select(.name == $job_name)) | .[0].html_url')
+        echo "url=${html_url}" >> $GITHUB_OUTPUT
+    - name: Post Pending Status to Pull Request
+      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
+      run: |
+        curl -X POST -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/${{github.event.inputs.sha}}" \
+        -d '{
+        "context": "${{ github.event.inputs.repo }}${{ env.status_suffix }}",
+        "target_url": "${{ steps.get_job.outputs.url }}",
+        "state": "pending"
+        }'
     - name: Set up Go
+      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       uses: actions/setup-go@v4
       with:
         go-version: '^1.19.1'
-    - name: Build
+    - name: Build Provider
+      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
         cd provider
         go build
-    - name: Lint
-      run: |
-        cd provider
-        make lint
-      if: ${{ always() }} # This step will always run, even if the previous fails
-    - name: Test
+    - name: Run Unit Tests
+      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
         cd provider
         make test
-      if: ${{ always() }} # This step will always run, even if the previous fails
-
-
+    - name: Lint Check
+      if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
+      run: |
+        cd provider
+        make lint
+    - name: Documentation Check
+      if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
+      run: |
+        cd provider
+        make docscheck
+    - name: Post Result Status to Pull Request
+      if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
+      run: |
+        curl -X POST -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/${{github.event.inputs.sha}}" \
+        -d '{
+        "context": "${{ github.event.inputs.repo }}${{ env.status_suffix }}",
+        "target_url": "${{ steps.get_job.outputs.url }}",
+        "state": "${{ job.status }}"
+        }'

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -28,9 +28,9 @@ jobs:
         ref: ${{ github.event.client_payload.branch }}
         path: provider
     - name: Set up Go
-      uses: golang/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: '1.19.x'
+        go-version: '^1.19.1'
     - name: Build
       run: |
         cd provider

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -47,7 +47,6 @@ jobs:
       run: |
         cd provider
         gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
-        echo "url=${html_url}" >> $GITHUB_OUTPUT
         if [ -z "$gofiles" ]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -1,4 +1,4 @@
-name: Terraform Build and Unit Test
+name: Provider Build and Unit Test
 
 permissions:
   actions: read


### PR DESCRIPTION
Transition provider units test and builds to run as a github action.

The following changes have been made:
 - Condensed separate statuses for build and lint into a single status.
 - Details link will bring to you directly to the associated workflow job
 - Unit tests will only run if the build compiles
 - Code checkout, build, unit tests linting and status updating is done directly on the github action
 
 The following features were retained:
  - only build and run unit tests if there are code changes
  - Check for code changes and conditionally run based on this
  - Always run linter and docs check if even if code fails to compile
  
Build run examples
 - [compilation failures](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/4888787703/jobs/8726763523)
 - [skipped due to no code changes](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/4889010745/jobs/8727178431)
 - [happy path](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/4889099279/jobs/8727344225)
 
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
