### PR TITLE
Remove need to add custom_import code or specially configured import_formats for resources with parent fields that contain `/`s

### DIFF
--- a/mmv1/products/cloudiot/DeviceRegistry.yaml
+++ b/mmv1/products/cloudiot/DeviceRegistry.yaml
@@ -34,7 +34,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
       '{{name}}',
     ]
 legacy_name: 'google_cloudiot_registry'
-import_format: ['projects/{{project}}/locations/{{region}}/registries/{{name}}']
+import_format: ['projects/{{project}}/locations/{{region}}/registries/{{name}}', '{{project}}/locations/{{region}}/registries/{{name}}']
 id_format: 'projects/{{project}}/locations/{{region}}/registries/{{name}}'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/cloudiot.go.erb

--- a/mmv1/products/cloudiot/DeviceRegistry.yaml
+++ b/mmv1/products/cloudiot/DeviceRegistry.yaml
@@ -34,7 +34,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
       '{{name}}',
     ]
 legacy_name: 'google_cloudiot_registry'
-import_format: ['{{project}}/locations/{{region}}/registries/{{name}}']
+import_format: ['projects/{{project}}/locations/{{region}}/registries/{{name}}']
 id_format: 'projects/{{project}}/locations/{{region}}/registries/{{name}}'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/cloudiot.go.erb

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -65,7 +65,6 @@ examples:
       pubsub_topic: 'fhir-notifications'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
-  custom_import: templates/terraform/custom_import/healthcare_fhir_store.go.erb
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: 'dataset'

--- a/mmv1/products/storage/ObjectAccessControl.yaml
+++ b/mmv1/products/storage/ObjectAccessControl.yaml
@@ -41,7 +41,7 @@ examples:
       bucket_name: 'static-content-bucket'
       object_name: 'public-object'
 id_format: '{{bucket}}/{{object}}/{{entity}}'
-import_format: ['{{bucket}}/{{%object}}/{{entity}}']
+import_format: ['{{&bucket}}/{{%object}}/{{&entity}}']
 mutex: 'storage/buckets/{{bucket}}/objects/{{object}}'
 skip_sweeper: true
 properties:

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -166,7 +166,7 @@ module Provider
     def format2regex(format)
       format
         .gsub(/\{\{%([[:word:]]+)\}\}/, '(?P<\1>.+)')
-        .gsub(/\{\{([[:word:]]+)\}\}/, '(?P<\1>[^/]+)')
+        .gsub(/\{\{([[:word:]]+)\}\}/, '(?P<\1>.+)')
     end
 
     # Capitalize the first letter of a property name.

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -157,9 +157,13 @@ module Provider
     # For instance,
     #   projects/{{project}}/global/networks/{{name}}
     # is transformed to
-    #   projects/(?P<project>[^/]+)/global/networks/(?P<name>[^/]+)
+    #   projects/(?P<project>.+)/global/networks/(?P<name>.+)
     #
-    # Values marked with % are URL-encoded, and will match any number of /'s.
+    # Values marked with & are encoded to match a token containing no additional /'s, 
+    # primarily for the use case of multiple tokens in a row where any token after the first 
+    # is specifically expected to contain multiple /'s.
+    #
+    # Values marked with % have no difference from the base functionality and is maintained to preserve compatability.
     #
     # Note: ?P indicates a Python-compatible named capture group. Named groups
     # aren't common in JS-based regex flavours, but are in Perl-based ones
@@ -167,6 +171,7 @@ module Provider
       format
         .gsub(/\{\{%([[:word:]]+)\}\}/, '(?P<\1>.+)')
         .gsub(/\{\{([[:word:]]+)\}\}/, '(?P<\1>.+)')
+        .gsub(/\{\{&([[:word:]]+)\}\}/, '(?P<\1>[^/]+)')
     end
 
     # Capitalize the first letter of a property name.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/12060
From local testing there appears to be no break in usability by using the url encoded version of the regex on all resources period. Several sub-resources already use the existing version you can generate by adding a % symbol to the start of the token within the import format string e.g. `{{%<parent>}}` without custom code needed. Could possibly be correct idea to just update all existing custom imports to actually be using the % variable field in their import formats and displaying this guideline our docs, because the change can generate extra false positives for regex that have extraneous leading values or multiple tokenfields in sequence and then send an invalid request -- e.g. a value of `foo/bar/boo/far` and `foobar////////////foo/bar////boo/far` could pass existing regex checks for `{{foobar}}/{{boo}}/{{far}}` shoving everything ahead of the first token match into that token i.e. `{{foobar}}` would become `foo/bar` -- but this would then be rejected by the API in response to the get request regardless. 

For a more detailed example:
```/a/b/d/e/f/g/projects/projfoo/foobars/broken/////example/locations/locfoo/babyfield```
will pass the generated regex for 
```{{barfoo}}/projects/{{project}}/foobars/{{foobar}}/locations/{{location}}/{{babyfieldname}}```
providing the values `{{barfoo}} = a/b/d/e/f/g`, `{{project}}=projfoo`, `{{foobar}}=broken/////example`, `{{location}}=locfoo`, and `{{babyfieldname}}=babyfield` when replacing all the tokens in the existing import formats.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
