### PR TITLE
Enable using different values for the field purpose.

### DIFF
--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -89,7 +89,7 @@ properties:
       The immutable purpose of this CryptoKey. See the
       [purpose reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKeyPurpose)
       for possible inputs.
-    default_value: :ENCRYPT_DECRYPT
+    default_value: 'ENCRYPT_DECRYPT'
     immutable: true
   - !ruby/object:Api::Type::String
     name: 'rotationPeriod'

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -89,6 +89,7 @@ properties:
       The immutable purpose of this CryptoKey. See the
       [purpose reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKeyPurpose)
       for possible inputs.
+    default_value: :ENCRYPT_DECRYPT
     immutable: true
   - !ruby/object:Api::Type::String
     name: 'rotationPeriod'

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -83,18 +83,12 @@ properties:
     name: 'labels'
     description: |
       Labels with user-defined metadata to apply to this resource.
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'purpose'
     description: |
       The immutable purpose of this CryptoKey. See the
       [purpose reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKeyPurpose)
       for possible inputs.
-    values:
-      - 'ENCRYPT_DECRYPT'
-      - 'ASYMMETRIC_SIGN'
-      - 'ASYMMETRIC_DECRYPT'
-      - 'MAC'
-    default_value: :ENCRYPT_DECRYPT
     immutable: true
   - !ruby/object:Api::Type::String
     name: 'rotationPeriod'

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -89,6 +89,7 @@ properties:
       The immutable purpose of this CryptoKey. See the
       [purpose reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKeyPurpose)
       for possible inputs.
+      Default value is "ENCRYPT_DECRYPT".
     default_value: 'ENCRYPT_DECRYPT'
     immutable: true
   - !ruby/object:Api::Type::String


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Updated the field purpose to be of type String that enables using different values for the field .

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
kms: removed validation for `purpose` in `google_kms_crypto_key` to allow newly added values for the field
```