### PR TITLE
Add copyright header on handwritten files copied by tpgtools

### DIFF
--- a/tpgtools/handwritten.go
+++ b/tpgtools/handwritten.go
@@ -40,6 +40,13 @@ func copyHandwrittenFiles(inPath string, outPath string) {
 		}
 	}
 
+	// Log warning about unexpected outPath values before adding copyright headers
+	// Matches equivalent in MMv1, see below:
+	// https://github.com/hashicorp/magic-modules/blob/48ce1004bafd4b4ef1be7565eaa6727adabd0670/mmv1/provider/core.rb#L202-L206
+	if !isOutputFolderExpected(outPath) {
+		glog.Infof("Unexpected output folder (%s) detected when deciding to add HashiCorp copyright headers. Watch out for unexpected changes to copied files", outPath)
+	}
+
 	fs, err := ioutil.ReadDir(inPath)
 	if err != nil {
 		glog.Fatal(err)
@@ -87,5 +94,26 @@ func copyHandwrittenFiles(inPath string, outPath string) {
 		if err != nil {
 			glog.Exit(err)
 		}
+	}
+}
+
+// isOutputFolderExpected returns a boolean indicating if the output folder is present in an allow list.
+// Intention is to warn users about unexpected diffs if they have renamed their cloned copy of downstream repos,
+// as this affects detecting which downstream they're building and whether to add copyright headers.
+// Written to match `expected_output_folder?` method in MMv1, see below:
+// https://github.com/hashicorp/magic-modules/blob/48ce1004bafd4b4ef1be7565eaa6727adabd0670/mmv1/provider/core.rb#L266-L282
+func isOutputFolderExpected(outPath string) bool {
+	pathComponents := strings.Split(outPath, "/")
+	folderName := pathComponents[len(pathComponents)-1] // last element
+
+	switch folderName {
+	case "terraform-provider-google",
+		"terraform-provider-google-beta",
+		"terraform-next",
+		"terraform-google-conversion",
+		"tfplan2cai":
+		return true
+	default:
+		return false
 	}
 }

--- a/tpgtools/handwritten.go
+++ b/tpgtools/handwritten.go
@@ -72,8 +72,7 @@ func copyHandwrittenFiles(inPath string, outPath string) {
 		}
 
 		// Add HashiCorp copyright header only if generating TPG/TPGB
-		if strings.HasSuffix(outPath, "/terraform-provider-google") ||
-			strings.HasSuffix(outPath, "/terraform-provider-google-beta") {
+		if strings.HasSuffix(outPath, "/terraform-provider-google") || strings.HasSuffix(outPath, "/terraform-provider-google-beta") {
 			if strings.HasSuffix(f.Name(), ".go") {
 				copyrightHeader := []byte("// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n")
 				b = append(copyrightHeader, b...)

--- a/tpgtools/handwritten.go
+++ b/tpgtools/handwritten.go
@@ -64,6 +64,15 @@ func copyHandwrittenFiles(inPath string, outPath string) {
 			continue
 		}
 
+		// Add HashiCorp copyright header only if generating TPG/TPGB
+		if strings.HasSuffix(outPath, "/terraform-provider-google") ||
+			strings.HasSuffix(outPath, "/terraform-provider-google-beta") {
+			if strings.HasSuffix(f.Name(), ".go") {
+				copyrightHeader := []byte("// Copyright (c) HashiCorp, Inc.\n// SPDX-License-Identifier: MPL-2.0\n")
+				b = append(copyrightHeader, b...)
+			}
+		}
+
 		// Format file if ending in .go
 		if strings.HasSuffix(f.Name(), ".go") {
 			b, err = formatSource(bytes.NewBuffer(b))


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is the tpgtools equivalent to this PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/7937

The new code adds a HashiCorp copyright header to the copied files if the TPG/TPGB downstreams are being generated.
If an unexpected output folder name is supplied then we issue an INFO log warning that there may be unexpected diffs (i.e. to remove all headers in TPG/TPGB codebase that has been renamed).

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] ~~Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).~~
- [x] ~~[Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.~~
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
