### PR TITLE
Add support for Empty Dir Volumes and the Container Dependencies to Cloud Run v2

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -556,6 +556,7 @@ properties:
                         The different types of medium supported for EmptyDir.
                       values:
                         - :MEMORY
+                      default_value: :MEMORY
                     - !ruby/object:Api::Type::String
                       name: 'sizeLimit'
                       description: |-

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -95,6 +95,7 @@ examples:
       secret_id: 'secret'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_job_emptydir'
+    min_version: 'beta'
     primary_resource_id: 'default'
     primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-job%s\", context[\"random_suffix\"\
       ])"
@@ -545,6 +546,7 @@ properties:
                   name: 'emptyDir'
                   description: |-
                     Ephemeral storage used as a shared volume.
+                  min_version: beta
                   # exactly_one_of:
                   #   - template.0.template.0.volumes.0.secret
                   #   - template.0.template.0.volumes.0.cloudSqlInstance

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -93,6 +93,13 @@ examples:
     vars:
       cloud_run_job_name: 'cloudrun-job'
       secret_id: 'secret'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudrunv2_job_emptydir'
+    primary_resource_id: 'default'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-job%s\", context[\"random_suffix\"\
+      ])"
+    vars:
+      cloud_run_job_name: 'cloudrun-job'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -488,6 +488,7 @@ properties:
                   # exactly_one_of:
                   #   - template.0.template.0.volumes.0.secret
                   #   - template.0.template.0.volumes.0.cloudSqlInstance
+                  #   - template.0.template.0.volumes.0.emptyDir
                   properties:
                     - !ruby/object:Api::Type::String
                       name: 'secret'
@@ -526,12 +527,32 @@ properties:
                   # exactly_one_of:
                   #   - template.0.template.0.volumes.0.secret
                   #   - template.0.template.0.volumes.0.cloudSqlInstance
+                  #   - template.0.template.0.volumes.0.emptyDir
                   properties:
                     - !ruby/object:Api::Type::Array
                       name: 'instances'
                       description: |-
                         The Cloud SQL instance connection names, as can be found in https://console.cloud.google.com/sql/instances. Visit https://cloud.google.com/sql/docs/mysql/connect-run for more information on how to connect Cloud SQL and Cloud Run. Format: {project}:{location}:{instance}
                       item_type: Api::Type::String
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'emptyDir'
+                  description: |-
+                    Ephemeral storage used as a shared volume.
+                  # exactly_one_of:
+                  #   - template.0.template.0.volumes.0.secret
+                  #   - template.0.template.0.volumes.0.cloudSqlInstance
+                  #   - template.0.template.0.volumes.0.emptyDir
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: 'medium'
+                      description: |-
+                        The different types of medium supported for EmptyDir.
+                      values:
+                        - :MEMORY
+                    - !ruby/object:Api::Type::String
+                      name: 'sizeLimit'
+                      description: |-
+                          Limit on the storage usable by this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. This field's values are of the 'Quantity' k8s type: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir.
           - !ruby/object:Api::Type::String
             name: 'timeout'
             description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -106,6 +106,7 @@ examples:
       secret_id: 'secret-1'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_service_multicontainer'
+    min_version: 'beta'
     primary_resource_id: 'default'
     primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-service%s\", context[\"\
       random_suffix\"])"
@@ -585,6 +586,7 @@ properties:
               name: 'dependsOn'
               description: |-
                 Containers which should be started before this container. If specified the container will wait to start until all containers with the listed names are healthy.
+              min_version: beta
               item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'volumes'
@@ -653,6 +655,7 @@ properties:
               name: 'emptyDir'
               description: |-
                 Ephemeral storage used as a shared volume.
+              min_version: beta
               # exactly_one_of:
               #   - template.0.volumes.0.secret
               #   - template.0.volumes.0.cloudSqlInstance

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -597,6 +597,7 @@ properties:
               # exactly_one_of:
               #   - template.0.volumes.0.secret
               #   - template.0.volumes.0.cloudSqlInstance
+              #   - template.0.volumes.0.emptyDir
               properties:
                 - !ruby/object:Api::Type::String
                   name: 'secret'
@@ -634,12 +635,32 @@ properties:
               # exactly_one_of:
               #   - template.0.volumes.0.secret
               #   - template.0.volumes.0.cloudSqlInstance
+              #   - template.0.volumes.0.emptyDir
               properties:
                 - !ruby/object:Api::Type::Array
                   name: 'instances'
                   description: |-
                     The Cloud SQL instance connection names, as can be found in https://console.cloud.google.com/sql/instances. Visit https://cloud.google.com/sql/docs/mysql/connect-run for more information on how to connect Cloud SQL and Cloud Run. Format: {project}:{location}:{instance}
                   item_type: Api::Type::String
+            - !ruby/object:Api::Type::NestedObject
+              name: 'emptyDir'
+              description: |-
+                Ephemeral storage used as a shared volume.
+              # exactly_one_of:
+              #   - template.0.volumes.0.secret
+              #   - template.0.volumes.0.cloudSqlInstance
+              #   - template.0.volumes.0.emptyDir
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: 'medium'
+                  description: |-
+                    The different types of medium supported for EmptyDir.
+                  values:
+                    - :MEMORY
+                - !ruby/object:Api::Type::String
+                  name: 'sizeLimit'
+                  description: |-
+                      Limit on the storage usable by this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. This field's values are of the 'Quantity' k8s type: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir.
       - !ruby/object:Api::Type::Enum
         name: 'executionEnvironment'
         description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -664,6 +664,7 @@ properties:
                     The different types of medium supported for EmptyDir.
                   values:
                     - :MEMORY
+                  default_value: :MEMORY
                 - !ruby/object:Api::Type::String
                   name: 'sizeLimit'
                   description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -253,7 +253,7 @@ properties:
       - !ruby/object:Api::Type::Array
         name: 'containers'
         description: |-
-          Holds the single container that defines the unit of execution for this task.
+          Holds the containers that define the unit of execution for this Service.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String
@@ -574,6 +574,11 @@ properties:
                         The name of the service to place in the gRPC HealthCheckRequest
                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
                         If this is not specified, the default behavior is defined by gRPC.
+            - !ruby/object:Api::Type::Array
+              name: 'dependsOn'
+              description: |-
+                Containers which should be started before this container. If specified the container will wait to start until all containers with the listed names are healthy.
+              item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'volumes'
         description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -104,6 +104,13 @@ examples:
     vars:
       cloud_run_service_name: 'cloudrun-service'
       secret_id: 'secret-1'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudrunv2_service_multicontainer'
+    primary_resource_id: 'default'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-service%s\", context[\"\
+      random_suffix\"])"
+    vars:
+      cloud_run_service_name: 'cloudrun-service'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'

--- a/mmv1/products/cloudrunv2/product.yaml
+++ b/mmv1/products/cloudrunv2/product.yaml
@@ -20,6 +20,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://run.googleapis.com/v2/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://run.googleapis.com/v2/
 apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: Cloud Run API

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir.tf.erb
@@ -1,4 +1,5 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
   launch_stage = "BETA"

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir.tf.erb
@@ -1,0 +1,29 @@
+resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
+  location = "us-central1"
+  launch_stage = "BETA"
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+	volume_mounts {
+	  name = "empty-dir-volume"
+	  mount_path = "/mnt"
+	}
+      }
+      volumes {
+        name = "empty-dir-volume"
+	empty_dir {
+	  medium = "MEMORY"
+	  size_limit = "128Mi"
+	}
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_multicontainer.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_multicontainer.tf.erb
@@ -1,8 +1,9 @@
 resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
   location = "us-central1"
-  ingress = "INGRESS_TRAFFIC_ALL"
   launch_stage = "BETA"
+  ingress = "INGRESS_TRAFFIC_ALL"
   template {
     containers {
       name = "hello-1"

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_multicontainer.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_multicontainer.tf.erb
@@ -1,0 +1,37 @@
+resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+  location = "us-central1"
+  ingress = "INGRESS_TRAFFIC_ALL"
+  launch_stage = "BETA"
+  template {
+    containers {
+      name = "hello-1"
+      ports {
+        container_port = 8080
+      }
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      depends_on = ["hello-2"]
+      volume_mounts {
+        name = "empty-dir-volume"
+	mount_path = "/mnt"
+      }
+    }
+    containers {
+      name = "hello-2"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    volumes {
+      name = "empty-dir-volume"
+      empty_dir {
+        medium = "MEMORY"
+        size_limit = "256Mi"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}


### PR DESCRIPTION
Adds support for the Empty Dir volume type in Cloud Run v2 Services and Jobs as well as Service container dependencies using the depends_on container field.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: Added the beta field `template.containers.depends_on` to `google_cloud_run_v2_service`.
```
```release-note:enhancement
cloudrunv2: Added the beta field `template.volumes.empty_dir` to `google_cloud_run_v2_service`.
```
```release-note:enhancement
cloudrunv2: Added the beta field `template.template.volumes.empty_dir` to `google_cloud_run_v2_job`.
```
