### PR TITLE
Add copyright headers to handwritten files that are specific to TPG/TPGB

### DIFF
--- a/mmv1/third_party/terraform/acctest/gcp_sweeper.go
+++ b/mmv1/third_party/terraform/acctest/gcp_sweeper.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package acctest
 
 import (

--- a/mmv1/third_party/terraform/acctest/provider_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/provider_test_utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package acctest
 
 import (

--- a/mmv1/third_party/terraform/acctest/test_utils.go
+++ b/mmv1/third_party/terraform/acctest/test_utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package acctest
 
 import (

--- a/mmv1/third_party/terraform/acctest/vcr_utils.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package acctest
 
 import "os"

--- a/mmv1/third_party/terraform/data_sources/data_source_access_approval_folder_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_access_approval_folder_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_access_approval_organization_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_access_approval_organization_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_access_approval_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_access_approval_project_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_artifact_registry_repository.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_artifact_registry_repository.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_certificate_authority.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_certificate_authority.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_cloud_run_locations.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_cloud_run_locations.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_cloud_run_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_cloud_run_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_health_check.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_health_check.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_lb_ip_ranges.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_lb_ip_ranges.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_endpoint_group_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_compute_network_peering.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_container_registry_image.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_container_registry_image.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_container_registry_repository.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_container_registry_repository.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_dns_keys.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_keys.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_managed_zone.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_dns_record_set.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_dns_record_set.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_app_engine_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_app_engine_default_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connection.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connection.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connector.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_connector.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_gateway.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_beyondcorp_app_gateway.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloudbuild_trigger.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloudbuild_trigger.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions2_function.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions2_function.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_cloudfunctions_function.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_composer_environment.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_composer_environment.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_composer_image_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_composer_image_versions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_address.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_address.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_bucket.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_bucket.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_backend_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_default_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_default_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_disk.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_disk.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_forwarding_rule.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_forwarding_rule.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_global_address.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_global_address.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_ha_vpn_gateway.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_ha_vpn_gateway.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group_manager.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_group_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_serial_port.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_instance_serial_port.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_network.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_network_endpoint_group.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_network_endpoint_group.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_ssl_certificate.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_region_ssl_certificate.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_router.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_router.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_router_nat.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_router_nat.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_certificate.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_certificate.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_ssl_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_install_manifest.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_install_manifest.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_attached_versions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_aws_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_aws_versions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_azure_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_azure_versions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_cluster.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_cluster.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_container_engine_versions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_folder.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_folder_organization_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_folder_organization_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_game_services_game_server_deployment_rollout.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_game_services_game_server_deployment_rollout.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_global_compute_forwarding_rule.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_global_compute_forwarding_rule.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_role.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_role.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret_ciphertext.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_kms_secret_ciphertext.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_logging_project_cmek_settings.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_logging_project_cmek_settings.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_logging_sink.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_logging_sink.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_monitoring_uptime_check_ips.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_monitoring_uptime_check_ips.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_organization.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_organization.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_project.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_project_organization_policy.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project_organization_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_project_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_project_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_projects.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_projects.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_access_token.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_access_token.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_id_token.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_id_token.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_jwt.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_jwt.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_account_key.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_account_key.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_service_networking_peered_dns_domain.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_sql_ca_certs.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_sql_ca_certs.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_project_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_storage_transfer_project_service_account.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_iap_client.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_iap_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_istio_canonical_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_istio_canonical_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_notification_channel.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_notification_channel.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_app_engine.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_app_engine.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_cluster_istio.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_cluster_istio.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_mesh_istio.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_mesh_istio.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_test.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_monitoring_service_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_pubsub_subscription.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_pubsub_topic.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_pubsub_topic.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_redis_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_redis_instance.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version_access.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_secret_manager_secret_version_access.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sourcerepo_repository.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sourcerepo_repository.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_spanner_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_spanner_instance.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_backup_run.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_backup_run.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_database.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_database.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_database_instance.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_database_instance.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_database_instances.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_database_instances.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_sql_databases.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_sql_databases.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_storage_bucket_object_content.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_storage_bucket_object_content.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_tags_tag_key.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_tags_tag_key.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_tags_tag_value.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_tags_tag_value.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_vpc_access_connector.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_models/provider_model.go.erb
+++ b/mmv1/third_party/terraform/framework_models/provider_model.go.erb
@@ -1,4 +1,7 @@
 <% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_config.go.erb
@@ -1,4 +1,7 @@
 <% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_provider_test.go.erb
@@ -1,4 +1,7 @@
 <% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_test_utils.go.erb
+++ b/mmv1/third_party/terraform/framework_utils/framework_test_utils.go.erb
@@ -1,4 +1,7 @@
 <% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_transport.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_transport.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_utils.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/framework_utils/framework_validators.go
+++ b/mmv1/third_party/terraform/framework_utils/framework_validators.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package google
 
 import (

--- a/mmv1/third_party/terraform/version/version.go
+++ b/mmv1/third_party/terraform/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 var (


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

# Context

HashiCorp has this dependabot-style system for asserting that copyright headers are present in their public repos: https://github.com/hashicorp/terraform-provider-google/pull/13624

If we merge these automated PRs the changes will be lost as soon as the next update is merged from Magic Modules.

Instead, we need to update the code generator to add these headers 'at source'.

# Description

This PR adds the copyright headers to handwritten files that are only used in TPG/TPGB and are not present in terraform-google-conversion.

The only files in terraform-google-conversion affected by this PR should be go.mod and go.sum

This PR corresponds to # 1 in the list below:


>1. Adding hardcoded headers to handwritten files that are used in TPG/TPGB and not used in terraform-google-conversion
>2. Provide Magic Modules with knowledge of what downstream it is making when logic in the templates is being evaluated, and have HashiCorp copyright be templated in only if TPG/TPGB is being generated.
>3. Handle handwritten files, specifically util files and packages like `transport`, that are copied into their downstream repo as-is and don't benefit from templating to introduce logic. The only edits to these files I'm aware of is the changing of import paths when the private version of the provider is built, and that's done without templating.


---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
