### PR TITLE
Support new machine types for regional commitment

### DIFF
--- a/mmv1/products/compute/RegionCommitment.yaml
+++ b/mmv1/products/compute/RegionCommitment.yaml
@@ -158,7 +158,7 @@ properties:
             Name of the accelerator type resource. Applicable only when the type is ACCELERATOR.
   - !ruby/object:Api::Type::String
     name: 'type'
-    output: true
+    default_from_api: true
     description: |
       The type of commitment, which affects the discount rate and the eligible resources.
       The type could be one of the following value: `MEMORY_OPTIMIZED`, `ACCELERATOR_OPTIMIZED`, 


### PR DESCRIPTION
Supporting new types of compute for regional commitment.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests. - **test failed because of "google-beta/resource_compute_subnetwork.go:43:22: undefined: cidr"**
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know) **- Same**
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
compute: added support for additional machine types in `google_compute_region_commitment`
```
