### PR TITLE
Move sweeper FirebaseAndroidApp to the service package

### DIFF
--- a/mmv1/third_party/terraform/acctest/gcp_sweeper.go
+++ b/mmv1/third_party/terraform/acctest/gcp_sweeper.go
@@ -2,8 +2,10 @@ package acctest
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -52,4 +54,12 @@ func IsSweepableTestResource(resourceName string) bool {
 		}
 	}
 	return false
+}
+
+func AddTestSweepers(name string, sweeper func(region string) error) {
+	_, filename, _, _ := runtime.Caller(0)
+	resource.AddTestSweepers(name+filename, &resource.Sweeper{
+		Name: name,
+		F:    sweeper,
+	})
 }

--- a/mmv1/third_party/terraform/acctest/gcp_sweeper.go
+++ b/mmv1/third_party/terraform/acctest/gcp_sweeper.go
@@ -1,7 +1,9 @@
 package acctest
 
 import (
+	"encoding/hex"
 	"fmt"
+	"hash/crc32"
 	"runtime"
 	"strings"
 
@@ -58,7 +60,12 @@ func IsSweepableTestResource(resourceName string) bool {
 
 func AddTestSweepers(name string, sweeper func(region string) error) {
 	_, filename, _, _ := runtime.Caller(0)
-	resource.AddTestSweepers(name+filename, &resource.Sweeper{
+	hash := crc32.NewIEEE()
+	hash.Write([]byte(filename))
+	hashedFilename := hex.EncodeToString(hash.Sum(nil))
+	uniqueName := name + "_" + hashedFilename
+
+	resource.AddTestSweepers(uniqueName, &resource.Sweeper{
 		Name: name,
 		F:    sweeper,
 	})

--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_sweeper.go
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_sweeper.go
@@ -1,4 +1,4 @@
-package google
+package firebase
 
 import (
 	"context"

--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_sweeper.go
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_sweeper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -14,7 +15,8 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("FirebaseAndroidApp", &resource.Sweeper{
+	_, filename, _, _ := runtime.Caller(0)
+	resource.AddTestSweepers("FirebaseAndroidApp"+filename, &resource.Sweeper{
 		Name: "FirebaseAndroidApp",
 		F:    testSweepFirebaseAndroidApp,
 	})

--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_sweeper.go
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_sweeper.go
@@ -4,22 +4,16 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"runtime"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func init() {
-	_, filename, _, _ := runtime.Caller(0)
-	resource.AddTestSweepers("FirebaseAndroidApp"+filename, &resource.Sweeper{
-		Name: "FirebaseAndroidApp",
-		F:    testSweepFirebaseAndroidApp,
-	})
+	acctest.AddTestSweepers("FirebaseAndroidApp", testSweepFirebaseAndroidApp)
 }
 
 // At the time of writing, the CI only passes us-central1 as the region

--- a/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
@@ -1,4 +1,4 @@
-package google_test
+package google
 
 import (
 	"testing"

--- a/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
@@ -1,9 +1,11 @@
-package google
+package google_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	_ "github.com/hashicorp/terraform-provider-google/google/services/firebase"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This reverts commit aad16c50e8589dda9162acc72d44c05488a50826.

Also, append the file name to the sweeper name to make it unique.


<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
