### PR TITLE
Adding check for when to ForceNew create on Hyperdisk DiffSupress

### DIFF
--- a/mmv1/templates/terraform/constants/disk.erb
+++ b/mmv1/templates/terraform/constants/disk.erb
@@ -2,14 +2,16 @@
 <% unless compiler == "terraformvalidator-codegen" -%>
 // diffsupress for hyperdisk provisioned_iops
 func hyperDiskIopsUpdateDiffSupress(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	forceNewCheck := []string{"pd-extreme"}
 	if !strings.Contains(d.Get("type").(string), "hyperdisk") {
 		resourceSchema := ResourceComputeDisk().Schema
 		for field := range resourceSchema {
-			if field == "provisioned_iops" && d.HasChange(field) {
+			if field == "provisioned_iops" && d.HasChange(field) && tpgresource.StringContainsSlice(forceNewCheck, d.Get("type").(string)) {
 				if err := d.ForceNew(field); err != nil {
 					return err
 				}
 			}
+
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -923,15 +923,6 @@ func privateNetworkCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta
 	return nil
 }
 
-// helper function to see if string within list contains a particular substring
-func stringContainsSlice(arr []string, str string) bool {
-	for _, i := range arr {
-		if strings.Contains(str, i) {
-			return true
-		}
-	}
-	return false
-}
 
 // Point in time recovery for MySQL database instances needs binary_log_enabled set to true and
 // not point_in_time_recovery_enabled, which is confusing to users. This checks for
@@ -941,7 +932,7 @@ func pitrSupportDbCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v 
 	pitr := diff.Get("settings.0.backup_configuration.0.point_in_time_recovery_enabled").(bool)
 	dbVersion := diff.Get("database_version").(string)
 	dbVersionPitrValid := []string{"POSTGRES", "SQLSERVER"}
-	if pitr && !stringContainsSlice(dbVersionPitrValid, dbVersion) {
+	if pitr && !tpgresource.StringContainsSlice(dbVersionPitrValid, dbVersion) {
 		return fmt.Errorf("point_in_time_recovery_enabled is only available for the following %v. You may want to consider using binary_log_enabled instead and remove point_in_time_recovery_enabled (removing point_in_time_recovery_enabled and adding binary_log_enabled will enable pitr for MYSQL)", dbVersionPitrValid)
 	}
 	return nil

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -418,6 +418,16 @@ func StringInSlice(arr []string, str string) bool {
 	return false
 }
 
+// helper function to see if  strings within a list contains a particular substring
+func StringContainsSlice(arr []string, str string) bool {
+	for _, i := range arr {
+		if strings.Contains(str, i) {
+			return true
+		}
+	}
+	return false
+}
+
 func MigrateStateNoop(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	return is, nil
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/14936

Observed an issue where disk SKUs outside of extreme-pd were getting deleted when provisioned_iops was set on them before the API could send error that this feild was not supported


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed issue where non-`pd-extreme` disks configured with an `provisioned_iops` argument were deleted before the API return an error saying this is not a supported field for that disk type
```
