### PR TITLE
Add example of Function v2 and Scheduler HTTP trigger with auth

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -92,6 +92,25 @@ examples:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudfunctions2_scheduler_auth'
+    primary_resource_id: 'function'
+    vars:
+      bucket_name: 'gcf-source'
+      service_account: 'gcf-sa'
+      function: 'gcf-function'
+      zip_path: 'function-source.zip'
+    test_env_vars:
+      project: :PROJECT_NAME
+    test_vars_overrides:
+      zip_path: '"./test-fixtures/cloudfunctions2/function-source.zip"'
+      primary_resource_id: '"terraform-test"'
+      location:
+        '"us-central1"'
+        # ignore these fields during import step
+    ignore_read_extra:
+      - 'build_config.0.source.0.storage_source.0.object'
+      - 'build_config.0.source.0.storage_source.0.bucket'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_basic_gcs'
     primary_resource_id: 'function'
     vars:

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -110,7 +110,7 @@ examples:
     ignore_read_extra:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
-    skip_test: true 
+    skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_basic_gcs'
     primary_resource_id: 'function'

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -110,6 +110,7 @@ examples:
     ignore_read_extra:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
+    skip_test: true 
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_basic_gcs'
     primary_resource_id: 'function'

--- a/mmv1/templates/terraform/examples/cloudfunctions2_scheduler_auth.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_scheduler_auth.tf.erb
@@ -1,0 +1,80 @@
+# [START function_v2_scheduler_auth]
+locals {
+  project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
+}
+
+resource "google_service_account" "account" {
+  account_id   = "<%= ctx[:vars]['service_account'] %>"
+  display_name = "Test Service Account"
+}
+
+resource "google_storage_bucket" "bucket" {
+  name                        = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  location                    = "US"
+  uniform_bucket_level_access = true
+}
+ 
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "<%= ctx[:vars]['zip_path'] %>"  # Add path to the zipped function source code
+}
+
+resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['function'] %>" # name should use kebab-case so generated Cloud Run service name will be the same
+  location    = "us-central1"
+  description = "a new function"
+ 
+  build_config {
+    runtime     = "nodejs16"
+    entry_point = "helloHttp"  # Set the entry point
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+ 
+  service_config {
+    min_instance_count    = 1
+    available_memory      = "256M"
+    timeout_seconds       = 60
+    service_account_email = google_service_account.account.email
+  }
+}
+
+resource "google_cloudfunctions2_function_iam_member" "invoker" {
+  project        = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.project
+  location       = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.location
+  cloud_function = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "serviceAccount:${google_service_account.account.email}"
+}
+
+resource "google_cloud_run_service_iam_member" "cloud_run_invoker" {
+  project  = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.project
+  location = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.location
+  service  = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.account.email}"
+}
+
+resource "google_cloud_scheduler_job" "invoke_cloud_function" {
+  name        = "invoke-<%= ctx[:vars]['function'] %>"
+  description = "Schedule the HTTPS trigger for cloud function"
+  schedule    = "0 0 * * *" # every day at midnight
+  project     = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.project
+  region      = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.location
+
+  http_target {
+    uri         = google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.service_config[0].uri
+    http_method = "POST"
+    oidc_token {
+      audience              = "${google_cloudfunctions2_function.<%= ctx[:primary_resource_id] %>.service_config[0].uri}/"
+      service_account_email = google_service_account.account.email
+    }
+  }
+}
+
+# [END function_v2_scheduler_auth]


### PR DESCRIPTION
### Why I'm proposing this PR

I had pretty hard time making Terraform work with Cloud Function V2 and Cloud Scheduler http trigger with authentication. I could not find any examples in docs about such setup, so I want to share a working example in documentation and save some hours of debugging for other people. 

Also:

- GCP docs are not really clear on how IAM should be specified in case of http trigger with auth. There are some `gcloud` commands in docs [but they does not work as expected](https://issuetracker.google.com/issues/284853816).
- It is not easy to translate docs to Terraform config.
- Existing Terraform examples do not provide answer to auth configuration on CF service level. There were some project level IAM in examples but project level is too permissive imho.
- It was not very clear that when creating CF v2 it will also create Cloud Run service and you need to add proper IAM there too.
- Existing examples for CF that set IAM permissions are only setting `roles/run.invoker` on project level but based on my tests you also need to set `roles/cloudfunctions.invoker` to CR service account to make it work.
- When doing some tests I found out that even when you use function name with underscores like `function_name`, associated Cloud Run service name will use dash like `function-name`. I've added a comment suggesting to use `kebab-case` for function names in this case.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```