### PR TITLE
Add flag to skip reading projects in google_billing_account

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
@@ -42,7 +42,7 @@ func DataSourceGoogleBillingAccount() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"read_projects": {
+			"lookup_projects": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -103,7 +103,7 @@ func dataSourceBillingAccountRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("one of billing_account or display_name must be set")
 	}
 
-	if d.Get("read_projects").(bool) {
+	if d.Get("lookup_projects").(bool) {
 		resp, err := config.NewBillingClient(userAgent).BillingAccounts.Projects.List(billingAccount.Name).Do()
 		if err != nil {
 			return fmt.Errorf("Error reading billing account projects: %s", err)

--- a/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_billing_account.go
@@ -42,6 +42,11 @@ func DataSourceGoogleBillingAccount() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"read_projects": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -98,11 +103,17 @@ func dataSourceBillingAccountRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("one of billing_account or display_name must be set")
 	}
 
-	resp, err := config.NewBillingClient(userAgent).BillingAccounts.Projects.List(billingAccount.Name).Do()
-	if err != nil {
-		return fmt.Errorf("Error reading billing account projects: %s", err)
+	if d.Get("read_projects").(bool) {
+		resp, err := config.NewBillingClient(userAgent).BillingAccounts.Projects.List(billingAccount.Name).Do()
+		if err != nil {
+			return fmt.Errorf("Error reading billing account projects: %s", err)
+		}
+		projectIds := flattenBillingProjects(resp.ProjectBillingInfo)
+
+		if err := d.Set("project_ids", projectIds); err != nil {
+			return fmt.Errorf("Error setting project_ids: %s", err)
+		}
 	}
-	projectIds := flattenBillingProjects(resp.ProjectBillingInfo)
 
 	d.SetId(tpgresource.GetResourceNameFromSelfLink(billingAccount.Name))
 	if err := d.Set("name", billingAccount.Name); err != nil {
@@ -113,9 +124,6 @@ func dataSourceBillingAccountRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if err := d.Set("open", billingAccount.Open); err != nil {
 		return fmt.Errorf("Error setting open: %s", err)
-	}
-	if err := d.Set("project_ids", projectIds); err != nil {
-		return fmt.Errorf("Error setting project_ids: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/tests/data_source_google_billing_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_billing_account_test.go
@@ -85,6 +85,7 @@ func testAccCheckGoogleBillingAccount_byName(name string) string {
 	return fmt.Sprintf(`
 data "google_billing_account" "acct" {
   billing_account = "%s"
+  read_projects = false
 }
 `, name)
 }

--- a/mmv1/third_party/terraform/tests/data_source_google_billing_account_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_billing_account_test.go
@@ -85,7 +85,7 @@ func testAccCheckGoogleBillingAccount_byName(name string) string {
 	return fmt.Sprintf(`
 data "google_billing_account" "acct" {
   billing_account = "%s"
-  read_projects = false
+  lookup_projects = false
 }
 `, name)
 }

--- a/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `billing_account` (Optional) - The name of the billing account in the form `{billing_account_id}` or `billingAccounts/{billing_account_id}`.
 * `display_name` (Optional) - The display name of the billing account.
 * `open` (Optional) - `true` if the billing account is open, `false` if the billing account is closed.
-* `read_projects` (Optional) - `true` if projects associated with the billing account should be read, `false` if this step
+* `lookup_projects` (Optional) - `true` if projects associated with the billing account should be read, `false` if this step
 should be skipped. Setting `false` may be useful if the user permissions do not allow listing projects. Defaults to `true`.
 
 ~> **NOTE:** One of `billing_account` or `display_name` must be specified.
@@ -43,5 +43,5 @@ The following additional attributes are exported:
 
 * `id` - The billing account ID.
 * `name` - The resource name of the billing account in the form `billingAccounts/{billing_account_id}`.
-* `project_ids` - The IDs of any projects associated with the billing account. `read_projects` must not be false
+* `project_ids` - The IDs of any projects associated with the billing account. `lookup_projects` must not be false
 for this to be populated.

--- a/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 * `billing_account` (Optional) - The name of the billing account in the form `{billing_account_id}` or `billingAccounts/{billing_account_id}`.
 * `display_name` (Optional) - The display name of the billing account.
 * `open` (Optional) - `true` if the billing account is open, `false` if the billing account is closed.
+* `read_projects` (Optional) - `true` if projects associated with the billing account should be read, `false` if this step
+should be skipped. Setting `false` may be useful if the user permissions do not allow listing projects. Defaults to `true`.
 
 ~> **NOTE:** One of `billing_account` or `display_name` must be specified.
 
@@ -41,4 +43,5 @@ The following additional attributes are exported:
 
 * `id` - The billing account ID.
 * `name` - The resource name of the billing account in the form `billingAccounts/{billing_account_id}`.
-* `project_ids` - The IDs of any projects associated with the billing account.
+* `project_ids` - The IDs of any projects associated with the billing account. `read_projects` must not be false
+for this to be populated.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/11548

not committed to the name `read_projects`. If you can think of a better name (list, lookup maybe?) let me know.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
billing: added `lookup_projects` to `google_billing_account` datasource that skips reading the list of associated projects
```
