### PR TITLE
Add `status` output field to `google_cloudfunctions_function` to resource and data source.

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -459,6 +459,11 @@ func ResourceCloudFunctionsFunction() *schema.Resource {
 					},
 				},
 			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Describes the current stage of a deployment.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -703,6 +708,10 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 
 	if err := d.Set("secret_volumes", flattenSecretVolumes(function.SecretVolumes)); err != nil {
 		return fmt.Errorf("Error setting secret_volumes: %s", err)
+	}
+
+	if err := d.Set("status", function.Status); err != nil {
+		return fmt.Errorf("Error setting status: %s", err)
 	}
 
 	if function.HttpsTrigger != nil {

--- a/mmv1/third_party/terraform/tests/data_source_google_cloudfunctions_function_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_cloudfunctions_function_test.go
@@ -2,9 +2,10 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -29,6 +30,8 @@ func TestAccDataSourceGoogleCloudFunctionsFunction_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceState(funcDataNameHttp,
 						"google_cloudfunctions_function.function_http"),
+					resource.TestCheckResourceAttr(funcDataNameHttp,
+						"status", "ACTIVE"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -285,6 +285,8 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 						"min_instances", "3"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"ingress_settings", "ALLOW_INTERNAL_ONLY"),
+					resource.TestCheckResourceAttr(funcResourceName,
+						"status", "ACTIVE"),
 					testAccCloudFunctionsFunctionSource(fmt.Sprintf("gs://%s/index.zip", bucketName), &function),
 					testAccCloudFunctionsFunctionTrigger(FUNCTION_TRIGGER_HTTP, &function),
 					resource.TestCheckResourceAttr(funcResourceName,
@@ -390,7 +392,6 @@ func TestAccCloudFunctionsFunction_buildworkerpool(t *testing.T) {
 	zipFilePath := createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
 	proj := acctest.GetTestProjectFromEnv()
 
-
 	defer os.Remove(zipFilePath) // clean up
 
 	VcrTest(t, resource.TestCase{
@@ -438,9 +439,9 @@ func TestAccCloudFunctionsFunction_pubsub(t *testing.T) {
 				Config: testAccCloudFunctionsFunction_pubsub(functionName, bucketName,
 					topicName, zipFilePath),
 				Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(funcResourceName,
-            "max_instances", "3000"),
-        ),
+					resource.TestCheckResourceAttr(funcResourceName,
+						"max_instances", "3000"),
+				),
 			},
 			{
 				ResourceName:            funcResourceName,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds [the status field](https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#cloudfunctionstatus) to `google_cloudfunctions_function` as a computed output/attribute. The data source is implemented using methods and schemas from the resource, so this change impacts both the resource and data source.

I've updated acceptance tests for the resource and data source to assert the field is there and takes the expected value.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudfunctions: added `status` attribute to the `google_cloudfunctions_function` resource and data source
```
