### PR TITLE
upgrade terraform core to 1.2.5 for VCR

### DIFF
--- a/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/gcb-terraform-vcr-tester/Dockerfile
@@ -12,8 +12,8 @@ ENV PATH $PATH:/root/google-cloud-sdk/bin
 
 ADD test_terraform_vcr.sh /test_terraform_vcr.sh
 
-RUN wget https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip
-RUN unzip terraform_1.1.8_linux_amd64.zip && rm terraform_1.1.8_linux_amd64.zip
+RUN wget https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_linux_amd64.zip
+RUN unzip terraform_1.2.5_linux_amd64.zip && rm terraform_1.2.5_linux_amd64.zip
 RUN mv ./terraform /bin/terraform
 
 ENTRYPOINT ["/test_terraform_vcr.sh"]


### PR DESCRIPTION
note terraform 1.2.5 is already used by team-city

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
