### PR TITLE
Removed allowFailure blocks for TGC downstream builds

### DIFF
--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -106,7 +106,6 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       id: tgc-head
-      allowFailure: true
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["merged", "tpg-head"]
       args:
@@ -117,7 +116,6 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       id: tgc-base
-      allowFailure: true
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["merged", "tpg-base"]
       args:


### PR DESCRIPTION
Although these allow the downstream builds to proceed, they hide issues in the downstream build process that then cause the actual downstream build to fail after merge. Failures in the downstream build don't have a separate associated status, so they need to be reported as an overall failure of generate-diffs.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
