### PR TITLE
Update default value for node pool config

### DIFF
--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -232,7 +232,7 @@ properties:
                         description:
                           Hostname of the machine. VM's name will be used if
                           this field is empty.
-                        required: true
+                        default_from_api: true
       - !ruby/object:Api::Type::NestedObject
         name: 'dhcpIpConfig'
         description: Configuration settings for a DHCP IP configuration.

--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -109,19 +109,21 @@ properties:
       - !ruby/object:Api::Type::Integer
         name: "replicas"
         description: The number of nodes in the node pool.
-        default_value: 1
+        default_value: 3
       - !ruby/object:Api::Type::String
         name: "imageType"
         required: true
         description: |
           The OS image to be used for each node in a node pool.
           Currently `cos`, `ubuntu`, `ubuntu_containerd` and `windows` are supported.
+        default_value: "ubuntu_containerd"
       - !ruby/object:Api::Type::String
         name: "image"
         description: The OS image name in vCenter, only valid when using Windows.
       - !ruby/object:Api::Type::Integer
         name: "bootDiskSizeGb"
         description: VMware disk size to be used during creation.
+        default_value: 40
       - !ruby/object:Api::Type::Array
         name: "taints"
         description: The initial taints assigned to nodes of this node pool.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
google_gkeonprem_vmware_node_pool: set default values of node pool config fields `boot_disk_size_db` and `image_type`
google_gkeonprem_vmware_node_pool: update default value of node pool config field `replicas` from 1 to 3
google_gkeonprem_vmware_cluster: update `hostname` of `ip_block` from required to default_from_api
```
