### PR TITLE
Add New Field Network Attachment in Compute Instance Template Resource

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -302,6 +302,16 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 		if internalIP == "" {
 			internalIP = iface.NetworkIP
 		}
+
+		<% if version == "beta" -%>
+		if iface.NetworkAttachment != "" {
+			networkAttachment, err := tpgresource.GetRelativePath(iface.NetworkAttachment)
+			if err != nil {
+				return nil, "", "", "", err
+			}
+			flattened[i]["network_attachment"] = networkAttachment
+		}
+		<% end -%>
 	}
 	return flattened, region, internalIP, externalIP, nil
 }
@@ -346,11 +356,37 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 	for i, raw := range configs {
 		data := raw.(map[string]interface{})
 
+
+		<% if version == "beta" -%>
+		var networkAttachment = ""
+		network := data["network"].(string)
+		subnetwork := data["subnetwork"].(string)
+		if networkAttachmentObj, ok := data["network_attachment"]; ok {
+			networkAttachment = networkAttachmentObj.(string)
+		}
+		// Checks if networkAttachment is not specified in resource, network or subnetwork have to be specifed.
+		if networkAttachment == "" && network == "" && subnetwork == "" {
+			return nil, fmt.Errorf("exactly one of network, subnetwork, or network_attachment must be provided")
+		}
+
+
+		if networkAttachment != "" {
+			if network != "" {
+				return nil, fmt.Errorf("Cannot have a network provided with networkAttachment given that networkAttachment is associated with a network already")
+			}
+			if subnetwork != "" {
+				return nil, fmt.Errorf("Cannot have a subnetwork provided with networkAttachment given that networkAttachment is associated with a subnetwork already")
+			}
+		}
+		<% else -%>
+
 		network := data["network"].(string)
 		subnetwork := data["subnetwork"].(string)
 		if network == "" && subnetwork == "" {
 			return nil, fmt.Errorf("exactly one of network or subnetwork must be provided")
 		}
+
+		<% end -%>
 
 		nf, err := tpgresource.ParseNetworkFieldValue(network, d, config)
 		if err != nil {
@@ -366,6 +402,9 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 		ifaces[i] = &compute.NetworkInterface{
 			NetworkIP:         data["network_ip"].(string),
 			Network:           nf.RelativeLink(),
+			<% if version == "beta" -%>
+			NetworkAttachment: networkAttachment,
+			<% end -%>
 			Subnetwork:        sf.RelativeLink(),
 			AccessConfigs:     expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges:     expandAliasIpRanges(data["alias_ip_range"].([]interface{})),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -409,6 +409,17 @@ Google Cloud KMS.`,
 							Description:      `The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided.`,
 						},
 
+						<% if version == 'beta' -%>
+						"network_attachment": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         true,
+							Computed:         true,
+							DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
+						},
+						<% end -%>
+
 						"subnetwork_project": {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1139,6 +1139,48 @@ func TestAccComputeInstanceTemplate_sourceImageEncryptionKey(t *testing.T) {
 	})
 }
 
+<% if version == "beta" -%>
+func TestAccComputeInstanceTemplate_NetworkAttachment(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	testNetworkName := BootstrapSharedTestNetwork(t, "attachment-network")
+	subnetName := BootstrapSubnet(t, "tf-test-subnet", testNetworkName)
+	networkAttachmentName := BootstrapNetworkAttachment(t, "tf-test-attachment", subnetName)
+
+	// Need to have the full network attachment name in the format project/{project_id}/regions/{region_id}/networkAttachments/{networkAttachmentName}
+	fullFormNetworkAttachmentName := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", acctest.GetTestProjectFromEnv(), acctest.GetTestRegionFromEnv(), networkAttachmentName)
+
+	context := map[string]interface{}{
+		"subnet":             subnetName,
+		"suffix":             (RandString(t, 10)),
+		"network_attachment": fullFormNetworkAttachmentName,
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_network_attachment(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateHasNetworkAttachment(&instanceTemplate, fmt.Sprintf("https://www.googleapis.com/compute/beta/%s", fullFormNetworkAttachmentName)),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccCheckComputeInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := GoogleProviderConfig(t)
@@ -1468,6 +1510,19 @@ func testAccCheckComputeInstanceTemplateHasMinCpuPlatform(instanceTemplate *comp
 		return nil
 	}
 }
+
+<% if version == "beta" -%>
+func testAccCheckComputeInstanceTemplateHasNetworkAttachment(instanceTemplate *compute.InstanceTemplate, networkAttachmentName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, networkInterface := range instanceTemplate.Properties.NetworkInterfaces {
+			if networkInterface.NetworkAttachment != "" && networkInterface.NetworkAttachment == networkAttachmentName {
+				return nil
+			}
+		}
+		return fmt.Errorf("Network Attachment %s, was not found in the instance template", networkAttachmentName)
+	}
+}
+<% end -%>
 
 func testAccCheckComputeInstanceTemplateHasInstanceResourcePolicies(instanceTemplate *compute.InstanceTemplate, resourcePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -3266,3 +3321,39 @@ resource "google_compute_instance_template" "template" {
 }
 `, context)
 }
+
+<% if version == "beta" -%>
+func testAccComputeInstanceTemplate_network_attachment(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%{suffix}"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+  }
+
+  network_interface {
+	network = "default"
+  }
+
+  network_interface {
+	network_attachment = "%{network_attachment}"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/utils/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_test_utils.go
@@ -760,6 +760,130 @@ func BootstrapSharedCaPoolInLocation(t *testing.T, location string) string {
 	return poolName
 }
 
+func BootstrapSubnet(t *testing.T, subnetName string, networkName string) string {
+	projectID := acctest.GetTestProjectFromEnv()
+	region := acctest.GetTestRegionFromEnv()
+
+	config := BootstrapConfig(t)
+	if config == nil {
+		t.Fatal("Could not bootstrap config.")
+	}
+
+	computeService := config.NewComputeClient(config.UserAgent)
+	if computeService == nil {
+		t.Fatal("Could not create compute client.")
+	}
+
+	// In order to create a networkAttachment we need to bootstrap a subnet.
+	_, err := computeService.Subnetworks.Get(projectID, region, subnetName).Do()
+	if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		log.Printf("[DEBUG] Subnet %q not found, bootstrapping", subnetName)
+
+		networkUrl := fmt.Sprintf("%sprojects/%s/global/networks/%s", config.ComputeBasePath, projectID, networkName)
+		url := fmt.Sprintf("%sprojects/%s/regions/%s/subnetworks", config.ComputeBasePath, projectID, region)
+
+		subnetObj := map[string]interface{}{
+			"name":        subnetName,
+			"region ":     region,
+			"network":     networkUrl,
+			"ipCidrRange": "10.77.1.0/28",
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   projectID,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+			Body:      subnetObj,
+			Timeout:   4 * time.Minute,
+		})
+
+		log.Printf("Response is, %s", res)
+		if err != nil {
+			t.Fatalf("Error bootstrapping test subnet %s: %s", subnetName, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for network creation to finish")
+		err = ComputeOperationWaitTime(config, res, projectID, "Error bootstrapping test subnet", config.UserAgent, 4*time.Minute)
+		if err != nil {
+			t.Fatalf("Error bootstrapping test subnet %s: %s", subnetName, err)
+		}
+	}
+
+	subnet, err := computeService.Subnetworks.Get(projectID, region, subnetName).Do()
+
+	if subnet == nil {
+		t.Fatalf("Error getting test subnet %s: is nil", subnetName)
+	}
+
+	if err != nil {
+		t.Fatalf("Error getting test subnet %s: %s", subnetName, err)
+	}
+	return subnet.Name
+}
+
+func BootstrapNetworkAttachment(t *testing.T, networkAttachmentName string, subnetName string) string {
+	projectID := acctest.GetTestProjectFromEnv()
+	region := acctest.GetTestRegionFromEnv()
+
+	config := BootstrapConfig(t)
+	if config == nil {
+		return ""
+	}
+
+	computeService := config.NewComputeClient(config.UserAgent)
+	if computeService == nil {
+		return ""
+	}
+
+	networkAttachment, err := computeService.NetworkAttachments.Get(projectID, region, networkAttachmentName).Do()
+	if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		// Create Network Attachment Here.
+		log.Printf("[DEBUG] Network Attachment %s not found, bootstrapping", networkAttachmentName)
+		url := fmt.Sprintf("%sprojects/%s/regions/%s/networkAttachments", config.ComputeBasePath, projectID, region)
+
+		subnetURL := fmt.Sprintf("%sprojects/%s/regions/%s/subnetworks/%s", config.ComputeBasePath, projectID, region, subnetName)
+		networkAttachmentObj := map[string]interface{}{
+			"name":                 networkAttachmentName,
+			"region":               region,
+			"subnetworks":          []string{subnetURL},
+			"connectionPreference": "ACCEPT_AUTOMATIC",
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   projectID,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+			Body:      networkAttachmentObj,
+			Timeout:   4 * time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("Error bootstrapping test Network Attachment %s: %s", networkAttachmentName, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for network creation to finish")
+		err = ComputeOperationWaitTime(config, res, projectID, "Error bootstrapping shared test subnet", config.UserAgent, 4*time.Minute)
+		if err != nil {
+			t.Fatalf("Error bootstrapping test Network Attachment %s: %s", networkAttachmentName, err)
+		}
+	}
+
+	networkAttachment, err = computeService.NetworkAttachments.Get(projectID, region, networkAttachmentName).Do()
+
+	if networkAttachment == nil {
+		t.Fatalf("Error getting test network attachment %s: is nil", networkAttachmentName)
+	}
+
+	if err != nil {
+		t.Fatalf("Error getting test Network Attachment %s: %s", networkAttachmentName, err)
+	}
+
+	return networkAttachment.Name
+}
+
 func setupProjectsAndGetAccessToken(org, billing, pid, service string, config *transport_tpg.Config) (string, error) {
 	// Create project-1 and project-2
 	rmService := config.NewResourceManagerClient(config.UserAgent)

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -198,6 +198,8 @@ The `disk_encryption_key` block supports:
     to. The subnetwork must exist in the same `region` this instance will be
     created in. Either `network` or `subnetwork` must be provided.
 
+* `network_interface` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.  s
+
 * `subnetwork_project` - The ID of the project in which the subnetwork belongs.
     If it is not provided, the provider project is used.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -470,6 +470,8 @@ The following arguments are supported:
 * `subnetwork` - (Optional) the name of the subnetwork to attach this interface
     to. The subnetwork must exist in the same `region` this instance will be
     created in. Either `network` or `subnetwork` must be provided.
+    
+* `network_interface` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.  
 
 * `subnetwork_project` - (Optional) The ID of the project in which the subnetwork belongs.
     If it is not provided, the provider project is used.


### PR DESCRIPTION
…attachment

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I have made changes to the magic-modules repo to support a new field, network attachment resource for the compute instance template resource. It will enable creating compute workloads with PSC (Private Service Connect) Network Interfaces.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/14615


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added field `network_attachment` to `google_compute_instance_template`
```
