### PR TITLE
Crv1 service annotation suppress

### DIFF
--- a/mmv1/templates/terraform/constants/cloud_run_service.go.erb
+++ b/mmv1/templates/terraform/constants/cloud_run_service.go.erb
@@ -15,6 +15,10 @@ func cloudrunAnnotationDiffSuppress(k, old, new string, d *schema.ResourceData) 
 		return true
 	}
 
+  	if strings.HasSuffix(k, "run.googleapis.com/ingress") {
+	      	return old == "all" && new == ""
+	}
+
 	// Let diff be determined by annotations (above)
 	if strings.Contains(k, "annotations.%") {
 		return true

--- a/mmv1/templates/terraform/constants/cloud_run_service.go.erb
+++ b/mmv1/templates/terraform/constants/cloud_run_service.go.erb
@@ -7,7 +7,7 @@ func revisionNameCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v i
 	return nil
 }
 
-var cloudRunGoogleProvidedAnnotations = regexp.MustCompile(`serving\.knative\.dev/(?:(?:creator)|(?:lastModifier))$|run\.googleapis\.com/(?:(?:ingress-status))$|cloud\.googleapis\.com/(?:(?:location))`)
+var cloudRunGoogleProvidedAnnotations = regexp.MustCompile(`serving\.knative\.dev/(?:(?:creator)|(?:lastModifier))$|run\.googleapis\.com/(?:(?:ingress-status)|(?:operation-id))$|cloud\.googleapis\.com/(?:(?:location))`)
 
 func cloudrunAnnotationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// Suppress diffs for the annotations provided by Google

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -9,6 +9,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestCloudrunAnnotationDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		K, Old, New        string
+		ExpectDiffSuppress bool
+	}{
+		"missing run.googleapis.com/operation-id": {
+			K:                  "metadata.0.annotations.run.googleapis.com/operation-id",
+			Old:                "12345abc",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"missing run.googleapis.com/ingress": {
+			K:                  "metadata.0.annotations.run.googleapis.com/ingress",
+			Old:                "all",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"explicit run.googleapis.com/ingress": {
+			K:                  "metadata.0.annotations.run.googleapis.com/ingress",
+			Old:                "all",
+			New:                "internal",
+			ExpectDiffSuppress: false,
+		},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			if got := cloudrunAnnotationDiffSuppress(tc.K, tc.Old, tc.New, nil); got != tc.ExpectDiffSuppress {
+				t.Errorf("got %t; want %t", got, tc.ExpectDiffSuppress)
+			}
+		})
+	}
+}
+
 func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Improve suppression of Cloud Run V1 Service annotation diffs by suppressing the API provided "run.googleapis.com/operation-id" diff and suppressing the API provided default value "all" of the "run.googleapis.com/ingress" annotation.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13578.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**
```release-note:bug
cloudrun: fixed an issues where the system annotation "run.googleapis.com/operation-id" and "run.googleapis.com/ingress" may cause permadiffs for `metadata.annotation` in `google_cloud_run_service`
```
