### PR TITLE
Added publish_to_stackdriver field in google_data_loss_prevention_job_trigger resource

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -89,6 +89,11 @@ examples:
       trigger: 'trigger'
     test_env_vars:
       project: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dlp_job_trigger_publish_to_stackdriver'
+    primary_resource_id: 'publish_to_stackdriver'
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/wrap_object.go.erb
   custom_import: templates/terraform/custom_import/dlp_import.go.erb
@@ -892,6 +897,7 @@ properties:
                 - publish_summary_to_cscc
                 - job_notification_emails
                 - deidentify
+                - publish_to_stackdriver
               description: |
                 If set, the detailed findings will be persisted to the specified OutputStorageConfig. Only a single instance of this action can be specified. Compatible with: Inspect, Risk
               properties:
@@ -948,6 +954,7 @@ properties:
                 - publish_summary_to_cscc
                 - job_notification_emails
                 - deidentify
+                - publish_to_stackdriver
               description: |
                 Publish a message into a given Pub/Sub topic when the job completes.
               properties:
@@ -965,6 +972,7 @@ properties:
                 - publish_summary_to_cscc
                 - job_notification_emails
                 - deidentify
+                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -979,6 +987,7 @@ properties:
                 - publish_summary_to_cscc
                 - job_notification_emails
                 - deidentify
+                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -993,6 +1002,7 @@ properties:
                 - publish_summary_to_cscc
                 - job_notification_emails
                 - deidentify
+                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -1007,6 +1017,7 @@ properties:
                 - publish_summary_to_cscc
                 - job_notification_emails
                 - deidentify
+                - publish_to_stackdriver
               description: |
                 Create a de-identified copy of the requested table or files.
               properties:
@@ -1085,3 +1096,18 @@ properties:
                             The ID of the table. The ID must contain only letters (a-z,
                             A-Z), numbers (0-9), or underscores (_). The maximum length
                             is 1,024 characters.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'publishToStackdriver'
+              exactly_one_of:
+                - save_findings
+                - pub_sub
+                - publish_findings_to_cloud_data_catalog
+                - publish_summary_to_cscc
+                - job_notification_emails
+                - deidentify
+                - publish_to_stackdriver
+              allow_empty_object: true
+              send_empty_value: true
+              properties: []
+              description: |
+                Enable Stackdriver metric dlp.googleapis.com/findingCount.

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_publish_to_stackdriver.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_publish_to_stackdriver.tf.erb
@@ -1,0 +1,25 @@
+resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id] %>" {
+  parent       = "projects/<%= ctx[:test_env_vars]['project'] %>"
+  description  = "Description for the job_trigger created by terraform"
+  display_name = "TerraformDisplayName"
+
+  triggers {
+    schedule {
+      recurrence_period_duration = "86400s"
+    }
+  }
+
+  inspect_job {
+    inspect_template_name = "sample-inspect-template"
+    actions {
+      publish_to_stackdriver {}
+    }
+    storage_config {
+      cloud_storage_options {
+        file_set {
+          url = "gs://mybucket/directory/"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added support for `publish_to_stackdriver` field in the `google_data_loss_prevention_job_trigger` resource.
fixes https://github.com/hashicorp/terraform-provider-google/issues/13768

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `publish_to_stackdriver` field to `google_data_loss_prevention_job_trigger` resource
```
