### PR TITLE
Adding in additional field for provisioned_throughput for Hyper disk Throughput SKUs

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -430,11 +430,20 @@ properties:
     name: 'provisionedIops'
     description: |
       Indicates how many IOPS must be provisioned for the disk.
-      Note: Update currently only supported by hyperdisk skus, allowing for an update of IOPS every 4 hours
+      Note: Update currently only supported by hyperdisk skus, allowing for an update of IOPS every 4 hours without deletion and recreations
     required: false
     default_from_api: true
     update_verb: :PATCH
     update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=provisionedIops'
+  - !ruby/object:Api::Type::Integer
+    name: 'provisionedThroughput'
+    description: |
+      Indicates how much Throughput must be provisioned for the disk.
+      Note: Update currently only supported by hyperdisk skus, allowing for an update of Throughput every 4 hours without deletion and recreations
+    required: false
+    default_from_api: true
+    update_verb: :PATCH
+    update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=provisionedThroughput'
   - !ruby/object:Api::Type::NestedObject
     name: 'asyncPrimaryDisk'
     min_version: 'beta'

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -430,7 +430,8 @@ properties:
     name: 'provisionedIops'
     description: |
       Indicates how many IOPS must be provisioned for the disk.
-      Note: Update currently only supported by hyperdisk skus, allowing for an update of IOPS every 4 hours without deletion and recreations
+      Note: Updating currently is only supported by hyperdisk skus without the need to delete and recreate the disk, hyperdisk
+      allows for an update of IOPS every 4 hours. To update your hyperdisk more frequently, you'll need to manually delete and recreate it 
     required: false
     default_from_api: true
     update_verb: :PATCH
@@ -439,8 +440,8 @@ properties:
     name: 'provisionedThroughput'
     description: |
       Indicates how much Throughput must be provisioned for the disk.
-      Note: Update currently only supported by hyperdisk skus, allowing for an update of Throughput every 4 hours without deletion and recreations
-    required: false
+      Note: Updating currently is only supported by hyperdisk skus without the need to delete and recreate the disk, hyperdisk
+      allows for an update of Throughput every 4 hours. To update your hyperdisk more frequently, you'll need to manually delete and recreate it 
     default_from_api: true
     update_verb: :PATCH
     update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=provisionedThroughput'

--- a/mmv1/templates/terraform/update_encoder/hyper_disk.go.erb
+++ b/mmv1/templates/terraform/update_encoder/hyper_disk.go.erb
@@ -1,5 +1,5 @@
 
-if d.HasChange("provisioned_iops") && strings.Contains(d.Get("type").(string), "hyperdisk"){
+if (d.HasChange("provisioned_iops") && strings.Contains(d.Get("type").(string), "hyperdisk")) || (d.HasChange("provisioned_throughput") && strings.Contains(d.Get("type").(string), "hyperdisk")) {
     nameProp := d.Get("name")
     if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, nameProp)) {
         obj["name"] = nameProp

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -409,6 +409,64 @@ func TestAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(t *testing.T) {
 	})
 }
 
+func TestAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(t *testing.T) {
+	t.Parallel()
+
+	context_1 := map[string]interface{}{
+		"random_suffix":          RandString(t, 10),
+		"provisioned_throughput": 180,
+		"disk_size":              2048,
+		"lifecycle_bool":         true,
+		"zone":                   "us-east4-c"
+	}
+	context_2 := map[string]interface{}{
+		"random_suffix":          context_1["random_suffix"],
+		"provisioned_throughput": 20,
+		"disk_size":              2048,
+		"lifecycle_bool":         true,
+		"zone":                   "us-east4-c"
+	}
+	context_3 := map[string]interface{}{
+		"random_suffix":          context_1["random_suffix"],
+		"provisioned_throughput": 20,
+		"disk_size":              2048,
+		"lifecycle_bool":         true,
+		"zone":                   "us-east4-c"
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context_1),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context_2),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context_3),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeDisk_fromSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -987,6 +1045,23 @@ func testAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(context map[string]i
 	  }
 `, context)
 }
+
+func testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context map[string]interface{}) string {
+	return Nprintf(`
+	resource "google_compute_disk" "foobar" {
+		name  = "tf-test-hyperdisk-%{random_suffix}"
+		type = "hyperdisk-throughput"
+		# Not currenlty in all regions
+		zone  = "%{zone}"
+		provisioned_throughput = %{provisioned_throughput}
+		size = %{disk_size}
+		lifecycle {
+		  prevent_destroy = %{lifecycle_bool}
+		}
+	  }
+`, context)
+}
+
 
 
 func testAccComputeDisk_pdExtremeImplicitProvisionedIops(diskName string) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -1042,7 +1042,7 @@ func testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context map[st
 	resource "google_compute_disk" "foobar" {
 		name                   = "tf-test-hyperdisk-%{random_suffix}"
 		type                   = "hyperdisk-throughput"
-		zone                   = "us-east4-c""
+		zone                   = "us-east4-c"
 		provisioned_throughput = %{provisioned_throughput}
 		size                   = 2048
 		lifecycle {
@@ -1051,7 +1051,6 @@ func testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context map[st
 	  }
 `, context)
 }
-
 
 
 func testAccComputeDisk_pdExtremeImplicitProvisionedIops(diskName string) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -360,19 +360,16 @@ func TestAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(t *testing.T) {
 	context_1 := map[string]interface{}{
 		"random_suffix":    RandString(t, 10),
 		"provisioned_iops": 10000,
-		"disk_size":        64,
 		"lifecycle_bool":   true,
 	}
 	context_2 := map[string]interface{}{
 		"random_suffix":    context_1["random_suffix"],
 		"provisioned_iops": 11000,
-		"disk_size":        64,
 		"lifecycle_bool":   true,
 	}
 	context_3 := map[string]interface{}{
 		"random_suffix":    context_1["random_suffix"],
 		"provisioned_iops": 11000,
-		"disk_size":        64,
 		"lifecycle_bool":   false,
 	}
 
@@ -415,23 +412,17 @@ func TestAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(t *testing.T) 
 	context_1 := map[string]interface{}{
 		"random_suffix":          RandString(t, 10),
 		"provisioned_throughput": 180,
-		"disk_size":              2048,
 		"lifecycle_bool":         true,
-		"zone":                   "us-east4-c"
 	}
 	context_2 := map[string]interface{}{
 		"random_suffix":          context_1["random_suffix"],
 		"provisioned_throughput": 20,
-		"disk_size":              2048,
 		"lifecycle_bool":         true,
-		"zone":                   "us-east4-c"
 	}
 	context_3 := map[string]interface{}{
 		"random_suffix":          context_1["random_suffix"],
 		"provisioned_throughput": 20,
-		"disk_size":              2048,
-		"lifecycle_bool":         true,
-		"zone":                   "us-east4-c"
+		"lifecycle_bool":         false,
 	}
 
 	VcrTest(t, resource.TestCase{
@@ -1035,12 +1026,12 @@ resource "google_compute_instance_group_manager" "manager" {
 func testAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(context map[string]interface{}) string {
 	return Nprintf(`
 	resource "google_compute_disk" "foobar" {
-		name  = "tf-test-hyperdisk-%{random_suffix}"
-		type = "hyperdisk-extreme"
-		provisioned_iops = %{provisioned_iops}
-		size = %{disk_size}
+		name                    = "tf-test-hyperdisk-%{random_suffix}"
+		type                    = "hyperdisk-extreme"
+		provisioned_iops        = %{provisioned_iops}
+		size                    = 64
 		lifecycle {
-		  prevent_destroy = %{lifecycle_bool}
+		  prevent_destroy       = %{lifecycle_bool}
 		}
 	  }
 `, context)
@@ -1049,14 +1040,13 @@ func testAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(context map[string]i
 func testAccComputeDisk_pdHyperDiskProvisionedThroughputLifeCycle(context map[string]interface{}) string {
 	return Nprintf(`
 	resource "google_compute_disk" "foobar" {
-		name  = "tf-test-hyperdisk-%{random_suffix}"
-		type = "hyperdisk-throughput"
-		# Not currenlty in all regions
-		zone  = "%{zone}"
+		name                   = "tf-test-hyperdisk-%{random_suffix}"
+		type                   = "hyperdisk-throughput"
+		zone                   = "us-east4-c""
 		provisioned_throughput = %{provisioned_throughput}
-		size = %{disk_size}
+		size                   = 2048
 		lifecycle {
-		  prevent_destroy = %{lifecycle_bool}
+		  prevent_destroy      = %{lifecycle_bool}
 		}
 	  }
 `, context)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Launched this week for GCP [Doc link](https://cloud.google.com/compute/docs/disks/modify-hyperdisks#expandable-1) adding in functionality for modification and setting of provisioned_throughput


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement 
compute: added `provisioned_throughput` field to `google_compute_disk` used by `hyperdisk-throughput` pd type
```
