### PR TITLE
cloud_identity: Add option for dyamic groups

### DIFF
--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -50,6 +50,17 @@ examples:
     test_env_vars:
       org_domain: :ORG_DOMAIN
       cust_id: :CUST_ID
+  - !ruby/object:Provider::Terraform::Examples
+    name:
+      'cloud_identity_groups_dynamic'
+    skip_test: true
+    primary_resource_id: 'cloud_identity_group_dynamic'
+    vars:
+      id_group: 'my-engineering-group'
+    test_env_vars:
+      org_domain: :ORG_DOMAIN
+      cust_id: :CUST_ID
+      query: 'user.organizations.exists(org, org.department=='engineering')'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_create: templates/terraform/post_create/set_computed_name.erb
   custom_import: templates/terraform/custom_import/cloud_identity_group_import.go.erb
@@ -128,6 +139,30 @@ properties:
     description: |
       An extended description to help users determine the purpose of a Group.
       Must not be longer than 4,096 characters.
+  - !ruby/object:Api::Type::String
+    name: 'dynamicGroupQuery'
+    # Custom expand to save having to define an entire dynamicGroupMetadata object
+    # which is an object containing an array of objects, but currently there is only
+    # one valid format, and only one variable.
+    # In the future, we can add a `dynamicGroupMetadata` property to this resource
+    # to allow full configurability if other options become supported.
+    custom_expand: 'templates/terraform/custom_expand/cloudidentity_group.go.erb'
+    description: |
+      Query that determines the memberships of the dynamic group.
+
+      It's not possible to create google_cloud_identity_group_membership resources that reference groups that set this query, as membership becomes managed automatically.
+      For a list of all valid attribues referr to the [API reference](https://cloud.google.com/identity/docs/how-to/dynamic-groups-attributes)
+
+      Examples:
+      
+      All users with at least one organizations.department of engineering.
+      user.organizations.exists(org, org.department=='engineering')
+
+      All users with at least one location that has area of foo and building_id of bar.
+      user.locations.exists(loc, loc.area=='foo' && loc.building_id=='bar')
+
+      All users with any variation of the name John Doe (case-insensitive queries add equalsIgnoreCase() to the value being queried).
+      user.name.value.equalsIgnoreCase('jOhn DoE')
   - !ruby/object:Api::Type::String
     name: 'createTime'
     output: true

--- a/mmv1/templates/terraform/custom_expand/cloudidentity_group.go.erb
+++ b/mmv1/templates/terraform/custom_expand/cloudidentity_group.go.erb
@@ -1,0 +1,32 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+    query := v.(string)
+
+    dynamicGroupMetadata := map[string]interface{} {
+        "queries": []map[string]interface{} {
+            {
+                "resourceType": "USER",
+                "query": query,
+            },
+        },
+    }
+
+	return dynamicGroupMetadata, nil
+}

--- a/mmv1/templates/terraform/examples/cloud_identity_groups_dynamic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_identity_groups_dynamic.tf.erb
@@ -1,0 +1,16 @@
+resource "google_cloud_identity_group" "<%= ctx[:primary_resource_id] %>" {
+  display_name         = "<%= ctx[:vars]['id_group'] %>"
+  initial_group_config = "EMPTY"
+
+  parent = "customers/<%= ctx[:test_env_vars]['cust_id'] %>"
+
+  group_key {
+  	id = "<%= ctx[:vars]['id_group'] %>@<%= ctx[:test_env_vars]['org_domain'] %>"
+  }
+
+  dynamicGroupQuery = "<%= ctx[:test_env_vars]['query']"
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add option to set dynamic group metadata query.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloud_identity: added `dynamicGroupQuery` to `google_cloud_identity_group` for automatic membership
```
