### PR TITLE
Added stored_info_type_id field in google_data_loss_prevention_stored_info_type

### DIFF
--- a/mmv1/products/dlp/StoredInfoType.yaml
+++ b/mmv1/products/dlp/StoredInfoType.yaml
@@ -47,11 +47,19 @@ examples:
       object_name: tf-test-object
     test_env_vars:
       project: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dlp_stored_info_type_with_id'
+    primary_resource_id: 'with_stored_info_type_id'
+    vars:
+      name: 'id-'
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   resource_definition: templates/terraform/resource_definition/dlp_stored_info_type.go.erb
   constants: templates/terraform/constants/dlp_stored_info_type.go.erb
   decoder: templates/terraform/decoders/dlp_stored_info_type.go.erb
   encoder: templates/terraform/encoders/dlp_stored_info_type.go.erb
+  update_encoder: templates/terraform/update_encoder/dlp_stored_info_type.go.erb
   custom_import: templates/terraform/custom_import/dlp_import.go.erb
 parameters:
   - !ruby/object:Api::Type::String
@@ -81,6 +89,15 @@ properties:
     name: 'displayName'
     description: |
       User set display name of the info type.
+  - !ruby/object:Api::Type::String
+    name: 'storedInfoTypeId'
+    description: |
+      The storedInfoType ID can contain uppercase and lowercase letters, numbers, and hyphens;
+      that is, it must match the regular expression: [a-zA-Z\d-_]+. The maximum length is 100
+      characters. Can be empty to allow the system to generate one.
+    immutable: true
+    default_from_api: true
+    url_param_only: true
   - !ruby/object:Api::Type::NestedObject
     name: 'regex'
     description: Regular expression which defines the rule.

--- a/mmv1/templates/terraform/decoders/dlp_stored_info_type.go.erb
+++ b/mmv1/templates/terraform/decoders/dlp_stored_info_type.go.erb
@@ -16,4 +16,9 @@ config := configRaw.(map[string]interface{})
 // Name comes back on the top level, so set here
 config["name"] = name
 
+configMeta := meta.(*transport_tpg.Config)
+if err := d.Set("stored_info_type_id", flattenDataLossPreventionStoredInfoTypeName(res["name"], d, configMeta)); err != nil {
+  return nil, fmt.Errorf("Error reading StoredInfoType: %s", err)
+}
+
 return config, nil

--- a/mmv1/templates/terraform/examples/dlp_stored_info_type_with_id.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_stored_info_type_with_id.tf.erb
@@ -1,0 +1,11 @@
+resource "google_data_loss_prevention_stored_info_type" "<%= ctx[:primary_resource_id] %>" {
+  parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+  description = "Description"
+  display_name = "Displayname"
+  stored_info_type_id = "<%= ctx[:vars]['name'] %>"
+
+  regex {
+    pattern = "patient"
+    group_indexes = [2]
+  }
+}

--- a/mmv1/templates/terraform/update_encoder/dlp_stored_info_type.go.erb
+++ b/mmv1/templates/terraform/update_encoder/dlp_stored_info_type.go.erb
@@ -1,5 +1,5 @@
 <%# The license inside this block applies to this file.
-	# Copyright 2020 Google Inc.
+	# Copyright 2023 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -14,8 +14,4 @@
 -%>
 	newObj := make(map[string]interface{})
 	newObj["config"] = obj
-	storedInfoTypeIdProp, ok := d.GetOk("stored_info_type_id")
-	if ok && storedInfoTypeIdProp != nil {
-		newObj["storedInfoTypeId"] = storedInfoTypeIdProp
-	}
 	return newObj, nil

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_stored_info_type_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_stored_info_type_test.go
@@ -351,3 +351,68 @@ resource "google_data_loss_prevention_stored_info_type" "basic" {
 }
 `, context)
 }
+
+func TestAccDataLossPreventionStoredInfoType_dlpStoredInfoTypeStoredInfoTypeId(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       acctest.GetTestProjectFromEnv(),
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionStoredInfoTypeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionStoredInfoType_dlpStoredInfoTypeStoredInfoTypeId(context),
+			},
+			{
+				ResourceName:      "google_data_loss_prevention_stored_info_type.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataLossPreventionStoredInfoType_dlpStoredInfoTypeStoredInfoTypeIdUpdate(context),
+			},
+			{
+				ResourceName:      "google_data_loss_prevention_stored_info_type.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionStoredInfoType_dlpStoredInfoTypeStoredInfoTypeId(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_stored_info_type" "basic" {
+	parent = "projects/%{project}"
+	description = "Description"
+	display_name = "Displayname"
+	stored_info_type_id = "tf-test-%{random_suffix}"
+
+	regex {
+		pattern = "patient"
+		group_indexes = [2]
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionStoredInfoType_dlpStoredInfoTypeStoredInfoTypeIdUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_stored_info_type" "basic" {
+	parent = "projects/%{project}"
+	description = "Description"
+	display_name = "Displayname"
+	stored_info_type_id = "tf-test-update-%{random_suffix}"
+
+	regex {
+		pattern = "patient"
+		group_indexes = [2]
+	}
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added `stored_info_type_id` field in the `google_data_loss_prevention_stored_info_type` resource.
fixes https://github.com/hashicorp/terraform-provider-google/issues/8054

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `stored_info_type_id` field to `google_data_loss_prevention_stored_info_type` resource
```