### PR TITLE
fix enforce_on_key_configs

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -280,7 +280,6 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 									"enforce_on_key_configs": {
 										Type:        schema.TypeList,
 										Description: `Enforce On Key Config of this security policy`,
-										ForceNew:    true,
 										Optional:    true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -5,6 +5,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+<% if version != 'ga' -%>
+	"strings"
+<% end -%>
 
 	"time"
 
@@ -771,7 +774,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-
+	<% if version == 'ga' -%>
 	if d.HasChange("rule") {
 		o, n := d.GetChange("rule")
 		oSet := o.(*schema.Set)
@@ -787,12 +790,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			priority := int64(rule.(map[string]interface{})["priority"].(int))
 			nPriorities[priority] = true
 			if !oPriorities[priority] {
-			<% if version == 'ga' -%>
 				client := config.NewComputeClient(userAgent)
-			<% else -%>
-				client := config.NewComputeClient(userAgent)
-			<% end -%>
-
 				// If the rule is in new and its priority does not exist in old, then add it.
 				op, err := client.SecurityPolicies.AddRule(project, sp, expandSecurityPolicyRule(rule)).Do()
 
@@ -805,11 +803,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return err
 				}
 			} else if !oSet.Contains(rule) {
-			<% if version == 'ga' -%>
 				client := config.NewComputeClient(userAgent)
-			<% else -%>
-				client := config.NewComputeClient(userAgent)
-			<% end -%>
 
 				// If the rule is in new, and its priority is in old, but its hash is different than the one in old, update it.
 				op, err := client.SecurityPolicies.PatchRule(project, sp, expandSecurityPolicyRule(rule)).Priority(priority).Do()
@@ -828,11 +822,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 		for _, rule := range oSet.List() {
 			priority := int64(rule.(map[string]interface{})["priority"].(int))
 			if !nPriorities[priority] {
-			<% if version == 'ga' -%>
 				client := config.NewComputeClient(userAgent)
-			<% else -%>
-				client := config.NewComputeClient(userAgent)
-			<% end -%>
 
 				// If the rule's priority is in old but not new, remove it.
 				op, err := client.SecurityPolicies.RemoveRule(project, sp).Priority(priority).Do()
@@ -848,6 +838,109 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			}
 		}
 	}
+
+	<% else -%>
+	if d.HasChange("rule") {
+		o, n := d.GetChange("rule")
+		oSet := o.(*schema.Set)
+		nSet := n.(*schema.Set)
+
+		oPriorities := map[int64]bool{}
+		nPriorities := map[int64]bool{}
+		oRules := make(map[int64]map[string]interface{})
+		nRules := make(map[int64]map[string]interface{})
+
+		for _, rule := range oSet.List() {
+			oPriorities[int64(rule.(map[string]interface{})["priority"].(int))] = true
+			oRules[int64(rule.(map[string]interface{})["priority"].(int))] = rule.(map[string]interface{})
+		}
+
+		for _, rule := range nSet.List() {
+			nRules[int64(rule.(map[string]interface{})["priority"].(int))] = rule.(map[string]interface{})
+			priority := int64(rule.(map[string]interface{})["priority"].(int))
+			nPriorities[priority] = true
+
+			if !oPriorities[priority] {
+				client := config.NewComputeClient(userAgent)
+
+				// If the rule is in new and its priority does not exist in old, then add it.
+				op, err := client.SecurityPolicies.AddRule(project, sp, expandSecurityPolicyRule(rule)).Do()
+
+				if err != nil {
+					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
+				}
+
+				err = ComputeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), userAgent, d.Timeout(schema.TimeoutUpdate))
+				if err != nil {
+					return err
+				}
+			} else if !oSet.Contains(rule) {
+
+				oMap := make(map[string]interface{})
+				nMap := make(map[string]interface{})
+
+				updateMask := []string{}
+
+				if oRules[priority]["rate_limit_options"] != nil {
+					for _, oValue := range oRules[priority]["rate_limit_options"].([]interface{}) {
+						oMap = oValue.(map[string]interface{})
+					}
+				}
+
+				if nRules[priority]["rate_limit_options"] != nil {
+					for _, nValue := range nRules[priority]["rate_limit_options"].([]interface{}) {
+						nMap = nValue.(map[string]interface{})
+					}
+				}
+
+				if fmt.Sprintf("%v", oMap["enforce_on_key"]) != fmt.Sprintf("%v", nMap["enforce_on_key"]) {
+					updateMask = append(updateMask, "rate_limit_options.enforce_on_key")
+				}
+
+				if fmt.Sprintf("%v", oMap["enforce_on_key_configs"]) != fmt.Sprintf("%v", nMap["enforce_on_key_configs"]) {
+					updateMask = append(updateMask, "rate_limit_options.enforce_on_key_configs")
+				}
+
+				if fmt.Sprintf("%v", oMap["enforce_on_key_name"]) != fmt.Sprintf("%v", nMap["enforce_on_key_name"]) {
+					updateMask = append(updateMask, "rate_limit_options.enforce_on_key_name")
+				}
+
+				client := config.NewComputeClient(userAgent)
+
+				// If the rule is in new, and its priority is in old, but its hash is different than the one in old, update it.
+				op, err := client.SecurityPolicies.PatchRule(project, sp, expandSecurityPolicyRule(rule)).Priority(priority).UpdateMask(strings.Join(updateMask, ",")).Do()
+
+				if err != nil {
+					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
+				}
+
+				err = ComputeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), userAgent, d.Timeout(schema.TimeoutUpdate))
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		for _, rule := range oSet.List() {
+			priority := int64(rule.(map[string]interface{})["priority"].(int))
+			if !nPriorities[priority] {
+				client := config.NewComputeClient(userAgent)
+
+				// If the rule's priority is in old but not new, remove it.
+				op, err := client.SecurityPolicies.RemoveRule(project, sp).Priority(priority).Do()
+
+				if err != nil {
+					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
+				}
+
+				err = ComputeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), userAgent, d.Timeout(schema.TimeoutUpdate))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	<% end -%>
 
 	return resourceComputeSecurityPolicyRead(d, meta)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -365,6 +365,14 @@ func TestAccComputeSecurityPolicy_EnforceOnKeyUpdates(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccComputeSecurityPolicy_withRateLimitOptions_withoutRateLimitOptions(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccComputeSecurityPolicy_withRateLimitOptions_withEnforceOnKeyName(spName),
 			},
 			{
@@ -396,9 +404,18 @@ func TestAccComputeSecurityPolicy_EnforceOnKeyUpdates(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeSecurityPolicy_withRateLimitOptions_withEnforceOnKeyName(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
+
 
 <% end -%>
 
@@ -1262,6 +1279,27 @@ resource "google_compute_security_policy" "policy" {
 				interval_sec = 60
 			}
 		}
+	}
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withRateLimitOptions_withoutRateLimitOptions(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name        = "%s"
+	description = "throttle rule with enforce_on_key_configs"
+
+	rule {
+		action   = "deny(403)"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
 	}
 }
 `, spName)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14905


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed wrongly trigger recreation on changes of `enforce_on_key_configs` on `google_compute_security_policy`
```
