### PR TITLE
Add support for more fields to URL Map tests

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -1923,6 +1923,9 @@ properties:
       succeed only if all of the test cases pass. You can specify a maximum of 100
       tests per UrlMap.
     item_type: !ruby/object:Api::Type::NestedObject
+      exactly_one_of:
+        - service
+        - expected_redirect_response_code
       properties:
         - !ruby/object:Api::Type::String
           name: 'description'
@@ -1945,6 +1948,42 @@ properties:
           required: true
           description: The backend service or backend bucket link that should be matched by this test.
           custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+        - !ruby/object:Api::Type::Array
+          name: 'headers'
+          description: |
+            HTTP headers for this request. If headers contains a host header, then host must also match the header value.
+          item_type: !ruby/object:Api::Type::NestedObject
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'name'
+                required: true
+                description: |
+                  Header name.
+              - !ruby/object:Api::Type::String
+                name: 'value'
+                required: true
+                description: |
+                  Header value.
+        - !ruby/object:Api::Type::String
+          name: 'expected_output_url'
+          required: true
+          description: |
+            The expected output URL evaluated by the load balancer containing the scheme, host, path and query parameters.
+            For rules that forward requests to backends, the test passes only when expectedOutputUrl matches the request
+            forwarded by the load balancer to backends. For rules with urlRewrite, the test verifies that the forwarded
+            request matches hostRewrite and pathPrefixRewrite in the urlRewrite action. When service is specified,
+            expectedOutputUrl`s scheme is ignored.
+            For rules with urlRedirect, the test passes only if expectedOutputUrl matches the URL in the load balancer's
+            redirect response. If urlRedirect specifies httpsRedirect, the test passes only if the scheme in
+            expectedOutputUrl is also set to HTTPS. If urlRedirect specifies stripQuery, the test passes only if
+            expectedOutputUrl does not contain any query parameters.
+            expectedOutputUrl is optional when service is specified.
+        - !ruby/object:Api::Type::Integer
+          name: 'expected_redirect_response_code'
+          required: true
+          description: |
+            For rules with urlRedirect, the test passes only if expectedRedirectResponseCode matches the HTTP status code in load balancer's redirect response.
+            expectedRedirectResponseCode cannot be set when service is set.
   - !ruby/object:Api::Type::NestedObject
     name: 'defaultUrlRedirect'
     exactly_one_of:

--- a/mmv1/templates/terraform/examples/url_map_path_template_match.tf.erb
+++ b/mmv1/templates/terraform/examples/url_map_path_template_match.tf.erb
@@ -34,6 +34,15 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
       service = google_compute_backend_service.user-backend.id
       priority = 2
     }
+
+    route_rules {
+      match_rules {
+        path_template_match = "/xyzwebservices/v2/xyz/users/*/orders/*"
+      }
+      url_redirect {
+        hostRedirect = "mysite2.com"
+      }
+    }
   }
 
   test {
@@ -42,6 +51,17 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
     path    = "/xyzwebservices/v2/xyz/users/123/carts/456"
     expected_output_url = "http://mysite.com/123-456"
     service = google_compute_backend_service.cart-backend.id
+  }
+
+  test {
+    host    = "mysite.com"
+    path    = "/xyzwebservices/v2/xyz/users/123/orders/456"
+    headers {
+      name  = "X-Test-Header"
+      value = "my-value"
+    }
+    expected_output_url = "http://mysite2.com/xyzwebservices/v2/xyz/users/123/orders/456"
+    expected_redirect_response_code = 301
   }
 }
 

--- a/mmv1/templates/terraform/examples/url_map_path_template_match.tf.erb
+++ b/mmv1/templates/terraform/examples/url_map_path_template_match.tf.erb
@@ -35,6 +35,14 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
       priority = 2
     }
   }
+
+  test {
+    service = google_compute_backend_bucket.static.id
+    host    = "mysite.com"
+    path    = "/xyzwebservices/v2/xyz/users/123/carts/456"
+    expected_output_url = "http://mysite.com/123-456"
+    service = google_compute_backend_service.cart-backend.id
+  }
 }
 
 resource "google_compute_backend_service" "cart-backend" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

* `tests[].headers[].name`
* `tests[].headers[].value`
* `tests[].expectedOutputUrl`
* `tests[].expectedRedirectResponseCode`

https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps/insert

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).  
  See https://github.com/hashicorp/terraform-provider-google/issues/9536
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add support for more fields to URL Map tests
```
