### PR TITLE
Fix import formats of Firebase apps

### DIFF
--- a/mmv1/products/firebase/AndroidApp.yaml
+++ b/mmv1/products/firebase/AndroidApp.yaml
@@ -15,11 +15,11 @@
 name: 'AndroidApp'
 min_version: beta
 base_url: projects/{{project}}/androidApps
-self_link: '{{name}}'
+self_link: 'projects/{{project}}/androidApps/{{app_id}}'
 update_verb: :PATCH
 update_mask: true
 delete_verb: :POST
-delete_url: '{{name}}:remove'
+delete_url: 'projects/{{project}}/androidApps/{{app_id}}:remove'
 description: |
   A Google Cloud Firebase Android application instance
 references: !ruby/object:Api::Resource::ReferenceLinks
@@ -46,12 +46,16 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 import_format:
   [
-    'projects/{{project}}/androidApps/{{appId}}',
-    'androidApps/{{appId}}',
-    '{{appId}}',
+    '{{project}} projects/{{project}}/androidApps/{{app_id}}',
+    'projects/{{project}}/androidApps/{{app_id}}',
+    'androidApps/{{app_id}}',
+    '{{app_id}}',
   ]
 autogen_async: true
 skip_sweeper: true
+identity:
+  - appId
+  - name
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firebase_android_app_basic'
@@ -78,7 +82,6 @@ virtual_fields:
       serving traffic. Set to `DELETE` to delete the AndroidApp. Defaults to `DELETE`.
     default_value: DELETE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/self_link_as_name.erb
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/firebase/AppleApp.yaml
+++ b/mmv1/products/firebase/AppleApp.yaml
@@ -15,7 +15,7 @@
 name: 'AppleApp'
 min_version: beta
 base_url: projects/{{project}}/iosApps
-self_link: '{{name}}'
+self_link: 'projects/{{project}}/iosApps/{{app_id}}'
 update_verb: :PATCH
 delete_verb: :POST
 delete_url: 'projects/{{project}}/iosApps/{{app_id}}:remove'
@@ -45,9 +45,17 @@ async: !ruby/object:Api::OpAsync
     path: 'error'
     message: 'message'
 import_format:
-  ['projects/{{project}}/iosApps/{{appId}}', 'iosApps/{{appId}}', '{{appId}}']
+  [
+    '{{project}} projects/{{project}}/iosApps/{{app_id}}',
+    'projects/{{project}}/iosApps/{{app_id}}',
+    'iosApps/{{app_id}}',
+    '{{app_id}}'
+  ]
 autogen_async: true
 skip_sweeper: true
+identity:
+  - appId
+  - name
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firebase_apple_app_basic'
@@ -90,7 +98,6 @@ virtual_fields:
       serving traffic. Set to `DELETE` to delete the Apple. Defaults to `DELETE`.
     default_value: DELETE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/self_link_as_name.erb
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/firebase/WebApp.yaml
+++ b/mmv1/products/firebase/WebApp.yaml
@@ -15,11 +15,11 @@
 name: 'WebApp'
 min_version: beta
 base_url: projects/{{project}}/webApps
-self_link: '{{name}}'
+self_link: 'projects/{{project}}/webApps/{{app_id}}'
 update_verb: :PATCH
 update_mask: true
 delete_verb: :POST
-delete_url: '{{name}}:remove'
+delete_url: 'projects/{{project}}/webApps/{{app_id}}:remove'
 description: |
   A Google Cloud Firebase web application instance
 references: !ruby/object:Api::Resource::ReferenceLinks
@@ -44,9 +44,18 @@ async: !ruby/object:Api::OpAsync
   error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
-import_format: ['{{project}} {{name}}']
+import_format:
+  [
+    '{{project}} projects/{{project}}/webApps/{{app_id}}',
+    'projects/{{project}}/webApps/{{app_id}}',
+    'webApps/{{app_id}}',
+    '{{app_id}}',
+  ]
 autogen_async: true
 skip_sweeper: true
+identity:
+  - appId
+  - name
 examples:
   - !ruby/object:Provider::Terraform::Examples  # TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
     skip_vcr: true
@@ -73,7 +82,6 @@ virtual_fields:
       serving traffic. Set to `DELETE` to delete the WebApp. Default to `ABANDON`
     default_value: ABANDON
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/self_link_as_name.erb
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:
   - !ruby/object:Api::Type::String


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

* Use snake_case app_id
* Addresses an old issue with `google_firebase_webapp` import

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). https://github.com/hashicorp/terraform-provider-google/issues/14606 https://github.com/hashicorp/terraform-provider-google/issues/7907
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firebase: added additional import formats for app resources, removed the need to supply duplicate projects in some cases
```
