### PR TITLE
Fixed accesscontextmanager spec requirements

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -419,9 +419,9 @@ properties:
           Currently only projects are allowed.
           Format: projects/{project_number}
         at_least_one_of:
-          - status.0.resources
-          - status.0.access_levels
-          - status.0.restricted_services
+          - spec.0.resources
+          - spec.0.access_levels
+          - spec.0.restricted_services
         item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'accessLevels'
@@ -437,9 +437,9 @@ properties:
 
           Format: accessPolicies/{policy_id}/accessLevels/{access_level_name}
         at_least_one_of:
-          - status.0.resources
-          - status.0.access_levels
-          - status.0.restricted_services
+          - spec.0.resources
+          - spec.0.access_levels
+          - spec.0.restricted_services
         item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'restrictedServices'
@@ -450,9 +450,9 @@ properties:
           buckets inside the perimeter must meet the perimeter's access
           restrictions.
         at_least_one_of:
-          - status.0.resources
-          - status.0.access_levels
-          - status.0.restricted_services
+          - spec.0.resources
+          - spec.0.access_levels
+          - spec.0.restricted_services
         item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'vpcAccessibleServices'

--- a/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
@@ -401,9 +401,9 @@ properties:
               # TODO: (mbang) won't work for arrays yet, uncomment here once they are supported.
               # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
               # at_least_one_of:
-              #   - status.0.resources
-              #   - status.0.access_levels
-              #   - status.0.restricted_services
+              #   - spec.0.resources
+              #   - spec.0.access_levels
+              #   - spec.0.restricted_services
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'accessLevels'
@@ -421,9 +421,9 @@ properties:
               # TODO: (mbang) won't work for arrays yet, uncomment here once they are supported.
               # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
               # at_least_one_of:
-              #   - status.0.resources
-              #   - status.0.access_levels
-              #   - status.0.restricted_services
+              #   - spec.0.resources
+              #   - spec.0.access_levels
+              #   - spec.0.restricted_services
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'restrictedServices'
@@ -436,9 +436,9 @@ properties:
               # TODO: (mbang) won't work for arrays yet, uncomment here once they are supported.
               # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
               # at_least_one_of:
-              #   - status.0.resources
-              #   - status.0.access_levels
-              #   - status.0.restricted_services
+              #   - spec.0.resources
+              #   - spec.0.access_levels
+              #   - spec.0.restricted_services
               item_type: Api::Type::String
             - !ruby/object:Api::Type::NestedObject
               name: 'vpcAccessibleServices'


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14612

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
accesscontextmanager: Fixed incorrect schema in spec for `google_access_context_manager_service_perimeter`. 
```
