### PR TITLE
WIP: Vertex AI Schedule resource

### DIFF
--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -184,35 +184,20 @@ properties:
                 description: Runtime config of the pipeline.
                 required: true
                 properties:
-                  - !ruby/object:Api::Type::Map
+                  - !ruby/object:Api::Type::String
                     name: parameters
                     description: |
                       Deprecated. Use RuntimeConfig.parameter_values instead. The runtime parameters of the PipelineJob.
                       The parameters will be passed into PipelineJob.pipeline_spec to replace the placeholders at runtime.
                       This field is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.0.0 or lower,
-                      such as pipelines built using Kubeflow Pipelines SDK 1.8 or lower.
-                    key_name: key
-                    key_description: |
-                      The name of the pipeline parameter.
-                    value_type: !ruby/object:Api::Type::NestedObject
-                      name: value
-                      exactly_one_of:
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameters.intValue
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameters.doubleValue
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameters.stringValue
-                      properties:
-                        - !ruby/object:Api::Type::String
-                          name: intValue
-                          required: true
-                          description: Integer value
-                        - !ruby/object:Api::Type::Double
-                          name: doubleValue
-                          required: true
-                          description: Double value
-                        - !ruby/object:Api::Type::String
-                          name: stringValue
-                          required: true
-                          description: String value
+                      such as pipelines built using Kubeflow Pipelines SDK 1.8 or lower. Expects a JSON-encoded string.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
                   - !ruby/object:Api::Type::String
                     name: gcsOutputDirectory
                     description: |
@@ -223,53 +208,21 @@ properties:
                       The service account specified in this pipeline must have the storage.objects.get
                       and storage.objects.create permissions for this bucket.
                     required: true
-                  - !ruby/object:Api::Type::Map
+                  - !ruby/object:Api::Type::String
                     name: parameterValues
                     description: |
                       The runtime parameters of the PipelineJob. The parameters will be passed into
                       PipelineJob.pipeline_spec to replace the placeholders at runtime. This field
                       is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.1.0,
                       such as pipelines built using Kubeflow Pipelines SDK 1.9 or higher and the v2 DSL.
-                    key_name: key
-                    key_description: |
-                      The name of the pipeline parameter.
-                    value_type: !ruby/object:Api::Type::NestedObject
-                      name: value
-                      exactly_one_of:
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.nullValue
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.numberValue
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.stringValue
-                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.boolValue
-                        # - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.structureValue
-                        # - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.listValue
-                      properties:
-                        - !ruby/object:Api::Type::String # TODO null type
-                          name: nullValue
-                          required: true
-                          description: Null value
-                        - !ruby/object:Api::Type::Double
-                          name: numberValue
-                          required: true
-                          description: Number value
-                        - !ruby/object:Api::Type::String
-                          name: stringValue
-                          required: true
-                          description: String value
-                        - !ruby/object:Api::Type::Boolean
-                          name: boolValue
-                          required: true
-                          description: Boolean value
-                        # TODO how to allow for arbitrary object?
-                        # - !ruby/object:Api::Object
-                        #   name: structureValue
-                        #   required: true
-                        #   description: Structure value
-                        # TODO how to allow arbitrary type in list?
-                        # - !ruby/object:Api::Type::Array
-                        #   name: listValue
-                        #   required: true
-                        #   description: List value
-                        #   item_type: Api::Type::String
+                      Expects a JSON-encoded string.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
                   - !ruby/object:Api::Type::Enum
                     name: failurePolicy
                     description: |

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Resource
 name: Schedule
-min_version: beta
 base_url: projects/{{project}}/locations/{{region}}/schedules
 self_link: 'projects/{{project}}/locations/{{region}}/schedules/{{name}}'
 update_verb: :PATCH
@@ -150,6 +149,7 @@ properties:
             description: |
               The resource name of the Location to create the PipelineJob in. Format: projects/{project}/locations/{location}
             required: true
+            pattern: projects/{{project}}/locations/{{region}}
           - !ruby/object:Api::Type::NestedObject
             name: pipelineJob
             description: The PipelineJob to create.

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -219,14 +219,19 @@ properties:
               - !ruby/object:Api::Type::Map
                 name: inputArtifacts
                 description: |
-                  The runtime artifacts of the PipelineJob. The key will be the input artifact name and the value would be
-                  an Artifact resource id from MLMD. Which is the last portion of an artifact resource name:
-                  projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
-                  The artifact must stay within the same project, location and default metadatastore as the pipeline.
+                  The runtime artifacts of the PipelineJob. The key will be the input artifact name and the value
+                  would be one of the InputArtifact.
                 key_name: key
                 key_description: |
                   The name of the input artifact.
-                value_type: !ruby/object:Api::Type::String
+                value_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: artifactId
+                      description: |
+                        Artifact resource id from MLMD. Which is the last portion of an artifact resource name:
+                        projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
+                        The artifact must stay within the same project, location and default metadatastore as the pipeline.
                         
           - !ruby/object:Api::Type::String
             name: serviceAccount

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -101,7 +101,7 @@ properties:
     description: |
       Whether to backfill missed runs when the schedule is resumed from PAUSED state.
       If set to true, all missed runs will be scheduled. New runs will be scheduled after the
-      backfill is complete. This will also update Schedule.catch_up field. Default to false.
+      backfill is complete. Default to false.
     required: false
     default_from_api: true
   - !ruby/object:Api::Type::Integer
@@ -117,12 +117,6 @@ properties:
       Whether new scheduled runs can be queued when max_concurrent_runs
       limit is reached. If set to true, new runs will be queued instead of skipped.
       Default to false.
-  # - !ruby/object:Api::Type::Boolean
-  #   name: catchUp
-  #   description: |
-  #     Whether to backfill missed runs when the schedule is resumed from
-  #     PAUSED state. If set to true, all missed runs will be scheduled. New runs will
-  #     be scheduled after the backfill is complete. Default to false.
   - !ruby/object:Api::Type::NestedObject
     name: createPipelineJobRequest
     description: |

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -52,6 +52,13 @@ properties:
       characters long and can consist of any UTF-8 characters.
     required: true
   - !ruby/object:Api::Type::String
+    name: cron
+    description: |
+      The scheduled run time based on the user-specified schedule.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+      resolution and up to nine fractional digits. Examples:
+      "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+  - !ruby/object:Api::Type::String
     name: startTime
     description: |
       Timestamp after which the first run can be scheduled. Default to
@@ -117,52 +124,59 @@ properties:
   #     PAUSED state. If set to true, all missed runs will be scheduled. New runs will
   #     be scheduled after the backfill is complete. Default to false.
   - !ruby/object:Api::Type::NestedObject
-    name: timeSpecification
-    description: The time specification to launch scheduled runs.
-    exactly_one_of:
-      - time_specification.0.cron
+    name: createPipelineJobRequest
+    description: |
+      Request for PipelineService.CreatePipelineJob.
+      CreatePipelineJobRequest.parent field is required
+      (format: projects/{project}/locations/{location}).
     properties:
       - !ruby/object:Api::Type::String
-        name: cron
+        name: parent
         description: |
-          The scheduled run time based on the user-specified schedule.
-          A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
-          resolution and up to nine fractional digits. Examples:
-          "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
-  - !ruby/object:Api::Type::NestedObject
-    name: request
-    description: |
-      The API request template to launch the scheduled runs. 
-      User-specified ID is not supported in the request template.
-    exactly_one_of:
-      - request.0.create_pipeline_job_request
-    properties:
+          The resource name of the Location to create the PipelineJob in. Format: projects/{project}/locations/{location}
+        required: true
+        pattern: projects/{{project}}/locations/{{region}}
       - !ruby/object:Api::Type::NestedObject
-        name: createPipelineJobRequest
-        description: |
-          Request for PipelineService.CreatePipelineJob.
-          CreatePipelineJobRequest.parent field is required
-          (format: projects/{project}/locations/{location}).
+        name: pipelineJob
+        description: The PipelineJob to create.
+        required: true
         properties:
           - !ruby/object:Api::Type::String
-            name: parent
+            name: displayName
             description: |
-              The resource name of the Location to create the PipelineJob in. Format: projects/{project}/locations/{location}
-            required: true
-            pattern: projects/{{project}}/locations/{{region}}
+              The display name of the Pipeline. The name can be up to 128 characters long
+              and can consist of any UTF-8 characters.
+          - !ruby/object:Api::Type::String
+            name: pipelineSpec
+            description: The spec of the pipeline. Expects a JSON-encoded string.
+            custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+            state_func:
+              'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+              return s }'
+            validation: !ruby/object:Provider::Terraform::Validation
+              function: 'validation.StringIsJSON'
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: labels
+            description: |
+              The labels with user-defined metadata to organize PipelineJob.
+              Label keys and values can be no longer than 64 characters
+              (Unicode codepoints), can only contain lowercase letters,
+              numeric characters, underscores and dashes. International
+              characters are allowed. See https://goo.gl/xmQnxf for more
+              information and examples of labels.
           - !ruby/object:Api::Type::NestedObject
-            name: pipelineJob
-            description: The PipelineJob to create.
+            name: runtimeConfig
+            description: Runtime config of the pipeline.
             required: true
             properties:
               - !ruby/object:Api::Type::String
-                name: displayName
+                name: parameters
                 description: |
-                  The display name of the Pipeline. The name can be up to 128 characters long
-                  and can consist of any UTF-8 characters.
-              - !ruby/object:Api::Type::String
-                name: pipelineSpec
-                description: The spec of the pipeline. Expects a JSON-encoded string.
+                  Deprecated. Use RuntimeConfig.parameter_values instead. The runtime parameters of the PipelineJob.
+                  The parameters will be passed into PipelineJob.pipeline_spec to replace the placeholders at runtime.
+                  This field is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.0.0 or lower,
+                  such as pipelines built using Kubeflow Pipelines SDK 1.8 or lower. Expects a JSON-encoded string.
                 custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
                 custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                 state_func:
@@ -170,110 +184,77 @@ properties:
                   return s }'
                 validation: !ruby/object:Provider::Terraform::Validation
                   function: 'validation.StringIsJSON'
-              - !ruby/object:Api::Type::KeyValuePairs
-                name: labels
+              - !ruby/object:Api::Type::String
+                name: gcsOutputDirectory
                 description: |
-                  The labels with user-defined metadata to organize PipelineJob.
-                  Label keys and values can be no longer than 64 characters
-                  (Unicode codepoints), can only contain lowercase letters,
-                  numeric characters, underscores and dashes. International
-                  characters are allowed. See https://goo.gl/xmQnxf for more
-                  information and examples of labels.
-              - !ruby/object:Api::Type::NestedObject
-                name: runtimeConfig
-                description: Runtime config of the pipeline.
+                  A path in a Cloud Storage bucket, which will be treated as the root
+                  output directory of the pipeline. It is used by the system to generate the paths
+                  of output artifacts. The artifact paths are generated with a sub-path pattern
+                  {job_id}/{taskId}/{output_key} under the specified output directory.
+                  The service account specified in this pipeline must have the storage.objects.get
+                  and storage.objects.create permissions for this bucket.
                 required: true
-                properties:
-                  - !ruby/object:Api::Type::String
-                    name: parameters
-                    description: |
-                      Deprecated. Use RuntimeConfig.parameter_values instead. The runtime parameters of the PipelineJob.
-                      The parameters will be passed into PipelineJob.pipeline_spec to replace the placeholders at runtime.
-                      This field is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.0.0 or lower,
-                      such as pipelines built using Kubeflow Pipelines SDK 1.8 or lower. Expects a JSON-encoded string.
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
-                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
-                    state_func:
-                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
-                      return s }'
-                    validation: !ruby/object:Provider::Terraform::Validation
-                      function: 'validation.StringIsJSON'
-                  - !ruby/object:Api::Type::String
-                    name: gcsOutputDirectory
-                    description: |
-                      A path in a Cloud Storage bucket, which will be treated as the root
-                      output directory of the pipeline. It is used by the system to generate the paths
-                      of output artifacts. The artifact paths are generated with a sub-path pattern
-                      {job_id}/{taskId}/{output_key} under the specified output directory.
-                      The service account specified in this pipeline must have the storage.objects.get
-                      and storage.objects.create permissions for this bucket.
-                    required: true
-                  - !ruby/object:Api::Type::String
-                    name: parameterValues
-                    description: |
-                      The runtime parameters of the PipelineJob. The parameters will be passed into
-                      PipelineJob.pipeline_spec to replace the placeholders at runtime. This field
-                      is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.1.0,
-                      such as pipelines built using Kubeflow Pipelines SDK 1.9 or higher and the v2 DSL.
-                      Expects a JSON-encoded string.
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
-                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
-                    state_func:
-                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
-                      return s }'
-                    validation: !ruby/object:Provider::Terraform::Validation
-                      function: 'validation.StringIsJSON'
-                  - !ruby/object:Api::Type::Enum
-                    name: failurePolicy
-                    description: |
-                      Represents the failure policy of a pipeline. Currently, the default of a pipeline
-                      is that the pipeline will continue to run until no more tasks can be executed,
-                      also known as PIPELINE_FAILURE_POLICY_FAIL_SLOW. However, if a pipeline is set
-                      to PIPELINE_FAILURE_POLICY_FAIL_FAST, it will stop scheduling any new tasks when
-                      a task has failed. Any scheduled tasks will continue to completion.
-                    values:
-                      - :PIPELINE_FAILURE_POLICY_UNSPECIFIED
-                      - :PIPELINE_FAILURE_POLICY_FAIL_SLOW
-                      - :PIPELINE_FAILURE_POLICY_FAIL_FAST
-                    default_value: :PIPELINE_FAILURE_POLICY_UNSPECIFIED
-                  - !ruby/object:Api::Type::Map
-                    name: inputArtifacts
-                    description: |
-                      The runtime artifacts of the PipelineJob. The key will be the input artifact name and the value would be one of the InputArtifact.
-                    key_name: key
-                    key_description: |
-                      The name of the input artifact.
-                    value_type: !ruby/object:Api::Type::NestedObject
-                      name: value
-                      properties:
-                        - !ruby/object:Api::Type::String
-                          name: artifactId
-                          required: true
-                          description: |
-                            Artifact resource id from MLMD. Which is the last portion of an artifact resource name:
-                            projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
-                            The artifact must stay within the same project, location and default metadatastore as the pipeline.
               - !ruby/object:Api::Type::String
-                name: serviceAccount
+                name: parameterValues
                 description: |
-                  The service account that the pipeline workload runs as.
-                  If not specified, the Compute Engine default service account
-                  in the project will be used.
-                  See https://cloud.google.com/compute/docs/access/service-accounts#default_service_account
-                  Users starting the pipeline must have the iam.serviceAccounts.actAs
-                  permission on this service account.
-              - !ruby/object:Api::Type::String
-                name: network
+                  The runtime parameters of the PipelineJob. The parameters will be passed into
+                  PipelineJob.pipeline_spec to replace the placeholders at runtime. This field
+                  is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.1.0,
+                  such as pipelines built using Kubeflow Pipelines SDK 1.9 or higher and the v2 DSL.
+                  Expects a JSON-encoded string.
+                custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                state_func:
+                  'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                  return s }'
+                validation: !ruby/object:Provider::Terraform::Validation
+                  function: 'validation.StringIsJSON'
+              - !ruby/object:Api::Type::Enum
+                name: failurePolicy
                 description: |
-                  The full name of the Compute Engine network to which the Pipeline Job's workload
-                  should be peered. For example, projects/12345/global/networks/myVPC. Format is
-                  of the form projects/{project}/global/networks/{network}. Where {project} is a
-                  project number, as in 12345, and {network} is a network name.
-                  Private services access must already be configured for the network.
-                  Pipeline job will apply the network configuration to the Google Cloud resources
-                  being launched, if applied, such as Vertex AI Training or Dataflow job.
-                  If left unspecified, the workload is not peered with any network.
-              - !ruby/object:Api::Type::String
-                name: templateUri
-                description:
-                  A template uri from where the PipelineJob.pipeline_spec, if empty, will be downloaded.
+                  Represents the failure policy of a pipeline. Currently, the default of a pipeline
+                  is that the pipeline will continue to run until no more tasks can be executed,
+                  also known as PIPELINE_FAILURE_POLICY_FAIL_SLOW. However, if a pipeline is set
+                  to PIPELINE_FAILURE_POLICY_FAIL_FAST, it will stop scheduling any new tasks when
+                  a task has failed. Any scheduled tasks will continue to completion.
+                values:
+                  - :PIPELINE_FAILURE_POLICY_UNSPECIFIED
+                  - :PIPELINE_FAILURE_POLICY_FAIL_SLOW
+                  - :PIPELINE_FAILURE_POLICY_FAIL_FAST
+                default_value: :PIPELINE_FAILURE_POLICY_UNSPECIFIED
+              - !ruby/object:Api::Type::Map
+                name: inputArtifacts
+                description: |
+                  The runtime artifacts of the PipelineJob. The key will be the input artifact name and the value would be
+                  an Artifact resource id from MLMD. Which is the last portion of an artifact resource name:
+                  projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
+                  The artifact must stay within the same project, location and default metadatastore as the pipeline.
+                key_name: key
+                key_description: |
+                  The name of the input artifact.
+                value_type: !ruby/object:Api::Type::String
+                        
+          - !ruby/object:Api::Type::String
+            name: serviceAccount
+            description: |
+              The service account that the pipeline workload runs as.
+              If not specified, the Compute Engine default service account
+              in the project will be used.
+              See https://cloud.google.com/compute/docs/access/service-accounts#default_service_account
+              Users starting the pipeline must have the iam.serviceAccounts.actAs
+              permission on this service account.
+          - !ruby/object:Api::Type::String
+            name: network
+            description: |
+              The full name of the Compute Engine network to which the Pipeline Job's workload
+              should be peered. For example, projects/12345/global/networks/myVPC. Format is
+              of the form projects/{project}/global/networks/{network}. Where {project} is a
+              project number, as in 12345, and {network} is a network name.
+              Private services access must already be configured for the network.
+              Pipeline job will apply the network configuration to the Google Cloud resources
+              being launched, if applied, such as Vertex AI Training or Dataflow job.
+              If left unspecified, the workload is not peered with any network.
+          - !ruby/object:Api::Type::String
+            name: templateUri
+            description:
+              A template uri from where the PipelineJob.pipeline_spec, if empty, will be downloaded.

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -319,10 +319,3 @@ properties:
                 name: templateUri
                 description:
                   A template uri from where the PipelineJob.pipeline_spec, if empty, will be downloaded.
-          - !ruby/object:Api::Type::String
-            name: pipelineJobId
-            description: |
-              The ID to use for the PipelineJob, which will become the final component
-              of the PipelineJob name. If not provided, an ID will be automatically
-              generated. This value should be less than 128 characters, and valid
-              characters are /[a-z][0-9]-/.

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -216,23 +216,13 @@ properties:
                   - :PIPELINE_FAILURE_POLICY_FAIL_SLOW
                   - :PIPELINE_FAILURE_POLICY_FAIL_FAST
                 default_value: :PIPELINE_FAILURE_POLICY_UNSPECIFIED
-              - !ruby/object:Api::Type::Map
+              - !ruby/object:Api::Type::KeyValuePairs
                 name: inputArtifacts
                 description: |
                   The runtime artifacts of the PipelineJob. The key will be the input artifact name and the value
-                  would be one of the InputArtifact.
-                key_name: key
-                key_description: |
-                  The name of the input artifact.
-                value_type: !ruby/object:Api::Type::NestedObject
-                  properties:
-                    - !ruby/object:Api::Type::String
-                      name: artifactId
-                      description: |
-                        Artifact resource id from MLMD. Which is the last portion of an artifact resource name:
-                        projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
-                        The artifact must stay within the same project, location and default metadatastore as the pipeline.
-                        
+                  would be an Artifact resource id from MLMD, which is the last portion of an artifact resource name:
+                  projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
+                  The artifact must stay within the same project, location and default metadatastore as the pipeline.
           - !ruby/object:Api::Type::String
             name: serviceAccount
             description: |

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -1,0 +1,328 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: Schedule
+min_version: beta
+base_url: projects/{{project}}/locations/{{region}}/schedules
+self_link: 'projects/{{project}}/locations/{{region}}/schedules/{{name}}'
+update_verb: :PATCH
+description: |
+  An instance of a Schedule periodically schedules runs to make
+  API calls based on user specified time specification and API
+  request type.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/vertex-ai/docs'
+  api: 'https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.schedules'
+id_format: 'projects/{{project}}/locations/{{region}}/schedules/{{name}}'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  encoder: templates/terraform/encoders/vertex_ai_schedule.go.erb
+  update_encoder: templates/terraform/update_encoder/vertex_ai_schedule.go.erb
+  post_create: templates/terraform/post_create/vertex_ai_schedule.go.erb
+  post_update: templates/terraform/post_update/vertex_ai_schedule.go.erb
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'region'
+    description: |
+      Region where the scheduler job resides
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    description: |
+      The resource name of the Schedule.
+    required: true
+    immutable: true
+  - !ruby/object:Api::Type::String
+    name: displayName
+    description:
+      User provided name of the Schedule. The name can be up to 128
+      characters long and can consist of any UTF-8 characters.
+    required: true
+  - !ruby/object:Api::Type::String
+    name: startTime
+    description: |
+      Timestamp after which the first run can be scheduled. Default to
+      Schedule create time if not specified. A timestamp in RFC3339 UTC "Zulu"
+      format, with nanosecond resolution and up to nine fractional digits.
+      Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+  - !ruby/object:Api::Type::String
+    name: endTime
+    description: |
+      Timestamp after which no new runs can be scheduled. If specified,
+      The schedule will be completed when either endTime is reached or when
+      scheduled_run_count >= maxRunCount. If not specified, new runs will keep
+      getting scheduled until this Schedule is paused or deleted. Already scheduled
+      runs will be allowed to complete. Unset if not specified. A timestamp in
+      RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: "2014-10-02T15:01:23Z" and
+      "2014-10-02T15:01:23.045123456Z".
+  - !ruby/object:Api::Type::String
+    name: maxRunCount
+    description: |
+      Maximum run count of the schedule. If specified, The schedule will
+      be completed when either startedRunCount >= maxRunCount or when endTime is
+      reached. If not specified, new runs will keep getting scheduled until this
+      Schedule is paused or deleted. Already scheduled runs will be allowed to
+      complete. Unset if not specified.
+  - !ruby/object:Api::Type::String
+    name: state
+    description: |
+      State of the job.
+    output: true
+  - !ruby/object:Api::Type::Boolean
+    name: paused
+    description: |
+      Sets the job to a paused state. Jobs default to being enabled when this property is not set.
+    required: false
+    default_from_api: true
+    custom_flatten: templates/terraform/custom_flatten/vertex_ai_schedule_paused.go.erb
+  - !ruby/object:Api::Type::Boolean
+    name: catchUp
+    description: |
+      Whether to backfill missed runs when the schedule is resumed from PAUSED state.
+      If set to true, all missed runs will be scheduled. New runs will be scheduled after the
+      backfill is complete. This will also update Schedule.catch_up field. Default to false.
+    required: false
+    default_from_api: true
+  - !ruby/object:Api::Type::Integer
+    name: maxConcurrentRunCount
+    description: |
+      Maximum number of runs that can be started concurrently for this
+      Schedule. This is the limit for starting the scheduled requests and not the
+      execution of the operations/jobs created by the requests (if applicable).
+    required: true
+  - !ruby/object:Api::Type::Boolean
+    name: allowQueueing
+    description: |
+      Whether new scheduled runs can be queued when max_concurrent_runs
+      limit is reached. If set to true, new runs will be queued instead of skipped.
+      Default to false.
+  # - !ruby/object:Api::Type::Boolean
+  #   name: catchUp
+  #   description: |
+  #     Whether to backfill missed runs when the schedule is resumed from
+  #     PAUSED state. If set to true, all missed runs will be scheduled. New runs will
+  #     be scheduled after the backfill is complete. Default to false.
+  - !ruby/object:Api::Type::NestedObject
+    name: timeSpecification
+    description: The time specification to launch scheduled runs.
+    exactly_one_of:
+      - time_specification.0.cron
+    properties:
+      - !ruby/object:Api::Type::String
+        name: cron
+        description: |
+          The scheduled run time based on the user-specified schedule.
+          A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
+          resolution and up to nine fractional digits. Examples:
+          "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+  - !ruby/object:Api::Type::NestedObject
+    name: request
+    description: |
+      The API request template to launch the scheduled runs. 
+      User-specified ID is not supported in the request template.
+    exactly_one_of:
+      - request.0.create_pipeline_job_request
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: createPipelineJobRequest
+        description: |
+          Request for PipelineService.CreatePipelineJob.
+          CreatePipelineJobRequest.parent field is required
+          (format: projects/{project}/locations/{location}).
+        properties:
+          - !ruby/object:Api::Type::String
+            name: parent
+            description: |
+              The resource name of the Location to create the PipelineJob in. Format: projects/{project}/locations/{location}
+            required: true
+          - !ruby/object:Api::Type::NestedObject
+            name: pipelineJob
+            description: The PipelineJob to create.
+            required: true
+            properties:
+              - !ruby/object:Api::Type::String
+                name: displayName
+                description: |
+                  The display name of the Pipeline. The name can be up to 128 characters long
+                  and can consist of any UTF-8 characters.
+              # TODO how to allow for arbitrary object?
+              # - !ruby/object:Api::Object
+              #   name: pipelineSpec
+              #   description: The spec of the pipeline.
+                # required: true
+              - !ruby/object:Api::Type::KeyValuePairs
+                name: labels
+                description: |
+                  The labels with user-defined metadata to organize PipelineJob.
+                  Label keys and values can be no longer than 64 characters
+                  (Unicode codepoints), can only contain lowercase letters,
+                  numeric characters, underscores and dashes. International
+                  characters are allowed. See https://goo.gl/xmQnxf for more
+                  information and examples of labels.
+              - !ruby/object:Api::Type::NestedObject
+                name: runtimeConfig
+                description: Runtime config of the pipeline.
+                required: true
+                properties:
+                  - !ruby/object:Api::Type::Map
+                    name: parameters
+                    description: |
+                      Deprecated. Use RuntimeConfig.parameter_values instead. The runtime parameters of the PipelineJob.
+                      The parameters will be passed into PipelineJob.pipeline_spec to replace the placeholders at runtime.
+                      This field is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.0.0 or lower,
+                      such as pipelines built using Kubeflow Pipelines SDK 1.8 or lower.
+                    key_name: key
+                    key_description: |
+                      The name of the pipeline parameter.
+                    value_type: !ruby/object:Api::Type::NestedObject
+                      name: value
+                      exactly_one_of:
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameters.intValue
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameters.doubleValue
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameters.stringValue
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: intValue
+                          required: true
+                          description: Integer value
+                        - !ruby/object:Api::Type::Double
+                          name: doubleValue
+                          required: true
+                          description: Double value
+                        - !ruby/object:Api::Type::String
+                          name: stringValue
+                          required: true
+                          description: String value
+                  - !ruby/object:Api::Type::String
+                    name: gcsOutputDirectory
+                    description: |
+                      A path in a Cloud Storage bucket, which will be treated as the root
+                      output directory of the pipeline. It is used by the system to generate the paths
+                      of output artifacts. The artifact paths are generated with a sub-path pattern
+                      {job_id}/{taskId}/{output_key} under the specified output directory.
+                      The service account specified in this pipeline must have the storage.objects.get
+                      and storage.objects.create permissions for this bucket.
+                    required: true
+                  - !ruby/object:Api::Type::Map
+                    name: parameterValues
+                    description: |
+                      The runtime parameters of the PipelineJob. The parameters will be passed into
+                      PipelineJob.pipeline_spec to replace the placeholders at runtime. This field
+                      is used by pipelines built using PipelineJob.pipeline_spec.schema_version 2.1.0,
+                      such as pipelines built using Kubeflow Pipelines SDK 1.9 or higher and the v2 DSL.
+                    key_name: key
+                    key_description: |
+                      The name of the pipeline parameter.
+                    value_type: !ruby/object:Api::Type::NestedObject
+                      name: value
+                      exactly_one_of:
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.nullValue
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.numberValue
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.stringValue
+                        - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.boolValue
+                        # - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.structureValue
+                        # - request.0.create_pipeline_job_request.0.pipeline_job.0.runtime_config.0.parameterValues.listValue
+                      properties:
+                        - !ruby/object:Api::Type::String # TODO null type
+                          name: nullValue
+                          required: true
+                          description: Null value
+                        - !ruby/object:Api::Type::Double
+                          name: numberValue
+                          required: true
+                          description: Number value
+                        - !ruby/object:Api::Type::String
+                          name: stringValue
+                          required: true
+                          description: String value
+                        - !ruby/object:Api::Type::Boolean
+                          name: boolValue
+                          required: true
+                          description: Boolean value
+                        # TODO how to allow for arbitrary object?
+                        # - !ruby/object:Api::Object
+                        #   name: structureValue
+                        #   required: true
+                        #   description: Structure value
+                        # TODO how to allow arbitrary type in list?
+                        # - !ruby/object:Api::Type::Array
+                        #   name: listValue
+                        #   required: true
+                        #   description: List value
+                        #   item_type: Api::Type::String
+                  - !ruby/object:Api::Type::Enum
+                    name: failurePolicy
+                    description: |
+                      Represents the failure policy of a pipeline. Currently, the default of a pipeline
+                      is that the pipeline will continue to run until no more tasks can be executed,
+                      also known as PIPELINE_FAILURE_POLICY_FAIL_SLOW. However, if a pipeline is set
+                      to PIPELINE_FAILURE_POLICY_FAIL_FAST, it will stop scheduling any new tasks when
+                      a task has failed. Any scheduled tasks will continue to completion.
+                    values:
+                      - :PIPELINE_FAILURE_POLICY_UNSPECIFIED
+                      - :PIPELINE_FAILURE_POLICY_FAIL_SLOW
+                      - :PIPELINE_FAILURE_POLICY_FAIL_FAST
+                    default_value: :PIPELINE_FAILURE_POLICY_UNSPECIFIED
+                  - !ruby/object:Api::Type::Map
+                    name: inputArtifacts
+                    description: |
+                      The runtime artifacts of the PipelineJob. The key will be the input artifact name and the value would be one of the InputArtifact.
+                    key_name: key
+                    key_description: |
+                      The name of the input artifact.
+                    value_type: !ruby/object:Api::Type::NestedObject
+                      name: value
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: artifactId
+                          required: true
+                          description: |
+                            Artifact resource id from MLMD. Which is the last portion of an artifact resource name:
+                            projects/{project}/locations/{location}/metadataStores/default/artifacts/{artifactId}.
+                            The artifact must stay within the same project, location and default metadatastore as the pipeline.
+              - !ruby/object:Api::Type::String
+                name: serviceAccount
+                description: |
+                  The service account that the pipeline workload runs as.
+                  If not specified, the Compute Engine default service account
+                  in the project will be used.
+                  See https://cloud.google.com/compute/docs/access/service-accounts#default_service_account
+                  Users starting the pipeline must have the iam.serviceAccounts.actAs
+                  permission on this service account.
+              - !ruby/object:Api::Type::String
+                name: network
+                description: |
+                  The full name of the Compute Engine network to which the Pipeline Job's workload
+                  should be peered. For example, projects/12345/global/networks/myVPC. Format is
+                  of the form projects/{project}/global/networks/{network}. Where {project} is a
+                  project number, as in 12345, and {network} is a network name.
+                  Private services access must already be configured for the network.
+                  Pipeline job will apply the network configuration to the Google Cloud resources
+                  being launched, if applied, such as Vertex AI Training or Dataflow job.
+                  If left unspecified, the workload is not peered with any network.
+              - !ruby/object:Api::Type::String
+                name: templateUri
+                description:
+                  A template uri from where the PipelineJob.pipeline_spec, if empty, will be downloaded.
+          - !ruby/object:Api::Type::String
+            name: pipelineJobId
+            description: |
+              The ID to use for the PipelineJob, which will become the final component
+              of the PipelineJob name. If not provided, an ID will be automatically
+              generated. This value should be less than 128 characters, and valid
+              characters are /[a-z][0-9]-/.

--- a/mmv1/products/vertexai/Schedule.yaml
+++ b/mmv1/products/vertexai/Schedule.yaml
@@ -160,11 +160,16 @@ properties:
                 description: |
                   The display name of the Pipeline. The name can be up to 128 characters long
                   and can consist of any UTF-8 characters.
-              # TODO how to allow for arbitrary object?
-              # - !ruby/object:Api::Object
-              #   name: pipelineSpec
-              #   description: The spec of the pipeline.
-                # required: true
+              - !ruby/object:Api::Type::String
+                name: pipelineSpec
+                description: The spec of the pipeline. Expects a JSON-encoded string.
+                custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                state_func:
+                  'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                  return s }'
+                validation: !ruby/object:Provider::Terraform::Validation
+                  function: 'validation.StringIsJSON'
               - !ruby/object:Api::Type::KeyValuePairs
                 name: labels
                 description: |

--- a/mmv1/templates/terraform/custom_flatten/vertex_ai_schedule_paused.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/vertex_ai_schedule_paused.go.erb
@@ -1,0 +1,10 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    state := d.Get("state");
+    if state == "PAUSED" {
+        return true
+    }
+    if state == "ACTIVE" {
+        return false
+    }
+    return false // Job has an error state that's not paused or active
+}

--- a/mmv1/templates/terraform/encoders/vertex_ai_schedule.go.erb
+++ b/mmv1/templates/terraform/encoders/vertex_ai_schedule.go.erb
@@ -1,0 +1,2 @@
+delete(obj, "paused") // Field doesn't exist in API
+return obj, nil

--- a/mmv1/templates/terraform/examples/vertex_ai_schedule.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_schedule.tf.erb
@@ -1,0 +1,42 @@
+resource "google_vertex_ai_schedule" "schedule" {
+  display_name             = "<%= ctx[:vars]['display_name'] %>"
+  # start_time
+  # end_time
+  max_run_count            = "<%= ctx[:vars]['max_run_count'] %>"
+  max_concurrent_run_count = "<%= ctx[:vars]['max__concurrent_run_count'] %>"
+  allow_queueing           = "<%= ctx[:vars]['allow_queueing'] %>"
+  time_specification {
+    cron                   = "<%= ctx[:vars]['cron'] %>"
+  }
+  request {
+    create_pipeline_job_request {
+      parent                = "<%= ctx[:vars]['parent'] %>"
+      pipeline_job {
+        display_name        = "<%= ctx[:vars]['pipeline_job_display_name'] %>"
+        pipeline_spec {
+          # TODO
+        }
+        labels = {
+          "foo" = "bar"
+        }
+        runtime_config {
+          parameters {
+            # TODO
+          }
+          gcs_output_directory = "<%= ctx[:vars]['gcs_output_directory'] %>"
+          parameter_values {
+            # TODO
+          }
+          failure_policy = "<%= ctx[:vars]['failure_policy'] %>"
+          input_artifacts {
+            # TODO
+          }
+        }
+        service_account = "<%= ctx[:vars]['service_account'] %>"
+        network         = "<%= ctx[:vars]['network'] %>"
+        template_uri    = "<%= ctx[:vars]['template_uri'] %>"
+      }
+      pipeline_job_id       = "<%= ctx[:vars]['pipeline_job_id'] %>"
+    }
+  }
+}

--- a/mmv1/templates/terraform/post_create/vertex_ai_schedule.go.erb
+++ b/mmv1/templates/terraform/post_create/vertex_ai_schedule.go.erb
@@ -1,0 +1,30 @@
+endpoint := "resume" // Default to enabled
+logSuccessMsg := "Schedule state has been set to ACTIVE"
+reqBody := make(map[string]interface{})
+if paused, pausedOk := d.GetOk("paused"); pausedOk && paused.(bool) {
+	endpoint = "pause"
+	logSuccessMsg = "Schedule state has been set to PAUSED"
+} else if catchUp, catchUpOk := d.GetOk("catchUp"); catchUpOk && catchUp.(bool) {
+	reqBody["catchUp"] = catchUp
+}
+
+linkTmpl := fmt.Sprintf("{{VertexAIBasePath}projects/{{project}}/locations/{{region}}/schedules/{{name}}:%s", endpoint)
+url, err = tpgresource.ReplaceVars(d, config, linkTmpl)
+if err != nil {
+	return err
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config: config,
+	Method: "POST",
+	Project: billingProject,
+	RawURL: url,
+	UserAgent: userAgent,
+	Body: reqBody,
+	Timeout: d.Timeout(schema.TimeoutUpdate),
+})
+if err != nil {
+	return fmt.Errorf("Error setting Vertex Schedule status: %s", err)
+}
+
+log.Printf("[DEBUG] Finished updating Schedule %q status: %s", d.Id(), logSuccessMsg)

--- a/mmv1/templates/terraform/post_update/vertex_ai_schedule.go.erb
+++ b/mmv1/templates/terraform/post_update/vertex_ai_schedule.go.erb
@@ -1,0 +1,33 @@
+if d.HasChange("paused") {
+    endpoint := "resume" // Default to enabled
+    logSuccessMsg := "Job state has been set to ACTIVE"
+    reqBody := make(map[string]interface{})
+    if paused, pausedOk := d.GetOk("paused"); pausedOk {
+        if paused.(bool) {
+            endpoint = "pause"
+            logSuccessMsg = "Job state has been set to PAUSED"
+        }
+    } else if catchUp, catchUpOk := d.GetOk("catchUp"); catchUpOk && catchUp.(bool) {
+        reqBody["catchUp"] = catchUp
+    }
+
+    linkTmpl := fmt.Sprintf("{{VertexAIBasePath}}projects/{{project}}/locations/{{region}}/schedules/{{name}}:%s", endpoint)
+    url, err = tpgresource.ReplaceVars(d, config, linkTmpl)
+    if err != nil {
+        return err
+    }
+    _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config: config,
+        Method: "POST",
+        Project: billingProject,
+        RawURL: url,
+        UserAgent: userAgent,
+        Body: reqBody,
+        Timeout: d.Timeout(schema.TimeoutUpdate),
+    })
+    if err != nil {
+        return fmt.Errorf("Error setting Cloud Scheduler Job status: %s", err)
+    }
+
+    log.Printf("[DEBUG] Finished updating Job %q status: %s", d.Id(), logSuccessMsg)
+}

--- a/mmv1/templates/terraform/update_encoder/vertex_ai_schedule.go.erb
+++ b/mmv1/templates/terraform/update_encoder/vertex_ai_schedule.go.erb
@@ -1,0 +1,2 @@
+delete(obj, "paused") // Field doesn't exist in API
+return obj, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add `google_vertex_ai_schedule` resource for scheduling Vertex Pipelines

TODO

- [ ] check handling of `catchUp` field on create + update
- [x] Allow for different data types in `parameters` and `parameterValues` (e.g. nulls, lists of arbitrary type, arbitrary objects)
- [x] pipelineSpec - how to allow for arbitrary object (or is there another approach to take here?)
- [ ] acceptance tests
- [ ] automatically fill in `parent` field from `region` and `project` - create a custom expander?


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
vertexai: Added google_vertex_ai_schedule resource
```
