### PR TITLE
Add `test-fixtures/` to directories ignored by copywrite CLI

### DIFF
--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -212,7 +212,6 @@ module Provider
       # NOTE: these entries need to match the content of the .copywrite.hcl file originally
       #       created in https://github.com/GoogleCloudPlatform/magic-modules/pull/7336
       ignored_folders = [
-        '.github/',
         '.release/',
         '.changelog/',
         'examples/',

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -211,10 +211,13 @@ module Provider
       # Prevent adding copyright header to files with paths or names matching the strings below
       # NOTE: these entries need to match the content of the .copywrite.hcl file originally
       #       created in https://github.com/GoogleCloudPlatform/magic-modules/pull/7336
+      #       The test-fixtures folder is not included here as it's copied as a whole,
+      #       not file by file (see common~copy.yaml)
       ignored_folders = [
         '.release/',
         '.changelog/',
         'examples/',
+        'scripts/',
         'META.d/'
       ]
       ignored_files = [

--- a/mmv1/third_party/terraform/.copywrite.hcl.erb
+++ b/mmv1/third_party/terraform/.copywrite.hcl.erb
@@ -16,6 +16,11 @@ project {
     ".changelog/**",
     "examples/**",
     "scripts/**",
+<% if version.nil? || version == 'ga' -%>
+    "google/test-fixtures/**",
+<% else -%>
+    "google-<%= version -%>/test-fixtures/**",
+<% end -%>
     "META.d/*.yml",
     ".golangci.yml",
     ".goreleaser.yml",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
