### PR TITLE
Added missing file types in file_types enum and removed broken exactlyOneOf blocks in google_data_loss_prevention_job_trigger resource

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -762,6 +762,8 @@ properties:
                     - :AVRO
                     - :CSV
                     - :TSV
+                    - :POWERPOINT
+                    - :EXCEL
               - !ruby/object:Api::Type::Enum
                 name: 'sampleMethod'
                 description: |
@@ -912,14 +914,6 @@ properties:
           properties:
             - !ruby/object:Api::Type::NestedObject
               name: 'saveFindings'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               description: |
                 If set, the detailed findings will be persisted to the specified OutputStorageConfig. Only a single instance of this action can be specified. Compatible with: Inspect, Risk
               properties:
@@ -969,14 +963,6 @@ properties:
                         - :ALL_COLUMNS
             - !ruby/object:Api::Type::NestedObject
               name: 'pubSub'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               description: |
                 Publish a message into a given Pub/Sub topic when the job completes.
               properties:
@@ -987,14 +973,6 @@ properties:
                     Cloud Pub/Sub topic to send notifications to.
             - !ruby/object:Api::Type::NestedObject
               name: 'publishSummaryToCscc'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -1002,14 +980,6 @@ properties:
                 Publish the result summary of a DlpJob to the Cloud Security Command Center.
             - !ruby/object:Api::Type::NestedObject
               name: 'publishFindingsToCloudDataCatalog'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -1017,14 +987,6 @@ properties:
                 Publish findings of a DlpJob to Data Catalog.
             - !ruby/object:Api::Type::NestedObject
               name: 'jobNotificationEmails'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -1032,14 +994,6 @@ properties:
                 Sends an email when the job completes. The email goes to IAM project owners and technical Essential Contacts.
             - !ruby/object:Api::Type::NestedObject
               name: 'deidentify'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               description: |
                 Create a de-identified copy of the requested table or files.
               properties:
@@ -1120,14 +1074,6 @@ properties:
                             is 1,024 characters.
             - !ruby/object:Api::Type::NestedObject
               name: 'publishToStackdriver'
-              exactly_one_of:
-                - save_findings
-                - pub_sub
-                - publish_findings_to_cloud_data_catalog
-                - publish_summary_to_cscc
-                - job_notification_emails
-                - deidentify
-                - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []

--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -913,6 +913,15 @@ properties:
           properties:
             - !ruby/object:Api::Type::NestedObject
               name: 'saveFindings'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               description: |
                 If set, the detailed findings will be persisted to the specified OutputStorageConfig. Only a single instance of this action can be specified. Compatible with: Inspect, Risk
               properties:
@@ -962,6 +971,15 @@ properties:
                         - :ALL_COLUMNS
             - !ruby/object:Api::Type::NestedObject
               name: 'pubSub'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               description: |
                 Publish a message into a given Pub/Sub topic when the job completes.
               properties:
@@ -972,6 +990,15 @@ properties:
                     Cloud Pub/Sub topic to send notifications to.
             - !ruby/object:Api::Type::NestedObject
               name: 'publishSummaryToCscc'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -979,6 +1006,15 @@ properties:
                 Publish the result summary of a DlpJob to the Cloud Security Command Center.
             - !ruby/object:Api::Type::NestedObject
               name: 'publishFindingsToCloudDataCatalog'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -986,6 +1022,15 @@ properties:
                 Publish findings of a DlpJob to Data Catalog.
             - !ruby/object:Api::Type::NestedObject
               name: 'jobNotificationEmails'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []
@@ -993,6 +1038,15 @@ properties:
                 Sends an email when the job completes. The email goes to IAM project owners and technical Essential Contacts.
             - !ruby/object:Api::Type::NestedObject
               name: 'deidentify'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               description: |
                 Create a de-identified copy of the requested table or files.
               properties:
@@ -1073,6 +1127,15 @@ properties:
                             is 1,024 characters.
             - !ruby/object:Api::Type::NestedObject
               name: 'publishToStackdriver'
+              # TODO: uncomment here once they are supported(github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - save_findings
+              #   - pub_sub
+              #   - publish_findings_to_cloud_data_catalog
+              #   - publish_summary_to_cscc
+              #   - job_notification_emails
+              #   - deidentify
+              #   - publish_to_stackdriver
               allow_empty_object: true
               send_empty_value: true
               properties: []

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -463,6 +463,7 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 				file_set {
 					url = "gs://mybucket/directory/"
 				}
+				file_types = ["POWERPOINT", "EXCEL", "CSV", "TSV"]
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added missing file types in `inspect_job.storage_config.cloud_storage_options.file_types` enum and removed dummy exactlyOneOf blocks in the `google_data_loss_prevention_job_trigger` resource

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added missing file types `POWERPOINT` and `EXCEL` in `inspect_job.storage_config.cloud_storage_options.file_types` enum to `google_data_loss_prevention_job_trigger` resource
```