### PR TITLE
Remove sample for Storage release in ga

### DIFF
--- a/tpgtools/overrides/firebaserules/samples/release/storage_release.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/storage_release.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_firebaserules_release" "primary" {
+  provider     = google-beta
   name         = "firebase.storage/${google_storage_bucket.bucket.name}"
   ruleset_name = "projects/{{project}}/rulesets/${google_firebaserules_ruleset.storage.name}"
   project      = "{{project}}"
@@ -12,20 +13,23 @@ resource "google_firebaserules_release" "primary" {
 
 # Provision a non-default Cloud Storage bucket.
 resource "google_storage_bucket" "bucket" {
-  project = "{{project}}"
-  name    = "{{bucket}}"
+  provider = google-beta
+  project  = "{{project}}"
+  name     = "{{bucket}}"
   location = "{{region}}"
 }
 
 # Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
 resource "google_firebase_storage_bucket" "bucket" {
+  provider  = google-beta
   project   = "{{project}}"
   bucket_id = google_storage_bucket.bucket.name
 }
 
 # Create a ruleset of Firebase Security Rules from a local file.
 resource "google_firebaserules_ruleset" "storage" {
-  project = "{{project}}"
+  provider = google-beta
+  project  = "{{project}}"
   source {
     files {
       name    = "storage.rules"

--- a/tpgtools/overrides/firebaserules/samples/release/storage_release.yaml
+++ b/tpgtools/overrides/firebaserules/samples/release/storage_release.yaml
@@ -15,7 +15,6 @@ name: storage_release
 description: Creates a Firebase Rules Release for a Storage bucket
 type: release
 versions:
-- ga
 - beta
 resource: ./storage_release.tf.tmpl
 variables:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The `google_firebase_storage_bucket` resource used in the sample is beta-only.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). https://github.com/hashicorp/terraform-provider-google/issues/14583
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
