### PR TITLE
Remove the deprecated acctest utils functions

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_datastream_static_ips_test.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_datastream_static_ips_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccDataSourceGoogleDatastreamStaticIps_basic(t *testing.T) {
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
@@ -432,7 +432,7 @@ func TestAccAlloydbCluster_usingCMEK(t *testing.T) {
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -491,7 +491,7 @@ func TestAccAlloydbCluster_CMEKInAutomatedBackupIsUpdatable(t *testing.T) {
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_certificatemanager_certificate_upgrade_test.go
+++ b/mmv1/third_party/terraform/tests/resource_certificatemanager_certificate_upgrade_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 // Tests schema version migration by creating a certificate with an old version of the provider (4.59.0)
 // and then updating it with the current version the provider.
 func TestAccCertificateManagerCertificate_migration(t *testing.T) {
-	SkipIfVcr(t)
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 	name := fmt.Sprintf("tf-test-%d", RandInt(t))
 
@@ -26,7 +27,7 @@ func TestAccCertificateManagerCertificate_migration(t *testing.T) {
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { AccTestPreCheck(t) },
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go.erb
@@ -9,12 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccComputeDiskAsyncReplication(t *testing.T) {
 	t.Parallel()
 
-	region := GetTestRegionFromEnv()
+	region := acctest.GetTestRegionFromEnv()
 	if !tpgresource.StringInSlice([]string{"europe-west2", "europe-west1", "us-central1", "us-east1", "us-west1", "us-east4", "asia-east1", "australia-southeast1"}, region) {
 		return
 	}
@@ -44,7 +45,7 @@ func TestAccComputeDiskAsyncReplication(t *testing.T) {
 	secondaryRegionalDisk := fmt.Sprintf("tf-test-disk-rsecondary-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/tests/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_forwarding_rule_test.go.erb
@@ -84,7 +84,7 @@ func TestAccComputeForwardingRule_internalTcpUdpLbWithMigBackendExampleUpdate(t 
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -171,7 +171,7 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -203,7 +203,7 @@ func TestAccComputeForwardingRule_forwardingRuleRegionalSteeringExampleUpdate(t 
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_compute_network_peering_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_network_peering_test.go
@@ -110,10 +110,10 @@ func TestAccComputeNetworkPeering_stackType(t *testing.T) {
 	primaryNetworkName := fmt.Sprintf("tf-test-network-1-%d", RandInt(t))
 	peeringNetworkName := fmt.Sprintf("tf-test-network-2-%d", RandInt(t))
 	peeringName := fmt.Sprintf("tf-test-peering-%d", RandInt(t))
-	importId := fmt.Sprintf("%s/%s/%s", GetTestProjectFromEnv(), primaryNetworkName, peeringName)
+	importId := fmt.Sprintf("%s/%s/%s", acctest.GetTestProjectFromEnv(), primaryNetworkName, peeringName)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccComputeNetworkPeeringDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_inspect_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_inspect_template_test.go
@@ -245,12 +245,12 @@ func TestAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withInfoTypesVe
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       GetTestProjectFromEnv(),
+		"project":       acctest.GetTestProjectFromEnv(),
 		"random_suffix": RandString(t, 10),
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataLossPreventionInspectTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -541,12 +541,12 @@ func TestAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withExcludeByHo
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       GetTestProjectFromEnv(),
+		"project":       acctest.GetTestProjectFromEnv(),
 		"random_suffix": RandString(t, 10),
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataLossPreventionInspectTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
@@ -163,7 +163,7 @@ func TestAccDataflowFlexTemplateJob_FullUpdate(t *testing.T) {
 func TestAccDataflowFlexTemplateJob_withNetwork(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
-	SkipIfVcr(t)
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	randStr := RandString(t, 10)
@@ -211,7 +211,7 @@ func TestAccDataflowFlexTemplateJob_withNetwork(t *testing.T) {
 func TestAccDataflowFlexTemplateJob_withSubNetwork(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
-	SkipIfVcr(t)
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	randStr := RandString(t, 10)
@@ -260,7 +260,7 @@ func TestAccDataflowFlexTemplateJob_withSubNetwork(t *testing.T) {
 func TestAccDataflowFlexTemplateJob_withIpConfig(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
-	SkipIfVcr(t)
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	randStr := RandString(t, 10)
@@ -294,7 +294,7 @@ func TestAccDataflowFlexTemplateJob_withIpConfig(t *testing.T) {
 func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
-	SkipIfVcr(t)
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	randStr := RandString(t, 10)
@@ -328,7 +328,7 @@ func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
 func TestAccDataflowFlexTemplateJob_withAdditionalExperiments(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
-	SkipIfVcr(t)
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	randStr := RandString(t, 10)

--- a/mmv1/third_party/terraform/tests/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/tests/resource_firestore_field_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccFirestoreField_firestoreFieldUpdateAddIndexExample(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":    GetTestFirestoreProjectFromEnv(t),
+		"project_id":    acctest.GetTestFirestoreProjectFromEnv(t),
 		"random_suffix": RandString(t, 10),
 		"resource_name": "add_index",
 	}
@@ -22,7 +23,7 @@ func TestAccFirestoreField_firestoreFieldUpdateAddTTLExample(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":    GetTestFirestoreProjectFromEnv(t),
+		"project_id":    acctest.GetTestFirestoreProjectFromEnv(t),
 		"random_suffix": RandString(t, 10),
 		"resource_name": "add_ttl",
 	}
@@ -33,7 +34,7 @@ func testAccFirestoreField_runUpdateTest(updateConfig string, t *testing.T, cont
 	resourceName := context["resource_name"].(string)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckFirestoreFieldDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_cluster_test.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -22,7 +23,7 @@ func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBasic(t *testing.T) 
   context := map[string]interface{}{}
 
   VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { AccTestPreCheck(t) },
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
     ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGkeonpremBareMetalClusterDestroyProducer(t),
     Steps: []resource.TestStep{
@@ -55,7 +56,7 @@ func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLb(t *testing.
   context := map[string]interface{}{}
 
   VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { AccTestPreCheck(t) },
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
     ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGkeonpremBareMetalClusterDestroyProducer(t),
     Steps: []resource.TestStep{
@@ -88,7 +89,7 @@ func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBgpLb(t *testing.T) 
   context := map[string]interface{}{}
 
   VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { AccTestPreCheck(t) },
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
     ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGkeonpremBareMetalClusterDestroyProducer(t),
     Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_node_pool_test.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -22,7 +23,7 @@ func TestAccGkeonpremBareMetalNodePool_bareMetalNodePoolUpdate(t *testing.T) {
   context := map[string]interface{}{}
 
   VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { AccTestPreCheck(t) },
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
     ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGkeonpremBareMetalNodePoolDestroyProducer(t),
     Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_node_pool_test.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -22,7 +23,7 @@ func TestAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(t *testing.T) {
   context := map[string]interface{}{}
 
   VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { AccTestPreCheck(t) },
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
     ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
     CheckDestroy:             testAccCheckGkeonpremVmwareNodePoolDestroyProducer(t),
     Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_network_security_address_groups_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_address_groups_test.go.erb
@@ -4,17 +4,17 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccNetworkSecurityAddressGroups_update(t *testing.T){
     t.Parallel()
 
     addressGroupsName := fmt.Sprintf("tf-test-address-group-%s", RandString(t, 10))
-	projectName := GetTestProjectFromEnv()
+	projectName := acctest.GetTestProjectFromEnv()
 
     VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/tests/resource_network_security_authorization_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_authorization_policy_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccNetworkSecurityAuthorizationPolicy_update(t *testing.T) {
@@ -15,7 +16,7 @@ func TestAccNetworkSecurityAuthorizationPolicy_update(t *testing.T) {
 	authorizationPolicyName := fmt.Sprintf("tf-test-authorization-policy-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { AccTestPreCheck(t) },
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckNetworkSecurityAuthorizationPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_network_security_client_tls_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_client_tls_policy_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccNetworkSecurityClientTlsPolicy_update(t *testing.T) {
@@ -15,7 +16,7 @@ func TestAccNetworkSecurityClientTlsPolicy_update(t *testing.T) {
 	clientTlsPolicyName := fmt.Sprintf("tf-test-client-tls-policy-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { AccTestPreCheck(t) },
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckNetworkSecurityClientTlsPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_network_security_server_tls_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_server_tls_policy_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccNetworkSecurityServerTlsPolicy_update(t *testing.T) {
@@ -15,7 +16,7 @@ func TestAccNetworkSecurityServerTlsPolicy_update(t *testing.T) {
 	serverTlsPolicyName := fmt.Sprintf("tf-test-server-tls-policy-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { AccTestPreCheck(t) },
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckNetworkSecurityServerTlsPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccNetworkSecurityTlsInspectionPolicy_update(t *testing.T){
@@ -17,7 +18,7 @@ func TestAccNetworkSecurityTlsInspectionPolicy_update(t *testing.T){
 	  certificateAuthorityName := fmt.Sprintf("tf-test-tls-certificate-authority-%s", RandString(t, 10))
 
     VcrTest(t, resource.TestCase{
-		PreCheck:     func() { AccTestPreCheck(t) },
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckNetworkSecurityTlsInspectionPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_network_services_grpc_route_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_services_grpc_route_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccNetworkServicesGrpcRoute_update(t *testing.T) {
@@ -15,7 +16,7 @@ func TestAccNetworkServicesGrpcRoute_update(t *testing.T) {
 	grpcRouteName := fmt.Sprintf("tf-test-grpc-route-%s", RandString(t, 10))
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:     func() { AccTestPreCheck(t) },
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckNetworkServicesGrpcRouteDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go
@@ -1412,7 +1412,7 @@ func TestAccSqlDatabaseInstance_Smt(t *testing.T) {
 	rootPassword := RandString(t, 15)
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/tests/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_workstations_workstation_config_test.go.erb
@@ -314,7 +314,7 @@ func TestAccWorkstationsWorkstationConfig_updateHostDetails(t *testing.T) {
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -511,7 +511,7 @@ func TestAccWorkstationsWorkstationConfig_updateWorkingDir(t *testing.T) {
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
 		Steps: []resource.TestStep{
@@ -620,7 +620,7 @@ func TestAccWorkstationsWorkstationConfig_updatePersistentDirectorySourceSnapsho
 	}
 
 	VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -123,7 +123,7 @@ func setupTestResourceDataFromConfigMap(t *testing.T, s map[string]*schema.Schem
 // configure the provider.
 // The testing package will restore the original values after the test
 func unsetTestProviderConfigEnvs(t *testing.T) {
-	envs := providerConfigEnvNames()
+	envs := acctest.ProviderConfigEnvNames()
 	if len(envs) > 0 {
 		for _, k := range envs {
 			t.Setenv(k, "")

--- a/mmv1/third_party/terraform/utils/provider_test_utils.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test_utils.go.erb
@@ -5,65 +5,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-const TestEnvVar = acctest.TestEnvVar
-
 var TestAccProviders map[string]*schema.Provider
 var testAccProvider *schema.Provider
-
-// providerConfigEnvNames returns a list of all the environment variables that could be set by a user to configure the provider
-func providerConfigEnvNames() []string {
-	return acctest.ProviderConfigEnvNames()
-}
-
-var CredsEnvVars = acctest.CredsEnvVars
-
-var projectNumberEnvVars = acctest.ProjectNumberEnvVars
-
-var ProjectEnvVars = acctest.ProjectEnvVars
-
-var firestoreProjectEnvVars = acctest.FirestoreProjectEnvVars
-
-var regionEnvVars = acctest.RegionEnvVars
-
-var zoneEnvVars = acctest.ZoneEnvVars
-
-var orgEnvVars = acctest.OrgEnvVars
-
-// This value is the Customer ID of the GOOGLE_ORG_DOMAIN workspace.
-// See https://admin.google.com/ac/accountsettings when logged into an org admin for the value.
-var custIdEnvVars = acctest.CustIdEnvVars
-
-// This value is the username of an identity account within the GOOGLE_ORG_DOMAIN workspace.
-// For example in the org example.com with a user "foo@example.com", this would be set to "foo".
-// See https://admin.google.com/ac/users when logged into an org admin for a list.
-var identityUserEnvVars = acctest.IdentityUserEnvVars
-
-var orgEnvDomainVars = acctest.OrgEnvDomainVars
-
-var serviceAccountEnvVars = acctest.ServiceAccountEnvVars
-
-var orgTargetEnvVars = acctest.OrgTargetEnvVars
-
-// This is the billing account that will be charged for the infrastructure used during testing. For
-// that reason, it is also the billing account used for creating new projects.
-var billingAccountEnvVars = acctest.BillingAccountEnvVars
-
-// This is the billing account that will be modified to test billing-related functionality. It is
-// expected to have more permissions granted to the test user and support subaccounts.
-var masterBillingAccountEnvVars = acctest.MasterBillingAccountEnvVars
-
-// This value is the description used for test PublicAdvertisedPrefix setup to avoid required DNS
-// setup. This is only used during integration tests and would be invalid to surface to users
-var papDescriptionEnvVars = acctest.PapDescriptionEnvVars
-
 
 func init() {
 	configs = make(map[string]*transport_tpg.Config)
@@ -87,111 +36,4 @@ func GoogleProviderConfig(t *testing.T) *transport_tpg.Config {
 	rc := terraform.ResourceConfig{}
 	sdkProvider.Configure(context.Background(), &rc)
 	return sdkProvider.Meta().(*transport_tpg.Config)
-}
-
-func AccTestPreCheck(t *testing.T) {
-	acctest.AccTestPreCheck(t)
-}
-
-// GetTestRegion has the same logic as the provider's GetRegion, to be used in tests.
-func GetTestRegion(is *terraform.InstanceState, config *transport_tpg.Config) (string, error) {
-	return acctest.GetTestRegion(is, config)
-}
-
-// GetTestProject has the same logic as the provider's GetProject, to be used in tests.
-func GetTestProject(is *terraform.InstanceState, config *transport_tpg.Config) (string, error) {
-	return acctest.GetTestProject(is, config)
-}
-
-// AccTestPreCheck ensures at least one of the project env variables is set.
-func GetTestProjectNumberFromEnv() string {
-	return acctest.GetTestProjectNumberFromEnv()
-}
-
-// AccTestPreCheck ensures at least one of the project env variables is set.
-func GetTestProjectFromEnv() string {
-	return acctest.GetTestProjectFromEnv()
-}
-
-// AccTestPreCheck ensures at least one of the credentials env variables is set.
-func GetTestCredsFromEnv() string {
-	return acctest.GetTestCredsFromEnv()
-}
-
-// AccTestPreCheck ensures at least one of the region env variables is set.
-func GetTestRegionFromEnv() string {
-	return acctest.GetTestRegionFromEnv()
-}
-
-func GetTestZoneFromEnv() string {
-	return acctest.GetTestZoneFromEnv()
-}
-
-func GetTestCustIdFromEnv(t *testing.T) string {
-	return acctest.GetTestCustIdFromEnv(t)
-}
-
-func GetTestIdentityUserFromEnv(t *testing.T) string {
-	return acctest.GetTestIdentityUserFromEnv(t)
-}
-
-// Firestore can't be enabled at the same time as Datastore, so we need a new
-// project to manage it until we can enable Firestore programmatically.
-func GetTestFirestoreProjectFromEnv(t *testing.T) string {
-	return acctest.GetTestFirestoreProjectFromEnv(t)
-}
-
-// Returns the raw organization id like 1234567890, skipping the test if one is
-// not found.
-func GetTestOrgFromEnv(t *testing.T) string {
-	return acctest.GetTestOrgFromEnv(t)
-}
-
-// Alternative to GetTestOrgFromEnv that doesn't need *testing.T
-// If using this, you need to process unset values at the call site
-func UnsafeGetTestOrgFromEnv() string {
-	return acctest.UnsafeGetTestOrgFromEnv()
-}
-
-func GetTestOrgDomainFromEnv(t *testing.T) string {
-	return acctest.GetTestOrgDomainFromEnv(t)
-}
-
-func GetTestOrgTargetFromEnv(t *testing.T) string {
-	return acctest.GetTestOrgTargetFromEnv(t)
-}
-
-// This is the billing account that will be charged for the infrastructure used during testing. For
-// that reason, it is also the billing account used for creating new projects.
-func GetTestBillingAccountFromEnv(t *testing.T) string {
-	return acctest.GetTestBillingAccountFromEnv(t)
-}
-
-// This is the billing account that will be modified to test billing-related functionality. It is
-// expected to have more permissions granted to the test user and support subaccounts.
-func GetTestMasterBillingAccountFromEnv(t *testing.T) string {
-	return acctest.GetTestMasterBillingAccountFromEnv(t)
-}
-
-func GetTestServiceAccountFromEnv(t *testing.T) string {
-	return acctest.GetTestServiceAccountFromEnv(t)
-}
-
-func GetTestPublicAdvertisedPrefixDescriptionFromEnv(t *testing.T) string {
-	return acctest.GetTestPublicAdvertisedPrefixDescriptionFromEnv(t)
-}
-
-// Some tests fail during VCR. One common case is race conditions when creating resources.
-// If a test config adds two fine-grained resources with the same parent it is undefined
-// which will be created first, causing VCR to fail ~50% of the time
-func SkipIfVcr(t *testing.T) {
-	acctest.SkipIfVcr(t)
-}
-
-func SleepInSecondsForTest(t int) resource.TestCheckFunc {
-	return acctest.SleepInSecondsForTest(t)
-}
-
-func SkipIfEnvNotSet(t *testing.T, envs ...string) {
-	acctest.SkipIfEnvNotSet(t, envs...)
 }

--- a/mmv1/third_party/terraform/utils/test_utils.go.erb
+++ b/mmv1/third_party/terraform/utils/test_utils.go.erb
@@ -11,22 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	acctest_tpg "github.com/hashicorp/terraform-provider-google/google/acctest"
 )
-
-// Deprecated: For backward compatibility CheckDataSourceStateMatchesResourceState is still working,
-// but all new code should use CheckDataSourceStateMatchesResourceState in the acctest package instead.
-func CheckDataSourceStateMatchesResourceState(dataSourceName, resourceName string) func(*terraform.State) error {
-	return acctest_tpg.CheckDataSourceStateMatchesResourceState(dataSourceName, resourceName)
-}
-
-// Deprecated: For backward compatibility CheckDataSourceStateMatchesResourceStateWithIgnores is still working,
-// but all new code should use CheckDataSourceStateMatchesResourceStateWithIgnores in the acctest package instead.
-func CheckDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourceName string, ignoreFields map[string]struct{}) func(*terraform.State) error {
-	return acctest_tpg.CheckDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourceName, ignoreFields)
-}
 
 // General test utils
 

--- a/mmv1/third_party/terraform/utils/vcr_utils.go
+++ b/mmv1/third_party/terraform/utils/vcr_utils.go
@@ -52,10 +52,6 @@ type VcrSource struct {
 	source rand.Source
 }
 
-func isVcrEnabled() bool {
-	return acctest.IsVcrEnabled()
-}
-
 // Produces a rand.Source for VCR testing based on the given mode.
 // In RECORDING mode, generates a new seed and saves it to a file, using the seed for the source
 // In REPLAYING mode, reads a seed from a file and creates a source from it


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Remove the deprecated acctest utils functions.

The following functions are still in the google package and will be moved to the acctest package later.
* GoogleProviderConfig
* RandString
* RandInt
* ProtoV5ProviderFactories
* ProtoV5ProviderBetaFactories
* VcrTest


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
