### PR TITLE
Make service account name in bq transfer config mutable

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -15,8 +15,7 @@
 name: 'Config'
 base_url: projects/{{project}}/locations/{{location}}/transferConfigs?serviceAccountName={{service_account_name}}
 self_link: '{{name}}'
-# see comment at service_account_name, PATCHing service_account_name also required update_mask entry
-# update_url: "{{name}}?serviceAccountName={{service_account_name}}"
+update_url: "{{name}}?serviceAccountName={{service_account_name}}"
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -57,10 +56,6 @@ parameters:
   - !ruby/object:Api::Type::String
     name: 'serviceAccountName'
     url_param_only: true
-    # The API would support PATCHing the service account, but setting the
-    # update_mask accordingly for a url_param_only is currently not
-    # supported in magic-modules
-    immutable: true
     default_value: ''
     description: |
       Service account email. If this field is set, transfer config will

--- a/mmv1/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
@@ -156,12 +156,13 @@ func TestBigqueryDataTransferConfig_resourceBigqueryDTCParamsCustomDiffFuncForce
 // but it will get deleted by parallel tests, so they need to be run serially.
 func TestAccBigqueryDataTransferConfig(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"basic":           testAccBigqueryDataTransferConfig_scheduledQuery_basic,
-		"update":          testAccBigqueryDataTransferConfig_scheduledQuery_update,
-		"service_account": testAccBigqueryDataTransferConfig_scheduledQuery_with_service_account,
-		"no_destintation": testAccBigqueryDataTransferConfig_scheduledQuery_no_destination,
-		"booleanParam":    testAccBigqueryDataTransferConfig_copy_booleanParam,
-		"update_params":   testAccBigqueryDataTransferConfig_force_new_update_params,
+		"basic":                  testAccBigqueryDataTransferConfig_scheduledQuery_basic,
+		"update":                 testAccBigqueryDataTransferConfig_scheduledQuery_update,
+		"service_account":        testAccBigqueryDataTransferConfig_scheduledQuery_with_service_account,
+		"no_destintation":        testAccBigqueryDataTransferConfig_scheduledQuery_no_destination,
+		"booleanParam":           testAccBigqueryDataTransferConfig_copy_booleanParam,
+		"update_params":          testAccBigqueryDataTransferConfig_force_new_update_params,
+		"update_service_account": testAccBigqueryDataTransferConfig_scheduledQuery_update_service_account,
 	}
 
 	for name, tc := range testCases {
@@ -382,6 +383,78 @@ func testAccCheckBigqueryDataTransferConfigDestroyProducer(t *testing.T) func(s 
 	}
 }
 
+func testAccBigqueryDataTransferConfig_scheduledQuery_update_service_account(t *testing.T) {
+	random_suffix1 := RandString(t, 10)
+	random_suffix2 := RandString(t, 10)
+	transferConfigID := ""
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigqueryDataTransferConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryDataTransferConfig_scheduledQuery_updateServiceAccount(random_suffix1, random_suffix1),
+				Check:  testAccCheckDataTransferConfigID("google_bigquery_data_transfer_config.query_config", &transferConfigID),
+			},
+			{
+				ResourceName:            "google_bigquery_data_transfer_config.query_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "service_account_name"},
+			},
+			{
+				Config: testAccBigqueryDataTransferConfig_scheduledQuery_updateServiceAccount(random_suffix1, random_suffix2),
+				Check:  testAccCheckDataTransferConfigIDChange("google_bigquery_data_transfer_config.query_config", &transferConfigID),
+			},
+			{
+				ResourceName:            "google_bigquery_data_transfer_config.query_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "service_account_name"},
+			},
+		},
+	})
+}
+
+// Retrieve transfer config ID and stores it in transferConfigID
+func testAccCheckDataTransferConfigID(resourceName string, transferConfigID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Transfer config ID is not set")
+		}
+
+		*transferConfigID = rs.Primary.ID
+		return nil
+	}
+}
+
+// Check if transfer config ID matches the one stored in transferConfigID
+func testAccCheckDataTransferConfigIDChange(resourceName string, transferConfigID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Transfer config ID is not set")
+		}
+
+		if *transferConfigID != rs.Primary.ID {
+			return fmt.Errorf("Transfer config was recreated after changing service account")
+		}
+		return nil
+	}
+}
+
 func testAccBigqueryDataTransferConfig_scheduledQuery(random_suffix, random_suffix2, schedule, start_time, end_time, letter string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
@@ -581,4 +654,44 @@ resource "google_bigquery_data_transfer_config" "update_config" {
   }
 }
 `, random_suffix, random_suffix, random_suffix, path, random_suffix, table)
+}
+
+func testAccBigqueryDataTransferConfig_scheduledQuery_updateServiceAccount(random_suffix string, service_account string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {}
+
+resource "google_service_account" "bqwriter%s" {
+  account_id = "bqwriter%s"
+}
+
+resource "google_project_iam_member" "data_editor" {
+  project = data.google_project.project.project_id
+
+  role   = "roles/bigquery.dataEditor"
+  member = "serviceAccount:${google_service_account.bqwriter%s.email}"
+}
+
+resource "google_bigquery_dataset" "my_dataset" {
+  dataset_id    = "my_dataset%s"
+  friendly_name = "foo"
+  description   = "bar"
+  location      = "asia-northeast1"
+}
+
+resource "google_bigquery_data_transfer_config" "query_config" {
+  depends_on = [google_project_iam_member.data_editor]
+
+  display_name           = "my-query-%s"
+  location               = "asia-northeast1"
+  data_source_id         = "scheduled_query"
+  schedule               = "every 15 minutes"
+  destination_dataset_id = google_bigquery_dataset.my_dataset.dataset_id
+  service_account_name   = google_service_account.bqwriter%s.email
+  params = {
+    destination_table_name_template = "my_table"
+    write_disposition               = "WRITE_APPEND"
+    query                           = "SELECT 1 AS a"
+  }
+}
+`, service_account, service_account, service_account, random_suffix, random_suffix, service_account)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Changing service account name of a bigquery transfer config forces replacement of the transfer config, which is unnecessary. This change makes the service account name mutable and adds a handwritten test for service account name change.

fixes issue [#14123](https://github.com/hashicorp/terraform-provider-google/issues/14123)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: made service account name mutable in bigquerydatatransfer config
```
