### PR TITLE
Add Fleet field in resource_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1952,10 +1952,9 @@ func ResourceContainerCluster() *schema.Resource {
 							Description:      `The Fleet host project of the cluster.`
 						},
                                           	"membership": {
-                                                Type:             schema.TypeString,
-                                                Computed:         true,
-                                                Description:      `The Fleet membership of the cluster.`
-
+							Type:             schema.TypeString,
+							Computed:         true,
+							Description:      `The Fleet membership of the cluster.`
                                           	},
 					},
 				},

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1937,6 +1937,29 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+			"fleet": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: `Fleet information of the cluster.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project": {
+							Type:         schema.TypeString,
+							Optional:         true,
+                                                	Computed:         true,
+							Description:      `The Fleet host project of the cluster.`
+						},
+                                          	"membership": {
+                                                Type:             schema.TypeString,
+                                                Computed:         true,
+                                                Description:      `The Fleet membership of the cluster.`
+
+                                          	},
+					},
+				},
+			},
 		},
 	}
 }
@@ -2201,6 +2224,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("monitoring_config"); ok {
 		cluster.MonitoringConfig = expandMonitoringConfig(v)
 	}
+	
+	if v, ok := d.GetOk("fleet"); ok {
+                cluster.Fleet = expandFleet(v)
+        }       
 
 <% unless version == 'ga' -%>
 	if err := validateNodePoolAutoConfig(cluster); err != nil {
@@ -2597,6 +2624,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("monitoring_config", flattenMonitoringConfig(cluster.MonitoringConfig)); err != nil {
 		return err
 	}
+	
+	if err := d.Set("fleet", flattenFleet(cluster.Fleet)); err != nil {
+                return err
+        }
 
 <% unless version == 'ga' -%>
 	if err := d.Set("node_pool_auto_config", flattenNodePoolAutoConfig(cluster.NodePoolAutoConfig)); err != nil {
@@ -3531,6 +3562,21 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		log.Printf("[INFO] GKE cluster %s monitoring config has been updated", d.Id())
 	}
+
+        if d.HasChange("fleet") {
+                req := &container.UpdateClusterRequest{
+                        Update: &container.ClusterUpdate{
+                                Fleet: expandFleet(d.Get("fleet")),
+                        },
+                }
+                updateF := updateFunc(req, "updating GKE cluster fleet")
+                // Call update serially.
+                if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+                        return err
+                }
+        
+                log.Printf("[INFO] GKE cluster %s fleet has been updated", d.Id())
+        } 
 
 	if d.HasChange("resource_labels") {
 		resourceLabels := d.Get("resource_labels").(map[string]interface{})
@@ -4893,6 +4939,18 @@ func expandNodePoolAutoConfigNetworkTags(configured interface{}) *container.Netw
 }
 <% end -%>
 
+func expandFleet(configured interface{}) *container.Fleet {
+        l := configured.([]interface{})
+        if len(l) == 0 || l[0] == nil {
+                return nil 
+        }       
+                
+        config := l[0].(map[string]interface{})
+        return &container.Fleet{
+                Project: config["project"].(string),
+        }       
+}  
+
 func flattenNotificationConfig(c *container.NotificationConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
@@ -5566,6 +5624,18 @@ func flattenGatewayApiConfig(c *container.GatewayAPIConfig) []map[string]interfa
 			"channel":        c.Channel,
 		},
 	}
+}
+
+func flattenFleet(c *container.Fleet) []map[string]interface{} {
+      if c == nil {
+                return nil
+      }         
+      return []map[string]interface{}{
+                {
+                      "project": c.Project,
+                      "membership": c.Membership,
+                },
+        }       
 }
 
 func flattenContainerClusterLoggingConfig(c *container.LoggingConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3570,6 +3570,44 @@ func TestAccContainerCluster_withGatewayApiConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withFleet(t *testing.T) {
+        t.Parallel() 
+        clusterName := fmt.Sprintf("tf-test-cluster-%s", RandString(t, 10))
+        pid := getTestProjectFromEnv()
+  
+        vcrTest(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+                Steps: []resource.TestStep{
+                        {
+                                Config: testAccContainerCluster_withFleetEnabled(pid, clusterName),
+                        },
+                        {
+                                ResourceName:            "google_container_cluster.with_fleet",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                        },
+                        {
+                                Config: testAccContainerCluster_updateFleet(pid, clusterName, false),
+                        },
+                        {
+                                ResourceName:            "google_container_cluster.with_fleet",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                        },
+                        {
+                                Config: testAccContainerCluster_updateFleet(pid, clusterName, true),
+                        },
+                        {
+                                ResourceName:            "google_container_cluster.with_fleet",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                        }, 
+                },
+        })
+}
+
 <% unless version == 'ga' -%>
 func TestAccContainerCluster_withTPUConfig(t *testing.T) {
 	t.Parallel()
@@ -6650,6 +6688,51 @@ resource "google_container_cluster" "with_workload_identity_config" {
 `, projectID, clusterName, workloadIdentityConfig)
 }
 
+func testAccContainerCluster_withFleetEnabled(projectID string, clusterName string) string {
+        return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "with_fleet" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  fleet {
+    project = "${data.google_project.project.project_id}"
+  }
+}
+`, projectID, clusterName)
+}
+
+func testAccContainerCluster_updateFleet(projectID string, clusterName string, enable bool) string {
+        fleet := ""
+        if enable {
+                fleet = `
+			fleet {
+                  		project = "${data.google_project.project.project_id}"
+                	}`
+        } else {
+                fleet = `
+                        fleet {
+                        project = ""
+                	}`
+        }
+        return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "with_fleet" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  remove_default_node_pool = true
+  %s
+}
+`, projectID, clusterName, fleet)
+}
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccContainerCluster_sharedVpc(org, billingId, projectName, name string, suffix string) string {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1187,6 +1187,10 @@ and all pods running on the nodes. Specified as a map from the key, such as
 
 * `audit_mode` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Sets which mode of auditing should be used for the cluster's workloads. Accepted values are DISABLED, BASIC.
 
+<a name="nested_fleet"></a>The `fleet` block supports:
+  
+* `project` - (Optional) The Fleet host project the cluster will be registered to.
+  
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Expose the `Fleet` field in resource_container_cluster.
- API reference of the field: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#fleet
- `project` is a mutable config field
- `membership` is output_only field 

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14761

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added `fleet` in `google_container_cluster`

```
