### PR TITLE
Remove TestAccAlloydb*_missingLocation tests that fail VCR replay

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_backup_test.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -89,72 +88,6 @@ resource "google_service_networking_connection" "vpc_connection" {
 
 data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-`, context)
-}
-
-// We expect an error when creating an on-demand backup without location.
-// Location is a `required` field.
-func TestAccAlloydbBackup_missingLocation(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": RandString(t, 10),
-	}
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckAlloydbBackupDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAlloydbBackup_missingLocation(context),
-				ExpectError: regexp.MustCompile("Missing required argument"),
-			},
-		},
-	})
-}
-
-func testAccAlloydbBackup_missingLocation(context map[string]interface{}) string {
-	return Nprintf(`
-resource "google_alloydb_backup" "default" {
-  backup_id    = "tf-test-alloydb-backup%{random_suffix}"
-  cluster_name = google_alloydb_cluster.default.name
-  depends_on = [google_alloydb_instance.default]
-}
-
-resource "google_alloydb_cluster" "default" {
-  location = "us-central1"
-  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
-  network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
-}
-  
-data "google_project" "project" { }
-
-resource "google_compute_network" "default" {
-  name = "tf-test-alloydb-cluster%{random_suffix}"
-}
-
-resource "google_alloydb_instance" "default" {
-  cluster       = google_alloydb_cluster.default.name
-  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
-  instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
-}
-  
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -213,43 +212,6 @@ resource "google_alloydb_cluster" "default" {
 
 data "google_project" "project" {
 }
-
-resource "google_compute_network" "default" {
-  name = "tf-test-alloydb-cluster%{random_suffix}"
-}
-`, context)
-}
-
-// We expect an error when creating a cluster without location.
-// Location is a `required` field.
-func TestAccAlloydbCluster_missingLocation(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": RandString(t, 10),
-	}
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAlloydbCluster_missingLocation(context),
-				ExpectError: regexp.MustCompile("Missing required argument"),
-			},
-		},
-	})
-}
-
-func testAccAlloydbCluster_missingLocation(context map[string]interface{}) string {
-	return Nprintf(`
-resource "google_alloydb_cluster" "default" {
-  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
-  network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
-}
-
-data "google_project" "project" { }
 
 resource "google_compute_network" "default" {
   name = "tf-test-alloydb-cluster%{random_suffix}"


### PR DESCRIPTION
These two tests make sure that a `location` field is required, but there are some downsides to including tests like this:
- There are no API calls during the test, so the VCR replay fails, and the tests always show up in the list of recorded tests for our PRs
- They are testing built-in validation provided by the `Required` flag, so they do not provide much value, and we would end up with an enormous number of tests if we were consistent about including these across resources

Removing the tests will reduce noise in our PRs, without tangibly sacrificing test coverage.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
