### PR TITLE
Set supported PD fields on workstation_config as mutable.

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -291,7 +291,6 @@ properties:
               immutable: true
             - !ruby/object:Api::Type::Enum
               name: 'reclaimPolicy'
-              default_value: :DELETE
               description: |
                 Whether the persistent disk should be deleted when the workstation is deleted. Valid values are `DELETE` and `RETAIN`. Defaults to `DELETE`.
               values:

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -256,7 +256,6 @@ properties:
     description: |
       Directories to persist across workstation sessions.
     default_from_api: true
-    immutable: true
     item_type: !ruby/object:Api::Type::NestedObject
       properties:
         - !ruby/object:Api::Type::String
@@ -268,41 +267,40 @@ properties:
         - !ruby/object:Api::Type::NestedObject
           name: 'gcePd'
           description: |
-            PersistentDirectory backed by a Compute Engine regional persistent disk.
+            A directory to persist across workstation sessions, backed by a Compute Engine regional persistent disk. Can only be updated if not empty during creation.
           default_from_api: true
-          immutable: true
           properties:
             - !ruby/object:Api::Type::String
               name: 'fsType'
               description: |
-                Type of file system that the disk should be formatted with. The workstation image must support this file system type. Must be empty if sourceSnapshot is set.
+                Type of file system that the disk should be formatted with. The workstation image must support this file system type. Must be empty if `sourceSnapshot` is set. Defaults to `ext4`.
               default_from_api: true
               immutable: true
             - !ruby/object:Api::Type::String
               name: 'diskType'
               description: |
-                Type of the disk to use.
+                The type of the persistent disk for the home directory. Defaults to `pd-standard`.
               default_from_api: true
               immutable: true
             - !ruby/object:Api::Type::Integer
               name: 'sizeGb'
               description: |-
-                Size of the disk in GB. Must be empty if sourceSnapshot is set.
+                The GB capacity of a persistent home directory for each workstation created with this configuration. Must be empty if `sourceSnapshot` is set.
+                Valid values are `10`, `50`, `100`, `200`, `500`, or `1000`. Defaults to `200`. If less than `200` GB, the `diskType` must be `pd-balanced` or `pd-ssd`.
               default_from_api: true
               immutable: true
             - !ruby/object:Api::Type::Enum
               name: 'reclaimPolicy'
+              default_value: :DELETE
               description: |
-                What should happen to the disk after the workstation is deleted. Defaults to DELETE.
-              immutable: true
+                Whether the persistent disk should be deleted when the workstation is deleted. Valid values are `DELETE` and `RETAIN`. Defaults to `DELETE`.
               values:
                 - :DELETE
                 - :RETAIN
             - !ruby/object:Api::Type::String
               name: 'sourceSnapshot'
               description: |
-                The snapshot to use as the source for the disk. This can be the snapshot's `self_link`, `id`, or a string in the format of `projects/{project}/global/snapshots/{snapshot}`. If set, sizeGb and fsType must be empty.
-              immutable: true
+                Name of the snapshot to use as the source for the disk. This can be the snapshot's `self_link`, `id`, or a string in the format of `projects/{project}/global/snapshots/{snapshot}`. If set, `sizeGb` and `fsType` must be empty. Can only be updated if it has an existing value.
               # TODO(esu): Add conflicting fields once complex lists are supported.
   - !ruby/object:Api::Type::NestedObject
     name: 'container'

--- a/mmv1/templates/terraform/examples/workstation_config_persistent_directories.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_persistent_directories.tf.erb
@@ -50,6 +50,8 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
     mount_path = "/home"
     gce_pd {
       size_gb        = 200
+      fs_type        = "ext4"
+      disk_type      = "pd-standard"
       reclaim_policy = "DELETE"
     }
   }

--- a/mmv1/third_party/terraform/tests/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_workstations_workstation_config_test.go.erb
@@ -611,4 +611,159 @@ resource "google_workstations_workstation_config" "default" {
 }
 `, context)
 }
+
+func TestAccWorkstationsWorkstationConfig_updatePersistentDirectorySourceSnapshot(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_withSourceDiskSnapshot(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+			{
+				Config: testAccWorkstationsWorkstationConfig_withUpdatedSourceDiskSnapshot(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_withSourceDiskSnapshot(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_compute_disk" "test_source_disk" {
+  provider = google-beta
+  name     = "tf-test-workstation-source-disk%{random_suffix}"
+  size     = 10
+  type     = "pd-ssd"
+  zone     = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "test_source_snapshot" {
+  provider    = google-beta
+  name        = "tf-test-workstation-source-snapshot%{random_suffix}"
+  source_disk = google_compute_disk.test_source_disk.name
+  zone        = "us-central1-a"
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  persistent_directories {
+    mount_path = "/home"
+
+    gce_pd {
+      source_snapshot = google_compute_snapshot.test_source_snapshot.id
+      reclaim_policy  = "DELETE"
+    }
+  }
+}
+`, context)
+}
+
+func testAccWorkstationsWorkstationConfig_withUpdatedSourceDiskSnapshot(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_compute_disk" "test_source_disk" {
+  provider = google-beta
+  name     = "tf-test-workstation-source-disk%{random_suffix}"
+  size     = 10
+  type     = "pd-ssd"
+  zone     = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "test_source_snapshot" {
+  provider    = google-beta
+  name        = "tf-test-workstation-source-snapshot%{random_suffix}"
+  source_disk = google_compute_disk.test_source_disk.name
+  zone        = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "test_source_snapshot2" {
+  provider    = google-beta
+  name        = "tf-test-workstation-source-snapshot2%{random_suffix}"
+  source_disk = google_compute_disk.test_source_disk.name
+  zone        = "us-central1-a"
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider                   = google-beta
+  workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+  network                    = google_compute_network.default.id
+  subnetwork                 = google_compute_subnetwork.default.id
+  location                   = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  persistent_directories {
+    mount_path = "/home"
+
+    gce_pd {
+      source_snapshot = google_compute_snapshot.test_source_snapshot2.id
+      reclaim_policy  = "RETAIN"
+    }
+  }
+}
+`, context)
+}
 <% end -%>


### PR DESCRIPTION
This change updates several fields on `google_workstations_workstation_config` to be mutable. In particular:

- `persistentDirectories.gcePd` (the top-level PD block) can now be updated if the config has an existing PD config
- `persistentDirectories.gcePd[0].reclaimPolicy` can now be updated
- `persistentDirectories.gcePd[0].sourceSnapshot` can now be updated if the existing PD config had a value for this field

The other values are set as `default_from_api` even though the defaults are known, since some of them have exclusivity rules with neighboring keys.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: Support update of PD fields `reclaim_policy` and `source_snapshot` on `google_workstations_workstation_config` (beta)
```
