### PR TITLE
Fix an issue with non-string template variables

### DIFF
--- a/tools/missing-test-detector/reader.go
+++ b/tools/missing-test-detector/reader.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -204,7 +205,9 @@ func readConfigBasicLit(configBasicLit *ast.BasicLit) (Step, error) {
 		return nil, err
 	} else {
 		// Remove template variables because they interfere with hcl parsing.
-		configStr = strings.ReplaceAll(configStr, "%", "")
+		pattern := regexp.MustCompile("%{[^{}]*}")
+		// Replace with a value that can be parsed outside quotation marks.
+		configStr = pattern.ReplaceAllString(configStr, "true")
 		parser := hclparse.NewParser()
 		file, diagnostics := parser.ParseHCL([]byte(configStr), "config.hcl")
 		if diagnostics.HasErrors() {

--- a/tools/missing-test-detector/reader_test.go
+++ b/tools/missing-test-detector/reader_test.go
@@ -37,6 +37,7 @@ func TestReadCoveredResourceTestFile(t *testing.T) {
 				"field_six": "\"value-three\"",
 			},
 		},
+		"field_seven": "true",
 	}); !reflect.DeepEqual(coveredResource, expectedResource) {
 		t.Errorf("found wrong fields in covered resource config: %#v, expected %#v", coveredResource, expectedResource)
 	}

--- a/tools/missing-test-detector/testdata/covered_resource_test.go
+++ b/tools/missing-test-detector/testdata/covered_resource_test.go
@@ -28,6 +28,7 @@ resource "covered_resource" "resource" {
       field_six = "value-three"
     }
   }
+  field_seven = %{bool}
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
