### PR TITLE
Revert "fix: Update config.go and framework_config.go to use transport.Creds for all cases"

### DIFF
--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -601,7 +601,7 @@ func GetCredentials(ctx context.Context, data ProviderModel, initialCredentialsO
 			return *creds
 		}
 
-		creds, err := transport.Creds(ctx, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
+		creds, err := googleoauth.CredentialsFromJSON(ctx, []byte(contents), clientScopes...)
 		if err != nil {
 			diags.AddError("unable to parse credentials", err.Error())
 			return googleoauth.Credentials{}
@@ -625,12 +625,14 @@ func GetCredentials(ctx context.Context, data ProviderModel, initialCredentialsO
 
 	tflog.Info(ctx, "Authenticating using DefaultClient...")
 	tflog.Info(ctx, fmt.Sprintf("  -- Scopes: %s", clientScopes))
-	creds, err := transport.Creds(context.Background(), option.WithScopes(clientScopes...))
+	defaultTS, err := googleoauth.DefaultTokenSource(context.Background(), clientScopes...)
 	if err != nil {
 		diags.AddError(fmt.Sprintf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  "+
 			"No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'"), err.Error())
 		return googleoauth.Credentials{}
 	}
 
-	return *creds
+	return googleoauth.Credentials{
+		TokenSource: defaultTS,
+	}
 }

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -1161,7 +1161,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 			return *creds, nil
 		}
 
-		creds, err := transport.Creds(c.Context, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
+		creds, err := googleoauth.CredentialsFromJSON(c.Context, []byte(contents), clientScopes...)
 		if err != nil {
 			return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials from '%s': %s", contents, err)
 		}
@@ -1183,12 +1183,14 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 
 	log.Printf("[INFO] Authenticating using DefaultClient...")
 	log.Printf("[INFO]   -- Scopes: %s", clientScopes)
-	creds, err := transport.Creds(context.Background(), option.WithScopes(clientScopes...))
+	defaultTS, err := googleoauth.DefaultTokenSource(context.Background(), clientScopes...)
 	if err != nil {
 		return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
 	}
 
-	return *creds, nil
+	return googleoauth.Credentials{
+		TokenSource: defaultTS,
+	}, err
 }
 
 // Remove the `/{{version}}/` from a base path if present.


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#7875

```release-note:bug
provider: fixed an issue where `google_client_config` datasource return `null` for `access_token`
```