### PR TITLE
Revert "add dataflow flex parameters (#6921)"

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -3,15 +3,14 @@ package google
 <% unless version == 'ga' -%>
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"google.golang.org/api/googleapi"
 
@@ -31,12 +30,6 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 		Read:   resourceDataflowFlexTemplateJobRead,
 		Update: resourceDataflowFlexTemplateJobUpdate,
 		Delete: resourceDataflowFlexTemplateJobDelete,
-		CustomizeDiff: customdiff.All(
-			resourceDataflowFlexJobTypeCustomizeDiff,
-		),
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 		Schema: map[string]*schema.Schema{
 
 			"container_spec_gcs_path": {
@@ -58,12 +51,6 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				Description: `The region in which the created job should run.`,
 			},
 
-			"transform_name_mapping": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: `Only applicable when updating a pipeline. Map of transform name prefixes of the job to be replaced with the corresponding name prefixes of the new job.`,
-			},
-
 			"on_delete": {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),
@@ -75,7 +62,6 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				Type:             schema.TypeMap,
 				Optional:         true,
 				DiffSuppressFunc: resourceDataflowJobLabelDiffSuppress,
-				Description:      `User labels to be specified for the job. Keys and values should follow the restrictions specified in the labeling restrictions page. NOTE: Google-provided Dataflow templates often provide default labels that begin with goog-dataflow-provided. Unless explicitly set in config, these labels will be ignored to prevent diffs on re-apply.`,
 			},
 
 			"parameters": {
@@ -100,118 +86,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				Computed: true,
 			},
 
-			"type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: `The type of this job, selected from the JobType enum.`,
-			},
-
-			"num_workers": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				// ForceNew applies to both stream and batch jobs
-				ForceNew:    true,
-				Description: `The initial number of Google Compute Engine instances for the job.`,
-			},
-
-			"max_workers": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				// ForceNew applies to both stream and batch jobs
-				ForceNew:    true,
-				Description: `The maximum number of Google Compute Engine instances to be made available to your pipeline during execution, from 1 to 1000.`,
-			},
-
-			"service_account_email": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The Service Account email used to create the job.`,
-			},
-
-			"temp_location": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The Cloud Storage path to use for temporary files. Must be a valid Cloud Storage URL, beginning with gs://.`,
-			},
-
-			"staging_location": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The Cloud Storage path to use for staging files. Must be a valid Cloud Storage URL, beginning with gs://.`,
-			},
-
-			"sdk_container_image": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `Docker registry location of container image to use for the 'worker harness. Default is the container for the version of the SDK. Note this field is only valid for portable pipelines.`,
-			},
-
-			"network": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				DiffSuppressFunc: compareSelfLinkOrResourceName,
-				Description:      `The network to which VMs will be assigned. If it is not provided, "default" will be used.`,
-			},
-
-			"subnetwork": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				DiffSuppressFunc: compareSelfLinkOrResourceName,
-				Description:      `The subnetwork to which VMs will be assigned. Should be of the form "regions/REGION/subnetworks/SUBNETWORK".`,
-			},
-
-			"machine_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The machine type to use for the job.`,
-			},
-
-			"kms_key_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The name for the Cloud KMS key for the job. Key format is: projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`,
-			},
-
-			"ip_configuration": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  `The configuration for VM IPs. Options are "WORKER_IP_PUBLIC" or "WORKER_IP_PRIVATE".`,
-				ValidateFunc: validation.StringInSlice([]string{"WORKER_IP_PUBLIC", "WORKER_IP_PRIVATE"}, false),
-			},
-
-			"additional_experiments": {
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Computed:    true,
-				Description: `List of experiments that should be used by the job. An example value is ["enable_stackdriver_agent_metrics"].`,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-
-			"enable_streaming_engine": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `Indicates if the job should use the streaming engine feature.`,
-			},
-
-			"autoscaling_algorithm": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The algorithm to use for autoscaling`,
-			},
-
-			"launcher_machine_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The machine type to use for launching the job. The default is n1-standard-1.`,
-			},
-
-			"skip_wait_on_job_termination": {
+     "skip_wait_on_job_termination": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -240,17 +115,14 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	env, err := resourceDataflowFlexJobSetupEnv(d, config)
-	if err != nil {
-		return err
-	}
-
 	request := dataflow.LaunchFlexTemplateRequest{
 		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
 			ContainerSpecGcsPath: d.Get("container_spec_gcs_path").(string),
 			JobName:              d.Get("name").(string),
 			Parameters:           tpgresource.ExpandStringMap(d, "parameters"),
-			Environment:          &env,
+			Environment: &dataflow.FlexTemplateRuntimeEnvironment{
+				AdditionalUserLabels: tpgresource.ExpandStringMap(d, "labels"),
+			},
 		},
 	}
 
@@ -273,31 +145,6 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 	}
 
 	return resourceDataflowFlexTemplateJobRead(d, meta)
-}
-
-func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_tpg.Config) (dataflow.FlexTemplateRuntimeEnvironment, error) {
-
-	additionalExperiments := convertStringSet(d.Get("additional_experiments").(*schema.Set))
-
-	env := dataflow.FlexTemplateRuntimeEnvironment{
-		AdditionalUserLabels:  tpgresource.ExpandStringMap(d, "labels"),
-		AutoscalingAlgorithm:  d.Get("autoscaling_algorithm").(string),
-		NumWorkers:            int64(d.Get("num_workers").(int)),
-		MaxWorkers:            int64(d.Get("max_workers").(int)),
-		Network:               d.Get("network").(string),
-		ServiceAccountEmail:   d.Get("service_account_email").(string),
-		Subnetwork:            d.Get("subnetwork").(string),
-		TempLocation:          d.Get("temp_location").(string),
-		StagingLocation:       d.Get("staging_location").(string),
-		MachineType:           d.Get("machine_type").(string),
-		KmsKeyName:            d.Get("kms_key_name").(string),
-		IpConfiguration:       d.Get("ip_configuration").(string),
-		EnableStreamingEngine: d.Get("enable_streaming_engine").(bool),
-		AdditionalExperiments: additionalExperiments,
-		SdkContainerImage:     d.Get("sdk_container_image").(string),
-		LauncherMachineType:   d.Get("launcher_machine_type").(string),
-	}
-	return env, nil
 }
 
 // resourceDataflowFlexTemplateJobRead reads a Flex Template Job resource.
@@ -325,17 +172,11 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Dataflow job %s", jobId))
 	}
 
-	if err := d.Set("job_id", job.Id); err != nil {
-		return fmt.Errorf("Error setting job_id: %s", err)
-	}
 	if err := d.Set("state", job.CurrentState); err != nil {
 		return fmt.Errorf("Error setting state: %s", err)
 	}
 	if err := d.Set("name", job.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
-	}
-	if err := d.Set("type", job.Type); err != nil {
-		return fmt.Errorf("Error setting type: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
@@ -343,48 +184,8 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 	if err := d.Set("labels", job.Labels); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
-	if err := d.Set("kms_key_name", job.Environment.ServiceKmsKeyName); err != nil {
-		return fmt.Errorf("Error setting kms_key_name: %s", err)
-	}
-	if err := d.Set("service_account_email", job.Environment.ServiceAccountEmail); err != nil {
-		return fmt.Errorf("Error setting service_account_email: %s", err)
-	}
 
-	sdkPipelineOptions, err := ConvertToMap(job.Environment.SdkPipelineOptions)
-	if err != nil {
-		return err
-	}
-	optionsMap := sdkPipelineOptions["options"].(map[string]interface{})
-
-	if err := d.Set("temp_location", optionsMap["tempLocation"]); err != nil {
-		return fmt.Errorf("Error setting temp_gcs_location: %s", err)
-	}
-	if err := d.Set("network", optionsMap["network"]); err != nil {
-		return fmt.Errorf("Error setting network: %s", err)
-	}
-	if err := d.Set("num_workers", optionsMap["numWorkers"]); err != nil {
-		return fmt.Errorf("Error setting num_workers: %s", err)
-	}
-	if err := d.Set("max_workers", optionsMap["maxWorkers"]); err != nil {
-		return fmt.Errorf("Error setting max_workers: %s", err)
-	}
-	if err := d.Set("staging_location", optionsMap["stagingLocation"]); err != nil {
-		return fmt.Errorf("Error setting staging_location: %s", err)
-	}
-	if err := d.Set("sdk_container_image", optionsMap["sdkContainerImage"]); err != nil {
-		return fmt.Errorf("Error setting sdk_container_image: %s", err)
-	}
-	if err := d.Set("network", optionsMap["network"]); err != nil {
-		return fmt.Errorf("Error setting network: %s", err)
-	}
-	if err := d.Set("subnetwork", optionsMap["subnetwork"]); err != nil {
-		return fmt.Errorf("Error setting subnetwork: %s", err)
-	}
-	if err := d.Set("machine_type", optionsMap["workerMachineType"]); err != nil {
-		return fmt.Errorf("Error setting machine_type: %s", err)
-	}
-
-	if ok := shouldStopDataflowJobDeleteQuery(job.CurrentState, d.Get("skip_wait_on_job_termination").(bool)); ok {
+  if ok := shouldStopDataflowJobDeleteQuery(job.CurrentState, d.Get("skip_wait_on_job_termination").(bool)); ok {
 		log.Printf("[DEBUG] Removing resource '%s' because it is in state %s.\n", job.Name, job.CurrentState)
 		d.SetId("")
 		return nil
@@ -454,13 +255,6 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	tnamemapping := expandStringMap(d, "transform_name_mapping")
-
-	env, err := resourceDataflowFlexJobSetupEnv(d, config)
-	if err != nil {
-		return err
-	}
-
 	// wait until current job is running or terminated
 	err = waitForDataflowJobState(d, config, d.Id(), userAgent, d.Timeout(schema.TimeoutUpdate), "JOB_STATE_RUNNING")
 	if err != nil {
@@ -469,12 +263,12 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
 
 	request := dataflow.LaunchFlexTemplateRequest{
 		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
-
 			ContainerSpecGcsPath: d.Get("container_spec_gcs_path").(string),
 			JobName:              d.Get("name").(string),
 			Parameters:           tpgresource.ExpandStringMap(d, "parameters"),
-			TransformNameMappings: tnamemapping,
-			Environment:          &env,
+			Environment: &dataflow.FlexTemplateRuntimeEnvironment{
+				AdditionalUserLabels: tpgresource.ExpandStringMap(d, "labels"),
+			},
 			Update:               true,
 		},
 	}
@@ -561,10 +355,10 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
 	}
 
 	// Wait for state to reach terminal state (canceled/drained/done plus cancelling/draining if skipWait)
-	skipWait := d.Get("skip_wait_on_job_termination").(bool)
-	var ok bool
-	ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
-	for !ok {
+  skipWait := d.Get("skip_wait_on_job_termination").(bool)
+  var ok bool
+  ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
+  for !ok {
 		log.Printf("[DEBUG] Waiting for job with job state %q to terminate...", d.Get("state").(string))
 		time.Sleep(5 * time.Second)
 
@@ -572,7 +366,7 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return fmt.Errorf("Error while reading job to see if it was properly terminated: %v", err)
 		}
-		ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
+    ok = shouldStopDataflowJobDeleteQuery(d.Get("state").(string), skipWait)
 	}
 
 	// Only remove the job from state if it's actually successfully hit a final state.
@@ -582,30 +376,6 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
 		return nil
 	}
 	return fmt.Errorf("Unable to cancel the dataflow job '%s' - final state was %q.", d.Id(), d.Get("state").(string))
-}
-
-func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// All non-virtual fields are ForceNew for batch jobs
-	if d.Get("type") == "JOB_TYPE_BATCH" {
-		resourceSchema := ResourceDataflowFlexTemplateJob().Schema
-		for field := range resourceSchema {
-			if field == "on_delete" {
-				continue
-			}
-			// Labels map will likely have suppressed changes, so we check each key instead of the parent field
-			if field == "labels" {
-				if err := resourceDataflowJobIterateMapForceNew(field, d); err != nil {
-					return err
-				}
-			} else if d.HasChange(field) {
-				if err := d.ForceNew(field); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
@@ -27,7 +27,6 @@ func TestAccDataflowFlexTemplateJob_basic(t *testing.T) {
 	randStr := RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
 	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -35,16 +34,10 @@ func TestAccDataflowFlexTemplateJob_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, topic),
+				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, "mytopic"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job", false),
+					testAccDataflowJobExists(t, "google_dataflow_flex_template_job.job"),
 				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
 			},
 		},
 	})
@@ -59,8 +52,6 @@ func TestAccDataflowFlexTemplateJob_streamUpdate(t *testing.T) {
 	randStr := RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
 	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
-	topic2 := "tf-test-topic-2" + randStr
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -68,28 +59,22 @@ func TestAccDataflowFlexTemplateJob_streamUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, topic),
+				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, "mytopic"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job", false),
+					testAccDataflowJobExists(t, "google_dataflow_flex_template_job.job"),
 				),
 			},
 			{
-				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, topic2),
+				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, "mytopic2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job", true),
+					testAccDataflowJobHasOption(t, "google_dataflow_flex_template_job.job", "topic", "projects/myproject/topics/mytopic2"),
 				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "transform_name_mapping", "state", "container_spec_gcs_path"},
 			},
 		},
 	})
 }
 
-func TestAccDataflowFlexTemplateJob_streamFailUpdate(t *testing.T) {
+func TestAccDataflowFlexTemplateJob_streamUpdateFail(t *testing.T) {
 	// This resource uses custom retry logic that cannot be sped up without
 	// modifying the actual resource
 	acctest.SkipIfVcr(t)
@@ -98,7 +83,6 @@ func TestAccDataflowFlexTemplateJob_streamFailUpdate(t *testing.T) {
 	randStr := RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
 	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -106,15 +90,15 @@ func TestAccDataflowFlexTemplateJob_streamFailUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, topic),
+				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, "mytopic"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job", false),
+					testAccDataflowJobExists(t, "google_dataflow_flex_template_job.job"),
 				),
 			},
 			{
-				Config: testAccDataflowFlexTemplateJob_basicfail(job, bucket),
+				Config: testAccDataflowFlexTemplateJob_basic(job, bucket, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobHasOption(t, "google_dataflow_flex_template_job.flex_job", "topic", "projects/myproject/topics/tf-test-topic"+randStr, true),
+					testAccDataflowJobHasOption(t, "google_dataflow_flex_template_job.job", "topic", "projects/myproject/topics/mytopic"),
 				),
 				ExpectError: regexp.MustCompile(`Error waiting for Job with job ID "[^"]+" to be updated: the job with ID "[^"]+" has terminated with state "JOB_STATE_FAILED" instead of expected state "JOB_STATE_RUNNING"`),
 			},
@@ -122,7 +106,7 @@ func TestAccDataflowFlexTemplateJob_streamFailUpdate(t *testing.T) {
 	})
 }
 
-func TestAccDataflowFlexTemplateJob_FullUpdate(t *testing.T) {
+func TestAccDataflowFlexTemplateJob_withServiceAccount(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
 	acctest.SkipIfVcr(t)
@@ -131,7 +115,8 @@ func TestAccDataflowFlexTemplateJob_FullUpdate(t *testing.T) {
 	randStr := RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
 	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
+	accountId := "tf-test-dataflow-sa" + randStr
+	zone := "us-central1-b"
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -139,294 +124,35 @@ func TestAccDataflowFlexTemplateJob_FullUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowFlexTemplateJob_dataflowFlexTemplateJobFull(job, bucket, topic),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_fullupdate",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
-			},
-			{
-				Config: testAccDataflowFlexTemplateJob_dataflowFlexTemplateJobFullUpdate(job, bucket, topic),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_fullupdate",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
+				Config: testAccDataflowFlexTemplateJob_serviceAccount(job, bucket, accountId, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowJobExists(t, "google_dataflow_flex_template_job.job"),
+					testAccDataflowFlexTemplateJobHasServiceAccount(t, "google_dataflow_flex_template_job.job", accountId, zone),
+				),
 			},
 		},
 	})
 }
 
-func TestAccDataflowFlexTemplateJob_withNetwork(t *testing.T) {
-	// Dataflow responses include serialized java classes and bash commands
-	// This makes body comparison infeasible
-	SkipIfVcr(t)
-	t.Parallel()
-
-	randStr := RandString(t, 10)
-	job := "tf-test-dataflow-job-" + randStr
-	network1 := "tf-test-dataflow-net" + randStr
-	network2 := "tf-test-dataflow-net2" + randStr
-	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataflowFlexTemplateJob_network(job, network1, bucket, topic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_network", false),
-					testAccDataflowFlexTemplateJobHasNetwork(t, "google_dataflow_flex_template_job.flex_job_network", network1, false),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_network",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
-			},
-			{
-				Config: testAccDataflowFlexTemplateJob_networkUpdate(job, network1, network2, bucket, topic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_network", true),
-					testAccDataflowFlexTemplateJobHasNetwork(t, "google_dataflow_flex_template_job.flex_job_network", network2, true),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_network",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
-			},
-		},
-	})
-}
-
-func TestAccDataflowFlexTemplateJob_withSubNetwork(t *testing.T) {
-	// Dataflow responses include serialized java classes and bash commands
-	// This makes body comparison infeasible
-	SkipIfVcr(t)
-	t.Parallel()
-
-	randStr := RandString(t, 10)
-	job := "tf-test-dataflow-job-" + randStr
-	network := "tf-test-dataflow-net" + randStr
-	subnetwork1 := "tf-test-dataflow-subnetwork" + randStr
-	subnetwork2 := "tf-test-dataflow-subnetwork2" + randStr
-	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataflowFlexTemplateJob_subnetwork(job, network, subnetwork1, bucket, topic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_subnetwork", false),
-					testAccDataflowFlexTemplateJobHasSubNetwork(t, "google_dataflow_flex_template_job.flex_job_subnetwork", subnetwork1, false),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_subnetwork",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
-			},
-			{
-				Config: testAccDataflowFlexTemplateJob_subnetworkUpdate(job, network, subnetwork1, subnetwork2, bucket, topic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_subnetwork", true),
-					testAccDataflowFlexTemplateJobHasSubNetwork(t, "google_dataflow_flex_template_job.flex_job_subnetwork", subnetwork2, true),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_subnetwork",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
-			},
-		},
-	})
-}
-
-func TestAccDataflowFlexTemplateJob_withIpConfig(t *testing.T) {
-	// Dataflow responses include serialized java classes and bash commands
-	// This makes body comparison infeasible
-	SkipIfVcr(t)
-	t.Parallel()
-
-	randStr := RandString(t, 10)
-	job := "tf-test-dataflow-job-" + randStr
-	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
-	network := "tf-test-dataflow-net" + randStr
-	subnetwork := "tf-test-dataflow-subnetwork" + randStr
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataflowFlexTemplateJob_ipConfig(job, network, subnetwork, bucket, topic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_ipconfig", false),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_ipconfig",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "ip_configuration", "state", "container_spec_gcs_path"},
-			},
-		},
-	})
-}
-
-func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
-	// Dataflow responses include serialized java classes and bash commands
-	// This makes body comparison infeasible
-	SkipIfVcr(t)
-	t.Parallel()
-
-	randStr := RandString(t, 10)
-	job := "tf-test-dataflow-job-" + randStr
-	key_ring := "tf-test-dataflow-kms-ring-" + randStr
-	crypto_key := "tf-test-dataflow-kms-key-" + randStr
-	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataflowFlexTemplateJob_kms(job, key_ring, crypto_key, bucket, topic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_kms", false),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_kms",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "container_spec_gcs_path"},
-			},
-		},
-	})
-}
-
-func TestAccDataflowFlexTemplateJob_withAdditionalExperiments(t *testing.T) {
-	// Dataflow responses include serialized java classes and bash commands
-	// This makes body comparison infeasible
-	SkipIfVcr(t)
-	t.Parallel()
-
-	randStr := RandString(t, 10)
-	job := "tf-test-dataflow-job-" + randStr
-	additionalExperiments := []string{"enable_stackdriver_agent_metrics", "use_runner_v2"}
-	bucket := "tf-test-dataflow-bucket-" + randStr
-	topic := "tf-test-topic" + randStr
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataflowFlexTemplateJob_additionalExperiments(job, bucket, topic, additionalExperiments),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_experiments", false),
-					testAccDataflowFlexTemplateJobHasAdditionalExperiments(t, "google_dataflow_flex_template_job.flex_job_experiments", additionalExperiments, false),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_flex_template_job.flex_job_experiments",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "additional_experiments", "container_spec_gcs_path"},
-			},
-		},
-	})
-}
-
-func testAccDataflowFlexTemplateJobHasNetwork(t *testing.T, res, expected string, wait bool) resource.TestCheckFunc {
+func testAccDataflowFlexTemplateJobHasServiceAccount(t *testing.T, res, expectedId, zone string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		instanceTmpl, err := testAccDataflowFlexTemplateGetGeneratedInstanceTemplate(t, s, res)
+		instance, err := testAccDataflowFlexTemplateJobGetGeneratedInstance(t, s, res, zone)
 		if err != nil {
-			return fmt.Errorf("Error getting dataflow job instance template: %s", err)
+			return fmt.Errorf("Error getting dataflow job instance: %s", err)
 		}
-		if len(instanceTmpl.Properties.NetworkInterfaces) == 0 {
-			return fmt.Errorf("no network interfaces in template properties: %+v", instanceTmpl.Properties)
+		accounts := instance.ServiceAccounts
+		if len(accounts) != 1 {
+			return fmt.Errorf("Found multiple service accounts (%d) for dataflow job %q, expected 1", len(accounts), res)
 		}
-		actual := instanceTmpl.Properties.NetworkInterfaces[0].Network
-		if GetResourceNameFromSelfLink(actual) != GetResourceNameFromSelfLink(expected) {
-			return fmt.Errorf("network mismatch: %s != %s", actual, expected)
+		actualId := strings.Split(accounts[0].Email, "@")[0]
+		if expectedId != actualId {
+			return fmt.Errorf("service account mismatch, expected account ID = %q, actual email = %q", expectedId, accounts[0].Email)
 		}
 		return nil
 	}
 }
 
-func testAccDataflowFlexTemplateJobHasSubNetwork(t *testing.T, res, expected string, wait bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		instanceTmpl, err := testAccDataflowFlexTemplateGetGeneratedInstanceTemplate(t, s, res)
-		if err != nil {
-			return fmt.Errorf("Error getting dataflow job instance template: %s", err)
-		}
-		if len(instanceTmpl.Properties.NetworkInterfaces) == 0 {
-			return fmt.Errorf("no network interfaces in template properties: %+v", instanceTmpl.Properties)
-		}
-		actual := instanceTmpl.Properties.NetworkInterfaces[0].Subnetwork
-		if GetResourceNameFromSelfLink(actual) != GetResourceNameFromSelfLink(expected) {
-			return fmt.Errorf("subnetwork mismatch: %s != %s", actual, expected)
-		}
-		return nil
-	}
-}
-
-func testAccDataflowFlexTemplateJobHasAdditionalExperiments(t *testing.T, res string, experiments []string, wait bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[res]
-		if !ok {
-			return fmt.Errorf("resource %q not found in state", res)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-		config := GoogleProviderConfig(t)
-
-		job, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).View("JOB_VIEW_ALL").Do()
-		if err != nil {
-			return fmt.Errorf("dataflow job does not exist")
-		}
-
-		for _, expectedExperiment := range experiments {
-			var contains = false
-			for _, actualExperiment := range job.Environment.Experiments {
-				if actualExperiment == expectedExperiment {
-					contains = true
-				}
-			}
-			if contains != true {
-				return fmt.Errorf("Expected experiment '%s' not found in experiments", expectedExperiment)
-			}
-		}
-
-		return nil
-	}
-}
-
-func testAccDataflowFlexTemplateGetGeneratedInstanceTemplate(t *testing.T, s *terraform.State, res string) (*compute.InstanceTemplate, error) {
+func testAccDataflowFlexTemplateJobGetGeneratedInstance(t *testing.T, s *terraform.State, res, zone string) (*compute.Instance, error) {
 	rs, ok := s.RootModule().Resources[res]
 	if !ok {
 		return nil, fmt.Errorf("resource %q not in state", res)
@@ -434,93 +160,45 @@ func testAccDataflowFlexTemplateGetGeneratedInstanceTemplate(t *testing.T, s *te
 	if rs.Primary.ID == "" {
 		return nil, fmt.Errorf("resource %q does not have an ID set", res)
 	}
-	filter := fmt.Sprintf("properties.labels.dataflow_job_id = %s", rs.Primary.ID)
+	filter := fmt.Sprintf("labels.goog-dataflow-job-id = %s", rs.Primary.ID)
 
 	config := GoogleProviderConfig(t)
 
-	var instanceTemplate *compute.InstanceTemplate
+	var instance *compute.Instance
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		instanceTemplates, rerr := config.NewComputeClient(config.UserAgent).InstanceTemplates.
-			List(config.Project).
+		instances, rerr := config.NewComputeClient(config.UserAgent).Instances.
+			List(config.Project, zone).
 			Filter(filter).
 			MaxResults(2).
-			Fields("items/properties").Do()
+			Do()
 		if rerr != nil {
 			return resource.NonRetryableError(rerr)
 		}
-		if len(instanceTemplates.Items) == 0 {
-			return resource.RetryableError(fmt.Errorf("no instance template found for dataflow job %q", rs.Primary.ID))
+		if len(instances.Items) == 0 {
+			return resource.RetryableError(fmt.Errorf("no instance found for dataflow job %q", rs.Primary.ID))
 		}
-		if len(instanceTemplates.Items) > 1 {
-			return resource.NonRetryableError(fmt.Errorf("Wrong number of matching instance templates for dataflow job: %s, %d", rs.Primary.ID, len(instanceTemplates.Items)))
+		if len(instances.Items) > 1 {
+			return resource.NonRetryableError(fmt.Errorf("Wrong number of matching instances for dataflow job: %s, %d", rs.Primary.ID, len(instances.Items)))
 		}
-		instanceTemplate = instanceTemplates.Items[0]
-		if instanceTemplate == nil || instanceTemplate.Properties == nil {
-			return resource.NonRetryableError(fmt.Errorf("invalid instance template has no properties"))
+		instance = instances.Items[0]
+		if instance == nil {
+			return resource.NonRetryableError(fmt.Errorf("invalid instance"))
 		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return instanceTemplate, nil
+	return instance, nil
 }
 
+// note: this config creates a job that doesn't actually do anything, but still runs
 func testAccDataflowFlexTemplateJob_basic(job, bucket, topicName string) string {
-	return fmt.Sprintf(`
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-resource "google_dataflow_flex_template_job" "flex_job" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-}
-`, topicName, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_basicfail(job, bucket string) string {
+	topicField := ""
+	if topicName != "" {
+		topicField = fmt.Sprintf("topic = \"projects/myproject/topics/%s\"", topicName)
+	}
 	return fmt.Sprintf(`
 data "google_storage_bucket_object" "flex_template" {
   name   = "latest/flex/Streaming_Data_Generator"
@@ -537,64 +215,39 @@ resource "google_storage_bucket" "bucket" {
 resource "google_storage_bucket_object" "schema" {
   name = "schema.json"
   bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
+  content = "{}"
 }
 
-resource "google_dataflow_flex_template_job" "flex_job" {
+resource "google_dataflow_flex_template_job" "job" {
   name = "%s"
   container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
   on_delete = "cancel"
   parameters = {
     schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
     qps = "1"
-    sinkType= "BIGQUERY"
-	outputTableSpec = "projectid:datasetid.tableid"
+    %s
   }
   labels = {
    "my_labels" = "value"
   }
 }
-`, bucket, job)
+`, bucket, job, topicField)
 }
 
-func testAccDataflowFlexTemplateJob_dataflowFlexTemplateJobFull(job, bucket, topicName string) string {
+// note: this config creates a job that doesn't actually do anything, but still runs
+func testAccDataflowFlexTemplateJob_serviceAccount(job, bucket, accountId, zone string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
 
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
 resource "google_service_account" "dataflow-sa" {
-  count = 2
-  account_id   = "dataflow-sa-${count.index}"
+  account_id   = "%s"
   display_name = "DataFlow Service Account"
 }
 
 resource "google_project_iam_member" "dataflow-worker" {
-  count = 2
   project = data.google_project.project.project_id
   role   = "roles/dataflow.worker"
-  member = "serviceAccount:${google_service_account.dataflow-sa[count.index].email}"
-}
-
-resource "google_project_iam_member" "dataflow-storage" {
-  count = 2
-  project = data.google_project.project.project_id
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.dataflow-sa[count.index].email}"
+  member = "serviceAccount:${google_service_account.dataflow-sa.email}"
 }
 
 data "google_storage_bucket_object" "flex_template" {
@@ -612,584 +265,29 @@ resource "google_storage_bucket" "bucket" {
 resource "google_storage_bucket_object" "schema" {
   name = "schema.json"
   bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
+  content = "{}"
 }
 
-resource "google_dataflow_flex_template_job" "flex_job_fullupdate" {
+resource "google_dataflow_flex_template_job" "job" {
   name = "%s"
   container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
   on_delete = "cancel"
   parameters = {
     schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
     qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value-1"
-  }
-  service_account_email = google_service_account.dataflow-sa[0].email
-  machine_type = "n1-standard-2"
-}
-`, topicName, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_dataflowFlexTemplateJobFullUpdate(job, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-resource "google_service_account" "dataflow-sa" {
-	count = 2
-	account_id   = "dataflow-sa-${count.index}"
-	display_name = "DataFlow Service Account"
-}
-
-  resource "google_project_iam_member" "dataflow-worker" {
-	count = 2
-	project = data.google_project.project.project_id
-	role   = "roles/dataflow.worker"
-	member = "serviceAccount:${google_service_account.dataflow-sa[count.index].email}"
-}
-
-  resource "google_project_iam_member" "dataflow-storage" {
-	count = 2
-	project = data.google_project.project.project_id
-	role   = "roles/storage.admin"
-	member = "serviceAccount:${google_service_account.dataflow-sa[count.index].email}"
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-resource "google_dataflow_flex_template_job" "flex_job_fullupdate" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value-update"
-  }
-  service_account_email = google_service_account.dataflow-sa[1].email
-  machine_type = "n2-standard-2"
-}
-`, topicName, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_network(job, network1, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-resource "google_compute_network" "net1" {
-  name                    = "%s"
-  auto_create_subnetworks = true
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-resource "google_dataflow_flex_template_job" "flex_job_network" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
+    topic = "projects/myproject/topics/mytopic"
+    serviceAccount = google_service_account.dataflow-sa.email
+    zone = "%s"
   }
   labels = {
    "my_labels" = "value"
   }
-  network           = google_compute_network.net1.name
-
 }
-`, topicName, network1, bucket, job)
+`, accountId, bucket, job, zone)
 }
 
-func testAccDataflowFlexTemplateJob_networkUpdate(job, network1, network2, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-resource "google_compute_network" "net1" {
-  name                    = "%s"
-  auto_create_subnetworks = true
-}
-
-resource "google_compute_network" "net2" {
-	name                    = "%s"
-	auto_create_subnetworks = true
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-resource "google_dataflow_flex_template_job" "flex_job_network" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-  network           = google_compute_network.net2.name
-
-}
-`, topicName, network1, network2, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_subnetwork(job, network, subnetwork1, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-resource "google_compute_network" "net" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "subnet1" {
-  name          = "%s"
-  ip_cidr_range = "10.1.0.0/24"
-  network       = google_compute_network.net.self_link
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-resource "google_dataflow_flex_template_job" "flex_job_subnetwork" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-  subnetwork        = google_compute_subnetwork.subnet1.self_link
-
-}
-`, topicName, network, subnetwork1, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_subnetworkUpdate(job, network, subnetwork1, subnetwork2, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-resource "google_compute_network" "net" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "subnet1" {
-  name          = "%s"
-  ip_cidr_range = "10.1.0.0/24"
-  network       = google_compute_network.net.self_link
-}
-
-resource "google_compute_subnetwork" "subnet2" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/24"
-  network       = google_compute_network.net.self_link
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-resource "google_dataflow_flex_template_job" "flex_job_subnetwork" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-  subnetwork        = google_compute_subnetwork.subnet2.self_link
-
-}
-`, topicName, network, subnetwork1, subnetwork2, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_ipConfig(job, network, subnetwork, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-  name = "%s"
-}
-
-resource "google_compute_network" "net" {
-  name          = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "subnet" {
-  name          = "%s"
-  ip_cidr_range = "10.1.0.0/24"
-  network       = google_compute_network.net.self_link
-  private_ip_google_access = true
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-resource "google_dataflow_flex_template_job" "flex_job_ipconfig" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-  ip_configuration = "WORKER_IP_PRIVATE"
-  subnetwork        = google_compute_subnetwork.subnet.self_link
-
-}
-`, topicName, network, subnetwork, bucket, job)
-}
-
-func testAccDataflowFlexTemplateJob_kms(job, key_ring, crypto_key, bucket, topicName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-	name = "%s"
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-resource "google_project_iam_member" "kms-project-dataflow-binding" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@dataflow-service-producer-prod.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "kms-project-compute-binding" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = "serviceAccount:service-${data.google_project.project.number}@compute-system.iam.gserviceaccount.com"
-}
-
-resource "google_kms_key_ring" "keyring" {
-  name     = "%s"
-  location = "global"
-}
-
-resource "google_kms_crypto_key" "crypto_key" {
-  name            = "%s"
-  key_ring        = google_kms_key_ring.keyring.id
-  rotation_period = "100000s"
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-resource "google_dataflow_flex_template_job" "flex_job_kms" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-  kms_key_name		= google_kms_crypto_key.crypto_key.id
-
-}
-`, topicName, bucket, key_ring, crypto_key, job)
-}
-
-func testAccDataflowFlexTemplateJob_additionalExperiments(job, bucket, topicName string, experiments []string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {}
-
-resource "google_pubsub_topic" "example" {
-	name = "%s"
-}
-
-resource "google_storage_bucket" "bucket" {
-  name = "%s"
-  location = "US-CENTRAL1"
-  force_destroy = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "schema" {
-  name = "schema.json"
-  bucket = google_storage_bucket.bucket.name
-  content = <<EOF
-{
-	"eventId": "{{uuid()}}",
-	"eventTimestamp": {{timestamp()}},
-	"ipv4": "{{ipv4()}}",
-	"ipv6": "{{ipv6()}}",
-	"country": "{{country()}}",
-	"username": "{{username()}}",
-	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
-	"score": {{integer(100, 10000)}},
-	"completed": {{bool()}}
-}
-EOF
-}
-
-data "google_storage_bucket_object" "flex_template" {
-  name   = "latest/flex/Streaming_Data_Generator"
-  bucket = "dataflow-templates"
-}
-resource "google_dataflow_flex_template_job" "flex_job_experiments" {
-  name = "%s"
-  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
-  on_delete = "cancel"
-  parameters = {
-    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
-    qps = "1"
-    topic = google_pubsub_topic.example.id
-  }
-  labels = {
-   "my_labels" = "value"
-  }
-  additional_experiments = ["%s"]
-
-}
-`, topicName, bucket, job, strings.Join(experiments, `", "`))
-}
-
-func testAccDataflowFlexJobHasOption(t *testing.T, res, option, expectedValue string, wait bool) resource.TestCheckFunc {
+func testAccDataflowJobHasOption(t *testing.T, res, option, expectedValue string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if wait {
-			time.Sleep(300 * time.Second)
-		}
 		rs, ok := s.RootModule().Resources[res]
 		if !ok {
 			return fmt.Errorf("resource %q not found in state", res)
@@ -1213,29 +311,6 @@ func testAccDataflowFlexJobHasOption(t *testing.T, res, option, expectedValue st
 
 		if optionsMap[option] != expectedValue {
 			return fmt.Errorf("Option %s do not match. Got %s while expecting %s", option, optionsMap[option], expectedValue)
-		}
-
-		return nil
-	}
-}
-
-func testAccDataflowFlexJobExists(t *testing.T, resource string, wait bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if wait {
-			time.Sleep(300 * time.Second)
-		}
-		rs, ok := s.RootModule().Resources[resource]
-		if !ok {
-			return fmt.Errorf("resource %q not in state", resource)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		config := GoogleProviderConfig(t)
-		_, err := config.NewDataflowClient(config.UserAgent).Projects.Locations.Jobs.Get(config.Project, config.Region, rs.Primary.ID).Do()
-		if err != nil {
-			return fmt.Errorf("could not confirm Dataflow Job %q exists: %v", rs.Primary.ID, err)
 		}
 
 		return nil


### PR DESCRIPTION
This reverts commit 17924bacb33874a8251102f916d9191b402d6869.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Not entirely sure that this is the approach we'll end up taking, but resolves https://github.com/hashicorp/terraform-provider-google/issues/14679 if we do. I'm really not a fan of reverting things we've released, but the fix-forward here is complicated and will lead to surprising behaviours pretty much no matter what.

See https://github.com/hashicorp/terraform-provider-google/issues/14679#issuecomment-1564717191 for a description of the primary problem we ran into here.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
dataflow: reverted new behavior for the `google_dataflow_flex_template_job` introduced in `4.66.0`. Multiple fields were added to the resource that conflicted with existing parameter values, and the new fields were not documented. These values should be configurable through the `parameters` object. Additionally, Terraform will no longer propose recreating batch jobs. (beta only)
```

```release-note:bug
dataflow: resolved a regression where new fields introduced in `google_dataflow_flex_template_job` would conflict with preexisting `parameters` values configured by users (beta only)
```
