### PR TITLE
Add retry for internal 160009 errors

### DIFF
--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -234,6 +234,19 @@ func ServiceUsageServiceBeingActivated(err error) (bool, string) {
 	return false, ""
 }
 
+// See https://github.com/hashicorp/terraform-provider-google/issues/14691 for
+// details on the error message this handles
+func ServiceUsageInternalError160009(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 3 {
+		if strings.Contains(gerr.Body, "encountered internal error") && strings.Contains(gerr.Body, "160009") && strings.Contains(gerr.Body, "with failed services") {
+			return true, "retrying internal error 160009."
+		}
+
+		return false, ""
+	}
+	return false, ""
+}
+
 // Retry if Bigquery operation returns a 403 with a specific message for
 // concurrent operations (which are implemented in terms of 'edit quota').
 func IsBigqueryIAMQuotaError(err error) (bool, string) {

--- a/mmv1/third_party/terraform/utils/serviceusage_operation.go
+++ b/mmv1/third_party/terraform/utils/serviceusage_operation.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/serviceusage/v1"
 )
 
@@ -21,19 +20,4 @@ func serviceUsageOperationWait(config *transport_tpg.Config, op *serviceusage.Op
 		return err
 	}
 	return ServiceUsageOperationWaitTime(config, m, project, activity, userAgent, timeout)
-}
-
-func handleServiceUsageRetryableError(err error) error {
-	if err == nil {
-		return nil
-	}
-	if gerr, ok := err.(*googleapi.Error); ok {
-		if (gerr.Code == 400 || gerr.Code == 412) && gerr.Message == "Precondition check failed." {
-			return &googleapi.Error{
-				Code:    503,
-				Message: "api returned \"precondition failed\" while enabling service",
-			}
-		}
-	}
-	return err
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14691

This does a bit of refactoring- I did that to wrap my head around the existing logic, and hopefully make it more clear. Sorry for the extra noise!

I've confirmed our existing tests pass (`TestAccProjectService_`, `TestAccProject_deleteDefaultNetwork`), but was unable to reproduce the error so far to confirm the fix works.

Our logs show some escape characters in the sequence (the relevant bit is `"[service pubsub.googleapis.com encountered internal error: type: \"googleapis.com\" subject: \"160009\" ] with failed services [pubsub.googleapis.com]",`) so I looked for a few different parts of the string in the body rather than one long string- without a repro, I'm not 100% certain what the correct characters would be.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: added retries to handle internal error: type: "googleapis.com" subject: "160009" when activating services
```

```release-note:bug
cloudresourcemanager: added retries to handle internal error: type: "googleapis.com" subject: "160009" when activating "compute.googleapis.com" to destroy the default network when `auto_create_network` is `false`
```
