### PR TITLE
Remove default from optional `rule_visibility` field

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -487,7 +487,6 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 									"rule_visibility": {
 										Type: schema.TypeString,
 										Optional: true,
-										Default: "STANDARD",
 										ValidateFunc: validation.StringInSlice([]string{"STANDARD", "PREMIUM"}, false),
 										Description: `Rule visibility. Supported values include: "STANDARD", "PREMIUM".`,
 									},

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -201,6 +201,28 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicy_withoutAdaptiveProtection(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withoutAdaptiveProtection(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 	t.Parallel()
 
@@ -1062,6 +1084,21 @@ resource "google_compute_security_policy" "policy" {
       ]
     }
     log_level    = "VERBOSE"
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withoutAdaptiveProtection(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  adaptive_protection_config {
+    layer_7_ddos_defense_config {
+      enable = false
+    }
   }
 }
 `, spName)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`google_compute_security_policy` -> `adaptive_protection_config` -> `layer_7_ddos_defense_config` -> `rule_visibility` is optional, but had a default value, and was required to be either PREMIUM or STANDARD.

This means that:

1. If you did not include this block at all, you get a persistent message about changing this from `false` (in state) to `null` (in config, due to the missing default).
2. If you included this block with `enable = false`, you'd get a plan attempting to set `rule_visibility = "STANDARD"`, which would then fail:

   > Invalid value for field
   > 'resource.adaptiveProtectionConfig.layer7DdosDefenseConfig.enable':
   > 'false'. Cannot set layer 7 DDoS options if it's not enabled.

This fixes the second problem, but not the first.

Part of https://github.com/hashicorp/terraform-provider-google/issues/12743


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed persistent diff for `layer_7_ddos_defense_config` in security policies
```
