### PR TITLE
added excluded_fields and included_fields to data_loss_prevention_job_trigger resource

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -828,6 +828,29 @@ properties:
                       required: true
                       description: |
                         Name of a BigQuery field to be returned with the findings.
+              - !ruby/object:Api::Type::Array
+                name: 'includedFields'
+                description: |
+                  Limit scanning only to these fields.
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'name'
+                      required: true
+                      description: |
+                        Name describing the field to which scanning is limited.
+              - !ruby/object:Api::Type::Array
+                name: 'excludedFields'
+                description: |
+                  References to fields excluded from scanning.
+                  This allows you to skip inspection of entire columns which you know have no findings.
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'name'
+                      required: true
+                      description: |
+                        Name describing the field excluded from scanning.
           - !ruby/object:Api::Type::NestedObject
             name: 'hybridOptions'
             allow_empty_object: true

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -323,8 +323,8 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerUpdateExample3(t *testing.
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       getTestProjectFromEnv(),
-		"random_suffix": randString(t, 10),
+		"project":       acctest.GetTestProjectFromEnv(),
+		"random_suffix": RandString(t, 10),
 	}
 
 	VcrTest(t, resource.TestCase{
@@ -358,8 +358,8 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerUpdateExample4(t *testing.
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       getTestProjectFromEnv(),
-		"random_suffix": randString(t, 10),
+		"project":       acctest.GetTestProjectFromEnv(),
+		"random_suffix": RandString(t, 10),
 	}
 
 	VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -319,6 +319,76 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerInspectCustomInfoTypes(t *
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerUpdateExample3(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       getTestProjectFromEnv(),
+		"random_suffix": randString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerIncludedFields(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.included_fields",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerIncludedFieldsUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.included_fields_update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerUpdateExample4(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       getTestProjectFromEnv(),
+		"random_suffix": randString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerExcludedFields(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.excluded_fields",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerExcludedFieldsUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.excluded_fields_update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -400,6 +470,94 @@ resource "google_data_loss_prevention_job_trigger" "identifying_fields" {
 `, context)
 }
 
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerIncludedFields(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "included_fields" {
+	parent = "projects/%{project}"
+	description = "Starting description"
+	display_name = "display"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			big_query_options {
+				table_reference {
+					project_id = "project"
+					dataset_id = "dataset"
+					table_id = "table_to_scan"
+				}
+				rows_limit = 1000
+				sample_method = "RANDOM_START"
+				included_fields {
+					name = "field"
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerExcludedFields(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "excluded_fields" {
+	parent = "projects/%{project}"
+	description = "Starting description"
+	display_name = "display"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			big_query_options {
+				table_reference {
+					project_id = "project"
+					dataset_id = "dataset"
+					table_id = "table_to_scan"
+				}
+				rows_limit = 1000
+				sample_method = "RANDOM_START"
+				excluded_fields {
+					name = "field"
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -472,6 +630,94 @@ resource "google_data_loss_prevention_job_trigger" "identifying_fields_update" {
 				rows_limit = 1000
 				sample_method = "RANDOM_START"
 				identifying_fields {
+					name = "different"
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerIncludedFieldsUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "included_fields_update" {
+	parent = "projects/%{project}"
+	description = "An updated description"
+	display_name = "Different"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			big_query_options {
+				table_reference {
+					project_id = "project"
+					dataset_id = "dataset"
+					table_id = "table_to_scan"
+				}
+				rows_limit = 1000
+				sample_method = "RANDOM_START"
+				included_fields {
+					name = "different"
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerExcludedFieldsUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "excluded_fields_update" {
+	parent = "projects/%{project}"
+	description = "An updated description"
+	display_name = "Different"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			big_query_options {
+				table_reference {
+					project_id = "project"
+					dataset_id = "dataset"
+					table_id = "table_to_scan"
+				}
+				rows_limit = 1000
+				sample_method = "RANDOM_START"
+				excluded_fields {
 					name = "different"
 				}
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added `included_fields` and `excluded_fields` to `data_loss_prevention_job_trigger` with relevent tests
fixes https://github.com/hashicorp/terraform-provider-google/issues/8807
fixes https://github.com/hashicorp/terraform-provider-google/issues/8838


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
dlp: added fields `included_fields` and `excluded_fields` to resource `google_data_loss_prevention_job_trigger`
```
