### PR TITLE
feat: support encoding_format

### DIFF
--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -478,7 +478,6 @@ properties:
           certificate and CRLs. If this is omitted, CA certificates and CRLs
           will be published in PEM.
         values:
-          - :ENCODING_FORMAT_UNSPECIFIED
           - :PEM
           - :DER
   - !ruby/object:Api::Type::KeyValuePairs

--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -471,6 +471,16 @@ properties:
           in all issued Certificates. If this is false, CRLs will not be published and the corresponding X.509 extension will not
           be written in issued certificates. CRLs will expire 7 days from their creation. However, we will rebuild daily. CRLs are
           also rebuilt shortly after a certificate is revoked.
+      - !ruby/object:Api::Type::Enum
+        name: 'encodingFormat'
+        description: |
+          Specifies the encoding format of each CertificateAuthority's CA
+          certificate and CRLs. If this is omitted, CA certificates and CRLs
+          will be published in PEM.
+        values:
+          - :ENCODING_FORMAT_UNSPECIFIED
+          - :PEM
+          - :DER
   - !ruby/object:Api::Type::KeyValuePairs
     name: labels
     description: |

--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
@@ -6,6 +6,7 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
   publishing_options {
     publish_ca_cert = false
     publish_crl = true
+    encoding_format = "PEM"
   }
   labels = {
     foo = "bar"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Support encoding_format on CaPool

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: added support for encoding_format on CaPool
```
