### PR TITLE
Remove concurrency group

### DIFF
--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -25,11 +25,7 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
-
-concurrency:
-  group: test-tpg-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}
-  cancel-in-progress: true
-
+        
 jobs:
   build-and-unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's troubling that there are concurrency conflicts. I'm not sure why this might be the case! It's possible using inputs as parameters to the concurrency group is causing this issue? This is a blind attempt to patch it in the meantime


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
