### PR TITLE
Make SQL database flags a set

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -46,6 +46,21 @@ var sqlDatabaseAuthorizedNetWorkSchemaElem *schema.Resource = &schema.Resource{
 	},
 }
 
+var sqlDatabaseFlagSchemaElem *schema.Resource = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"value": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: `Value of the flag.`,
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: `Name of the flag.`,
+		},
+	},
+}
+
 var (
 	backupConfigurationKeys = []string{
 		"settings.0.backup_configuration.0.binary_log_enabled",
@@ -362,22 +377,10 @@ is set to true. Defaults to ZONAL.`,
 							Description:      `The name of server instance collation.`,
 						},
 						"database_flags": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"value": {
-										Type:        schema.TypeString,
-										Required:    true,
-										Description: `Value of the flag.`,
-									},
-									"name": {
-										Type:        schema.TypeString,
-										Required:    true,
-										Description: `Name of the flag.`,
-									},
-								},
-							},
+							Set:      schema.HashResource(sqlDatabaseFlagSchemaElem),
+							Elem:     sqlDatabaseFlagSchemaElem,
 						},
 						"disk_autoresize": {
 							Type:             schema.TypeBool,
@@ -1261,7 +1264,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		DeletionProtectionEnabled:  _settings["deletion_protection_enabled"].(bool),
 		UserLabels:                 tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration:        expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
-		DatabaseFlags:              expandDatabaseFlags(_settings["database_flags"].([]interface{})),
+		DatabaseFlags:              expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
 		IpConfiguration:            expandIpConfiguration(_settings["ip_configuration"].([]interface{}), databaseVersion),
 		LocationPreference:         expandLocationPreference(_settings["location_preference"].([]interface{})),
 		MaintenanceWindow:          expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1671,6 +1671,34 @@ func TestAccSqlDatabaseInstance_Timezone(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_updateDifferentFlagOrder(t *testing.T) {
+	t.Parallel()
+
+	instance := "tf-test-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_flags(instance),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config:             testGoogleSqlDatabaseInstance_flags_update(instance),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_sqlMysqlInstancePvpExample(t *testing.T) {
 	t.Parallel()
 
@@ -3828,6 +3856,50 @@ func checkInstanceTypeIsPresent(resourceName string) func(*terraform.State) erro
 		}
 		return nil
 	}
+}
+
+func testGoogleSqlDatabaseInstance_flags(instance string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+
+    database_flags {
+      name  = "character_set_server"
+      value = "utf8mb4"
+    }
+    database_flags {
+      name  = "auto_increment_increment"
+      value = "2"
+    }
+  }
+}`, instance)
+}
+
+func testGoogleSqlDatabaseInstance_flags_update(instance string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+
+    database_flags {
+      name  = "auto_increment_increment"
+      value = "2"
+    }
+    database_flags {
+      name  = "character_set_server"
+      value = "utf8mb4"
+    }
+  }
+}`, instance)
 }
 
 func testGoogleSqlDatabaseInstance_readReplica(instance string) string {

--- a/mmv1/third_party/tgc/sql_database_instance.go
+++ b/mmv1/third_party/tgc/sql_database_instance.go
@@ -110,7 +110,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 		PricingPlan:         _settings["pricing_plan"].(string),
 		UserLabels:          tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration: expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
-		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].([]*schema.Set{}).List()),
+		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List().([]interface{})),
 		IpConfiguration:     expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
 		LocationPreference:  expandLocationPreference(_settings["location_preference"].([]interface{})),
 		MaintenanceWindow:   expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),

--- a/mmv1/third_party/tgc/sql_database_instance.go
+++ b/mmv1/third_party/tgc/sql_database_instance.go
@@ -110,7 +110,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 		PricingPlan:         _settings["pricing_plan"].(string),
 		UserLabels:          tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration: expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
-		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List().([]interface{})),
+		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
 		IpConfiguration:     expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
 		LocationPreference:  expandLocationPreference(_settings["location_preference"].([]interface{})),
 		MaintenanceWindow:   expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),

--- a/mmv1/third_party/tgc/sql_database_instance.go
+++ b/mmv1/third_party/tgc/sql_database_instance.go
@@ -110,7 +110,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 		PricingPlan:         _settings["pricing_plan"].(string),
 		UserLabels:          tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration: expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
-		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].([]interface{})),
+		DatabaseFlags:       expandDatabaseFlags(_settings["database_flags"].([]*schema.Set{}).List()),
 		IpConfiguration:     expandIpConfiguration(_settings["ip_configuration"].([]interface{})),
 		LocationPreference:  expandLocationPreference(_settings["location_preference"].([]interface{})),
 		MaintenanceWindow:   expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),


### PR DESCRIPTION
These are not ordered semantically, so changing the order shouldn't create a diff.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13663.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed diffs when re-ordering existing `database_flags`
```
