### PR TITLE
Added multiple sensitivity_score fields in google_data_loss_prevention_job_trigger

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -253,6 +253,20 @@ properties:
                           name: 'version'
                           description: |
                             Version of the information type to use. By default, the version is set to stable
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'sensitivityScore'
+                          description: |
+                            Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                          properties:
+                            - !ruby/object:Api::Type::Enum
+                              name: 'score'
+                              required: true
+                              description: |
+                                The sensitivity score applied to the resource.
+                              values:
+                                - :SENSITIVITY_LOW
+                                - :SENSITIVITY_MODERATE
+                                - :SENSITIVITY_HIGH
                     - !ruby/object:Api::Type::Integer
                       name: 'maxFindings'
                       description: Max findings limit for the given infoType.
@@ -276,6 +290,20 @@ properties:
                   name: 'version'
                   description: |
                     Version of the information type to use. By default, the version is set to stable
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'sensitivityScore'
+                  description: |
+                    Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: 'score'
+                      required: true
+                      description: |
+                        The sensitivity score applied to the resource.
+                      values:
+                        - :SENSITIVITY_LOW
+                        - :SENSITIVITY_MODERATE
+                        - :SENSITIVITY_HIGH
           - !ruby/object:Api::Type::Array
             name: 'ruleSet'
             description: |
@@ -299,6 +327,20 @@ properties:
                         name: 'version'
                         description: |
                           Version of the information type to use. By default, the version is set to stable.
+                      - !ruby/object:Api::Type::NestedObject
+                        name: 'sensitivityScore'
+                        description: |
+                          Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                        properties:
+                          - !ruby/object:Api::Type::Enum
+                            name: 'score'
+                            required: true
+                            description: |
+                              The sensitivity score applied to the resource.
+                            values:
+                              - :SENSITIVITY_LOW
+                              - :SENSITIVITY_MODERATE
+                              - :SENSITIVITY_HIGH
                 - !ruby/object:Api::Type::Array
                   name: 'rules'
                   required: true
@@ -450,6 +492,20 @@ properties:
                                       name: 'version'
                                       description: |
                                         Version of the information type to use. By default, the version is set to stable.
+                                    - !ruby/object:Api::Type::NestedObject
+                                      name: 'sensitivityScore'
+                                      description: |
+                                        Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                                      properties:
+                                        - !ruby/object:Api::Type::Enum
+                                          name: 'score'
+                                          required: true
+                                          description: |
+                                            The sensitivity score applied to the resource.
+                                          values:
+                                            - :SENSITIVITY_LOW
+                                            - :SENSITIVITY_MODERATE
+                                            - :SENSITIVITY_HIGH
                           - !ruby/object:Api::Type::NestedObject
                             name: 'excludeByHotword'
                             description:
@@ -515,6 +571,20 @@ properties:
                       name: 'version'
                       description: |
                         Version of the information type to use. By default, the version is set to stable.
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'sensitivityScore'
+                      description: |
+                        Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                      properties:
+                        - !ruby/object:Api::Type::Enum
+                          name: 'score'
+                          required: true
+                          description: |
+                            The sensitivity score applied to the resource.
+                          values:
+                            - :SENSITIVITY_LOW
+                            - :SENSITIVITY_MODERATE
+                            - :SENSITIVITY_HIGH
                 - !ruby/object:Api::Type::Enum
                   name: 'likelihood'
                   description: |
@@ -533,6 +603,20 @@ properties:
                     If set to EXCLUSION_TYPE_EXCLUDE this infoType will not cause a finding to be returned. It still can be used for rules matching.
                   values:
                     - :EXCLUSION_TYPE_EXCLUDE
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'sensitivityScore'
+                  description: |
+                    Optional custom sensitivity for this InfoType. This only applies to data profiling.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: 'score'
+                      required: true
+                      description: |
+                        The sensitivity score applied to the resource.
+                      values:
+                        - :SENSITIVITY_LOW
+                        - :SENSITIVITY_MODERATE
+                        - :SENSITIVITY_HIGH
                 - !ruby/object:Api::Type::NestedObject
                   name: 'regex'
                   description: Regular expression which defines the rule.

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_job_trigger_test.go
@@ -477,6 +477,49 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerInspectOptionalExample(t *
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScore(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project": acctest.GetTestProjectFromEnv(),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScoreBasic(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScoreUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScoreUpdate2(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -2344,6 +2387,396 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 			cloud_storage_options {
 				file_set {
 					url = "gs://mybucket/directory/"
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScoreBasic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "basic" {
+	parent       = "projects/%{project}"
+	description  = "Starting description"
+	display_name = "display"
+	
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+	
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+			}
+		}
+		inspect_config {
+			custom_info_types {
+				info_type {
+					name = "MY_CUSTOM_TYPE"
+					sensitivity_score {
+						score = "SENSITIVITY_MODERATE"
+					}
+				}
+				sensitivity_score {
+					score = "SENSITIVITY_HIGH"
+				}
+			}
+			info_types {
+				name = "EMAIL_ADDRESS"
+				sensitivity_score {
+					score = "SENSITIVITY_LOW"
+				}
+			}
+			info_types {
+				name = "PERSON_NAME"
+			}
+			info_types {
+				name = "LAST_NAME"
+			}
+			info_types {
+				name = "DOMAIN_NAME"
+			}
+			info_types {
+				name = "PHONE_NUMBER"
+			}
+			info_types {
+				name = "FIRST_NAME"
+			}
+		
+			min_likelihood		= "UNLIKELY"
+			include_quote		= false
+			exclude_info_types  = false
+			rule_set {
+				info_types {
+					name = "EMAIL_ADDRESS"
+					sensitivity_score {
+						score = "SENSITIVITY_LOW"
+					}
+				}
+				rules {
+					exclusion_rule {
+						regex {
+							pattern = ".+@example.com"
+						}
+						matching_type = "MATCHING_TYPE_FULL_MATCH"
+					}
+				}
+			}
+			rule_set {
+				info_types {
+					name = "EMAIL_ADDRESS"
+				}
+				info_types {
+					name = "DOMAIN_NAME"
+				}
+				info_types {
+					name = "PHONE_NUMBER"
+				}
+				info_types {
+					name = "PERSON_NAME"
+				}
+				info_types {
+					name = "FIRST_NAME"
+				}
+				rules {
+					exclusion_rule {
+						exclude_info_types {
+							info_types {
+								name = "LAST_NAME"
+								sensitivity_score {
+									score = "SENSITIVITY_HIGH"
+								}
+							}
+						}
+						matching_type = "MATCHING_TYPE_PARTIAL_MATCH"
+					}
+				}
+			}
+		
+			limits {
+				max_findings_per_item	 = 10
+				max_findings_per_request = 50
+				max_findings_per_info_type {
+					max_findings = "75"
+					info_type {
+						name = "PERSON_NAME"
+						sensitivity_score {
+							score = "SENSITIVITY_MODERATE"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScoreUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "basic" {
+	parent       = "projects/%{project}"
+	description  = "Starting description"
+	display_name = "display"
+	
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+	
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+			}
+		}
+		inspect_config {
+			custom_info_types {
+				info_type {
+					name = "MY_CUSTOM_TYPE"
+				}
+				sensitivity_score {
+					score = "SENSITIVITY_MODERATE"
+				}
+			}
+			info_types {
+				name = "EMAIL_ADDRESS"
+			}
+			info_types {
+				name = "PERSON_NAME"
+			}
+			info_types {
+				name = "LAST_NAME"
+			}
+			info_types {
+				name = "DOMAIN_NAME"
+			}
+			info_types {
+				name = "PHONE_NUMBER"
+			}
+			info_types {
+				name = "FIRST_NAME"
+			}
+		
+			min_likelihood		= "UNLIKELY"
+			include_quote		= false
+			exclude_info_types  = false
+			rule_set {
+				info_types {
+					name = "EMAIL_ADDRESS"
+					sensitivity_score {
+						score = "SENSITIVITY_HIGH"
+					}
+				}
+				rules {
+					exclusion_rule {
+						regex {
+							pattern = ".+@example.com"
+						}
+						matching_type = "MATCHING_TYPE_FULL_MATCH"
+					}
+				}
+			}
+			rule_set {
+				info_types {
+					name = "EMAIL_ADDRESS"
+				}
+				info_types {
+					name = "DOMAIN_NAME"
+				}
+				info_types {
+					name = "PHONE_NUMBER"
+				}
+				info_types {
+					name = "PERSON_NAME"
+				}
+				info_types {
+					name = "FIRST_NAME"
+				}
+				rules {
+					exclusion_rule {
+						exclude_info_types {
+							info_types {
+								name = "LAST_NAME"
+							}
+						}
+						matching_type = "MATCHING_TYPE_PARTIAL_MATCH"
+					}
+				}
+			}
+		
+			limits {
+				max_findings_per_item	 = 10
+				max_findings_per_request = 50
+				max_findings_per_info_type {
+					max_findings = "75"
+					info_type {
+						name = "PERSON_NAME"
+						sensitivity_score {
+							score = "SENSITIVITY_LOW"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScoreUpdate2(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "basic" {
+	parent       = "projects/%{project}"
+	description  = "Starting description"
+	display_name = "display"
+	
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+	
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "dataset123"
+					}
+				}
+			}
+		}
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+			}
+		}
+		inspect_config {
+			custom_info_types {
+				info_type {
+					name = "MY_CUSTOM_TYPE"
+					sensitivity_score {
+						score = "SENSITIVITY_HIGH"
+					}
+				}
+			}
+			info_types {
+				name = "EMAIL_ADDRESS"
+				sensitivity_score {
+					score = "SENSITIVITY_MODERATE"
+				}
+			}
+			info_types {
+				name = "PERSON_NAME"
+			}
+			info_types {
+				name = "LAST_NAME"
+			}
+			info_types {
+				name = "DOMAIN_NAME"
+			}
+			info_types {
+				name = "PHONE_NUMBER"
+			}
+			info_types {
+				name = "FIRST_NAME"
+			}
+		
+			min_likelihood		= "UNLIKELY"
+			include_quote		= false
+			exclude_info_types  = false
+			rule_set {
+				info_types {
+					name = "EMAIL_ADDRESS"
+					sensitivity_score {
+						score = "SENSITIVITY_MODERATE"
+					}
+				}
+				rules {
+					exclusion_rule {
+						regex {
+							pattern = ".+@example.com"
+						}
+						matching_type = "MATCHING_TYPE_FULL_MATCH"
+					}
+				}
+			}
+			rule_set {
+				info_types {
+					name = "EMAIL_ADDRESS"
+				}
+				info_types {
+					name = "DOMAIN_NAME"
+				}
+				info_types {
+					name = "PHONE_NUMBER"
+				}
+				info_types {
+					name = "PERSON_NAME"
+				}
+				info_types {
+					name = "FIRST_NAME"
+				}
+				rules {
+					exclusion_rule {
+						exclude_info_types {
+							info_types {
+								name = "LAST_NAME"
+							}
+						}
+						matching_type = "MATCHING_TYPE_PARTIAL_MATCH"
+					}
+				}
+			}
+		
+			limits {
+				max_findings_per_item	 = 10
+				max_findings_per_request = 50
+				max_findings_per_info_type {
+					max_findings = "75"
+					info_type {
+						name = "PERSON_NAME"
+						sensitivity_score {
+							score = "SENSITIVITY_HIGH"
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added multiple `sensitivity_score` fields in the `info_type` block to the `google_data_loss_prevention_job_trigger` resource.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added multiple `sensitivity_score` field to `google_data_loss_prevention_job_trigger` resource
```
