### PR TITLE
compute - bump network_performance_config to ga

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -417,7 +417,6 @@ func ResourceComputeInstance() *schema.Resource {
 					},
 				},
 			},
-<% unless version == 'ga' -%>
 			"network_performance_config": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -436,7 +435,6 @@ func ResourceComputeInstance() *schema.Resource {
 					},
 				},
 			},
-<% end -%>
 			"allow_stopping_for_update": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -1260,11 +1258,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(instance.MachineType)); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-<% unless version == 'ga' -%>
 	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instance.NetworkPerformanceConfig)); err != nil {
 		return err
 	}
-<% end -%>
 	// Set the networks
 	// Use the first external IP found for the default connection info.
 	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, instance.NetworkInterfaces)

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -1066,12 +1066,10 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network interfaces: %s", err)
 	}
-<% unless version == 'ga' -%>
 	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network performance config: %s", err)
 	}
-<% end -%>
 	accels, err := expandInstanceGuestAccelerators(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
@@ -1091,9 +1089,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		Metadata:                   metadata,
 		Name:                       d.Get("name").(string),
 		NetworkInterfaces:          networkInterfaces,
-<% unless version == 'ga' -%>
 		NetworkPerformanceConfig:   networkPerformanceConfig,
-<% end -%>
 		Tags:                       resourceInstanceTags(d),
 		Labels:                     tpgresource.ExpandLabels(d),
 		ServiceAccounts:            expandServiceAccounts(d.Get("service_account").([]interface{})),

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -1202,12 +1202,10 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-<% unless version == 'ga' -%>
 	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
 	if err != nil {
 		return nil
 	}
-<% end -%>
 	reservationAffinity, err := expandReservationAffinity(d)
 	if err != nil {
 		return err
@@ -1223,9 +1221,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		Disks:                      disks,
 		Metadata:                   metadata,
 		NetworkInterfaces:          networks,
-<% unless version == 'ga' -%>
 		NetworkPerformanceConfig:   networkPerformanceConfig,
-<% end -%>
 		Scheduling:                 scheduling,
 		ServiceAccounts:            expandServiceAccounts(d.Get("service_account").([]interface{})),
 		Tags:                       resourceInstanceTags(d),

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -366,7 +366,6 @@ Google Cloud KMS.`,
 				Computed:    true,
 				Description: `The unique fingerprint of the metadata.`,
 			},
-<% unless version == 'ga' -%>
 			"network_performance_config": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -385,7 +384,6 @@ Google Cloud KMS.`,
 					},
 				},
 			},
-<% end -%>
 			"network_interface": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1596,11 +1594,9 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	if err = d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-<% unless version == 'ga' -%>
 	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceTemplate.Properties.NetworkPerformanceConfig)); err != nil {
 		return err
 	}
-<% end -%>
 	if instanceTemplate.Properties.NetworkInterfaces != nil {
 		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceTemplate.Properties.NetworkInterfaces)
 		if err != nil {

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
@@ -922,12 +922,10 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 	if err != nil {
 		return err
 	}
-<% unless version == 'ga' -%>
 	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
 	if err != nil {
 		return nil
 	}
-<% end -%>
 	reservationAffinity, err := expandReservationAffinity(d)
 	if err != nil {
 		return err
@@ -943,9 +941,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 		Disks:                      disks,
 		Metadata:                   metadata,
 		NetworkInterfaces:          networks,
-<% unless version == 'ga' -%>
 		NetworkPerformanceConfig:   networkPerformanceConfig,
-<% end -%>
 		Scheduling:                 scheduling,
 		ServiceAccounts:            expandServiceAccounts(d.Get("service_account").([]interface{})),
 		Tags:                       resourceInstanceTags(d),

--- a/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_region_instance_template.go.erb
@@ -348,7 +348,6 @@ Google Cloud KMS.`,
 				Description: `The unique fingerprint of the metadata.`,
 			},
 
-<% unless version == 'ga' -%>
 			"network_performance_config": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -367,7 +366,6 @@ Google Cloud KMS.`,
 					},
 				},
 			},
-<% end -%>
 
 			"network_interface": {
 				Type:        schema.TypeList,
@@ -1127,11 +1125,9 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	if err = d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-<% unless version == 'ga' -%>
 	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceProperties.NetworkPerformanceConfig)); err != nil {
 		return err
 	}
-<% end -%>
 	if instanceProperties.NetworkInterfaces != nil {
 		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceProperties.NetworkInterfaces)
 		if err != nil {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1299,7 +1299,6 @@ func TestAccComputeInstance_private_image_family(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeInstance_networkPerformanceConfig(t *testing.T) {
 	t.Parallel()
 
@@ -1324,7 +1323,6 @@ func TestAccComputeInstance_networkPerformanceConfig(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeInstance_forceChangeMachineTypeManually(t *testing.T) {
 	t.Parallel()
@@ -3066,7 +3064,6 @@ func testAccCheckComputeInstanceHasNetworkIP(instance *compute.Instance, network
 	}
 }
 
-<% unless version == "ga" -%>
 func testAccCheckComputeInstanceHasNetworkPerformanceConfig(instance *compute.Instance, bandwidthTier string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance.NetworkPerformanceConfig == nil {
@@ -3079,7 +3076,6 @@ func testAccCheckComputeInstanceHasNetworkPerformanceConfig(instance *compute.In
 		return nil
 	}
 }
-<% end -%>
 
 func testAccCheckComputeInstanceHasMultiNic(instance *compute.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -5211,7 +5207,6 @@ resource "google_compute_instance" "foobar" {
 `, disk, family, family, instance)
 }
 
-<% unless version == "ga" -%>
 func testAccComputeInstance_networkPerformanceConfig(disk string, image string, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -5263,7 +5258,6 @@ resource "google_compute_instance" "foobar" {
 }
 `, disk, image, instance)
 }
-<% end -%>
 
 func testAccComputeInstance_multiNic(instance, network, subnetwork string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -651,7 +651,6 @@ func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[str
 	return []map[string]interface{}{flattened}
 }
 
-<% unless version == "ga" -%>
 func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (*compute.NetworkPerformanceConfig, error) {
 	configs, ok := d.GetOk("network_performance_config")
 	if !ok {
@@ -682,4 +681,3 @@ func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[
 		},
 	}
 }
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: - promoted field `network_performance_config` to ga 
```
