### PR TITLE
Image storage location

### DIFF
--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -77,7 +77,7 @@ examples:
       image_name: 'example-image'
   - !ruby/object:Provider::Terraform::Examples
     name: "image_basic_storage_location"
-    primary_resource_id: "example-sl"
+    primary_resource_id: "example"
     vars:
       primary_resource_name: "fmt.Sprintf(\"tf-test-sl-example-image%s\", context[\"random_suffix\"])"
 properties:

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -149,6 +149,7 @@ properties:
       (regional or multi-regional). 
       Reference link: https://cloud.google.com/compute/docs/reference/rest/v1/images
     item_type: Api::Type::String
+    default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: 'diskSizeGb'
     description: |

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -79,6 +79,7 @@ examples:
     name: "image_basic_storage_location"
     primary_resource_id: "example"
     vars:
+      image_name: 'example-sl-image'
       primary_resource_name: "fmt.Sprintf(\"tf-test-sl-example-image%s\", context[\"random_suffix\"])"
 properties:
   - !ruby/object:Api::Type::Integer

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -75,6 +75,11 @@ examples:
     primary_resource_id: 'example'
     vars:
       image_name: 'example-image'
+  - !ruby/object:Provider::Terraform::Examples
+    name: "image_basic_storage_location"
+    primary_resource_id: "example-sl"
+    vars:
+      primary_resource_name: "fmt.Sprintf(\"tf-test-sl-example-image%s\", context[\"random_suffix\"])"
 properties:
   - !ruby/object:Api::Type::Integer
     name: 'archiveSizeBytes'
@@ -137,6 +142,13 @@ properties:
     description: |
       An optional description of this resource. Provide this property when
       you create the resource.
+  - !ruby/object:Api::Type::Array
+    name: 'storageLocations'
+    description: |
+      Cloud Storage bucket storage location of the image 
+      (regional or multi-regional). 
+      Reference link: https://cloud.google.com/compute/docs/reference/rest/v1/images
+    item_type: Api::Type::String
   - !ruby/object:Api::Type::Integer
     name: 'diskSizeGb'
     description: |

--- a/mmv1/templates/terraform/examples/image_basic_storage_location.tf.erb
+++ b/mmv1/templates/terraform/examples/image_basic_storage_location.tf.erb
@@ -1,0 +1,8 @@
+resource "google_compute_image" "example" {
+  name = "<%= ctx[:vars]['image_name'] %>"
+
+  raw_disk {
+    source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+  }
+  storage_locations = ["us-central1"]
+}

--- a/mmv1/templates/terraform/examples/image_basic_storage_location.tf.erb
+++ b/mmv1/templates/terraform/examples/image_basic_storage_location.tf.erb
@@ -4,5 +4,5 @@ resource "google_compute_image" "example" {
   raw_disk {
     source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
   }
-  storage_locations = ["us-central1"]
+  storage_locations = ["US-CENTRAL1"]
 }

--- a/mmv1/templates/terraform/examples/image_basic_storage_location.tf.erb
+++ b/mmv1/templates/terraform/examples/image_basic_storage_location.tf.erb
@@ -4,5 +4,5 @@ resource "google_compute_image" "example" {
   raw_disk {
     source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
   }
-  storage_locations = ["US-CENTRAL1"]
+  storage_locations = ["us-central1"]
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/6082

Recreated the PR as deleting the branch closed the old PR i.e. https://github.com/GoogleCloudPlatform/magic-modules/pull/7378

This is the PR to support StorageLocation for Image resource. This shall allow users to select the region and supply that as a list. 
However, this PR could not be tested because of the error : https://github.com/hashicorp/terraform-provider-google/issues/13846



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). Reference issue: https://github.com/hashicorp/terraform-provider-google/issues/6082
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement added support for storageLocation in Image resource.
    

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* Added support for storageLocation in Image resource 
```
