### PR TITLE
feat: added vmwareengine support #8516

### DIFF
--- a/mmv1/products/vmwareengine/Cluster.yaml
+++ b/mmv1/products/vmwareengine/Cluster.yaml
@@ -1,0 +1,157 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'Cluster'
+base_url: '{{parent}}/clusters'
+create_url: '{{parent}}/clusters?clusterId={{name}}'
+self_link: '{{parent}}/clusters/{{name}}'
+update_mask: true
+update_verb: :PATCH
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.clusters'
+description: |
+  A cluster in a private cloud.
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 5000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 160
+      update_minutes: 160
+      delete_minutes: 120
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error"
+    message: "message"
+  include_project: true
+
+import_format: ["{{%parent}}/clusters/{{name}}"]
+id_format: "{{parent}}/clusters/{{name}}"
+autogen_async: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_cluster_basic"
+    min_version: beta
+    primary_resource_id: "vmw-engine-ext-cluster"
+    vars:
+      name: "ext-cluster"
+      private_cloud_id: "sample-pc"
+      network_id: "pc-nw"
+      management_cluster_id: "sample-mgmt-cluster"
+    test_env_vars:
+      region: :REGION
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_cluster_full"
+    min_version: beta
+    primary_resource_id: "vmw-ext-cluster"
+    vars:
+      name: "ext-cluster"
+      private_cloud_id: "sample-pc"
+      network_id: "pc-nw"
+      management_cluster_id: "sample-mgmt-cluster"
+    test_env_vars:
+      region: :REGION
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "parent"
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      The resource name of the private cloud to create a new cluster in.
+      Resource names are schemeless URIs that follow the conventions in https://cloud.google.com/apis/design/resource_names.
+      For example: projects/my-project/locations/us-west1-a/privateClouds/my-cloud
+  - !ruby/object:Api::Type::String
+    name: "name"
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The ID of the Cluster.
+
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Creation time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and
+      up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Last updated time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Boolean
+    name: management
+    output: true
+    description: |
+      True if the cluster is a management cluster; false otherwise.
+      There can only be one management cluster in a private cloud and it has to be the first one.
+
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System-generated unique identifier for the resource.
+
+  - !ruby/object:Api::Type::Enum
+    name: 'state'
+    description: |
+      State of the Cluster.
+    output: true
+    values:
+      - :ACTIVE
+      - :CREATING
+      - :UPDATING
+      - :DELETING
+      - :REPAIRING
+
+  - !ruby/object:Api::Type::Map
+    name: 'nodeTypeConfigs'
+    description: |
+      The map of cluster node types in this cluster,
+      where the key is canonical identifier of the node type (corresponds to the NodeType).
+    key_name: 'node_type_id'
+    key_description: |
+      Canonical identifier of the NodeType.
+    value_type: !ruby/object:Api::Type::NestedObject
+      name: nodeTypeConfig
+      properties:
+        - !ruby/object:Api::Type::Integer
+          name: 'nodeCount'
+          description: |
+            The number of nodes of this type in the cluster.
+          required: true
+        - !ruby/object:Api::Type::Integer
+          name: 'customCoreCount'
+          default_value: 0
+          description: |
+            Customized number of cores available to each node of the type.
+            This number must always be one of `nodeType.availableCustomCoreCounts`.
+            If zero is provided max value from `nodeType.availableCustomCoreCounts` will be used.
+    update_mask_fields:
+      - "nodeTypeConfigs.*.nodeCount"

--- a/mmv1/products/vmwareengine/Network.yaml
+++ b/mmv1/products/vmwareengine/Network.yaml
@@ -1,0 +1,148 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'Network'
+min_version: beta
+base_url: 'projects/{{project}}/locations/{{location}}/vmwareEngineNetworks'
+self_link: 'projects/{{project}}/locations/{{location}}/vmwareEngineNetworks/{{name}}'
+create_url: 'projects/{{project}}/locations/{{location}}/vmwareEngineNetworks?vmwareEngineNetworkId={{name}}'
+update_mask: true
+update_verb: :PATCH
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.vmwareEngineNetworks'
+description: |
+  Provides connectivity for VMware Engine private clouds.
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error"
+    message: "message"
+
+import_format: ["projects/{{project}}/locations/{{location}}/vmwareEngineNetworks/{{name}}"]
+autogen_async: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_network_legacy"
+    min_version: beta
+    primary_resource_id: "vmw-engine-network"
+    test_env_vars:
+      location: :REGION
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "location"
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      The location where the VMwareEngineNetwork should reside.
+  - !ruby/object:Api::Type::String
+    name: "name"
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      The ID of the VMwareEngineNetwork.
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Creation time of this resource.
+
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+      Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Last update time of this resource.
+
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+      Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      User-provided description for this VMware Engine network.
+
+  - !ruby/object:Api::Type::Array
+    name: 'vpcNetworks'
+    description: |
+      VMware Engine service VPC networks that provide connectivity from a private cloud to customer projects,
+      the internet, and other Google Cloud services.
+    output: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      name: 'vpcNetwork'
+      properties:
+        - !ruby/object:Api::Type::Enum
+          name: 'type'
+          description: |
+            Type of VPC network (INTRANET, INTERNET, or GOOGLE_CLOUD)
+          output: true
+          values:
+            - :INTRANET
+            - :INTERNET
+            - :GOOGLE_CLOUD
+
+        - !ruby/object:Api::Type::String
+          name: 'network'
+          output: true
+          description: |
+            The relative resource name of the service VPC network this VMware Engine network is attached to.
+            For example: projects/123123/global/networks/my-network
+
+  - !ruby/object:Api::Type::Enum
+    name: 'state'
+    description: |
+      State of the VMware Engine network.
+    output: true
+    values:
+      - :CREATING
+      - :ACTIVE
+      - :UPDATING
+      - :DELETING
+
+  - !ruby/object:Api::Type::Enum
+    name: 'type'
+    required: true
+    description: |
+      VMware Engine network type.
+    values:
+      - :LEGACY
+
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System-generated unique identifier for the resource.
+
+  - !ruby/object:Api::Type::String
+    name: 'etag'
+    output: true
+    description: |
+      Checksum that may be sent on update and delete requests to ensure that the user-provided value is up to date before the server processes a request. 
+      The server computes checksums based on the value of other fields in the request.
+

--- a/mmv1/products/vmwareengine/product.yaml
+++ b/mmv1/products/vmwareengine/product.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: Vmwareengine
+display_name: Cloud VMware Engine
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://vmwareengine.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: VMwareEngine API
+    url: https://console.cloud.google.com/apis/library/vmwareengine.googleapis.com/

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_basic.tf.erb
@@ -1,0 +1,36 @@
+resource "google_vmwareengine_network" "cluster-nw" {
+  provider = google-beta
+   name              = "<%= ctx[:test_env_vars]['region'] %>-default"
+   location          = "<%= ctx[:test_env_vars]['region'] %>"
+   type              = "LEGACY"
+   description       = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "cluster-pc" {
+  provider = google-beta
+  location = "<%= ctx[:test_env_vars]['region'] %>-a"
+  name = "<%= ctx[:vars]['private_cloud_id'] %>"
+  description = "Sample test PC."
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.cluster-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "<%= ctx[:vars]['management_cluster_id'] %>"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_cluster" "<%= ctx[:primary_resource_id] %>" {
+    provider = google-beta
+    name = "<%= ctx[:vars]['name'] %>"
+    parent =  google_vmwareengine_private_cloud.cluster-pc.id
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+}

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_full.tf.erb
@@ -1,0 +1,38 @@
+resource "google_vmwareengine_network" "cluster-nw" {
+   provider          = google-beta
+   name              = "<%= ctx[:test_env_vars]['region'] %>-default"
+   location          = "<%= ctx[:test_env_vars]['region'] %>"
+   type              = "LEGACY"
+   description       = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "cluster-pc" {
+  provider = google-beta
+  location = "<%= ctx[:test_env_vars]['region'] %>-a"
+  name = "<%= ctx[:vars]['private_cloud_id'] %>"
+  description = "Sample test PC."
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.cluster-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "<%= ctx[:vars]['management_cluster_id'] %>"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+      custom_core_count = 32
+    }
+  }
+}
+
+resource "google_vmwareengine_cluster" "<%= ctx[:primary_resource_id] %>" {
+    provider = google-beta
+    name = "<%= ctx[:vars]['name'] %>"
+    parent =  google_vmwareengine_private_cloud.cluster-pc.id
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+      custom_core_count = 32
+    }
+}

--- a/mmv1/templates/terraform/examples/vmware_engine_network_legacy.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_network_legacy.tf.erb
@@ -1,0 +1,7 @@
+resource "google_vmwareengine_network" "<%= ctx[:primary_resource_id] %>" {
+    provider          = google-beta
+    name              = "<%= ctx[:test_env_vars]['location'] %>-default" #Legacy network IDs are in the format: {region-id}-default
+    location          = "<%= ctx[:test_env_vars]['location'] %>"
+    type              = "LEGACY"
+    description       = "VMwareEngine legacy network sample"
+}

--- a/mmv1/third_party/terraform/data_sources/data_source_google_vmwareengine_cluster.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_vmwareengine_cluster.go.erb
@@ -1,0 +1,34 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareengineCluster() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareengineCluster().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "parent", "name")
+	return &schema.Resource{
+		Read:   dataSourceVmwareengineClusterRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareengineClusterRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "{{parent}}/clusters/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceVmwareengineClusterRead(d, meta)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/data_sources/data_source_google_vmwareengine_network.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_vmwareengine_network.go.erb
@@ -1,0 +1,36 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareengineNetwork() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareengineNetwork().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "location", "name")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceVmwareengineNetworkRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareengineNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/vmwareEngineNetworks/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceVmwareengineNetworkRead(d, meta)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/data_sources/data_source_google_vmwareengine_private_cloud.go.erb
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_vmwareengine_private_cloud.go.erb
@@ -1,0 +1,36 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareenginePrivateCloud() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareenginePrivateCloud().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name", "location")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceVmwareenginePrivateCloudRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareenginePrivateCloudRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceVmwareenginePrivateCloudRead(d, meta)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/resources/resource_vmwareengine_private_cloud.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_vmwareengine_private_cloud.go.erb
@@ -1,0 +1,1018 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func ResourceVmwareenginePrivateCloud() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVmwareenginePrivateCloudCreate,
+		Read:   resourceVmwareenginePrivateCloudRead,
+		Update: resourceVmwareenginePrivateCloudUpdate,
+		Delete: resourceVmwareenginePrivateCloudDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceVmwareenginePrivateCloudImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(180 * time.Minute),
+			Update: schema.DefaultTimeout(160 * time.Minute),
+			Delete: schema.DefaultTimeout(120 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The location where the PrivateCloud should reside.`,
+			},
+			"management_cluster": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: false,
+				Description: `The management cluster for this private cloud. This field is required during creation of the private cloud to provide details for the default cluster.
+The following fields can't be changed after private cloud creation: ManagementCluster.clusterId, ManagementCluster.nodeTypeId.`,
+				MaxItems: 1,
+				Elem:     getManagementClusterSchema(),
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the PrivateCloud.`,
+			},
+			"network_config": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `Network configuration in the consumer project with which the peering has to be done.`,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"management_cidr": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Management CIDR used by VMware management appliances.`,
+						},
+						"vmware_engine_network": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Description: `The relative resource name of the VMware Engine network attached to the private cloud.
+Specify the name in the following form: projects/{project}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}
+where {project} can either be a project number or a project ID.`,
+						},
+						"management_ip_address_layout_version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+							Description: `The IP address layout version of the management IP address range.
+Possible versions include: * managementIpAddressLayoutVersion=1: Indicates the legacy
+IP address layout used by some existing private clouds. This is no longer supported for new private clouds
+as it does not support all features. * managementIpAddressLayoutVersion=2: Indicates the latest IP address layout
+used by all newly created private clouds. This version supports all current features.`,
+						},
+						"vmware_engine_network_canonical": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Description: `The canonical name of the VMware Engine network in
+the form: projects/{project_number}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}`,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `User-provided description for this private cloud.`,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: `Creation time of this resource.
+
+A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
+			},
+			"delete_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: `Time when the resource was scheduled for deletion.
+
+A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
+			},
+			"expire_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: `Time when the resource will be irreversibly deleted.
+
+A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
+			},
+			"hcx": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Details about a HCX Cloud Manager appliance.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fqdn": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Fully qualified domain name of the appliance.`,
+						},
+						"internal_ip": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Internal IP address of the appliance.`,
+						},
+						"state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateEnum([]string{"ACTIVE", "CREATING", ""}),
+							Description:  `State of the appliance. Possible values: ["ACTIVE", "CREATING"]`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Version of the appliance.`,
+						},
+					},
+				},
+			},
+			"nsx": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Details about a NSX Manager appliance.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fqdn": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Fully qualified domain name of the appliance.`,
+						},
+						"internal_ip": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Internal IP address of the appliance.`,
+						},
+						"state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateEnum([]string{"ACTIVE", "CREATING", ""}),
+							Description:  `State of the appliance. Possible values: ["ACTIVE", "CREATING"]`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Version of the appliance.`,
+						},
+					},
+				},
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `State of the resource. New values may be added to this enum when appropriate.`,
+			},
+			"uid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `System-generated unique identifier for the resource.`,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: `Last update time of this resource.
+
+A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
+			},
+			"vcenter": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Details about a vCenter Server management appliance.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fqdn": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Fully qualified domain name of the appliance.`,
+						},
+						"internal_ip": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Internal IP address of the appliance.`,
+						},
+						"state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateEnum([]string{"ACTIVE", "CREATING", ""}),
+							Description:  `State of the appliance. Possible values: ["ACTIVE", "CREATING"]`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Version of the appliance.`,
+						},
+					},
+				},
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func resourceVmwareenginePrivateCloudCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	obj := make(map[string]interface{})
+	descriptionProp, err := expandVmwareenginePrivateCloudDescription(d.Get("description"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("description"); !isEmptyValue(reflect.ValueOf(descriptionProp)) && (ok || !reflect.DeepEqual(v, descriptionProp)) {
+		obj["description"] = descriptionProp
+	}
+	networkConfigProp, err := expandVmwareenginePrivateCloudNetworkConfig(d.Get("network_config"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("network_config"); !isEmptyValue(reflect.ValueOf(networkConfigProp)) && (ok || !reflect.DeepEqual(v, networkConfigProp)) {
+		obj["networkConfig"] = networkConfigProp
+	}
+	managementClusterProp, err := expandVmwareenginePrivateCloudManagementCluster(d.Get("management_cluster"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("management_cluster"); !isEmptyValue(reflect.ValueOf(managementClusterProp)) && (ok || !reflect.DeepEqual(v, managementClusterProp)) {
+		obj["managementCluster"] = managementClusterProp
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds?privateCloudId={{name}}")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Creating new PrivateCloud: %#v", obj)
+	billingProject := ""
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for PrivateCloud: %s", err)
+	}
+	billingProject = project
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := getBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error creating PrivateCloud: %s", err)
+	}
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	err = VmwareengineOperationWaitTime(
+		config, res, project, "Creating PrivateCloud", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+
+	if err != nil {
+		// The resource didn't actually create
+		d.SetId("")
+		return fmt.Errorf("Error waiting to create PrivateCloud: %s", err)
+	}
+
+	log.Printf("[DEBUG] Finished creating PrivateCloud %q: %#v", d.Id(), res)
+
+	return resourceVmwareenginePrivateCloudRead(d, meta)
+}
+
+func resourceVmwareenginePrivateCloudRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for PrivateCloud: %s", err)
+	}
+	billingProject = project
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := getBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("VmwareenginePrivateCloud %q", d.Id()))
+	}
+
+	// We are only interested in management cluster of the PrivateCloud. It should always exist
+	// `management` property will be true only for ManagementCluster and there can only be one.
+	mgmtCluster, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url + "/clusters?filter=management=true",
+		UserAgent: userAgent,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error reading management cluster of PrivateCloud: %s", err)
+	}
+
+	// There can only be 1 management cluster and if the PC read is successfuly and
+	// we got response from cluster API then it should be present.
+	mgmtClusterObj := mgmtCluster["clusters"].([]interface{})[0]
+
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+
+	if err := d.Set("description", flattenVmwareenginePrivateCloudDescription(res["description"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("create_time", flattenVmwareenginePrivateCloudCreateTime(res["createTime"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("update_time", flattenVmwareenginePrivateCloudUpdateTime(res["updateTime"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("delete_time", flattenVmwareenginePrivateCloudDeleteTime(res["deleteTime"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("expire_time", flattenVmwareenginePrivateCloudExpireTime(res["expireTime"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("uid", flattenVmwareenginePrivateCloudUid(res["uid"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("state", flattenVmwareenginePrivateCloudState(res["state"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("network_config", flattenVmwareenginePrivateCloudNetworkConfig(res["networkConfig"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("management_cluster", flattenVmwareenginePrivateCloudManagementCluster(mgmtClusterObj, d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("hcx", flattenVmwareenginePrivateCloudHcx(res["hcx"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("nsx", flattenVmwareenginePrivateCloudNsx(res["nsx"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+	if err := d.Set("vcenter", flattenVmwareenginePrivateCloudVcenter(res["vcenter"], d, config)); err != nil {
+		return fmt.Errorf("Error reading PrivateCloud: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVmwareenginePrivateCloudUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for PrivateCloud: %s", err)
+	}
+	billingProject = project
+
+	obj := make(map[string]interface{})
+	descriptionProp, err := expandVmwareenginePrivateCloudDescription(d.Get("description"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("description"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, descriptionProp)) {
+		obj["description"] = descriptionProp
+	}
+	networkConfigProp, err := expandVmwareenginePrivateCloudNetworkConfig(d.Get("network_config"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("network_config"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, networkConfigProp)) {
+		obj["networkConfig"] = networkConfigProp
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Updating PrivateCloud %q: %#v", d.Id(), obj)
+	updateMask := []string{}
+
+	if d.HasChange("description") {
+		log.Printf("[DEBUG] description changed %q", d.Id())
+		updateMask = append(updateMask, "description")
+	}
+
+	if d.HasChange("network_config") {
+		log.Printf("[DEBUG] network_config changed %q", d.Id())
+		updateMask = append(updateMask, "networkConfig")
+	}
+
+	if d.HasChange("management_cluster[0].node_type_configs") {
+		log.Printf("[DEBUG] node_type_config changed %q", d.Id())
+	}
+
+	if d.HasChange("management_cluster") {
+		log.Printf("[DEBUG] management_cluster changed %q", d.Id())
+	}
+
+	// this function will be triggered when either PC needs core attributes
+	// needs to be updated or management cluster
+	// update is required. Checking this avoids PC API call when only management cluster
+	// is updated.
+	if len(updateMask) > 0 {
+		// updateMask is a URL parameter but not present in the schema, so tpgresource.ReplaceVars
+		// won't set it
+		// PS: don't update the url directly, its used for deriving cluster URL too and updating it will have impact.
+		patchUrl, err := transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+		if err != nil {
+			return err
+		}
+
+		// err == nil indicates that the billing_project value was found
+		if bp, err := getBillingProject(d, config); err == nil {
+			billingProject = bp
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "PATCH",
+			Project:   billingProject,
+			RawURL:    patchUrl,
+			UserAgent: userAgent,
+			Body:      obj,
+			Timeout:   d.Timeout(schema.TimeoutUpdate),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error updating PrivateCloud %q: %s", d.Id(), err)
+		} else {
+			log.Printf("[DEBUG] Finished updating PrivateCloud %q: %#v", d.Id(), res)
+		}
+
+		err = VmwareengineOperationWaitTime(
+			config, res, project, "Updating PrivateCloud", userAgent,
+			d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return err
+		}
+	}
+
+	// updates management cluster if required.
+	err = updateManagementCluster(d, config, url, billingProject, userAgent, project)
+	if err != nil {
+		return err
+	}
+
+	return resourceVmwareenginePrivateCloudRead(d, meta)
+}
+
+func updateManagementCluster(d *schema.ResourceData, config *transport_tpg.Config, parentUrl string, billingProject string, userAgent string, project string) error {
+	clusterObj := make(map[string]interface{})
+	managementClusterProp, err := expandVmwareenginePrivateCloudManagementCluster(d.Get("management_cluster"), d, config)
+	mgmtMap := managementClusterProp.(map[string]interface{})
+	clusterUrl := fmt.Sprintf("%s/clusters/%s", parentUrl, mgmtMap["clusterId"].(string))
+	clusterUpdateMask := []string{}
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("management_cluster"); !isEmptyValue(reflect.ValueOf(managementClusterProp)) && (ok || !reflect.DeepEqual(v, managementClusterProp)) {
+		clusterObj["nodeTypeConfigs"] = mgmtMap["nodeTypeConfigs"]
+	}
+
+	if d.HasChange("management_cluster") {
+		log.Printf("[DEBUG] managment_cluster changed %q", d.Id())
+		log.Printf("[DEBUG] clusterURL %s", clusterUrl)
+		clusterUpdateMask = append(clusterUpdateMask, "nodeTypeConfigs.*.nodeCount")
+	}
+
+	patchUrl, err := transport_tpg.AddQueryParams(clusterUrl, map[string]string{"updateMask": strings.Join(clusterUpdateMask, ",")})
+	if err != nil {
+		return err
+	}
+
+	// nothing to update
+	if len(clusterUpdateMask) == 0 {
+		return nil
+	}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   billingProject,
+		RawURL:    patchUrl,
+		UserAgent: userAgent,
+		Body:      clusterObj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error updating magament cluster %q: %s", d.Id(), err)
+	} else {
+		log.Printf("[DEBUG] Finished updating magament cluster %q: %#v", d.Id(), res)
+	}
+
+	err = VmwareengineOperationWaitTime(
+		config, res, project, "Updating Managment Cluster", userAgent,
+		d.Timeout(schema.TimeoutUpdate))
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceVmwareenginePrivateCloudDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := generateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for PrivateCloud: %s", err)
+	}
+	billingProject = project
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds/{{name}}?delay_hours=0")
+	if err != nil {
+		return err
+	}
+
+	var obj map[string]interface{}
+	log.Printf("[DEBUG] Deleting PrivateCloud %q", d.Id())
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := getBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutDelete),
+	})
+
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, "PrivateCloud")
+	}
+
+	err = VmwareengineOperationWaitTime(
+		config, res, project, "Deleting PrivateCloud", userAgent,
+		d.Timeout(schema.TimeoutDelete))
+
+	if err != nil {
+		return err
+	}
+	privateCloudPollRead := func(d *schema.ResourceData, meta interface{}) transport_tpg.PollReadFunc {
+		return func() (map[string]interface{}, error) {
+			config := meta.(*transport_tpg.Config)
+			url, err := tpgresource.ReplaceVars(d, config, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+			if err != nil {
+				return nil, err
+			}
+			billingProject := ""
+			project, err := getProject(d, config)
+			if err != nil {
+				return nil, fmt.Errorf("Error fetching project for PrivateCloud: %s", err)
+			}
+			billingProject = project
+			// err == nil indicates that the billing_project value was found
+			if bp, err := getBillingProject(d, config); err == nil {
+				billingProject = bp
+			}
+			userAgent, err := generateUserAgentString(d, config.UserAgent)
+			if err != nil {
+				return nil, err
+			}
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: userAgent,
+			})
+			if err != nil {
+				return res, err
+			}
+			return res, nil
+		}
+	}
+
+	err = PollingWaitTime(privateCloudPollRead(d, meta), PollCheckForAbsence, "Deleting PrivateCloud", d.Timeout(schema.TimeoutDelete), 10)
+	if err != nil {
+		return fmt.Errorf("Error waiting to delete PrivateCloud: %s", err)
+	}
+
+	log.Printf("[DEBUG] Finished deleting PrivateCloud %q: %#v", d.Id(), res)
+	return nil
+}
+
+func resourceVmwareenginePrivateCloudImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*transport_tpg.Config)
+	if err := tpgresource.ParseImportId([]string{
+		"projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/privateClouds/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<name>[^/]+)",
+		"(?P<location>[^/]+)/(?P<name>[^/]+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func flattenVmwareenginePrivateCloudDescription(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudCreateTime(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudUpdateTime(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudDeleteTime(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudExpireTime(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudUid(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudState(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNetworkConfig(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["management_cidr"] =
+		flattenVmwareenginePrivateCloudNetworkConfigManagementCidr(original["managementCidr"], d, config)
+	transformed["vmware_engine_network"] =
+		flattenVmwareenginePrivateCloudNetworkConfigVmwareEngineNetwork(original["vmwareEngineNetwork"], d, config)
+	transformed["vmware_engine_network_canonical"] =
+		flattenVmwareenginePrivateCloudNetworkConfigVmwareEngineNetworkCanonical(original["vmwareEngineNetworkCanonical"], d, config)
+	transformed["management_ip_address_layout_version"] =
+		flattenVmwareenginePrivateCloudNetworkConfigManagementIpAddressLayoutVersion(original["managementIpAddressLayoutVersion"], d, config)
+	return []interface{}{transformed}
+}
+
+func flattenVmwareenginePrivateCloudNetworkConfigManagementCidr(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNetworkConfigVmwareEngineNetwork(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNetworkConfigVmwareEngineNetworkCanonical(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNetworkConfigManagementIpAddressLayoutVersion(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// Handles the string fixed64 format
+	if strVal, ok := v.(string); ok {
+		if intVal, err := StringToFixed64(strVal); err == nil {
+			return intVal
+		}
+	}
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
+}
+
+func flattenVmwareenginePrivateCloudManagementCluster(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["cluster_id"] =
+		flattenVmwareenginePrivateCloudManagementClusterClusterId(original["name"], d, config)
+	transformed["node_type_configs"] =
+		flattenVmwareenginePrivateCloudManagementClusterNodeTypeConfigs(original["nodeTypeConfigs"], d, config)
+	transformed["create_time"] = flattenVmwareengineClusterCreateTime(original["createTime"], d, config)
+
+	transformed["update_time"] = flattenVmwareengineClusterUpdateTime(original["updateTime"], d, config)
+	transformed["management"] = flattenVmwareengineClusterManagement(original["management"], d, config)
+	transformed["uid"] = flattenVmwareengineClusterUid(original["uid"], d, config)
+	transformed["state"] = flattenVmwareengineClusterState(original["state"], d, config)
+
+	return []interface{}{transformed}
+}
+func flattenVmwareenginePrivateCloudManagementClusterClusterId(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	oldvalue := v.(string)
+	return oldvalue[strings.LastIndex(oldvalue, "/")+1:]
+}
+
+func flattenVmwareenginePrivateCloudManagementClusterNodeTypeConfigs(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return flattenVmwareengineClusterNodeTypeConfigs(v, d, config)
+}
+
+func flattenVmwareenginePrivateCloudHcx(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["internal_ip"] =
+		flattenVmwareenginePrivateCloudHcxInternalIp(original["internalIp"], d, config)
+	transformed["version"] =
+		flattenVmwareenginePrivateCloudHcxVersion(original["version"], d, config)
+	transformed["state"] =
+		flattenVmwareenginePrivateCloudHcxState(original["state"], d, config)
+	transformed["fqdn"] =
+		flattenVmwareenginePrivateCloudHcxFqdn(original["fqdn"], d, config)
+	return []interface{}{transformed}
+}
+
+func flattenVmwareenginePrivateCloudHcxInternalIp(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudHcxVersion(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudHcxState(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudHcxFqdn(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNsx(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["internal_ip"] =
+		flattenVmwareenginePrivateCloudNsxInternalIp(original["internalIp"], d, config)
+	transformed["version"] =
+		flattenVmwareenginePrivateCloudNsxVersion(original["version"], d, config)
+	transformed["state"] =
+		flattenVmwareenginePrivateCloudNsxState(original["state"], d, config)
+	transformed["fqdn"] =
+		flattenVmwareenginePrivateCloudNsxFqdn(original["fqdn"], d, config)
+	return []interface{}{transformed}
+}
+func flattenVmwareenginePrivateCloudNsxInternalIp(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNsxVersion(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNsxState(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudNsxFqdn(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudVcenter(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["internal_ip"] =
+		flattenVmwareenginePrivateCloudVcenterInternalIp(original["internalIp"], d, config)
+	transformed["version"] =
+		flattenVmwareenginePrivateCloudVcenterVersion(original["version"], d, config)
+	transformed["state"] =
+		flattenVmwareenginePrivateCloudVcenterState(original["state"], d, config)
+	transformed["fqdn"] =
+		flattenVmwareenginePrivateCloudVcenterFqdn(original["fqdn"], d, config)
+	return []interface{}{transformed}
+}
+func flattenVmwareenginePrivateCloudVcenterInternalIp(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudVcenterVersion(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudVcenterState(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenVmwareenginePrivateCloudVcenterFqdn(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func expandVmwareenginePrivateCloudDescription(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandVmwareenginePrivateCloudNetworkConfig(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedManagementCidr, err := expandVmwareenginePrivateCloudNetworkConfigManagementCidr(original["management_cidr"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedManagementCidr); val.IsValid() && !isEmptyValue(val) {
+		transformed["managementCidr"] = transformedManagementCidr
+	}
+
+	transformedVmwareEngineNetwork, err := expandVmwareenginePrivateCloudNetworkConfigVmwareEngineNetwork(original["vmware_engine_network"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedVmwareEngineNetwork); val.IsValid() && !isEmptyValue(val) {
+		transformed["vmwareEngineNetwork"] = transformedVmwareEngineNetwork
+	}
+
+	transformedVmwareEngineNetworkCanonical, err := expandVmwareenginePrivateCloudNetworkConfigVmwareEngineNetworkCanonical(original["vmware_engine_network_canonical"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedVmwareEngineNetworkCanonical); val.IsValid() && !isEmptyValue(val) {
+		transformed["vmwareEngineNetworkCanonical"] = transformedVmwareEngineNetworkCanonical
+	}
+
+	transformedManagementIpAddressLayoutVersion, err := expandVmwareenginePrivateCloudNetworkConfigManagementIpAddressLayoutVersion(original["management_ip_address_layout_version"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedManagementIpAddressLayoutVersion); val.IsValid() && !isEmptyValue(val) {
+		transformed["managementIpAddressLayoutVersion"] = transformedManagementIpAddressLayoutVersion
+	}
+
+	return transformed, nil
+}
+
+func expandVmwareenginePrivateCloudNetworkConfigManagementCidr(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandVmwareenginePrivateCloudNetworkConfigVmwareEngineNetwork(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandVmwareenginePrivateCloudNetworkConfigVmwareEngineNetworkCanonical(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandVmwareenginePrivateCloudNetworkConfigManagementIpAddressLayoutVersion(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandVmwareenginePrivateCloudManagementCluster(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedClusterId, err := expandVmwareenginePrivateCloudManagementClusterClusterId(original["cluster_id"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedClusterId); val.IsValid() && !isEmptyValue(val) {
+		transformed["clusterId"] = transformedClusterId
+	}
+
+	transformedNodeTypeConfigs, err := expandVmwareenginePrivateCloudManagementClusterNodeTypeConfigs(original["node_type_configs"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedNodeTypeConfigs); val.IsValid() && !isEmptyValue(val) {
+		transformed["nodeTypeConfigs"] = transformedNodeTypeConfigs
+	}
+
+	return transformed, nil
+}
+
+func expandVmwareenginePrivateCloudManagementClusterClusterId(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandVmwareenginePrivateCloudManagementClusterNodeTypeConfigs(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+	return expandVmwareengineClusterNodeTypeConfigs(v, d, config)
+}
+
+func getManagementClusterSchema() *schema.Resource {
+	clusterResource := ResourceVmwareengineCluster()
+
+	// renaming `name` to cluster_id
+	if _, ok := clusterResource.Schema["name"]; ok {
+		clusterResource.Schema["cluster_id"] = clusterResource.Schema["name"]
+		delete(clusterResource.Schema, "name")
+	}
+
+	// remove parent as its not required for management cluster.
+	if _, ok := clusterResource.Schema["parent"]; ok {
+		delete(clusterResource.Schema, "parent")
+	}
+
+	return clusterResource
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_vmwareengine_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_vmwareengine_cluster_test.go.erb
@@ -1,0 +1,84 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceVmwareEngineCluster_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":        acctest.GetTestRegionFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVmwareEngineCluster(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_cluster.ds", "google_vmwareengine_cluster.cls", map[string]struct{}{}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVmwareEngineCluster(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_vmwareengine_network" "default-nw" {
+   name              = "%{region}-default"
+   provider 		 = google-beta
+   location          = "%{region}"
+   type              = "LEGACY"
+}
+
+resource "google_vmwareengine_private_cloud" "pc" {
+  location = "%{region}-a"
+  name = "tf-test-sample-pc%{random_suffix}"
+  provider = google-beta
+  description = ""
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.default-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-sample-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_cluster" "cls" {
+    name = "tf-test-ext-cluster%{random_suffix}"
+	provider = google-beta
+    parent =  google_vmwareengine_private_cloud.pc.id
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+      custom_core_count = 32
+    }
+}
+
+data "google_vmwareengine_cluster" ds {
+  	name = "tf-test-ext-cluster%{random_suffix}"
+	provider = google-beta
+	parent = google_vmwareengine_private_cloud.pc.id
+	depends_on = [
+   	 google_vmwareengine_cluster.cls,
+  	]
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_vmwareengine_network_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_vmwareengine_network_test.go.erb
@@ -1,0 +1,56 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceVmwareEngineNetwork_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":        acctest.GetTestRegionFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineNetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVmwareEngineNetworkConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_network.ds", "google_vmwareengine_network.nw", map[string]struct{}{}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVmwareEngineNetworkConfig(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_vmwareengine_network" "nw" {
+    name              = "%{region}-default" #Legacy network IDs are in the format: {region-id}-default
+	provider = google-beta
+    location          = "%{region}"
+    type              = "LEGACY"
+    description       = "VMwareEngine legacy network sample"
+}
+
+
+data "google_vmwareengine_network" "ds" {
+  name = google_vmwareengine_network.nw.name
+  provider = google-beta
+  location = "%{region}"
+  depends_on = [
+    google_vmwareengine_network.nw,
+  ]
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/data_source_google_vmwareengine_private_cloud_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_vmwareengine_private_cloud_test.go.erb
@@ -1,0 +1,73 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceVmwareEnginePrivateCloud_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":        acctest.GetTestRegionFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVmwareEnginePrivateCloudConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_private_cloud.ds", "google_vmwareengine_private_cloud.pc", map[string]struct{}{}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVmwareEnginePrivateCloudConfig(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_vmwareengine_network" "default-nw" {
+   name              = "%{region}-default"
+   provider 		 = google-beta
+   location          = "%{region}"
+   type              = "LEGACY"
+}
+
+resource "google_vmwareengine_private_cloud" "pc" {
+  location = "%{region}-a"
+  name = "tf-test-sample-pc%{random_suffix}"
+  provider = google-beta
+  description = ""
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.default-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-sample-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+  }
+}
+
+data "google_vmwareengine_private_cloud" ds {
+	location = "%{region}-a"
+	provider = google-beta
+  	name = "tf-test-sample-pc%{random_suffix}"
+	depends_on = [
+   	 google_vmwareengine_private_cloud.pc,
+  	]
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_vmwareengine_private_cloud_sweeper_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_vmwareengine_private_cloud_sweeper_test.go.erb
@@ -1,0 +1,128 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	resource.AddTestSweepers("VmwareenginePrivateCloud", &resource.Sweeper{
+		Name: "VmwareenginePrivateCloud",
+		F:    testSweepVmwareenginePrivateCloud,
+	})
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareenginePrivateCloud(region string) error {
+	resourceName := "VmwareenginePrivateCloud"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := GetTestBillingAccountFromEnv(t)
+
+	// Setup variables to replace in list template
+	d := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project":         config.Project,
+			"region":          region,
+			"location":        region,
+			"zone":            "-",
+			"billing_account": billingId,
+		},
+	}
+
+	listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   config.Project,
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["privateClouds"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	// Keep count of items that aren't sweepable for logging.
+	nonPrefixCount := 0
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["name"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		name := GetResourceNameFromSelfLink(obj["name"].(string))
+		// Skip resources that shouldn't be sweeped
+		if !IsSweepableTestResource(name) {
+			nonPrefixCount++
+			continue
+		}
+
+		deleteTemplate := "https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds/{{name}}?delay_hours=0"
+		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   config.Project,
+			RawURL:    deleteUrl,
+			UserAgent: config.UserAgent,
+		})
+
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+
+	if nonPrefixCount > 0 {
+		log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+	}
+
+	return nil
+}
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_vmwareengine_private_cloud_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_vmwareengine_private_cloud_test.go.erb
@@ -1,0 +1,200 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudBasicExample(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"region":        GetTestRegionFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudBasicExample(context),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name"},
+			},
+		},
+	})
+}
+
+func testAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudBasicExample(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_vmwareengine_network" "default-nw" {
+   provider      	 = google-beta
+   name              = "%{region}-default"
+   location          = "%{region}"
+   type              = "LEGACY"
+}
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  provider = google-beta
+  location = "%{region}-a"
+  name = "tf-test-sample-pc%{random_suffix}"
+  description = ""
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.default-nw.id
+  }
+  management_cluster {
+    cluster_id = "tf-test-sample-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+  }
+}
+`, context)
+}
+
+func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdateAndExpand(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"region":        acctest.GetTestRegionFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+	configTemplate := privateCloudUpdateConfigTemplate(context)
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(configTemplate, "description1", 3),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name"},
+			},
+			{
+				Config: fmt.Sprintf(configTemplate, "description2", 4),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name"},
+			},
+		},
+	})
+}
+
+func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdateAndShrink(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"region":        acctest.GetTestRegionFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+	configTemplate := privateCloudUpdateConfigTemplate(context)
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(configTemplate, "description1", 4),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name"},
+			},
+			{
+				Config: fmt.Sprintf(configTemplate, "description2", 3),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name"},
+			},
+		},
+	})
+}
+
+func privateCloudUpdateConfigTemplate(context map[string]interface{}) string {
+
+	return Nprintf(`
+resource "google_vmwareengine_network" "default-nw" {
+   provider      	 = google-beta
+   name              = "%{region}-default"
+   location          = "%{region}"
+   type              = "LEGACY"
+}
+
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  location = "%{region}-a"
+  name = "tf-test-sample-pc%{random_suffix}"
+  provider = google-beta
+  description = "%s"
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.default-nw.id
+  }
+  management_cluster {
+    cluster_id = "tf-test-sample-mgmt-cluster-custom-core-count%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = %d
+      custom_core_count = 32
+    }
+  }
+}
+`, context)
+}
+
+func testAccCheckVmwareenginePrivateCloudDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_vmwareengine_private_cloud" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+			config := GoogleProviderConfig(t)
+			url, err := replaceVarsForTest(config, rs, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds/{{name}}")
+			if err != nil {
+				return err
+			}
+			billingProject := ""
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("VmwareenginePrivateCloud still exists at %s", url)
+			}
+		}
+		return nil
+	}
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -334,6 +334,11 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_vpc_access_connector":                      DataSourceVPCAccessConnector(),
 		"google_redis_instance":                            DataSourceGoogleRedisInstance(),
 		"google_vertex_ai_index":                           dataSourceVertexAIIndex(),
+		<% unless version == 'ga' -%>
+		"google_vmwareengine_private_cloud":              	DataSourceVmwareenginePrivateCloud(),
+		"google_vmwareengine_network":                    	DataSourceVmwareengineNetwork(),
+		"google_vmwareengine_cluster":                    	DataSourceVmwareengineCluster(),
+		<% end -%>
 		// ####### END datasources ###########
 		// ####### END handwritten datasources ###########
 	},
@@ -538,6 +543,9 @@ end     # products.each do
 				"google_storage_notification":                  ResourceStorageNotification(),
 				"google_storage_transfer_job":                  ResourceStorageTransferJob(),
 				"google_tags_location_tag_binding":             ResourceTagsLocationTagBinding(),
+				<% unless version == 'ga' -%>
+				"google_vmwareengine_private_cloud":            ResourceVmwareenginePrivateCloud(),
+				<% end -%>
 				// ####### END handwritten resources ###########
 			},
 			map[string]*schema.Resource{

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_cluster.html.markdown
@@ -1,0 +1,29 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get info about a Google VMwareEngine Cluster.
+---
+
+# google\_vmwareengine\_cluster
+
+Use this data source to get details about a Google VMwareEngine Cluster resource.
+
+To get more information about VMwareEngine Cluster, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.clusters)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_cluster" "my_cluster" {
+  provider = google-beta
+  name     = "my-pc"
+  parent   = "project/locations/us-west1-a/privateClouds/my-cloud"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource.
+* `parent` - (Required) The resource name of the private cloud that this cluster belongs.

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_network.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get info about a Google VMwareEngine Network.
+---
+
+# google\_vmwareengine\_network
+
+Use this data source to get details about a Google VMwareEngine network resource.
+
+To get more information about VMwareEngine Network, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.vmwareEngineNetworks)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_network" "my_nw" {
+  provider = google-beta
+  name     = "us-central1-default"
+  location = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource.
+* `location` - (Required) Location of the resource.
+
+- - -
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_private_cloud.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_private_cloud.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get info about a Google VMwareEngine PrivateCloud.
+---
+
+# google\_vmwareengine\_private_cloud
+
+Use this data source to get details about a Google VMwareEngine PrivateCloud resource.
+
+To get more information about VMwareEngine PrivateCloud, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_private_cloud" "my_pc" {
+  provider = google-beta
+  name     = "my-pc"
+  location = "us-central1-a"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource.
+* `location` - (Required) Location of the resource.
+
+- - -
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.

--- a/mmv1/third_party/terraform/website/docs/r/vmwareengine_private_cloud.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/vmwareengine_private_cloud.html.markdown
@@ -1,0 +1,223 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Represents a private cloud resource.
+---
+
+# google\_vmwareengine\_private\_cloud
+
+Represents a private cloud resource. Private clouds are zonal resources.
+To get more information about PrivateCloud, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds)
+
+## Example Usage - Vmware Engine Private Cloud Basic
+```hcl
+resource "google_vmwareengine_network" "default-nw" {
+   provider          = google-beta
+   name              = "us-west1-default"
+   location          = "us-west1"
+   type              = "LEGACY"
+}
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  provider = google-beta
+  location = "us-west1-a"
+  name = "sample-pc"
+  description = ""
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.default-nw.id
+  }
+  management_cluster {
+    cluster_id = "sample-mgmt-cluster"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+  }
+}
+```
+
+## Example Usage - Vmware Engine Private Cloud Full
+
+```hcl
+resource "google_vmwareengine_network" "default-nw" {
+   provider          = google-beta
+   name              = "us-west1-default"
+   location          = "us-west1"
+   type              = "LEGACY"
+   description       = "PC network description."
+}
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  provider = google-beta
+  location = "us-west1-a"
+  name = "sample-pc"
+  description = "Sample test PC."
+  network_config {
+    management_cidr = "192.168.30.0/24"
+    vmware_engine_network = google_vmwareengine_network.default-nw.id
+  }
+  management_cluster {
+    cluster_id = "sample-mgmt-cluster-custom-core-count"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+      custom_core_count = 32
+    }
+  }
+}
+```
+## Argument Reference
+The following arguments are supported:
+* `network_config` -
+  (Required)
+  Network configuration in the consumer project with which the peering has to be done.
+  Structure is [documented below](#nested_network_config).
+* `management_cluster` -
+  (Required)
+  The management cluster for this private cloud. The following fields can't be changed after private cloud creation: ManagementCluster.clusterId, ManagementCluster.nodeTypeId.
+  Structure is [documented below](#nested_management_cluster).
+* `location` -
+  (Required)
+  The location where the PrivateCloud should reside.
+* `name` -
+  (Required)
+  The ID of the PrivateCloud.
+<a name="nested_network_config"></a>The `network_config` block supports:
+* `management_cidr` -
+  (Required)
+  Management CIDR used by VMware management appliances.
+* `vmware_engine_network` -
+  (Optional)
+  The relative resource name of the VMware Engine network attached to the private cloud.
+  Specify the name in the following form: projects/{project}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}
+  where {project} can either be a project number or a project ID.
+* `vmware_engine_network_canonical` -
+
+  The canonical name of the VMware Engine network in
+  the form: projects/{project_number}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}
+* `management_ip_address_layout_version` -
+
+  The IP address layout version of the management IP address range.
+  Possible versions include: * managementIpAddressLayoutVersion=1: Indicates the legacy
+  IP address layout used by some existing private clouds. This is no longer supported for new private clouds
+  as it does not support all features. * managementIpAddressLayoutVersion=2: Indicates the latest IP address layout
+  used by all newly created private clouds. This version supports all current features.
+<a name="nested_management_cluster"></a>The `management_cluster` block supports:
+* `cluster_id` -
+  (Required)
+  The user-provided identifier of the new Cluster. The identifier must meet the following requirements:
+    * Only contains 1-63 alphanumeric characters and hyphens
+    * Begins with an alphabetical character
+    * Ends with a non-hyphen character
+    * Not formatted as a UUID
+    * Complies with RFC 1034 (https://datatracker.ietf.org/doc/html/rfc1034) (section 3.5)
+* `node_type_configs` -
+  (Optional)
+  The map of cluster node types in this cluster,
+  where the key is canonical identifier of the node type (corresponds to the NodeType).
+  Structure is [documented below](#nested_node_type_configs).
+<a name="nested_node_type_configs"></a>The `node_type_configs` block supports:
+* `node_type_id` - (Required) The identifier for this object. Format specified above.
+* `node_count` -
+  (Required)
+  The number of nodes of this type in the cluster.
+* `custom_core_count` -
+  (Optional)
+  Customized number of cores available to each node of the type.
+  This number must always be one of `nodeType.availableCustomCoreCounts`.
+  If zero is provided max value from `nodeType.availableCustomCoreCounts` will be used.
+- - -
+* `description` -
+  (Optional)
+  User-provided description for this private cloud.
+* `project` - (Optional) The ID of the project in which the resource belongs.
+    If it is not provided, the provider project is used.
+## Attributes Reference
+In addition to the arguments listed above, the following computed attributes are exported:
+* `id` - an identifier for the resource with format `projects/{{project}}/locations/{{location}}/privateClouds/{{name}}`
+* `create_time` -
+  Creation time of this resource.
+  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+  Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `update_time` -
+  Last update time of this resource.
+  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+  Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `delete_time` -
+  Time when the resource was scheduled for deletion.
+  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+  Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `expire_time` -
+  Time when the resource will be irreversibly deleted.
+  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+  Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `uid` -
+  System-generated unique identifier for the resource.
+* `state` -
+  State of the resource. New values may be added to this enum when appropriate.
+* `hcx` -
+  Details about a HCX Cloud Manager appliance.
+  Structure is [documented below](#nested_hcx).
+* `nsx` -
+  Details about a NSX Manager appliance.
+  Structure is [documented below](#nested_nsx).
+* `vcenter` -
+  Details about a vCenter Server management appliance.
+  Structure is [documented below](#nested_vcenter).
+<a name="nested_hcx"></a>The `hcx` block contains:
+* `internal_ip` -
+  (Optional)
+  Internal IP address of the appliance.
+* `version` -
+  (Optional)
+  Version of the appliance.
+* `state` -
+  (Optional)
+  State of the appliance.
+  Possible values are: `ACTIVE`, `CREATING`.
+* `fqdn` -
+  (Optional)
+  Fully qualified domain name of the appliance.
+<a name="nested_nsx"></a>The `nsx` block contains:
+* `internal_ip` -
+  (Optional)
+  Internal IP address of the appliance.
+* `version` -
+  (Optional)
+  Version of the appliance.
+* `state` -
+  (Optional)
+  State of the appliance.
+  Possible values are: `ACTIVE`, `CREATING`.
+* `fqdn` -
+  (Optional)
+  Fully qualified domain name of the appliance.
+<a name="nested_vcenter"></a>The `vcenter` block contains:
+* `internal_ip` -
+  (Optional)
+  Internal IP address of the appliance.
+* `version` -
+  (Optional)
+  Version of the appliance.
+* `state` -
+  (Optional)
+  State of the appliance.
+  Possible values are: `ACTIVE`, `CREATING`.
+* `fqdn` -
+  (Optional)
+  Fully qualified domain name of the appliance.
+## Timeouts
+This resource provides the following
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
+- `create` - Default is 180 minutes.
+- `update` - Default is 160 minutes.
+- `delete` - Default is 120 minutes.
+## Import
+PrivateCloud can be imported using any of these accepted formats:
+```
+$ terraform import google_vmwareengine_private_cloud.default projects/{{project}}/locations/{{location}}/privateClouds/{{name}}
+$ terraform import google_vmwareengine_private_cloud.default {{project}}/{{location}}/{{name}}
+$ terraform import google_vmwareengine_private_cloud.default {{location}}/{{name}}
+```
+## User Project Overrides
+This resource supports [User Project Overrides](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added basic support for VMwareEngine Network, Cluster, and PrivateCloud resources.
Version for the resources is currently set to beta
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8516

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:new-resource
    - release-note:new-datasource

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vmwareengine_network`
`google_vmwareengine_private_cloud`
`google_vmwareengine_cluster`
```

```release-note:new-datasource
`google_vmwareengine_network`
`google_vmwareengine_private_cloud`
`google_vmwareengine_cluster`
```
