### PR TITLE
feat(dataform): support workspace_compilation_overrides in google_dataform_repository

### DIFF
--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -74,3 +74,16 @@ properties:
         output: true
         description: |
           Indicates the status of the Git access token. https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories#TokenStatus
+  - !ruby/object:Api::Type::NestedObject
+    name: 'workspaceCompilationOverrides'
+    description: Optional. If set, fields of workspaceCompilationOverrides override the default compilation settings that are specified in dataform.json when creating workspace-scoped compilation results.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: defaultDatabase
+        description: Optional. The default database (Google Cloud project ID).
+      - !ruby/object:Api::Type::String
+        name: 'schemaSuffix'
+        description: Optional. The suffix that should be appended to all schema (BigQuery dataset ID) names.
+      - !ruby/object:Api::Type::String
+        name: 'tablePrefix'
+        description: Optional. The prefix that should be prepended to all table names.

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.erb
@@ -28,4 +28,10 @@ resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>" {
       default_branch = "main"
       authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
   }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
 }

--- a/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go
+++ b/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go
@@ -1,0 +1,127 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
+)
+
+func TestAccDataformRepository_updated(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckDataformRepositoryDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataformRepository_basic(context),
+			},
+			{
+				ResourceName:            "google_dataform_repository.dataform_respository",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+			{
+				Config: testAccDataformRepository_updated(context),
+			},
+			{
+				ResourceName:            "google_dataform_repository.dataform_respository",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+		},
+	})
+}
+
+func testAccDataformRepository_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sourcerepo_repository" "git_repository" {
+  provider = google-beta
+  name = "my/repository%{random_suffix}"
+}
+
+resource "google_secret_manager_secret" "secret" {
+  provider = google-beta
+  secret_id = "secret"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  provider = google-beta
+  secret = google_secret_manager_secret.secret.id
+
+  secret_data = "tf-test-secret-data%{random_suffix}"
+}
+
+resource "google_dataform_repository" "dataform_respository" {
+  provider = google-beta
+  name = "tf_test_dataform_repository%{random_suffix}"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
+}
+`, context)
+}
+
+func testAccDataformRepository_updated(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sourcerepo_repository" "git_repository" {
+  provider = google-beta
+  name = "my/repository%{random_suffix}"
+}
+
+resource "google_secret_manager_secret" "secret" {
+  provider = google-beta
+  secret_id = "secret"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  provider = google-beta
+  secret = google_secret_manager_secret.secret.id
+
+  secret_data = "tf-test-secret-data%{random_suffix}"
+}
+
+resource "google_dataform_repository" "dataform_respository" {
+  provider = google-beta
+  name = "tf_test_dataform_repository%{random_suffix}"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database_v2"
+    schema_suffix = "_suffix_v2"
+    table_prefix = "prefix_v2_"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go
+++ b/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccDataformRepository_updated(t *testing.T) {

--- a/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go
+++ b/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go
@@ -118,7 +118,6 @@ resource "google_dataform_repository" "dataform_respository" {
   }
 
   workspace_compilation_overrides {
-    default_database = "database_v2"
     schema_suffix = "_suffix_v2"
     table_prefix = "prefix_v2_"
   }

--- a/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go.erb
@@ -1,4 +1,6 @@
+<% autogen_exception -%>
 package google
+<% unless version == 'ga' -%>
 
 import (
 	"testing"
@@ -124,3 +126,4 @@ resource "google_dataform_repository" "dataform_respository" {
 }
 `, context)
 }
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14737


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataform: added field `workspace_compilation_overrides` to resource `google_dataform_repository` (beta)
```
