### PR TITLE
added multiple sensitivity_score fields to google_data_loss_prevention_deidentify_template

### DIFF
--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -230,18 +230,18 @@ properties:
                         description: |
                           Version name for this InfoType.
                       - !ruby/object:Api::Type::NestedObject
-                            name: 'sensitivityScore'
+                        name: 'sensitivityScore'
+                        description: |
+                          Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                        properties:
+                          - !ruby/object:Api::Type::Enum
+                            name: 'score'
                             description: |
-                              Optional custom sensitivity for this InfoType. This only applies to data profiling.
-                            properties:
-                              - !ruby/object:Api::Type::Enum
-                                name: 'score'
-                                description: |
-                                  The sensitivity score applied to the resource.
-                                values:
-                                  - :SENSITIVITY_LOW
-                                  - :SENSITIVITY_MODERATE
-                                  - :SENSITIVITY_HIGH
+                              The sensitivity score applied to the resource.
+                            values:
+                              - :SENSITIVITY_LOW
+                              - :SENSITIVITY_MODERATE
+                              - :SENSITIVITY_HIGH
                 - !ruby/object:Api::Type::NestedObject
                   name: 'primitiveTransformation'
                   required: true

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -170,6 +170,7 @@ properties:
                             properties:
                               - !ruby/object:Api::Type::Enum
                                 name: 'score'
+                                required: true
                                 description: |
                                   The sensitivity score applied to the resource.
                                 values:
@@ -236,6 +237,7 @@ properties:
                         properties:
                           - !ruby/object:Api::Type::Enum
                             name: 'score'
+                            required: true
                             description: |
                               The sensitivity score applied to the resource.
                             values:
@@ -465,6 +467,7 @@ properties:
                               properties:
                                 - !ruby/object:Api::Type::Enum
                                   name: 'score'
+                                  required: true
                                   description: |
                                     The sensitivity score applied to the resource.
                                   values:
@@ -592,6 +595,7 @@ properties:
                               properties:
                                 - !ruby/object:Api::Type::Enum
                                   name: 'score'
+                                  required: true
                                   description: |
                                     The sensitivity score applied to the resource.
                                   values:
@@ -1454,6 +1458,7 @@ properties:
                               properties:
                                 - !ruby/object:Api::Type::Enum
                                   name: 'score'
+                                  required: true
                                   description: |
                                     The sensitivity score applied to the resource.
                                   values:
@@ -2160,6 +2165,7 @@ properties:
                               properties:
                                 - !ruby/object:Api::Type::Enum
                                   name: 'score'
+                                  required: true
                                   description: |
                                     The sensitivity score applied to the resource.
                                   values:
@@ -2238,6 +2244,7 @@ properties:
                                   properties:
                                     - !ruby/object:Api::Type::Enum
                                       name: 'score'
+                                      required: true
                                       description: |
                                         The sensitivity score applied to the resource.
                                       values:
@@ -2515,6 +2522,7 @@ properties:
                                         properties:
                                           - !ruby/object:Api::Type::Enum
                                             name: 'score'
+                                            required: true
                                             description: |
                                               The sensitivity score applied to the resource.
                                             values:
@@ -3031,6 +3039,7 @@ properties:
                                         properties:
                                           - !ruby/object:Api::Type::Enum
                                             name: 'score'
+                                            required: true
                                             description: |
                                               The sensitivity score applied to the resource.
                                             values:

--- a/mmv1/products/dlp/DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/DeidentifyTemplate.yaml
@@ -163,6 +163,19 @@ properties:
                             name: 'version'
                             description: |
                               Version name for this InfoType.
+                          - !ruby/object:Api::Type::NestedObject
+                            name: 'sensitivityScore'
+                            description: |
+                              Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                            properties:
+                              - !ruby/object:Api::Type::Enum
+                                name: 'score'
+                                description: |
+                                  The sensitivity score applied to the resource.
+                                values:
+                                  - :SENSITIVITY_LOW
+                                  - :SENSITIVITY_MODERATE
+                                  - :SENSITIVITY_HIGH
                 - !ruby/object:Api::Type::NestedObject
                   name: 'allInfoTypes'
                   description:
@@ -216,6 +229,19 @@ properties:
                         name: 'version'
                         description: |
                           Version name for this InfoType.
+                      - !ruby/object:Api::Type::NestedObject
+                            name: 'sensitivityScore'
+                            description: |
+                              Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                            properties:
+                              - !ruby/object:Api::Type::Enum
+                                name: 'score'
+                                description: |
+                                  The sensitivity score applied to the resource.
+                                values:
+                                  - :SENSITIVITY_LOW
+                                  - :SENSITIVITY_MODERATE
+                                  - :SENSITIVITY_HIGH
                 - !ruby/object:Api::Type::NestedObject
                   name: 'primitiveTransformation'
                   required: true
@@ -432,6 +458,19 @@ properties:
                               name: 'version'
                               description: |
                                 Optional version name for this InfoType.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'sensitivityScore'
+                              description: |
+                                Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                              properties:
+                                - !ruby/object:Api::Type::Enum
+                                  name: 'score'
+                                  description: |
+                                    The sensitivity score applied to the resource.
+                                  values:
+                                    - :SENSITIVITY_LOW
+                                    - :SENSITIVITY_MODERATE
+                                    - :SENSITIVITY_HIGH
                         - !ruby/object:Api::Type::NestedObject
                           name: 'context'
                           description: |
@@ -546,6 +585,19 @@ properties:
                               name: 'version'
                               description: |
                                 Optional version name for this InfoType.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'sensitivityScore'
+                              description: |
+                                Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                              properties:
+                                - !ruby/object:Api::Type::Enum
+                                  name: 'score'
+                                  description: |
+                                    The sensitivity score applied to the resource.
+                                  values:
+                                    - :SENSITIVITY_LOW
+                                    - :SENSITIVITY_MODERATE
+                                    - :SENSITIVITY_HIGH
                         - !ruby/object:Api::Type::Enum
                           name: 'commonAlphabet'
                           description: |
@@ -1395,6 +1447,19 @@ properties:
                               name: 'version'
                               description: |
                                 Optional version name for this InfoType.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'sensitivityScore'
+                              description: |
+                                Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                              properties:
+                                - !ruby/object:Api::Type::Enum
+                                  name: 'score'
+                                  description: |
+                                    The sensitivity score applied to the resource.
+                                  values:
+                                    - :SENSITIVITY_LOW
+                                    - :SENSITIVITY_MODERATE
+                                    - :SENSITIVITY_HIGH
                         - !ruby/object:Api::Type::Enum
                           name: 'commonAlphabet'
                           description: |
@@ -2088,6 +2153,19 @@ properties:
                               name: 'version'
                               description: |
                                 Optional version name for this InfoType.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'sensitivityScore'
+                              description: |
+                                Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                              properties:
+                                - !ruby/object:Api::Type::Enum
+                                  name: 'score'
+                                  description: |
+                                    The sensitivity score applied to the resource.
+                                  values:
+                                    - :SENSITIVITY_LOW
+                                    - :SENSITIVITY_MODERATE
+                                    - :SENSITIVITY_HIGH
                         - !ruby/object:Api::Type::NestedObject
                           name: 'context'
                           description: |
@@ -2153,6 +2231,19 @@ properties:
                                   name: version
                                   description: |
                                     Version name for this InfoType.
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'sensitivityScore'
+                                  description: |
+                                    Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                                  properties:
+                                    - !ruby/object:Api::Type::Enum
+                                      name: 'score'
+                                      description: |
+                                        The sensitivity score applied to the resource.
+                                      values:
+                                        - :SENSITIVITY_LOW
+                                        - :SENSITIVITY_MODERATE
+                                        - :SENSITIVITY_HIGH
                           - !ruby/object:Api::Type::NestedObject
                             name: primitiveTransformation
                             required: true
@@ -2417,6 +2508,19 @@ properties:
                                         name: version
                                         description: |
                                           Optional version name for this InfoType.
+                                      - !ruby/object:Api::Type::NestedObject
+                                        name: 'sensitivityScore'
+                                        description: |
+                                          Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                                        properties:
+                                          - !ruby/object:Api::Type::Enum
+                                            name: 'score'
+                                            description: |
+                                              The sensitivity score applied to the resource.
+                                            values:
+                                              - :SENSITIVITY_LOW
+                                              - :SENSITIVITY_MODERATE
+                                              - :SENSITIVITY_HIGH
                                   - !ruby/object:Api::Type::Enum
                                     name: commonAlphabet
                                     description: |
@@ -2920,6 +3024,19 @@ properties:
                                         name: version
                                         description: |
                                           Optional version name for this InfoType.
+                                      - !ruby/object:Api::Type::NestedObject
+                                        name: 'sensitivityScore'
+                                        description: |
+                                          Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                                        properties:
+                                          - !ruby/object:Api::Type::Enum
+                                            name: 'score'
+                                            description: |
+                                              The sensitivity score applied to the resource.
+                                            values:
+                                              - :SENSITIVITY_LOW
+                                              - :SENSITIVITY_MODERATE
+                                              - :SENSITIVITY_HIGH
                                   - !ruby/object:Api::Type::NestedObject
                                     name: context
                                     description: |

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -395,7 +395,7 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
               name = "CUSTOM_INFO_TYPEF"
               version = "version-2"
               sensitivity_score {
-                score = "SENSITIVIY_MODERATE"
+                score = "SENSITIVITY_MODERATE"
               }
             }
           }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -171,7 +171,7 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
               name = "CUSTOM_INFO_TYPE"
               version = "version-1"
               sensitivity_score {
-                score = "SENSITIVITY_MEDIUM"
+                score = "SENSITIVITY_MODERATE"
               }
             }
           }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -56,6 +56,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
         }
         info_types {
           name = "CREDIT_CARD_NUMBER"
+          sensitivity_score {
+            score = "SENSITIVITY_MODERATE"
+          }
         }
 
         primitive_transformation {
@@ -167,6 +170,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CUSTOM_INFO_TYPE"
               version = "version-1"
+              sensitivity_score {
+                score = "SENSITIVITY_MEDIUM"
+              }
             }
           }
         }
@@ -190,6 +196,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CUSTOM_INFO_TYPE"
               version = "version-1"
+              sensitivity_score {
+                score = "SENSITIVITY_LOW"
+              }
             }
           }
         }
@@ -272,6 +281,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
       transformations {
         info_types {
           name = "CREDIT_CARD_NUMBER"
+          sensitivity_score {
+            score = "SENSITIVITY_HIGH"
+          }
         }
 
         primitive_transformation {
@@ -356,6 +368,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CUSTOM_INFO_TYPEf"
               version = "version-2"
+              sensitivity_score {
+                score="SENSITIVITY_LOW"
+              }
             }
           }
         }
@@ -379,6 +394,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CUSTOM_INFO_TYPEF"
               version = "version-2"
+              sensitivity_score {
+                score = "SENSITIVIY_MODERATE"
+              }
             }
           }
         }
@@ -591,6 +609,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CUSTOM_INFO_TYPE"
               version = "version-1"
+              sensitivity_score {
+                score = "SENSITIVITY_LOW"
+              }
             }
           }
         }
@@ -699,6 +720,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CREDIT_CARD_NUMBER"
               version = "version-1"
+              sensitivity_score {
+                score = "SENSITIVITY_HIGH"
+              }
             }
             context {
               name = "unconditionally-crypto-deterministic-field"
@@ -853,6 +877,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             surrogate_info_type {
               name = "CUSTOM_INFO_TYPE"
               version = "version-2"
+              sensitivity_score {
+                score = "SENSITIVITY_MODERATE"
+              }
             }
           }
         }
@@ -979,6 +1006,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
               # update info type
               name = "CREDIT_CARD_TRACK_NUMBER"
               version = "version-2"
+              sensitivity_score {
+                score = "SENSITIVITY_LOW"
+              }
             }
             context {
               name = "unconditionally-crypto-deterministic-field"
@@ -1064,6 +1094,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
           info_types {
             name = "COLOR_INFO"
             version = "latest"
+            sensitivity_score {
+              score = "SENSITIVITY_LOW"
+            }
           }
         }
       }
@@ -1100,6 +1133,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
           info_types {
             name = "COLOR_EXAMPLE"
             version = "0.1"
+            sensitivity_score {
+              score = "SENSITIVITY_MODERATE"
+            }
           }
         }
       }
@@ -2050,6 +2086,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             info_types {
               name = "CREDIT_CARD_NUMBER"
               version = "1.2"
+              sensitivity_score {
+                score = "SENSITIVITY_HIGH"
+              }
             } 
             primitive_transformation {
               replace_config {
@@ -2123,6 +2162,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
                 surrogate_info_type {
                   name = "CUSTOM_INFO_TYPE"
                   version = "version-1"
+                  sensitivity_score {
+                    score = "SENSITIVITY_LOW"
+                  }
                 }
               }
             }
@@ -2273,6 +2315,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
                 surrogate_info_type {
                   name = "CREDIT_CARD_NUMBER"
                   version = "version-1"
+                  sensitivity_score {
+                    score = "SENSITIVITY_LOW"
+                  }
                 }
                 context {
                   name = "unconditionally-crypto-deterministic-field"
@@ -2418,6 +2463,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
             info_types {
               name = "CREDIT_CARD_NUMBER"
               version = "1.5"
+              sensitivity_score {
+                score = "SENSITIVITY_MODERATE"
+              }
             } 
             primitive_transformation {
 
@@ -2502,6 +2550,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
                 surrogate_info_type {
                   name = "CUSTOM_INFO_TYPE"
                   version = "version-2"
+                  sensitivity_score {
+                    score = "SENSITIVITY_MODERATE"
+                  }
                 }
               }
             }
@@ -2681,6 +2732,9 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
 
                   name = "CREDIT_CARD_TRACK_NUMBER"
                   version = "version-2"
+                  sensitivity_score {
+                    score = "SENSITIVITY_MODERATE"
+                  }
                 }
                 context {
                   name = "unconditionally-crypto-deterministic-field"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added multiple `sensitivity_score` fields in the `info_types` and `surrogate_info_type` block to the `google_data_loss_prevention_deidentify_template` resource.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added multiple `sensitivity_score` field to `google_data_loss_prevention_deidentify_template` resource
```
