### PR TITLE
Fix resource name used in CloudBuildBitbucketServerConfig tests

### DIFF
--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -49,14 +49,19 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_bitbucket_server_config'
     primary_resource_id: 'bbs-config'
+    vars:
+      config_id: 'bbs-config'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_bitbucket_server_config_repositories'
     primary_resource_id: 'bbs-config-with-repos'
+    vars:
+      config_id: 'bbs-config'
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_bitbucket_server_config_peered_network'
     primary_resource_id: 'bbs-config-with-peered-network'
     vars:
+      config_id: 'bbs-config'
       network_name: 'vpc-network'
     test_vars_overrides:
       network_name: 'BootstrapSharedTestNetwork(t, "peered-network")'

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config.tf.erb
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_id] %>" {
-    config_id = "mybbsconfig"
+    config_id = "<%= ctx[:vars]['config_id'] %>"
     location = "us-central1"
     host_uri = "https://bbs.com"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_peered_network.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_peered_network.tf.erb
@@ -26,7 +26,7 @@ resource "google_service_networking_connection" "default" {
 }
 
 resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_id] %>" {
-    config_id = "mybbsconfig"
+    config_id = "<%= ctx[:vars]['config_id'] %>"
     location = "us-central1"
     host_uri = "https://bbs.com"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_repositories.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_repositories.tf.erb
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_id] %>" {
-    config_id = "mybbsconfig"
+    config_id = "<%= ctx[:vars]['config_id'] %>"
     location = "us-central1"
     host_uri = "https://bbs.com"
     secrets {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/14778

Fix `config_id` to include `tf-test` for sweeping, and random suffix for avoiding conflicts

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
