### PR TITLE
Showing error details for quota exceeded error for gce operations

### DIFF
--- a/mmv1/third_party/terraform/utils/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation.go.erb
@@ -176,12 +176,20 @@ func (e ComputeOperationError) Error() string {
 const errMsgSep = "\n\n"
 
 func writeOperationError(w io.StringWriter, opError *compute.OperationErrorErrors) {
-	w.WriteString(opError.Message + "TEST\n")
+	w.WriteString(opError.Message + "\n")
 
 	var lm *compute.LocalizedMessage
 	var link *compute.HelpLink
 
-	for _, ed := range opError.ErrorDetails {
+        for _, ed := range opError.ErrorDetails {
+                if opError.Code == "QUOTA_EXCEEDED" && ed.QuotaInfo != nil {
+			w.WriteString("\tmetric name = " + ed.QuotaInfo.MetricName + "\n")
+			w.WriteString("\tlimit name = " + ed.QuotaInfo.LimitName + "\n")
+			if ed.QuotaInfo.Dimensions != nil {
+				w.WriteString("\tdimensions = " + fmt.Sprint(ed.QuotaInfo.Dimensions) + "\n")
+			}
+			break
+		}
 		if lm == nil && ed.LocalizedMessage != nil {
 			lm = ed.LocalizedMessage
 		}

--- a/mmv1/third_party/terraform/utils/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation.go.erb
@@ -176,7 +176,7 @@ func (e ComputeOperationError) Error() string {
 const errMsgSep = "\n\n"
 
 func writeOperationError(w io.StringWriter, opError *compute.OperationErrorErrors) {
-	w.WriteString(opError.Message + "\n")
+	w.WriteString(opError.Message + "TEST\n")
 
 	var lm *compute.LocalizedMessage
 	var link *compute.HelpLink

--- a/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_operation_test.go.erb
@@ -17,7 +17,12 @@ const (
 	topLevelMsg             = "Top-level message."
 	localizedMsgTmpl        = "LocalizedMessage%d message"
 	helpLinkDescriptionTmpl = "Help%dLink%d Description"
-	helpLinkUrlTmpl         = "https://help%d.com/link%d"
+        helpLinkUrlTmpl         = "https://help%d.com/link%d"
+        quotaExceededMsg        = "Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1."
+	quotaExceededCode       = "QUOTA_EXCEEDED"
+	quotaMetricName         = "compute.googleapis.com/disks_total_storage"
+	quotaLimitName          = "DISKS-TOTAL-GB-per-project-region"
+
 )
 
 var locales = []string{"en-US", "es-US", "es-ES", "es-MX", "de-DE"}
@@ -54,6 +59,27 @@ func buildOperationError(numLocalizedMsg int, numHelpWithLinks []int) compute.Op
 
 	return compute.OperationError{Errors: opErrorErrors}
 
+}
+
+func buildOperationErrorQuotaExceeded(withDetails bool, withDimensions bool) compute.OperationError {
+	opError := &compute.OperationErrorErrors{Message: quotaExceededMsg, Code: quotaExceededCode}
+	opErrorErrors := []*compute.OperationErrorErrors{opError}
+	if withDetails {
+		quotaInfo := &compute.QuotaExceededInfo{
+			MetricName: quotaMetricName,
+			LimitName:  quotaLimitName,
+			Limit:      1100,
+		}
+		if withDimensions {
+			quotaInfo.Dimensions = map[string]string{"region": "us-central1"}
+		}
+		opError.ErrorDetails = append(opError.ErrorDetails,
+			&compute.OperationErrorErrorsErrorDetails{
+				QuotaInfo: quotaInfo,
+			})
+	}
+
+	return compute.OperationError{Errors: opErrorErrors}
 }
 
 func omitAlways(numLocalizedMsg int, numHelpWithLinks []int) []string {
@@ -182,6 +208,43 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"https://help1.com/link1",
 			},
 			expectOmits: append(omitAlways(2, []int{1}), []string{}...),
+                },
+                {
+			name:  "QuotaMessageOnly",
+			input: buildOperationErrorQuotaExceeded(false, false),
+			expectContains: []string{
+				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
+			},
+			expectOmits: append(omitAlways(0, []int{}), []string{
+				"metric name = compute.googleapis.com/disks_total_storage",
+			}...),
+		},
+		{
+			name:  "QuotaMessageWithDetailsNoDimensions",
+			input: buildOperationErrorQuotaExceeded(true, false),
+			expectContains: []string{
+				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
+				"metric name = compute.googleapis.com/disks_total_storage",
+				"limit name = DISKS-TOTAL-GB-per-project-region",
+			},
+			expectOmits: append(omitAlways(0, []int{}), []string{
+				"dimensions = map[region:us-central1]",
+			}...),
+		},
+		{
+			name:  "QuotaMessageWithDetailsWithDimensions",
+			input: buildOperationErrorQuotaExceeded(true, true),
+			expectContains: []string{
+				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
+				"metric name = compute.googleapis.com/disks_total_storage",
+				"limit name = DISKS-TOTAL-GB-per-project-region",
+				"dimensions = map[region:us-central1]",
+			},
+			expectOmits: append(omitAlways(0, []int{}), []string{
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			}...),
 		},
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Surfacing error details when compute operation has quota exceeded error while creating a GCE resource.

Quota exceeded error details are in quota_info. Design doc: [go/improve_quota_exceeded_response](https://goto.google.com/improve_quota_exceeded_response). This change will surface the details in the terraform response.
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: surface error details for Compute Operation with quota exceeded errors.
```
