### PR TITLE
Add field httpKeepAliveTimeoutSec to resources google_compute_target_http_proxy and google_compute_target_https_proxy (beta)

### DIFF
--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -57,7 +57,7 @@ examples:
     min_version: beta
     primary_resource_id: 'default'
     vars:
-      target_http_proxy_name: 'test-proxy'
+      target_http_proxy_name: 'test-http-keep-alive-timeout-proxy'
       url_map_name: 'url-map'
       backend_service_name: 'backend-service'
       http_health_check_name: 'http-health-check'

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -58,7 +58,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       target_http_proxy_name: 'test-proxy'
-      http_keep_alive_timeout_sec: 120
       url_map_name: 'url-map'
       backend_service_name: 'backend-service'
       http_health_check_name: 'http-health-check'

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -109,6 +109,7 @@ properties:
     default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: 'httpKeepAliveTimeoutSec'
+    min_version: beta
     description: |
       Specifies how long to keep a connection open, after completing a response,
       while there is no matching traffic (in seconds). If an HTTP keepalive is

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -53,6 +53,16 @@ examples:
       backend_service_name: 'backend-service'
       http_health_check_name: 'http-health-check'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'target_http_proxy_http_keep_alive_timeout'
+    min_version: beta
+    primary_resource_id: 'default'
+    vars:
+      target_http_proxy_name: 'test-proxy'
+      http_keep_alive_timeout_sec: 120
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'target_http_proxy_https_redirect'
     primary_resource_id: 'default'
     vars:
@@ -98,3 +108,12 @@ properties:
       This field only applies when the forwarding rule that references
       this target proxy has a loadBalancingScheme set to INTERNAL_SELF_MANAGED.
     default_from_api: true
+  - !ruby/object:Api::Type::Integer
+    name: 'httpKeepAliveTimeoutSec'
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (610 seconds) will be used. For Global
+      external HTTP(S) load balancer, the minimum allowed value is 5 seconds and
+      the maximum allowed value is 1200 seconds. For Global external HTTP(S)
+      load balancer (classic), this option is not available publicly.

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -153,6 +153,7 @@ properties:
     default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: 'httpKeepAliveTimeoutSec'
+    min_version: beta
     description: |
       Specifies how long to keep a connection open, after completing a response,
       while there is no matching traffic (in seconds). If an HTTP keepalive is

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -53,6 +53,17 @@ examples:
       url_map_name: 'url-map'
       backend_service_name: 'backend-service'
       http_health_check_name: 'http-health-check'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'target_https_proxy_http_keep_alive_timeout'
+    min_version: beta
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      http_keep_alive_timeout_sec: 120
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
 properties:
   - !ruby/object:Api::Type::Time
     name: 'creationTimestamp'
@@ -141,3 +152,12 @@ properties:
       This field only applies when the forwarding rule that references
       this target proxy has a loadBalancingScheme set to INTERNAL_SELF_MANAGED.
     default_from_api: true
+  - !ruby/object:Api::Type::Integer
+    name: 'httpKeepAliveTimeoutSec'
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (610 seconds) will be used. For Global
+      external HTTP(S) load balancer, the minimum allowed value is 5 seconds and
+      the maximum allowed value is 1200 seconds. For Global external HTTP(S)
+      load balancer (classic), this option is not available publicly.

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -59,7 +59,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       target_https_proxy_name: 'test-http-keep-alive-timeout-proxy'
-      http_keep_alive_timeout_sec: 120
       ssl_certificate_name: 'my-certificate'
       url_map_name: 'url-map'
       backend_service_name: 'backend-service'

--- a/mmv1/templates/terraform/examples/target_http_proxy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/target_http_proxy_basic.tf.erb
@@ -1,5 +1,5 @@
 # [START cloudloadbalancing_target_http_proxy_basic]
-resource "google_compute_target_http_proxy" "default" {
+resource "google_compute_target_http_proxy" "<%= ctx[:primary_resource_id] %>" {
   name    = "<%= ctx[:vars]['target_http_proxy_name'] %>"
   url_map = google_compute_url_map.default.id
 }

--- a/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
@@ -1,7 +1,7 @@
 # [START cloudloadbalancing_target_http_proxy_http_keep_alive_timeout]
-resource "google_compute_target_http_proxy" "default" {
+resource "google_compute_target_http_proxy" "<%= ctx[:primary_resource_id] %>" {
   name                        = "<%= ctx[:vars]['target_http_proxy_name'] %>"
-  http_keep_alive_timeout_sec = "<%= ctx[:vars]['http_keep_alive_timeout_sec'] %>"
+  http_keep_alive_timeout_sec = 120
   url_map                     = google_compute_url_map.default.id
 }
 

--- a/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
@@ -1,11 +1,13 @@
 # [START cloudloadbalancing_target_http_proxy_http_keep_alive_timeout]
 resource "google_compute_target_http_proxy" "<%= ctx[:primary_resource_id] %>" {
+  provider                    = google-beta
   name                        = "<%= ctx[:vars]['target_http_proxy_name'] %>"
   http_keep_alive_timeout_sec = 120
   url_map                     = google_compute_url_map.default.id
 }
 
 resource "google_compute_url_map" "default" {
+  provider        = google-beta
   name            = "<%= ctx[:vars]['url_map_name'] %>"
   default_service = google_compute_backend_service.default.id
 
@@ -26,6 +28,7 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider              = google-beta
   name                  = "<%= ctx[:vars]['backend_service_name'] %>"
   port_name             = "http"
   protocol              = "HTTP"
@@ -36,6 +39,7 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_http_health_check" "default" {
+  provider           = google-beta
   name               = "<%= ctx[:vars]['http_health_check_name'] %>"
   request_path       = "/"
   check_interval_sec = 1

--- a/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
@@ -1,8 +1,8 @@
 # [START cloudloadbalancing_target_http_proxy_http_keep_alive_timeout]
 resource "google_compute_target_http_proxy" "default" {
-  name    = "<%= ctx[:vars]['target_http_proxy_name'] %>"
+  name                        = "<%= ctx[:vars]['target_http_proxy_name'] %>"
   http_keep_alive_timeout_sec = "<%= ctx[:vars]['http_keep_alive_timeout_sec'] %>"
-  url_map = google_compute_url_map.default.id
+  url_map                     = google_compute_url_map.default.id
 }
 
 resource "google_compute_url_map" "default" {
@@ -26,10 +26,10 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "<%= ctx[:vars]['backend_service_name'] %>"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_http_health_check.default.id]

--- a/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_http_proxy_http_keep_alive_timeout.tf.erb
@@ -1,0 +1,44 @@
+# [START cloudloadbalancing_target_http_proxy_http_keep_alive_timeout]
+resource "google_compute_target_http_proxy" "default" {
+  name    = "<%= ctx[:vars]['target_http_proxy_name'] %>"
+  http_keep_alive_timeout_sec = "<%= ctx[:vars]['http_keep_alive_timeout_sec'] %>"
+  url_map = google_compute_url_map.default.id
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "<%= ctx[:vars]['url_map_name'] %>"
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+# [END cloudloadbalancing_target_http_proxy_http_keep_alive_timeout]

--- a/mmv1/templates/terraform/examples/target_http_proxy_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/target_http_proxy_https_redirect.tf.erb
@@ -1,5 +1,5 @@
 # [START cloudloadbalancing_target_http_proxy_https_redirect]
-resource "google_compute_target_http_proxy" "default" {
+resource "google_compute_target_http_proxy" "<%= ctx[:primary_resource_id] %>" {
   name    = "<%= ctx[:vars]['target_http_proxy_name'] %>"
   url_map = google_compute_url_map.default.id
 }

--- a/mmv1/templates/terraform/examples/target_https_proxy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/target_https_proxy_basic.tf.erb
@@ -1,5 +1,5 @@
 # [START cloudloadbalancing_target_https_proxy_basic]
-resource "google_compute_target_https_proxy" "default" {
+resource "google_compute_target_https_proxy" "<%= ctx[:primary_resource_id] %>" {
   name             = "<%= ctx[:vars]['target_https_proxy_name'] %>"
   url_map          = google_compute_url_map.default.id
   ssl_certificates = [google_compute_ssl_certificate.default.id]

--- a/mmv1/templates/terraform/examples/target_https_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_https_proxy_http_keep_alive_timeout.tf.erb
@@ -1,7 +1,7 @@
 # [START cloudloadbalancing_target_https_proxy_http_keep_alive_timeout]
-resource "google_compute_target_https_proxy" "default" {
+resource "google_compute_target_https_proxy" "<%= ctx[:primary_resource_id] %>" {
   name                        = "<%= ctx[:vars]['target_https_proxy_name'] %>"
-  http_keep_alive_timeout_sec = "<%= ctx[:vars]['http_keep_alive_timeout_sec'] %>"
+  http_keep_alive_timeout_sec = 120
   url_map                     = google_compute_url_map.default.id
   ssl_certificates            = [google_compute_ssl_certificate.default.id]
 }

--- a/mmv1/templates/terraform/examples/target_https_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_https_proxy_http_keep_alive_timeout.tf.erb
@@ -1,0 +1,53 @@
+# [START cloudloadbalancing_target_https_proxy_http_keep_alive_timeout]
+resource "google_compute_target_https_proxy" "default" {
+  name                        = "<%= ctx[:vars]['target_https_proxy_name'] %>"
+  http_keep_alive_timeout_sec = "<%= ctx[:vars]['http_keep_alive_timeout_sec'] %>"
+  url_map                     = google_compute_url_map.default.id
+  ssl_certificates            = [google_compute_ssl_certificate.default.id]
+}
+
+resource "google_compute_ssl_certificate" "default" {
+  name        = "<%= ctx[:vars]['ssl_certificate_name'] %>"
+  private_key = file("path/to/private.key")
+  certificate = file("path/to/certificate.crt")
+}
+
+resource "google_compute_url_map" "default" {
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  description = "a description"
+
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name                  = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+# [END cloudloadbalancing_target_https_proxy_http_keep_alive_timeout]

--- a/mmv1/templates/terraform/examples/target_https_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/target_https_proxy_http_keep_alive_timeout.tf.erb
@@ -1,5 +1,6 @@
 # [START cloudloadbalancing_target_https_proxy_http_keep_alive_timeout]
 resource "google_compute_target_https_proxy" "<%= ctx[:primary_resource_id] %>" {
+  provider                    = google-beta
   name                        = "<%= ctx[:vars]['target_https_proxy_name'] %>"
   http_keep_alive_timeout_sec = 120
   url_map                     = google_compute_url_map.default.id
@@ -7,12 +8,14 @@ resource "google_compute_target_https_proxy" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_compute_ssl_certificate" "default" {
+  provider    = google-beta
   name        = "<%= ctx[:vars]['ssl_certificate_name'] %>"
   private_key = file("path/to/private.key")
   certificate = file("path/to/certificate.crt")
 }
 
 resource "google_compute_url_map" "default" {
+  provider   = google-beta
   name        = "<%= ctx[:vars]['url_map_name'] %>"
   description = "a description"
 
@@ -35,6 +38,7 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider              = google-beta
   name                  = "<%= ctx[:vars]['backend_service_name'] %>"
   port_name             = "http"
   protocol              = "HTTP"
@@ -45,6 +49,7 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_http_health_check" "default" {
+  provider           = google-beta
   name               = "<%= ctx[:vars]['http_health_check_name'] %>"
   request_path       = "/"
   check_interval_sec = 1


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add the `httpKeepAliveTimeoutSec` field to Global Target HTTP Proxy and Global Target HTTPS Proxy resources.

Part of https://github.com/hashicorp/terraform-provider-google/issues/14867

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `httpKeepAliveTimeoutSec` to resource `google_compute_target_http_proxy` (beta)
```

```release-note:enhancement
compute: added field `httpKeepAliveTimeoutSec` to resource `google_compute_target_https_proxy` (beta)
```