### PR TITLE
Revert "Replaced users.list api with users.get api to increase efficiency."

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -1069,25 +1069,27 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	// Users in a replica instance are inherited from the master instance and should be left alone.
 	// This deletion is done immediately after the instance is created, in order to minimize the
 	// risk of it being left on the instance, which would present a security concern.
-	if sqlDatabaseIsMaster(d) && strings.Contains(strings.ToUpper(databaseVersion), "MYSQL") {
-		var user *sqladmin.User
+	if sqlDatabaseIsMaster(d) {
+		var users *sqladmin.UsersListResponse
 		err = transport_tpg.RetryTimeDuration(func() error {
-			user, err = config.NewSqlAdminClient(userAgent).Users.Get(project, instance.Name, "root").Host("%").Do()
+			users, err = config.NewSqlAdminClient(userAgent).Users.List(project, instance.Name).Do()
 			return err
 		}, d.Timeout(schema.TimeoutRead), transport_tpg.IsSqlOperationInProgressError)
 		if err != nil {
-			return fmt.Errorf("Error, attempting to fetch root user associated with instance %s: %s", instance.Name, err)
+			return fmt.Errorf("Error, attempting to list users associated with instance %s: %s", instance.Name, err)
 		}
-		if user != nil {
-			err = transport_tpg.Retry(func() error {
-				op, err = config.NewSqlAdminClient(userAgent).Users.Delete(project, instance.Name).Host(user.Host).Name(user.Name).Do()
-				if err == nil {
-					err = SqlAdminOperationWaitTime(config, op, project, "Delete default root User", userAgent, d.Timeout(schema.TimeoutCreate))
+		for _, u := range users.Items {
+			if u.Name == "root" && u.Host == "%" {
+				err = transport_tpg.Retry(func() error {
+					op, err = config.NewSqlAdminClient(userAgent).Users.Delete(project, instance.Name).Host(u.Host).Name(u.Name).Do()
+					if err == nil {
+						err = SqlAdminOperationWaitTime(config, op, project, "Delete default root User", userAgent, d.Timeout(schema.TimeoutCreate))
+					}
+					return err
+				})
+				if err != nil {
+					return fmt.Errorf("Error, failed to delete default 'root'@'*' user, but the database was created successfully: %s", err)
 				}
-				return err
-			})
-			if err != nil {
-				return fmt.Errorf("Error, failed to delete default 'root'@'*' user, but the database was created successfully: %s", err)
 			}
 		}
 	}

--- a/mmv1/third_party/terraform/resources/resource_sql_user.go
+++ b/mmv1/third_party/terraform/resources/resource_sql_user.go
@@ -123,7 +123,6 @@ func ResourceSqlUser() *schema.Resource {
 			"password_policy": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -207,6 +206,7 @@ func expandPasswordPolicy(cfg interface{}) *sqladmin.UserPasswordValidationPolic
 	raw := cfg.([]interface{})[0].(map[string]interface{})
 
 	upvp := &sqladmin.UserPasswordValidationPolicy{}
+
 	if v, ok := raw["allowed_failed_attempts"]; ok {
 		upvp.AllowedFailedAttempts = int64(v.(int))
 	}
@@ -316,15 +316,36 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	host := d.Get("host").(string)
 
-	var user *sqladmin.User
+	var users *sqladmin.UsersListResponse
 	err = nil
 	err = transport_tpg.RetryTime(func() error {
-		user, err = config.NewSqlAdminClient(userAgent).Users.Get(project, instance, name).Host(host).Do()
+		users, err = config.NewSqlAdminClient(userAgent).Users.List(project, instance).Do()
 		return err
 	}, 5)
 	if err != nil {
 		// move away from transport_tpg.HandleNotFoundError() as we need to handle both 404 and 403
 		return handleUserNotFoundError(err, d, fmt.Sprintf("SQL User %q in instance %q", name, instance))
+	}
+
+	var user *sqladmin.User
+	databaseInstance, err := config.NewSqlAdminClient(userAgent).Instances.Get(project, instance).Do()
+	if err != nil {
+		return err
+	}
+
+	for _, currentUser := range users.Items {
+		if !strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") {
+			name = strings.Split(name, "@")[0]
+		}
+
+		if currentUser.Name == name {
+			// Host can only be empty for postgres instances,
+			// so don't compare the host if the API host is empty.
+			if host == "" || currentUser.Host == host {
+				user = currentUser
+				break
+			}
+		}
 	}
 
 	if user == nil {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#7941

[teamcity failures related to change
](https://ci-oss.hashicorp.engineering/project.html?projectId=GoogleCloud&testNameId=-1376503269074295768&tab=testDetails)------- Stdout: -------
=== RUN   TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone
=== PAUSE TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone
=== CONT  TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone
    vcr_utils.go:145: Step 1/3 error: Error running apply: exit status 1
        
        Error: Error, attempting to fetch root user associated with instance tf-test-6wpfhz8uwy-clone1: googleapi: Error 404: Not Found, notFound
        
          with google_sql_database_instance.clone1,
          on terraform_plugin_test.tf line 40, in resource "google_sql_database_instance" "clone1":
          40: resource "google_sql_database_instance" "clone1" {
        
--- FAIL: TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone (2318.39s)
FAIL

```release-note:none
Release note
```
