### PR TITLE
fixed failing basic test for bigquery reservation

### DIFF
--- a/tpgtools/overrides/bigqueryreservation/samples/assignment/basic.tf.tmpl
+++ b/tpgtools/overrides/bigqueryreservation/samples/assignment/basic.tf.tmpl
@@ -4,6 +4,7 @@ resource "google_bigquery_reservation" "basic" {
   location = "us-central1"
   slot_capacity = 0
   ignore_idle_slots = false
+  edition = "ENTERPRISE"
 }
 
 resource "google_bigquery_reservation_assignment" "primary" {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14711

If this PR is for Terraform, I acknowledge that I have:

* [x]  Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
* [x]  Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
* [x]  [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
* [x]  [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
* [x]  Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

Release Note Template for Downstream PRs (will be copied)
```release-note:none
For reservations, we are returning edition as "ENTERPRISE", which wasn't explicitly set by the test.
```