### PR TITLE
Updating documentation to display an import_format functionality + broken docs link

### DIFF
--- a/docs/content/docs/getting-started/provider-documentation.md
+++ b/docs/content/docs/getting-started/provider-documentation.md
@@ -87,4 +87,4 @@ Terraform Provider Google (TPG) contains handwritten documentation for handwritt
 ### Generated documentation (mmv1)
 
 The majority of resources in TPG are generated, and the information used to generate provider code is also used to generate documentation. For information about how documentation is generated, see:
-- [Update MMv1 resource documentation](/magic-modules/docs/how-to/update-mmv1-resource-documentation)
+- [Add and update MMv1 resource documentation](/magic-modules/docs/how-to/mmv1-resource-documentation)

--- a/docs/content/docs/how-to/add-mmv1-resource.md
+++ b/docs/content/docs/how-to/add-mmv1-resource.md
@@ -297,7 +297,7 @@ Example: DomainMapping (DomainMappingLabelDiffSuppress)
 
 ## Documentation
 
-When adding a new MMv1 product or resource there are fields that you need to set within `product.yaml` and resource-level `ResourceName.yaml` that are specific to documentation for that resource. To learn more about MMv1 generated documentation and what YAML fields you need to pay attention to, see [Update MMv1 resource documentation](/magic-modules/docs/how-to/update-mmv1-resource-documentation).
+When adding a new MMv1 product or resource there are fields that you need to set within `product.yaml` and resource-level `ResourceName.yaml` that are specific to documentation for that resource. To learn more about MMv1 generated documentation and what YAML fields you need to pay attention to, see [Add and update MMv1 resource documentation](/magic-modules/docs/how-to/mmv1-resource-documentation).
 
 # Beta features
 

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -147,6 +147,10 @@ module Api
       # The Terraform resource id format used when calling #setId(...).
       # For instance, `{{name}}` means the id will be the resource name.
       attr_reader :id_format
+      # Sets the formats used to generate regex strings that match templated 
+      # values into a full self_link format for importing. Leading a token with `%`
+      # i.e. {{%parent}}/resource/{{resource}}
+      # will allow that token to hold multiple /'s.
       attr_reader :import_format
       attr_reader :custom_code
       attr_reader :docs

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -147,8 +147,10 @@ module Api
       # The Terraform resource id format used when calling #setId(...).
       # For instance, `{{name}}` means the id will be the resource name.
       attr_reader :id_format
-      # Sets the formats used to generate regex strings that match templated 
-      # values into a full self_link format for importing. Leading a token with `%`
+      # Override attribute used to handwrite the formats for generating regex strings
+      # that match templated values to a self_link when importing, only necessary when
+      # a resource is not adequately covered by the standard provider generated options.
+      # Leading a token with `%`
       # i.e. {{%parent}}/resource/{{resource}}
       # will allow that token to hold multiple /'s.
       attr_reader :import_format


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Currently the % token functionality is only clarified in terraform.rb, which is not a place most users check. `resource.rb` is linked in our docs and will make this much more visible to users, while also suggesting the usage case of parent fields to avoid the misunderstanding that custom_imports are as necessary (https://github.com/hashicorp/terraform-provider-google/issues/12060).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
