### PR TITLE
Add annotations support for v2 Cloud Run Job resource

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -132,12 +132,20 @@ properties:
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'labels'
     description: |-
-      KRM-style labels for the resource. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component, environment, state, etc. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels Cloud Run will populate some labels with 'run.googleapis.com' or 'serving.knative.dev' namespaces. Those labels are read-only, and user changes will not be preserved.
-  # blocked on b/244872932
-  # - !ruby/object:Api::Type::KeyValuePairs
-  #   name: "annotations"
-  #   description: |-
-  #     KRM-style annotations for the resource. Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects. Cloud Run will populate some annotations using 'run.googleapis.com' or 'serving.knative.dev' namespaces. This field follows Kubernetes annotations' namespacing, limits, and rules. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+      Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component,
+      environment, state, etc. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels.
+
+      Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+      All system labels in v1 now have a corresponding field in v2 Job.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: "annotations"
+    description: |-
+      Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
+
+      Cloud Run API v2 does not support annotations with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected on new resources.
+      All system annotations in v1 now have a corresponding field in v2 Job.
+
+      This field follows Kubernetes annotations' namespacing, limits, and rules.
   - !ruby/object:Api::Type::String
     name: 'client'
     description: |
@@ -184,12 +192,21 @@ properties:
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |-
-          KRM-style labels for the resource.
-      # blocked on b/244872932
-      # - !ruby/object:Api::Type::KeyValuePairs
-      #   name: "annotations"
-      #   description: |-
-      #     KRM-style annotations for the resource.
+          Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter,
+          or break down billing charges by team, component, environment, state, etc. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or
+          https://cloud.google.com/run/docs/configuring/labels.
+
+          Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+          All system labels in v1 now have a corresponding field in v2 ExecutionTemplate.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: "annotations"
+        description: |-
+          Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
+
+          Cloud Run API v2 does not support annotations with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+          All system annotations in v1 now have a corresponding field in v2 ExecutionTemplate.
+
+          This field follows Kubernetes annotations' namespacing, limits, and rules.
       - !ruby/object:Api::Type::Integer
         name: 'parallelism'
         description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -147,11 +147,20 @@ properties:
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'labels'
     description: |-
-      Map of string keys and values that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component, environment, state, etc. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels Cloud Run will populate some labels with 'run.googleapis.com' or 'serving.knative.dev' namespaces. Those labels are read-only, and user changes will not be preserved.
+      Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component,
+      environment, state, etc. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels.
+
+      Cloud Run API v2 does not support labels with  `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+      All system labels in v1 now have a corresponding field in v2 Service.
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'annotations'
     description: |-
-      Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects. Cloud Run will populate some annotations using 'run.googleapis.com' or 'serving.knative.dev' namespaces. This field follows Kubernetes annotations' namespacing, limits, and rules. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+      Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
+
+      Cloud Run API v2 does not support annotations with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected in new resources.
+      All system annotations in v1 now have a corresponding field in v2 Service.
+
+      This field follows Kubernetes annotations' namespacing, limits, and rules.
   - !ruby/object:Api::Type::String
     name: 'client'
     description: |
@@ -211,11 +220,20 @@ properties:
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |-
-          KRM-style labels for the resource.
+          Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component, environment, state, etc.
+          For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels.
+
+          Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+          All system labels in v1 now have a corresponding field in v2 RevisionTemplate.
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'annotations'
         description: |-
-          KRM-style annotations for the resource.
+          Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
+
+          Cloud Run API v2 does not support annotations with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+          All system annotations in v1 now have a corresponding field in v2 RevisionTemplate.
+
+          This field follows Kubernetes annotations' namespacing, limits, and rules.
       - !ruby/object:Api::Type::NestedObject
         name: 'scaling'
         description: |

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_job_test.go
@@ -49,12 +49,18 @@ func testAccCloudRunV2Job_cloudrunv2JobFull(context map[string]interface{}) stri
     labels = {
       label-1 = "value-1"
     }
+    annotations = {
+      job-annotation-1 = "job-value-1"
+    }
     client = "client-1"
     client_version = "client-version-1"
     
     template {
       labels = {
         label-1 = "value-1"
+      }
+      annotations = {
+        temp-annotation-1 = "temp-value-1"
       }
       parallelism = 4
       task_count = 4
@@ -115,12 +121,18 @@ resource "google_cloud_run_v2_job" "default" {
   labels = {
     label-1 = "value-update"
   }
+  annotations = {
+    job-annotation-1 = "job-value-update"
+  }
   client = "client-update"
   client_version = "client-version-update"
   
   template {
     labels = {
       label-1 = "value-update"
+    }
+    annotations = {
+      temp-annotation-1 = "temp-value-update"
     }
     parallelism = 2
     task_count = 8


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add annotations support for v2 Cloud Run Job resource. Also update the description of fields `annotations` and `labels`.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

cloudrunv2: added fields `annotations` and `template.annotations` to resource `google_cloud_run_v2_job`
```
