### PR TITLE
ensure google_cloudbuild_bitbucket_server_config tests get sweeped

### DIFF
--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -49,15 +49,20 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_bitbucket_server_config'
     primary_resource_id: 'bbs-config'
+    vars:
+      bbsname: 'my-bbsconfig'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_bitbucket_server_config_repositories'
     primary_resource_id: 'bbs-config-with-repos'
     skip_test: true
+    vars:
+      bbsname: 'my-bbsconfig'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_bitbucket_server_config_peered_network'
     primary_resource_id: 'bbs-config-with-peered-network'
     vars:
       network_name: 'vpc-network'
+      bbsname: 'my-bbsconfig'
     test_vars_overrides:
       network_name: 'BootstrapSharedTestNetwork(t, "peered-network")'
 custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config.tf.erb
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_id] %>" {
-    config_id = "mybbsconfig"
+    config_id = "<%= ctx[:vars]['bbsname'] %>"
     location = "us-central1"
     host_uri = "https://bbs.com"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_peered_network.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_peered_network.tf.erb
@@ -4,7 +4,7 @@ resource "google_project_service" "servicenetworking" {
   service = "servicenetworking.googleapis.com"
   disable_on_destroy = false
 }
- 
+
 data "google_compute_network" "vpc_network" {
     name       = "<%= ctx[:vars]['network_name'] %>"
     depends_on = [google_project_service.servicenetworking]
@@ -26,7 +26,7 @@ resource "google_service_networking_connection" "default" {
 }
 
 resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_id] %>" {
-    config_id = "mybbsconfig"
+    config_id = "<%= ctx[:vars]['bbsname'] %>"
     location = "us-central1"
     host_uri = "https://bbs.com"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_repositories.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_repositories.tf.erb
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_id] %>" {
-    config_id = "mybbsconfig"
+    config_id = "<%= ctx[:vars]['bbsname'] %>"
     location = "us-central1"
     host_uri = "https://bbs.com"
     secrets {


### PR DESCRIPTION
fixes [TestAccCloudBuildBitbucketServerConfig_cloudbuildBitbucketServerConfigExample](https://ci-oss.hashicorp.engineering/project.html?projectId=GoogleCloud&testNameId=2457000301783528893&tab=testDetails)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
