### PR TITLE
fix tpg/tpgb unit test concurrency conflict

### DIFF
--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -242,7 +242,7 @@ steps:
           - GoogleCloudPlatform/magic-modules  # remove after 07/2023
           - "21"                               # remove after 07/2023
       env:
-        - VERSION=beta
+        - VERSION=ga
         - COMMIT_SHA=$COMMIT_SHA
         - PR_NUMBER=$_PR_NUMBER
 


### PR DESCRIPTION
concurrency conflict in the sky is now resolved.. ga tests weren't getting run

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
