### PR TITLE
Rerun replaying mode after recording mode

### DIFF
--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -252,8 +252,6 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     # Clear replaying-log folder
     rm testlog/replaying_after_recording/*
     rm testlog/replaying_build_after_recording/*
-  fi
-
   if [[ -n $RECORDING_FAILED_TESTS ]]; then
     comment+="Tests failed during RECORDING mode:${NEWLINE} $RECORDING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
     RECORDING_FAILED_TESTS_COUNT=$(echo "$RECORDING_FAILED_TESTS" | wc -l)

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -251,7 +251,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_after_recording/"$3".log)]"}')
     if [[ -n $REPLAYING_FAILED_TESTS ]]; then
       comment+="Tests failed when rerunning REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
-      comment+="Tests failed when the VCR replayed the response due to non-determinism or randomness when the HTTP request was made.${NEWLINE}${NEWLINE}"
+      comment+="Tests failed due to non-determinism or randomness when the VCR replayed the response after the HTTP request was made.${NEWLINE}${NEWLINE}"
       comment+="Please fix these to complete your PR. If you do not know how VCR tests work, please work with the code reviewer to figure out the reason why the tests failed and fix the tests.${NEWLINE}"
     else
       comment+="All tests passed after rerunning REPLAYING mode.${NEWLINE}"

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -172,6 +172,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   comment+="[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)"
   add_comment "${comment}"
   # Clear fixtures folder
+  ls $VCR_PATH
   rm $VCR_PATH/*
 
   # Clear replaying-log folder
@@ -221,7 +222,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   RECORDING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" recording_test.log | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/recording/"$3".log)]"}')
   RECORDING_PASSED_TEST_LIST=$(grep "^--- PASS: TestAcc" recording_test.log | awk '{print $3}')
   echo "RECORDING_PASSED_TEST_LIST: ${RECORDING_PASSED_TEST_LIST}"
-
+  ls $VCR_PATH
 
   comment=""
   RECORDING_PASSED_TESTS_COUNT=0

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -226,9 +226,32 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   RECORDING_FAILED_TESTS_COUNT=0
   if [[ -n $RECORDING_PASSED_TESTS ]]; then
     comment+="Tests passed during RECORDING mode:${NEWLINE} $RECORDING_PASSED_TESTS ${NEWLINE}${NEWLINE}"
-    comment+="#### Action taken ${NEWLINE}"
-    comment+="Starting to rerun passed tests in REPLAYING mode to catch issues ${NEWLINE}${NEWLINE}"
     RECORDING_PASSED_TESTS_COUNT=$(echo "$RECORDING_PASSED_TESTS" | wc -l)
+
+    # Rerun passed tests in REPLAYING mode 3 times to catch issues
+    export VCR_MODE=REPLAYING
+    count=3
+    parallel --jobs 16 TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying_after_recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $GOOGLE_TEST_DIRECTORY -parallel 1 -count=$count -v -run="{}$" -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" ">" testlog/replaying_build_after_recording/{}_replaying_test.log ::: $RECORDING_PASSED_TEST_LIST
+
+    test_exit_code=$?
+
+    # store replaying individual build logs
+    gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_build_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/replaying_build_after_recording/
+
+    # store replaying test logs
+    gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/replaying_after_recording/
+
+    REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
+
+    if [[ -n $REPLAYING_FAILED_TESTS ]]; then
+      comment+="Rerun these tests in REPLAYING mode to catch issues ${NEWLINE}${NEWLINE}"
+      comment+="Tests failed after rerunning these tests in REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
+      comment+="Please fix these to complete your PR${NEWLINE}"
+    if
+
+    # Clear replaying-log folder
+    rm testlog/replaying_after_recording/*
+    rm testlog/replaying_build_after_recording/*
   fi
 
   if [[ -n $RECORDING_FAILED_TESTS ]]; then
@@ -245,75 +268,12 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
       # check for any uncaught errors in RECORDING mode
       comment+="Errors occurred during RECORDING mode. Please fix them to complete your PR${NEWLINE}"
     else
-      comment+="All tests passed${NEWLINE}"
+      comment+="All tests passed during RECORDING mode.${NEWLINE}"
     fi
   fi
 
   comment+="View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/recording) for each test"
   add_comment "${comment}"
-
-  # Rerun passed tests in REPLAYING mode 3 times to catch issues
-  if [[ -n $RECORDING_PASSED_TESTS ]]; then
-    export VCR_MODE=REPLAYING
-    count=3
-    parallel --jobs 16 TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying_after_recording/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $GOOGLE_TEST_DIRECTORY -parallel 1 -count=$count -v -run="{}$" -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" ">" testlog/replaying_build_after_recording/{}_replaying_test.log ::: $RECORDING_PASSED_TEST_LIST
-
-    test_exit_code=$?
-
-    # Concatenate replaying build logs to one file
-    for test in $RECORDING_PASSED_TEST_LIST
-    do
-      cat testlog/replaying_build_after_recording/${test}_replaying_test.log >> replaying_build_after_recording.log
-    done
-
-    # store replaying build log
-    gsutil -h "Content-Type:text/plain" -q cp replaying_build_after_recording.log gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/
-
-    # store replaying individual build logs
-    gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_build_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/replaying_build_after_recording/
-
-    # store replaying test logs
-    gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/replaying_after_recording/
-
-    REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
-    REPLAYING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" replaying_build_after_recording.log | awk '{print $3}' | sort | uniq -c  | awk -v count=$count -v pr_number=$pr_number -v build_id=$build_id '$1 == count {print "`"$2"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
-
-    comment=""
-    REPLAYING_PASSED_TESTS_COUNT=0
-    REPLAYING_FAILED_TESTS_COUNT=0
-
-    if [[ -n $REPLAYING_PASSED_TESTS ]]; then
-      comment+="Tests passed all 3 times during REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
-      REPLAYING_PASSED_TESTS_COUNT=$(echo "$REPLAYING_PASSED_TESTS" | wc -l)
-    fi
-
-    if [[ -n $REPLAYING_FAILED_TESTS ]]; then
-      comment+="Tests failed during REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
-      REPLAYING_FAILED_TESTS_COUNT=$(echo "$REPLAYING_FAILED_TESTS" | wc -l)
-      if [[ $REPLAYING_PASSED_TESTS_COUNT+$REPLAYING_FAILED_TESTS_COUNT -lt $RECORDING_PASSED_TESTS ]]; then
-        comment+="Several tests got terminated during REPLAYING mode.${NEWLINE}"
-      fi
-      comment+="Please fix these to complete your PR${NEWLINE}"
-    else
-      if [[ $REPLAYING_PASSED_TESTS_COUNT+$REPLAYING_FAILED_TESTS_COUNT -lt $RECORDING_PASSED_TESTS ]]; then
-        comment+="Several tests got terminated during REPLAYING mode.${NEWLINE}"
-      elif [[ $test_exit_code -ne 0 ]]; then
-        # check for any uncaught errors in REPLAYING mode
-        comment+="Errors occurred during REPLAYING mode. Please fix them to complete your PR${NEWLINE}"
-      else
-        comment+="All tests passed${NEWLINE}"
-      fi
-    fi
-
-    comment+="View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/replaying_build_after_recording.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/replaying_build_after_recording) for each test"
-    add_comment "${comment}"
-
-    # Clear fixtures folder
-    rm $VCR_PATH/*
-
-    # Clear replaying-log folder
-    rm testlog/replaying_after_recording/*
-    rm testlog/replaying_build_after_recording/*
 else
   if [[ $test_exit_code -ne 0 ]]; then
     # check for any uncaught errors errors in REPLAYING mode

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -172,7 +172,6 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   comment+="[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)"
   add_comment "${comment}"
   # Clear fixtures folder
-  ls $VCR_PATH
   rm $VCR_PATH/*
 
   # Clear replaying-log folder
@@ -222,7 +221,6 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   RECORDING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" recording_test.log | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/recording/"$3".log)]"}')
   RECORDING_PASSED_TEST_LIST=$(grep "^--- PASS: TestAcc" recording_test.log | awk '{print $3}')
   echo "RECORDING_PASSED_TEST_LIST: ${RECORDING_PASSED_TEST_LIST}"
-  ls $VCR_PATH
 
   comment=""
   RECORDING_PASSED_TESTS_COUNT=0
@@ -230,7 +228,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   if [[ -n $RECORDING_PASSED_TESTS ]]; then
     comment+="Tests passed during RECORDING mode:${NEWLINE} $RECORDING_PASSED_TESTS ${NEWLINE}${NEWLINE}"
     RECORDING_PASSED_TESTS_COUNT=$(echo "$RECORDING_PASSED_TESTS" | wc -l)
-    comment+="Rerun these tests in REPLAYING mode to catch issues ${NEWLINE}${NEWLINE}"
+    comment+="##### Rerun these tests in REPLAYING mode to catch issues ${NEWLINE}${NEWLINE}"
 
     # Rerun passed tests in REPLAYING mode 3 times to catch issues
     export VCR_MODE=REPLAYING
@@ -251,14 +249,14 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     # store replaying test logs
     gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/replaying_after_recording/
 
-    REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
-    # REPLAYING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" replaying_build_after_recording.log | awk '{print $3}' | sort | uniq -c  | awk -v count=$count -v pr_number=$pr_number -v build_id=$build_id '$1 == count {print "`"$2"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
+    REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_after_recording/"$3".log)]"}')
     if [[ -n $REPLAYING_FAILED_TESTS ]]; then
-      comment+="Tests failed after rerunning these tests in REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
+      comment+="Tests failed when rerunning REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
       comment+="Please fix these to complete your PR${NEWLINE}"
     else
-      comment+="All tests passed when rerunning these tests in REPLAYING mode.${NEWLINE}${NEWLINE}"
+      comment+="All tests passed after rerunning REPLAYING mode.${NEWLINE}"
     fi
+    comment+="---"
 
     # Clear replaying-log folder
     rm testlog/replaying_after_recording/*

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -220,6 +220,8 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   RECORDING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" recording_test.log | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/recording_build/"$3"_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/recording/"$3".log)]"}')
   RECORDING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" recording_test.log | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/recording/"$3".log)]"}')
   RECORDING_PASSED_TEST_LIST=$(grep "^--- PASS: TestAcc" recording_test.log | awk '{print $3}')
+  echo "RECORDING_PASSED_TEST_LIST: ${RECORDING_PASSED_TEST_LIST}"
+
 
   comment=""
   RECORDING_PASSED_TESTS_COUNT=0
@@ -227,6 +229,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   if [[ -n $RECORDING_PASSED_TESTS ]]; then
     comment+="Tests passed during RECORDING mode:${NEWLINE} $RECORDING_PASSED_TESTS ${NEWLINE}${NEWLINE}"
     RECORDING_PASSED_TESTS_COUNT=$(echo "$RECORDING_PASSED_TESTS" | wc -l)
+    comment+="Rerun these tests in REPLAYING mode to catch issues ${NEWLINE}${NEWLINE}"
 
     # Rerun passed tests in REPLAYING mode 3 times to catch issues
     export VCR_MODE=REPLAYING
@@ -236,7 +239,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     test_exit_code=$?
 
     # Concatenate recording build logs to one file
-    for test in $RECORDING_PASSED_TESTS
+    for test in $RECORDING_PASSED_TEST_LIST
     do
       cat testlog/replaying_build_after_recording/${test}_replaying_test.log >> replaying_build_after_recording.log
     done
@@ -248,12 +251,13 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/replaying_after_recording/
 
     REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
-
+    # REPLAYING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" replaying_build_after_recording.log | awk '{print $3}' | sort | uniq -c  | awk -v count=$count -v pr_number=$pr_number -v build_id=$build_id '$1 == count {print "`"$2"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_build_after_recording/"$3".log)]"}')
     if [[ -n $REPLAYING_FAILED_TESTS ]]; then
-      comment+="Rerun these tests in REPLAYING mode to catch issues ${NEWLINE}${NEWLINE}"
       comment+="Tests failed after rerunning these tests in REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
       comment+="Please fix these to complete your PR${NEWLINE}"
-    if
+    else
+      comment+="All tests passed when rerunning these tests in REPLAYING mode.${NEWLINE}${NEWLINE}"
+    fi
 
     # Clear replaying-log folder
     rm testlog/replaying_after_recording/*

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -255,7 +255,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     else
       comment+="All tests passed after rerunning REPLAYING mode.${NEWLINE}"
     fi
-    comment+="---${NEWLINE}"
+    comment+="${NEWLINE}---${NEWLINE}"
 
     # Clear replaying-log folder
     rm testlog/replaying_after_recording/*

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -276,8 +276,6 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     elif [[ $test_exit_code -ne 0 ]]; then
       # check for any uncaught errors in RECORDING mode
       comment+="Errors occurred during RECORDING mode. Please fix them to complete your PR${NEWLINE}"
-    else
-      comment+="All tests passed during RECORDING mode.${NEWLINE}"
     fi
   fi
 

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -235,6 +235,12 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
 
     test_exit_code=$?
 
+    # Concatenate recording build logs to one file
+    for test in $RECORDING_PASSED_TESTS
+    do
+      cat testlog/replaying_build_after_recording/${test}_replaying_test.log >> replaying_build_after_recording.log
+    done
+
     # store replaying individual build logs
     gsutil -h "Content-Type:text/plain" -m -q cp testlog/replaying_build_after_recording/* gs://ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/replaying_build_after_recording/
 

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -262,6 +262,8 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     # Clear replaying-log folder
     rm testlog/replaying_after_recording/*
     rm testlog/replaying_build_after_recording/*
+  fi
+
   if [[ -n $RECORDING_FAILED_TESTS ]]; then
     comment+="Tests failed during RECORDING mode:${NEWLINE} $RECORDING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
     RECORDING_FAILED_TESTS_COUNT=$(echo "$RECORDING_FAILED_TESTS" | wc -l)

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -251,7 +251,8 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     REPLAYING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" replaying_build_after_recording.log | sort -u -t' ' -k3,3 | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/replaying_build_after_recording/"$3"_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/replaying_after_recording/"$3".log)]"}')
     if [[ -n $REPLAYING_FAILED_TESTS ]]; then
       comment+="Tests failed when rerunning REPLAYING mode:${NEWLINE} $REPLAYING_FAILED_TESTS ${NEWLINE}${NEWLINE}"
-      comment+="Please fix these to complete your PR${NEWLINE}"
+      comment+="Tests failed when the VCR replayed the response due to non-determinism or randomness when the HTTP request was made.${NEWLINE}${NEWLINE}"
+      comment+="Please fix these to complete your PR. If you do not know how VCR tests work, please work with the code reviewer to figure out the reason why the tests failed and fix the tests.${NEWLINE}"
     else
       comment+="All tests passed after rerunning REPLAYING mode.${NEWLINE}"
     fi

--- a/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/containers/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -220,7 +220,6 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
   RECORDING_FAILED_TESTS=$(grep "^--- FAIL: TestAcc" recording_test.log | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/build-log/recording_build/"$3"_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/recording/"$3".log)]"}')
   RECORDING_PASSED_TESTS=$(grep "^--- PASS: TestAcc" recording_test.log | awk -v pr_number=$pr_number -v build_id=$build_id '{print "`"$3"`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-"pr_number"/artifacts/"build_id"/recording/"$3".log)]"}')
   RECORDING_PASSED_TEST_LIST=$(grep "^--- PASS: TestAcc" recording_test.log | awk '{print $3}')
-  echo "RECORDING_PASSED_TEST_LIST: ${RECORDING_PASSED_TEST_LIST}"
 
   comment=""
   RECORDING_PASSED_TESTS_COUNT=0
@@ -256,7 +255,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
     else
       comment+="All tests passed after rerunning REPLAYING mode.${NEWLINE}"
     fi
-    comment+="---"
+    comment+="---${NEWLINE}"
 
     # Clear replaying-log folder
     rm testlog/replaying_after_recording/*
@@ -283,6 +282,7 @@ if [[ -n $FAILED_TESTS_PATTERN ]]; then
 
   comment+="View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-$pr_number/artifacts/$build_id/recording) for each test"
   add_comment "${comment}"
+
 else
   if [[ $test_exit_code -ne 0 ]]; then
     # check for any uncaught errors errors in REPLAYING mode


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12366

For passed tests in recording mode, rerun 3 times in replaying mode to catch issues.

Built the new image `zhenhua-test-051901` and tested in PR https://github.com/GoogleCloudPlatform/magic-modules/pull/7950. Please check the comment in that PR.
https://github.com/GoogleCloudPlatform/magic-modules/pull/7950#issuecomment-1558679557


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
