### PR TITLE
actions attribute changed from required to optional

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -906,7 +906,6 @@ properties:
                   * `"pipeline" : "etl"`
       - !ruby/object:Api::Type::Array
         name: 'actions'
-        required: true
         description: |
           A task to execute on the completion of a job.
         item_type: !ruby/object:Api::Type::NestedObject

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -389,6 +389,50 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerUpdateExample4(t *testing.
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       acctest.GetTestProjectFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalBasic(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalBasic(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -2193,6 +2237,32 @@ resource "google_data_loss_prevention_job_trigger" "inspect" {
 						name = "LAST_NAME"
 						version = "0.1"
 					}
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalBasic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "basic" {
+	parent = "projects/%{project}"
+	description = "Starting description"
+	display_name = "display"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
 				}
 			}
 		}

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -398,9 +398,9 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalExample(t *
 	}
 
 	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalBasic(context),

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -2259,6 +2259,7 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 	}
 
 	inspect_job {
+		inspect_template_name = "fake"
 		storage_config {
 			cloud_storage_options {
 				file_set {
@@ -2270,4 +2271,3 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 }
 `, context)
 }
-

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -397,7 +397,7 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerActionsOptionalExample(t *
 		"random_suffix": RandString(t, 10),
 	}
 
-	vcrTest(t, resource.TestCase{
+	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
@@ -2270,3 +2270,4 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 }
 `, context)
 }
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
changed actions from required to optional and added test cases.
fixes https://github.com/hashicorp/terraform-provider-google/issues/11859


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: changed `actions` field from required to optional in `google_data_loss_prevention_job_trigger` resource
```
