### PR TITLE
Enable Firebase Extensions API

### DIFF
--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -231,6 +231,7 @@ module "project-services" {
     "firebaseappdistribution.googleapis.com",
     "firebasedatabase.googleapis.com",
     "firebasedynamiclinks.googleapis.com",
+    "firebaseextensions.googleapis.com",
     "firebasehosting.googleapis.com",
     "firebaseinstallations.googleapis.com",
     "firebaseremoteconfig.googleapis.com",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This issue to add Firebase Extension resources (https://github.com/hashicorp/terraform-provider-google/issues/14601) is currently being addressed in a PR but automated tests fail due to the Firebase Extension API not being enabled in the test project


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
