### PR TITLE
Always post the status for build and units tests - it has become a requirement for PR submission

### DIFF
--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -53,14 +53,14 @@ jobs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
     - name: Get Job URL
-      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
+      if: ${{ !cancelled() }}
       id: get_job
       run: |
         response=$(curl --get -Ss -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs")
         html_url=$(echo "$response" | jq -r --arg job_name "${{ github.job }}" '.jobs | map(select(.name == $job_name)) | .[0].html_url')
         echo "url=${html_url}" >> $GITHUB_OUTPUT
     - name: Post Pending Status to Pull Request
-      if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
+      if: ${{ !cancelled()() }}
       run: |
         curl -X POST -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
         -H "Accept: application/vnd.github.v3+json" \
@@ -96,7 +96,7 @@ jobs:
         cd provider
         make docscheck
     - name: Post Result Status to Pull Request
-      if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
+      if: ${{ !cancelled() }}
       run: |
         curl -X POST -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
         -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
We don't post the status if there were no changes to the code. This is actually a problem as this status's result has become a prerequisite for PR submission.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
