### PR TITLE
Adds `connectedProjects` field to resource `google_vpc_access_connector`

### DIFF
--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -141,7 +141,6 @@ properties:
     description: |
       List of projects using the connector.
     output: true
-    unordered_list: true
     item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'subnet'

--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -141,6 +141,7 @@ properties:
     description: |
       List of projects using the connector.
     output: true
+    unordered_list: true
     item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'subnet'

--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -136,6 +136,12 @@ properties:
       The fully qualified name of this VPC connector
     output: true
     ignore_read: true
+  - !ruby/object:Api::Type::Array
+    name: connectedProjects
+    description: |
+      List of projects using the connector.
+    output: true
+    item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'subnet'
     immutable: true

--- a/mmv1/third_party/validator/tests/data/example_vpc_access_connector.tfplan.json
+++ b/mmv1/third_party/validator/tests/data/example_vpc_access_connector.tfplan.json
@@ -49,7 +49,8 @@
                     "id": true,
                     "project": true,
                     "self_link": true,
-                    "state": true
+                    "state": true,
+                    "connected_projects": true
                 }
             }
         }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14760.
API reference: https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1/projects.locations.connectors

Did a manual test for the built binary with input:

```
provider "google-beta" {
  project = "xxx"
  region  = "us-central1"
}

resource "google_cloud_run_v2_service" "default" {
  name     = "tf-vpc-connector"
  project  = "xxx"
  location = "us-central1"

  template {
    containers {
      image = "us-docker.pkg.dev/cloudrun/container/hello"
    }
    vpc_access {
      connector = google_vpc_access_connector.connector.id
      egress = "ALL_TRAFFIC"
    }
  }
}

resource "google_vpc_access_connector" "connector" {
  provider = google-beta
  name          = "run-vpc2"
  project       = "xxx"
  network = "default"
  ip_cidr_range = "10.2.0.0/28"
  machine_type = "e2-standard-4"
  min_instances = 2
  max_instances = 3
  region        = "us-central1"
}

```

The output of `terraform  state show google_vpc_access_connector.connector` is 

```
# google_vpc_access_connector.connector:
resource "google_vpc_access_connector" "connector" {
    connected_projects = [
        "xxx",
    ]
    id                 = "projects/xxx/locations/us-central1/connectors/run-vpc2"
    ip_cidr_range      = "10.2.0.0/28"
    machine_type       = "e2-standard-4"
    max_instances      = 3
    max_throughput     = 300
    min_instances      = 2
    min_throughput     = 200
    name               = "run-vpc2"
    network            = "default"
    project            = "xxx"
    region             = "us-central1"
    self_link          = "projects/xxx/locations/us-central1/connectors/run-vpc2"
    state              = "READY"
}

```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vpcaccess: Added `connected_projects` attribute to resource `google_vpc_access_connector`.
```
