### PR TITLE
Error abort predicates

### DIFF
--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -188,6 +188,9 @@ module Api
       # An array of function names that determine whether an error is retryable.
       attr_reader :error_retry_predicates
 
+      # An array of function names that determine whether an error is not retryable.
+      attr_reader :error_abort_predicates
+
       attr_reader :schema_version
 
       # Set to true for resources that are unable to be deleted, such as KMS keyrings or project
@@ -284,6 +287,7 @@ module Api
 
       check :timeouts, type: Api::Timeouts
       check :error_retry_predicates, type: Array, item_type: String
+      check :error_abort_predicates, type: Array, item_type: String
       check :schema_version, type: Integer
       check :skip_delete, type: :boolean, default: false
       check :supports_indirect_user_project_override, type: :boolean, default: false

--- a/mmv1/products/activedirectory/Domain.yaml
+++ b/mmv1/products/activedirectory/Domain.yaml
@@ -53,6 +53,7 @@ import_format: ['{{name}}']
 autogen_async: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/self_link_as_name.erb
+error_abort_predicates: ['transport_tpg.IsQuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'active_directory_domain_basic'

--- a/mmv1/products/activedirectory/Domain.yaml
+++ b/mmv1/products/activedirectory/Domain.yaml
@@ -53,7 +53,7 @@ import_format: ['{{name}}']
 autogen_async: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/self_link_as_name.erb
-error_abort_predicates: ['transport_tpg.IsQuotaError']
+error_abort_predicates: ['transport_tpg.Is429QuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'active_directory_domain_basic'

--- a/mmv1/products/filestore/Backup.yaml
+++ b/mmv1/products/filestore/Backup.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Creating Backups': 'https://cloud.google.com/filestore/docs/create-backups'
   api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.backups'
 mutex: 'filestore/{{project}}'
-error_abort_predicates: ['transport_tpg.IsQuotaError']
+error_abort_predicates: ['transport_tpg.Is429QuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_backup_basic'

--- a/mmv1/products/filestore/Backup.yaml
+++ b/mmv1/products/filestore/Backup.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Creating Backups': 'https://cloud.google.com/filestore/docs/create-backups'
   api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.backups'
 mutex: 'filestore/{{project}}'
-error_retry_predicates: ['transport_tpg.IsNotFilestoreQuotaError']
+error_abort_predicates: ['transport_tpg.IsQuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_backup_basic'

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Use with Kubernetes': 'https://cloud.google.com/filestore/docs/accessing-fileshares'
     'Copying Data In/Out': 'https://cloud.google.com/filestore/docs/copying-data'
   api: 'https://cloud.google.com/filestore/docs/reference/rest/v1beta1/projects.locations.instances/create'
-error_retry_predicates: ['transport_tpg.IsNotFilestoreQuotaError']
+error_abort_predicates: ['transport_tpg.IsQuotaError']
 autogen_async: true
 schema_version: 1
 examples:

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Use with Kubernetes': 'https://cloud.google.com/filestore/docs/accessing-fileshares'
     'Copying Data In/Out': 'https://cloud.google.com/filestore/docs/copying-data'
   api: 'https://cloud.google.com/filestore/docs/reference/rest/v1beta1/projects.locations.instances/create'
-error_abort_predicates: ['transport_tpg.IsQuotaError']
+error_abort_predicates: ['transport_tpg.Is429QuotaError']
 autogen_async: true
 schema_version: 1
 examples:

--- a/mmv1/products/filestore/Snapshot.yaml
+++ b/mmv1/products/filestore/Snapshot.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Creating Snapshots': 'https://cloud.google.com/filestore/docs/create-snapshots'
   api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.snapshots'
 mutex: 'filestore/{{project}}'
-error_retry_predicates: ['transport_tpg.IsNotFilestoreQuotaError']
+error_abort_predicates: ['transport_tpg.IsQuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_snapshot_basic'

--- a/mmv1/products/filestore/Snapshot.yaml
+++ b/mmv1/products/filestore/Snapshot.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Creating Snapshots': 'https://cloud.google.com/filestore/docs/create-snapshots'
   api: 'https://cloud.google.com/filestore/docs/reference/rest/v1/projects.locations.instances.snapshots'
 mutex: 'filestore/{{project}}'
-error_abort_predicates: ['transport_tpg.IsQuotaError']
+error_abort_predicates: ['transport_tpg.Is429QuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_snapshot_basic'

--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -29,6 +29,7 @@ id_format: '{{name}}'
 import_format: ['{{name}}']
 mutex: alertPolicy/{{project}}
 error_retry_predicates: ['transport_tpg.IsMonitoringConcurrentEditError']
+error_abort_predicates: ['transport_tpg.IsQuotaError']
 examples:
   # skipping tests because the API is full of race conditions
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -29,7 +29,7 @@ id_format: '{{name}}'
 import_format: ['{{name}}']
 mutex: alertPolicy/{{project}}
 error_retry_predicates: ['transport_tpg.IsMonitoringConcurrentEditError']
-error_abort_predicates: ['transport_tpg.IsQuotaError']
+error_abort_predicates: ['transport_tpg.Is429QuotaError']
 examples:
   # skipping tests because the API is full of race conditions
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/networkservices/EdgeCacheKeyset.yaml
+++ b/mmv1/products/networkservices/EdgeCacheKeyset.yaml
@@ -42,6 +42,7 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 import_format:
   ['projects/{{project}}/locations/global/edgeCacheKeysets/{{name}}']
+error_abort_predicates: ['transport_tpg.IsQuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'network_services_edge_cache_keyset_basic'

--- a/mmv1/products/networkservices/EdgeCacheKeyset.yaml
+++ b/mmv1/products/networkservices/EdgeCacheKeyset.yaml
@@ -42,7 +42,7 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 import_format:
   ['projects/{{project}}/locations/global/edgeCacheKeysets/{{name}}']
-error_abort_predicates: ['transport_tpg.IsQuotaError']
+error_abort_predicates: ['transport_tpg.Is429QuotaError']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'network_services_edge_cache_keyset_basic'

--- a/mmv1/templates/terraform/custom_delete/appversion_delete.go.erb
+++ b/mmv1/templates/terraform/custom_delete/appversion_delete.go.erb
@@ -34,6 +34,9 @@ if d.Get("delete_service_on_destroy") == true {
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<% end -%>
 	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, "Service")
@@ -64,6 +67,9 @@ if d.Get("delete_service_on_destroy") == true {
 		Timeout: d.Timeout(schema.TimeoutDelete),
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <% end -%>
 	})
 	if err != nil {

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -147,6 +147,9 @@ func testAccCheck<%= resource_name -%>DestroyProducer(t *testing.T) func(s *terr
 			<% if object.error_retry_predicates -%>
 			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 			<% end -%>
+			<% if object.error_abort_predicates -%>
+			ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+			<% end -%>
 		})
 		if err == nil {
 				return fmt.Errorf("<%= resource_name -%> still exists at %s", url)

--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -229,6 +229,9 @@ func (u *<%= resource_name -%>IamUpdater) GetResourceIamPolicy() (*cloudresource
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<% end -%>
 	})
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
@@ -289,6 +292,9 @@ func (u *<%= resource_name -%>IamUpdater) SetResourceIamPolicy(policy *cloudreso
 		Timeout: u.d.Timeout(schema.TimeoutCreate),
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <% end -%>
 	})
 	if err != nil {

--- a/mmv1/templates/terraform/nested_query.go.erb
+++ b/mmv1/templates/terraform/nested_query.go.erb
@@ -253,6 +253,9 @@ func resource<%= resource_name -%>ListForPatch(d *schema.ResourceData, meta inte
     <% if object.error_retry_predicates -%>
     ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
     <% end -%>
+    <% if object.error_abort_predicates -%>
+    ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+    <% end -%>
   })
   if err != nil {
     return nil, err

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -56,6 +56,9 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
     <% if object.error_retry_predicates -%>
     ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
     <% end -%>
+    <% if object.error_abort_predicates -%>
+    ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+    <% end -%>
   })
 }
 

--- a/mmv1/templates/terraform/post_create/labels.erb
+++ b/mmv1/templates/terraform/post_create/labels.erb
@@ -30,6 +30,9 @@ if v, ok := d.GetOkExists("labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v
 		<% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 		<% end -%>
+		<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+		<% end -%>
 	})
 	if err != nil {
 		return fmt.Errorf("Error adding labels to <%= resource_name -%> %q: %s", d.Id(), err)

--- a/mmv1/templates/terraform/pre_delete/detach_disk.erb
+++ b/mmv1/templates/terraform/pre_delete/detach_disk.erb
@@ -7,6 +7,9 @@ readRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 <% if object.error_retry_predicates -%>
 	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <% end -%>
+<% if object.error_abort_predicates -%>
+	ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<% end -%>
 })
 if err != nil {
 	return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ComputeDisk %q", d.Id()))

--- a/mmv1/templates/terraform/pre_delete/detach_network.erb
+++ b/mmv1/templates/terraform/pre_delete/detach_network.erb
@@ -19,6 +19,9 @@ if d.Get("networks.#").(int) > 0 {
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<% end -%>
 	})
 	if err != nil {
 		return fmt.Errorf("Error updating Policy %q: %s", d.Id(), err)

--- a/mmv1/templates/terraform/pre_delete/response_policy_detach_network_gke.erb
+++ b/mmv1/templates/terraform/pre_delete/response_policy_detach_network_gke.erb
@@ -19,6 +19,9 @@ if d.Get("gke_clusters.#").(int) > 0 {
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<% end -%>
 	})
 	if err != nil {
 		return fmt.Errorf("Error updating Policy %q: %s", d.Id(), err)
@@ -45,6 +48,9 @@ if d.Get("networks.#").(int) > 0 {
 		Timeout: d.Timeout(schema.TimeoutUpdate),
 <% if object.error_retry_predicates -%>
 		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<% end -%>
+<% if object.error_abort_predicates -%>
+		ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <% end -%>
 	})
 	if err != nil {

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -268,6 +268,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%    if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%    end -%>
+<%    if object.error_abort_predicates -%>
+        ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<%    end -%>
     })
     if err != nil {
 <%    if object.custom_code.post_create_failure && object.async.nil? # Only add if not handled by async error handling -%>
@@ -443,6 +446,9 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
 <%      if object.error_retry_predicates -%>
             ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%      end -%>
+<%      if object.error_abort_predicates -%>
+            ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<%      end -%>
         })
         if err != nil {
             return res, err
@@ -516,6 +522,9 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
         UserAgent: userAgent,
 <%  if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<%  end -%>
+<%  if object.error_abort_predicates -%>
+        ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <%  end -%>
     })
     if err != nil {
@@ -722,6 +731,9 @@ if len(updateMask) > 0 {
 <%      if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%      end -%>
+<%      if object.error_abort_predicates -%>
+        ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
+<%      end -%>
     })
 
     if err != nil {
@@ -788,6 +800,9 @@ if len(updateMask) > 0 {
             UserAgent: userAgent,
 <%        if object.error_retry_predicates -%>
             ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<%        end -%>
+<%        if object.error_abort_predicates -%>
+            ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <%        end -%>
         })
         if err != nil {
@@ -876,6 +891,9 @@ if len(updateMask) > 0 {
             Timeout: d.Timeout(schema.TimeoutUpdate),
 <%        if object.error_retry_predicates -%>
             ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<%        end -%>
+<%        if object.error_abort_predicates -%>
+            ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <%        end -%>
         })
         if err != nil {
@@ -1001,6 +1019,9 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
         Timeout: d.Timeout(schema.TimeoutDelete),
 <%      if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
+<%      end -%>
+<%      if object.error_abort_predicates -%>
+        ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_abort_predicates.join(',') -%>},
 <%      end -%>
     })
     if err != nil {

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -409,15 +409,14 @@ func isCommonRetryableErrorCode(err error) (bool, string) {
 	return false, ""
 }
 
-// Retry if filestore operation returns a 429 with a specific message for
-// concurrent operations.
-func IsNotFilestoreQuotaError(err error) (bool, string) {
+// Do not retry if operation returns a 429
+func IsQuotaError(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 429 {
-			return false, ""
+			return true, "429s are not retryable for this resource"
 		}
 	}
-	return isCommonRetryableErrorCode(err)
+	return false, ""
 }
 
 // Retry if App Engine operation returns a 409 with a specific message for

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -410,7 +410,7 @@ func isCommonRetryableErrorCode(err error) (bool, string) {
 }
 
 // Do not retry if operation returns a 429
-func IsQuotaError(err error) (bool, string) {
+func Is429QuotaError(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 429 {
 			return true, "429s are not retryable for this resource"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/13220
fixes https://github.com/hashicorp/terraform-provider-google/issues/13075

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
filestore: fixed an issue causing 429 errors to be retried
```
