### PR TITLE
Allow adding copyright headers to non-templated files in downstream-selective way

### DIFF
--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -143,7 +143,7 @@ module Provider
 
           FileUtils.copy_entry source, target_file
 
-          add_hashicorp_copyright_header(output_folder, target)
+          add_hashicorp_copyright_header(output_folder, target) if File.extname(target) == '.go'
           replace_import_path(output_folder, target) if File.extname(target) == '.go'
         end
       end.map(&:join)

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -200,7 +200,7 @@ module Provider
     def add_hashicorp_copyright_header(output_folder, target)
       # only add copyright headers when generating TPG and TPGB
       return unless output_folder.end_with?('terraform-provider-google') ||
-        output_folder.end_with?('terraform-provider-google-beta')
+                    output_folder.end_with?('terraform-provider-google-beta')
 
       # Prevent adding copyright header to files with paths matching the strings below
       ignored_folders = [
@@ -219,21 +219,21 @@ module Provider
       should_add_header = true
       ignored_folders.each do |folder|
         # folder will be path leading to file
-        if target.start_with? folder
-          Google::LOGGER.debug 'Not adding HashiCorp copyright headers in ' +
-            "ignored folder #{folder} : #{target}"
-          should_add_header = false
-        end
+        next unless target.start_with? folder
+
+        Google::LOGGER.debug 'Not adding HashiCorp copyright headers in ' \
+                             "ignored folder #{folder} : #{target}"
+        should_add_header = false
       end
       return unless should_add_header
 
       ignored_files.each do |file|
         # file will be the filename and extension, with no preceding path
-        if target.end_with? file
-          Google::LOGGER.debug 'Not adding HashiCorp copyright headers to ' +
-            "ignored file #{file} : #{target}"
-          should_add_header = false
-        end
+        next unless target.end_with? file
+
+        Google::LOGGER.debug 'Not adding HashiCorp copyright headers to ' \
+                             "ignored file #{file} : #{target}"
+        should_add_header = false
       end
       return unless should_add_header
 

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -198,6 +198,11 @@ module Provider
     end
 
     def add_hashicorp_copyright_header(output_folder, target)
+      unless expected_output_folder?(output_folder)
+        Google::LOGGER.info "Unexpected output folder (#{output_folder}) detected " \
+                            'when deciding to add HashiCorp copyright headers. ' \
+                            'Watch out for unexpected changes to copied files'
+      end
       # only add copyright headers when generating TPG and TPGB
       return unless output_folder.end_with?('terraform-provider-google') ||
                     output_folder.end_with?('terraform-provider-google-beta')
@@ -255,6 +260,24 @@ module Provider
       File.write("#{output_folder}/#{target}", header)
 
       File.write("#{output_folder}/#{target}", data, mode: 'a') # append mode
+    end
+
+    def expected_output_folder?(output_folder)
+      expected_folders = %w[
+        terraform-provider-google
+        terraform-provider-google-beta
+        terraform-next
+        terraform-google-conversion
+      ]
+      folder_name = output_folder.split('/')[-1]
+      is_expected = false
+      expected_folders.each do |folder|
+        next unless folder_name == folder
+
+        is_expected = true
+        break
+      end
+      is_expected
     end
 
     def replace_import_path(output_folder, target)

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -198,32 +198,44 @@ module Provider
     end
 
     def add_hashicorp_copyright_header(output_folder, target)
-      return unless @target_version_name == 'ga' || @target_version_name == 'beta' # only add copyright headers when generating TPG and TPGB
+      # only add copyright headers when generating TPG and TPGB
+      return unless @target_version_name == 'ga' || @target_version_name == 'beta'
 
       # Prevent adding copyright header to files with paths matching the strings below
       # This will be refactored
-      ignored_folders = ['.github/', '.release/', '.changelog/', 'examples/', 'META.d/']
-      ignored_files = [ 'go.mod', '.goreleaser.yml', '.golangci.yml', 'terraform-registry-manifest.json']
+      ignored_folders = [
+        '.github/',
+        '.release/',
+        '.changelog/',
+        'examples/',
+        'META.d/'
+      ]
+      ignored_files = [
+        'go.mod',
+        '.goreleaser.yml',
+        '.golangci.yml',
+        'terraform-registry-manifest.json'
+      ]
 
       ignored_folders.each do |folder|
-          # folder will be path leading to file
-          if target.start_with? folder
-            Google::LOGGER.info "[SARAH FRENCH] NOT adding copyright header to files in folder #{folder} : #{target}"
-            return
-          end
+        # folder will be path leading to file
+        if target.start_with? folder
+          Google::LOGGER.info "[SARAH FRENCH] NOT adding header to : #{target}"
+          return
+        end
       end
       ignored_files.each do |file|
-          # file will be the filename and extension, with no preceding path
-          if target.end_with? file
-            Google::LOGGER.info "[SARAH FRENCH] NOT adding copyright header to file #{file} : #{target}"
-            return
-          end
+        # file will be the filename and extension, with no preceding path
+        if target.end_with? file
+          Google::LOGGER.info "[SARAH FRENCH] NOT adding header to : #{target}"
+          return
+        end
       end
 
-      Google::LOGGER.info "[SARAH FRENCH] adding copyright header to file : #{target}"
+      Google::LOGGER.info "[SARAH FRENCH] adding header to file : #{target}"
       data = File.read("#{output_folder}/#{target}")
       File.write("#{output_folder}/#{target}", "// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n")
-      File.write("#{output_folder}/#{target}", data, mode: "a") # append mode adds file content after previous write(s)
+      File.write("#{output_folder}/#{target}", data, mode: 'a') # append mode adds file content after previous write(s)
     end
 
     def replace_import_path(output_folder, target)

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -202,12 +202,12 @@ module Provider
       
       # Prevent adding copyright header to files with paths matching the strings below
       # This will be refactored
-      ignored_files = [ "go.mod", ".goreleaser.yml", ".golangci.yml", "terraform-registry-manifest.json", ".github/", ".release/", ".changelog/", "examples/", "run_diff.sh"]
+      ignored_files = [ 'go.mod', '.goreleaser.yml', '.golangci.yml', 'terraform-registry-manifest.json', '.github/', '.release/', '.changelog/', 'examples/', 'run_diff.sh']
       ignored_files.each do |name|
           return if target.contains? name
       end
       data = File.read("#{output_folder}/#{target}")
-      File.write("#{output_folder}/#{target}", "// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\nThis header was added by the `add_hashicorp_copyright_header` method\n")
+      File.write("#{output_folder}/#{target}", '// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\nThis header was added by the `add_hashicorp_copyright_header` method\n')
       File.write("#{output_folder}/#{target}", data, mode: "a") # append mode adds file content after previous write
     end
 

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -216,25 +216,31 @@ module Provider
         '.golangci.yml',
         'terraform-registry-manifest.json'
       ]
-
+      should_add_header = true
       ignored_folders.each do |folder|
         # folder will be path leading to file
         if target.start_with? folder
           Google::LOGGER.info "[SARAH FRENCH] NOT adding header to : #{target}"
-          return
+          should_add_header = false
         end
       end
+      return unless should_add_header
+
       ignored_files.each do |file|
         # file will be the filename and extension, with no preceding path
         if target.end_with? file
           Google::LOGGER.info "[SARAH FRENCH] NOT adding header to : #{target}"
-          return
+          should_add_header = false
         end
       end
+      return unless should_add_header
 
       Google::LOGGER.info "[SARAH FRENCH] adding header to file : #{target}"
       data = File.read("#{output_folder}/#{target}")
-      File.write("#{output_folder}/#{target}", "// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n")
+      File.write(
+        "#{output_folder}/#{target}",
+        "// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n"
+      )
       File.write("#{output_folder}/#{target}", data, mode: 'a') # append mode adds file content after previous write(s)
     end
 

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -270,7 +270,7 @@ module Provider
         terraform-next
         terraform-google-conversion
       ]
-      folder_name = output_folder.split('/')[-1]
+      folder_name = output_folder.split('/')[-1] # Possible issue with Windows OS
       is_expected = false
       expected_folders.each do |folder|
         next unless folder_name == folder

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -199,7 +199,8 @@ module Provider
 
     def add_hashicorp_copyright_header(output_folder, target)
       # only add copyright headers when generating TPG and TPGB
-      return unless output_folder.end_with?('terraform-provider-google') || output_folder.end_with?('terraform-provider-google-beta')
+      return unless output_folder.end_with?('terraform-provider-google') ||
+        output_folder.end_with?('terraform-provider-google-beta')
 
       # Prevent adding copyright header to files with paths matching the strings below
       ignored_folders = [
@@ -219,7 +220,8 @@ module Provider
       ignored_folders.each do |folder|
         # folder will be path leading to file
         if target.start_with? folder
-          Google::LOGGER.debug "Not adding HashiCorp copyright headers in ignored folder #{folder} : #{target}"
+          Google::LOGGER.debug 'Not adding HashiCorp copyright headers in ' +
+            "ignored folder #{folder} : #{target}"
           should_add_header = false
         end
       end
@@ -228,7 +230,8 @@ module Provider
       ignored_files.each do |file|
         # file will be the filename and extension, with no preceding path
         if target.end_with? file
-          Google::LOGGER.debug "Not adding HashiCorp copyright headers to ignored file #{file} : #{target}"
+          Google::LOGGER.debug 'Not adding HashiCorp copyright headers to ' +
+            "ignored file #{file} : #{target}"
           should_add_header = false
         end
       end
@@ -237,7 +240,7 @@ module Provider
       Google::LOGGER.debug "Adding HashiCorp copyright header to : #{target}"
       data = File.read("#{output_folder}/#{target}")
 
-      copyright_header = ['Copyright (c) HashiCorp, Inc','SPDX-License-Identifier: MPL-2.0']
+      copyright_header = ['Copyright (c) HashiCorp, Inc', 'SPDX-License-Identifier: MPL-2.0']
       lang = language_from_filename(target)
 
       # Some file types we don't want to add headers to
@@ -448,18 +451,20 @@ module Provider
       end
 
       header_string = header.join("\n")
-      header_string += "\n" # add trailing newline
+      "#{header_string}\n" # add trailing newline to returned value
     end
 
     def language_from_filename(filename)
-      extension = filename.split(".")[-1] 
+      extension = filename.split('.')[-1]
       case extension
-      when "go"
-        return :go
-      when "rb"
-        return :ruby
-      when "sh"
-        return :bash
+      when 'go'
+        :go
+      when 'rb'
+        :ruby
+      when 'yaml', 'yml'
+        :yaml
+      when 'sh'
+        :bash
       else
         raise "Unknown language for file extension: #{extension}"
       end

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -199,16 +199,31 @@ module Provider
 
     def add_hashicorp_copyright_header(output_folder, target)
       return unless @target_version_name == 'ga' || @target_version_name == 'beta' # only add copyright headers when generating TPG and TPGB
-      
+
       # Prevent adding copyright header to files with paths matching the strings below
       # This will be refactored
-      ignored_files = [ 'go.mod', '.goreleaser.yml', '.golangci.yml', 'terraform-registry-manifest.json', '.github/', '.release/', '.changelog/', 'examples/', 'run_diff.sh']
-      ignored_files.each do |name|
-          return if target.contains? name
+      ignored_folders = ['.github/', '.release/', '.changelog/', 'examples/', 'META.d/']
+      ignored_files = [ 'go.mod', '.goreleaser.yml', '.golangci.yml', 'terraform-registry-manifest.json']
+
+      ignored_folders.each do |folder|
+          # folder will be path leading to file
+          if target.start_with? folder
+            Google::LOGGER.info "[SARAH FRENCH] NOT adding copyright header to files in folder #{folder} : #{target}"
+            return
+          end
       end
+      ignored_files.each do |file|
+          # file will be the filename and extension, with no preceding path
+          if target.end_with? file
+            Google::LOGGER.info "[SARAH FRENCH] NOT adding copyright header to file #{file} : #{target}"
+            return
+          end
+      end
+
+      Google::LOGGER.info "[SARAH FRENCH] adding copyright header to file : #{target}"
       data = File.read("#{output_folder}/#{target}")
-      File.write("#{output_folder}/#{target}", '// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\nThis header was added by the `add_hashicorp_copyright_header` method\n')
-      File.write("#{output_folder}/#{target}", data, mode: "a") # append mode adds file content after previous write
+      File.write("#{output_folder}/#{target}", "// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n")
+      File.write("#{output_folder}/#{target}", data, mode: "a") # append mode adds file content after previous write(s)
     end
 
     def replace_import_path(output_folder, target)

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -248,7 +248,7 @@ module Provider
       Google::LOGGER.debug "Adding HashiCorp copyright header to : #{target}"
       data = File.read("#{output_folder}/#{target}")
 
-      copyright_header = ['Copyright (c) HashiCorp, Inc', 'SPDX-License-Identifier: MPL-2.0']
+      copyright_header = ['Copyright (c) HashiCorp, Inc.', 'SPDX-License-Identifier: MPL-2.0']
       lang = language_from_filename(target)
 
       # Some file types we don't want to add headers to

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -241,7 +241,7 @@ module Provider
         "#{output_folder}/#{target}",
         "// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n"
       )
-      File.write("#{output_folder}/#{target}", data, mode: 'a') # append mode adds file content after previous write(s)
+      File.write("#{output_folder}/#{target}", data, mode: 'a') # append mode
     end
 
     def replace_import_path(output_folder, target)

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -202,7 +202,6 @@ module Provider
       return unless output_folder.end_with?('terraform-provider-google') || output_folder.end_with?('terraform-provider-google-beta')
 
       # Prevent adding copyright header to files with paths matching the strings below
-      # This will be refactored
       ignored_folders = [
         '.github/',
         '.release/',
@@ -220,7 +219,7 @@ module Provider
       ignored_folders.each do |folder|
         # folder will be path leading to file
         if target.start_with? folder
-          Google::LOGGER.info "[SARAH FRENCH] NOT adding header to : #{target}"
+          Google::LOGGER.debug "Not adding HashiCorp copyright headers in ignored folder #{folder} : #{target}"
           should_add_header = false
         end
       end
@@ -229,13 +228,13 @@ module Provider
       ignored_files.each do |file|
         # file will be the filename and extension, with no preceding path
         if target.end_with? file
-          Google::LOGGER.info "[SARAH FRENCH] NOT adding header to : #{target}"
+          Google::LOGGER.debug "Not adding HashiCorp copyright headers to ignored file #{file} : #{target}"
           should_add_header = false
         end
       end
       return unless should_add_header
 
-      Google::LOGGER.info "[SARAH FRENCH] adding header to file : #{target}"
+      Google::LOGGER.debug "Adding HashiCorp copyright header to : #{target}"
       data = File.read("#{output_folder}/#{target}")
 
       copyright_header = ['Copyright (c) HashiCorp, Inc','SPDX-License-Identifier: MPL-2.0']
@@ -245,6 +244,7 @@ module Provider
       # because the headers are functional
       return unless lang != :bash
 
+      # File is not ignored and is appropriate file type to add header to
       header = comment_block(copyright_header, lang)
       File.write("#{output_folder}/#{target}", header)
 

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -246,8 +246,9 @@ module Provider
       lang = language_from_filename(target)
 
       # Some file types we don't want to add headers to
-      # because the headers are functional
-      return unless lang != :bash
+      # e.g. .sh where headers are functional
+      # Also, this guards against new filetypes being added and triggering build errors
+      return unless lang != :unsupported
 
       # File is not ignored and is appropriate file type to add header to
       header = comment_block(copyright_header, lang)
@@ -465,10 +466,8 @@ module Provider
         :ruby
       when 'yaml', 'yml'
         :yaml
-      when 'sh'
-        :bash
       else
-        raise "Unknown language for file extension: #{extension}"
+        :unsupported
       end
     end
   end

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -199,7 +199,7 @@ module Provider
 
     def add_hashicorp_copyright_header(output_folder, target)
       # only add copyright headers when generating TPG and TPGB
-      return unless @target_version_name == 'ga' || @target_version_name == 'beta'
+      return unless output_folder.end_with?('terraform-provider-google') || output_folder.end_with?('terraform-provider-google-beta')
 
       # Prevent adding copyright header to files with paths matching the strings below
       # This will be refactored

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -143,6 +143,7 @@ module Provider
 
           FileUtils.copy_entry source, target_file
 
+          add_hashicorp_copyright_header(output_folder, target)
           replace_import_path(output_folder, target) if File.extname(target) == '.go'
         end
       end.map(&:join)

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -202,7 +202,9 @@ module Provider
       return unless output_folder.end_with?('terraform-provider-google') ||
                     output_folder.end_with?('terraform-provider-google-beta')
 
-      # Prevent adding copyright header to files with paths matching the strings below
+      # Prevent adding copyright header to files with paths or names matching the strings below
+      # NOTE: these entries need to match the content of the .copywrite.hcl file originally
+      #       created in https://github.com/GoogleCloudPlatform/magic-modules/pull/7336
       ignored_folders = [
         '.github/',
         '.release/',

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -241,6 +241,10 @@ module Provider
       copyright_header = ['Copyright (c) HashiCorp, Inc','SPDX-License-Identifier: MPL-2.0']
       lang = language_from_filename(target)
 
+      # Some file types we don't want to add headers to
+      # because the headers are functional
+      return unless lang != :bash
+
       header = comment_block(copyright_header, lang)
       File.write("#{output_folder}/#{target}", header)
 
@@ -454,6 +458,8 @@ module Provider
         return :go
       when "rb"
         return :ruby
+      when "sh"
+        return :bash
       else
         raise "Unknown language for file extension: #{extension}"
       end

--- a/mmv1/provider/terraform/common~copy.yaml
+++ b/mmv1/provider/terraform/common~copy.yaml
@@ -111,5 +111,5 @@
 'website/<%= fname -%>': 'third_party/terraform/website/<%= fname -%>'
 <% end -%>
 <% end -%>
-'version': 'third_party/terraform/version'
+'version/version.go': 'third_party/terraform/version/version.go'
 'go.sum': 'third_party/terraform/go.sum'

--- a/mmv1/spec/hashicorp_copyright_spec.rb
+++ b/mmv1/spec/hashicorp_copyright_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'provider/core'
+
+describe 'Provider::Core.expected_output_folder?' do
+  # Inputs
+  config = 'foo'
+  api = Api::Compiler.new(File.read('spec/data/good-file.yaml')).run
+  version_name = 'ga'
+  start_time = Time.now
+
+  provider = Provider::Core.new(config, api, version_name, start_time)
+
+  it 'should identify `terraform-provider-google` as an expected output folder' do
+    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-provider-google'
+    expect(provider.expected_output_folder?(path)).to eq true
+  end
+
+  it 'should identify `terraform-provider-google-beta` as an expected output folder' do
+    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-provider-google-beta'
+    expect(provider.expected_output_folder?(path)).to eq true
+  end
+
+  it 'should identify `terraform-next` as an expected output folder' do
+    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-next'
+    expect(provider.expected_output_folder?(path)).to eq true
+  end
+
+  it 'should identify `terraform-google-conversion` as an expected output folder' do
+    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-google-conversion'
+    expect(provider.expected_output_folder?(path)).to eq true
+  end
+
+  it 'should identify `terraform-provider-google-unexpected-suffix` as an UNexpected output folder' do
+    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-provider-google-unexpected-suffix'
+    expect(provider.expected_output_folder?(path)).to eq false
+  end
+
+  it 'should identify `unexpected-prefix-terraform-provider-google` as an UNexpected output folder' do
+    path = '/User/PersonsName/go/src/github.com/hashicorp/unexpected-prefix-terraform-provider-google'
+    expect(provider.expected_output_folder?(path)).to eq false
+  end
+end

--- a/mmv1/spec/hashicorp_copyright_spec.rb
+++ b/mmv1/spec/hashicorp_copyright_spec.rb
@@ -1,8 +1,21 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'spec_helper'
 require 'provider/core'
 
 describe 'Provider::Core.expected_output_folder?' do
-  # Inputs
+  # Inputs for tests
   config = 'foo'
   api = Api::Compiler.new(File.read('spec/data/good-file.yaml')).run
   version_name = 'ga'
@@ -10,6 +23,7 @@ describe 'Provider::Core.expected_output_folder?' do
 
   provider = Provider::Core.new(config, api, version_name, start_time)
 
+  # rubocop:disable Layout/LineLength
   it 'should identify `terraform-provider-google` as an expected output folder' do
     path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-provider-google'
     expect(provider.expected_output_folder?(path)).to eq true
@@ -21,22 +35,23 @@ describe 'Provider::Core.expected_output_folder?' do
   end
 
   it 'should identify `terraform-next` as an expected output folder' do
-    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-next'
+    path = '/User/PersonsName/go/src/github.com/GoogleCloudPlatform/terraform-next'
     expect(provider.expected_output_folder?(path)).to eq true
   end
 
   it 'should identify `terraform-google-conversion` as an expected output folder' do
-    path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-google-conversion'
+    path = '/User/PersonsName/go/src/github.com/GoogleCloudPlatform/terraform-google-conversion'
     expect(provider.expected_output_folder?(path)).to eq true
   end
 
-  it 'should identify `terraform-provider-google-unexpected-suffix` as an UNexpected output folder' do
+  it 'should identify suffixed versions of expected folder names as unexpected' do
     path = '/User/PersonsName/go/src/github.com/hashicorp/terraform-provider-google-unexpected-suffix'
     expect(provider.expected_output_folder?(path)).to eq false
   end
 
-  it 'should identify `unexpected-prefix-terraform-provider-google` as an UNexpected output folder' do
+  it 'should identify prefixed versions of expected folder names as unexpected' do
     path = '/User/PersonsName/go/src/github.com/hashicorp/unexpected-prefix-terraform-provider-google'
     expect(provider.expected_output_folder?(path)).to eq false
   end
+  # rubocop:enable Layout/LineLength
 end

--- a/mmv1/third_party/terraform/acctest/gcp_sweeper.go
+++ b/mmv1/third_party/terraform/acctest/gcp_sweeper.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package acctest
 
 import (

--- a/mmv1/third_party/terraform/acctest/provider_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/provider_test_utils.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package acctest
 
 import (

--- a/mmv1/third_party/terraform/acctest/test_utils.go
+++ b/mmv1/third_party/terraform/acctest/test_utils.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package acctest
 
 import (

--- a/mmv1/third_party/terraform/acctest/vcr_utils.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package acctest
 
 import "os"

--- a/mmv1/third_party/terraform/data_sources/data_source_access_approval_folder_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_access_approval_folder_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_access_approval_organization_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_access_approval_organization_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_access_approval_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_access_approval_project_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_artifact_registry_repository.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_artifact_registry_repository.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_certificate_authority.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_certificate_authority.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_cloud_run_locations.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_cloud_run_locations.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_cloud_run_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_cloud_run_service.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_health_check.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_health_check.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_lb_ip_ranges.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_lb_ip_ranges.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_container_registry_image.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_container_registry_image.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_container_registry_repository.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_container_registry_repository.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_dns_keys.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_keys.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_managed_zone.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_dns_record_set.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_record_set.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_app_engine_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_app_engine_default_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connection.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connection.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connector.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connector.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_gateway.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_gateway.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloudbuild_trigger.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloudbuild_trigger.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions2_function.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions2_function.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions_function.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_composer_environment.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_composer_environment.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_composer_image_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_composer_image_versions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_address.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_address.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_bucket.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_bucket.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_service.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_default_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_disk.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_disk.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_forwarding_rule.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_forwarding_rule.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_global_address.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_global_address.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_ha_vpn_gateway.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_ha_vpn_gateway.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group_manager.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group_manager.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_serial_port.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_serial_port.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_network.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_network_endpoint_group.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_network_endpoint_group.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_ssl_certificate.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_ssl_certificate.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_router.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_router.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_router_nat.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_router_nat.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_certificate.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_certificate.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_policy.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_install_manifest.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_install_manifest.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_versions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_aws_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_aws_versions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_azure_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_azure_versions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_cluster.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_cluster.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_folder.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_folder_organization_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_folder_organization_policy.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_game_services_game_server_deployment_rollout.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_game_services_game_server_deployment_rollout.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_global_compute_forwarding_rule.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_global_compute_forwarding_rule.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_role.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_role.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret_ciphertext.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret_ciphertext.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_logging_project_cmek_settings.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_logging_project_cmek_settings.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_logging_sink.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_logging_sink.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_monitoring_uptime_check_ips.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_monitoring_uptime_check_ips.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_organization.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_organization.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_project.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_project_organization_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project_organization_policy.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_project_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project_service.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_projects.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_projects.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_access_token.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_access_token.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_id_token.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_id_token.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_jwt.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_jwt.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_key.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_key.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_networking_peered_dns_domain.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_sql_ca_certs.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_sql_ca_certs.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_project_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_iap_client.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_iap_client.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_istio_canonical_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_istio_canonical_service.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_notification_channel.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_notification_channel.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_app_engine.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_app_engine.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_cluster_istio.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_cluster_istio.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_mesh_istio.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_mesh_istio.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_test.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_pubsub_subscription.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_pubsub_topic.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_pubsub_topic.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_redis_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_redis_instance.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version_access.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version_access.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sourcerepo_repository.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sourcerepo_repository.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_spanner_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_spanner_instance.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_backup_run.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_backup_run.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_database.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_database.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_database_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_database_instance.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_database_instances.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_database_instances.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_databases.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_databases.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_storage_bucket_object_content.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_storage_bucket_object_content.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_tags_tag_key.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_tags_tag_key.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_tags_tag_value.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_tags_tag_value.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_models/provider_model.go.erb
+++ b/mmv1/third_party/terraform/framework_models/provider_model.go.erb
@@ -1,7 +1,4 @@
 <% autogen_exception -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -1,7 +1,4 @@
 <% autogen_exception -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -1,7 +1,4 @@
 <% autogen_exception -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_test_utils.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_test_utils.go.erb
@@ -1,7 +1,4 @@
 <% autogen_exception -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_transport.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_transport.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_utils.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_validators.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_validators.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package google
 
 import (

--- a/mmv1/third_party/terraform/main.go.erb
+++ b/mmv1/third_party/terraform/main.go.erb
@@ -1,7 +1,4 @@
 <% autogen_exception -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package main
 
 import (

--- a/mmv1/third_party/terraform/version/version.go
+++ b/mmv1/third_party/terraform/version/version.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package version
 
 var (


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

# Context

HashiCorp has this dependabot-style system for asserting that copyright headers are present in their public repos: https://github.com/hashicorp/terraform-provider-google/pull/13624

If we merge these automated PRs the changes will be lost as soon as the next update is merged from Magic Modules.

Instead, we need to update the code generator to add these headers 'at source'.

# Description

This PR adds the copyright headers to handwritten files that are shared between TPG/TPGB and terraform-google-conversion, but only when they're used to build TPG/TPGB.

The only files in terraform-google-conversion affected by this PR should be go.mod and go.sum

This PR corresponds to # 3 in the list below:


>1. Adding hardcoded headers to handwritten files that are used in TPG/TPGB and not used in terraform-google-conversion
>2. Provide Magic Modules with knowledge of what downstream it is making when logic in the templates is being evaluated, and have HashiCorp copyright be templated in only if TPG/TPGB is being generated.
>3. Handle handwritten files, specifically util files and packages like `transport`, that are copied into their downstream repo as-is and don't benefit from templating to introduce logic. The only edits to these files I'm aware of is the changing of import paths when the private version of the provider is built, and that's done without templating.

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
