### PR TITLE
Cleaned up how magic modules works document

### DIFF
--- a/docs/content/get-started/how-magic-modules-works.md
+++ b/docs/content/get-started/how-magic-modules-works.md
@@ -18,7 +18,7 @@ There are three types of resources supported by Magic Modules: MMv1, Handwritten
 
 ### MMv1
 
-MMv1 consists of a set of "products", which each contain one or more "resources".
+MMv1 consists of a set of "products"; each product contains one or more "resources".
 
 Each product has a folder in [`magic-modules/mmv1/products`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/products). The name of the folder is the "product name", which usually corresponds to the API subdomain covered by the product (such as `compute.googleapis.com`). Each product folder contains a product configuration file (`product.yaml`) and one or more resource configuration files (`ResourceName.yaml`). The actual name of a `ResourceName.yaml` file usually matches the name of a GCP API resource in the product's subdomain.
 

--- a/docs/content/get-started/how-magic-modules-works.md
+++ b/docs/content/get-started/how-magic-modules-works.md
@@ -8,7 +8,7 @@ aliases:
 
 # How Magic Modules works
 
-Magic Modules can be thought of as a source of truth for how to map a GCP API resource representation to a Terraform resource representation. Magic Modules uses that mapping (and additional handwritten code where necessary) to generate "downstream" repositories - in particular, the Terraform providers for Google Platform: [`google`](https://github.com/hashicorp/terraform-provider-google) (or TPG) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta) (or TPGB).
+Magic Modules can be thought of as a source of truth for how to map a GCP API resource representation to a Terraform resource (or datasource) representation. Magic Modules uses that mapping (and additional handwritten code where necessary) to generate "downstream" repositories - in particular, the Terraform providers for Google Platform: [`google`](https://github.com/hashicorp/terraform-provider-google) (or TPG) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta) (or TPGB).
 
 Generation of the downstream repositories happens for every new commit in a PR (to a temporary branch owned by the [`modular-magician`](https://github.com/modular-magician/) robot user) and on every merge into the main branch (to the main branch of downstreams). Generation for PR commits allows contributors to manually examine the changes, as well as allowing automatic running of unit tests, acceptance tests, and automated checks such as breaking change detection.
 
@@ -18,18 +18,43 @@ There are three types of resources supported by Magic Modules: MMv1, Handwritten
 
 ### MMv1
 
-MMv1 is a Ruby-based code generator that implements Terraform Provider Google (TPG) resources from YAML specification files.
+MMv1 consists of a set of "products", which each contain one or more "resources".
 
-MMv1-generated resources like [google_compute_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) can be identified by looking in their [Go source](https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_compute_address.go) for an `AUTO GENERATED CODE` header as well as a Type `MMv1`. MMv1-generated resources should have source code present under their product folders, like [mmv1/products/compute](./products/compute) for the [google_compute_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) resource.
+Each product has a folder in [`magic-modules/mmv1/products`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/products). The name of the folder is the "product name", which usually corresponds to the API subdomain covered by the product (such as `compute.googleapis.com`). Each product folder contains a product configuration file (`product.yaml`) and one or more resource configuration files (`ResourceName.yaml`). The actual name of a `ResourceName.yaml` file usually matches the name of a GCP API resource in the product's subdomain.
+
+MMv1 resource configurations may reference handwritten code stored in [`magic-modules/mmv1/templates/terraform`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform), which will be injected into the generated resource file. Many MMv1 resources also have one or more handwritten tests, which are stored in [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests)
+
+In the providers, MMv1-based resources are stored in `PROVIDER/services/PRODUCT/resource_PRODUCT_RESOURCE.go`, where `PROVIDER` is `google` or `google-beta`, `PRODUCT` is the product name, and RESOURCE is the GCP API resource's name converted to [snake case ↗](https://en.wikipedia.org/wiki/Snake_case).
+
+MMv1-based files start with the following header:
+
+```
+***     AUTO GENERATED CODE    ***    Type: MMv1     ***
+```
 
 ### Handwritten
 
-Handwritten resources like [google_container_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) can be identified if they have source code present under the [mmv1/third_party/terraform/resources](./resources) folder or by the absence of the `AUTO GENERATED CODE` header in their [Go source](https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_container_cluster.go) in the downstream repositories. Handwritten datasources should be under the [mmv1/third_party/terraform/data_sources](./data_sources) folder, tests under the [mmv1/third_party/terraform/tests](./tests) folder and web documentation under the [mmv1/third_party/terraform/website](./website) folder.
+Handwritten resources and datasources are technically part of MMv1; however, they are not generated from YAML configurations. Instead, they are written as Go code with minimal ruby "version guards" to exclude beta-only features from the `google` provider.
+
+Handwritten resources and datasources can be grouped by "service", which generally corresponds to the API subdomain the resource or datasource interacts with.
+
+In addition to the core implementation, handwritten resources and datasources will also have documentation, tests, and sweepers (which clean up stray resources left behind by tests). Each type of code is stored in the following locations:
+
+- Resource implementation: In the appropriate service folder inside [`magic-modules/mmv1/third_party/terraform/services`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/services)
+- Resource documentation: [`magic-modules/mmv1/third_party/terraform/website/docs/r`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/website/docs/r)
+- Datasource implementation: [`magic-modules/mmv1/third_party/terraform/data_sources`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/data_sources)
+- Datasource documentation: [`magic-modules/mmv1/third_party/terraform/webside/docs/d`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/webside/docs/d)
+- Tests: [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests)
+- Sweepers: [`magic-modules/mmv1/third_party/terraform/utils`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/utils)
+
+In the providers, handwritten resources and datasources are stored in `PROVIDER/services/SERVICE/FILENAME.go`, where `PROVIDER` is `google` or `google-beta`, `SERVICE` is the service name, and `FILENAME` is the name of the handwritten file in magic-modules. Handwritten files do not have an `AUTO GENERATED CODE` header.
 
 ### DCL aka tpgtools (maintenance mode)
 
-DCL is a Go-based code generator that implements Terraform Provider Google (TPG) resources from YAML specification files.
+DCL / tpgtools is similar to MMv1; however, it is in maintenance mode, which means that new resources using the DCL are not being added.
 
-DCL-generated resources like [google_bigquery_reservation_assignment](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_reservation_assignment) can be identified by looking in their [Go source](https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_bigquery_reservation_assignment.go) for an `AUTO GENERATED CODE` header as well as a Type `DCL`.
+DCL-based files start with the following header:
 
-DCL is in maintenance mode, which means that new resources using the DCL are not being added.
+```
+***     AUTO GENERATED CODE    ***    Type: DCL     ***
+```

--- a/docs/content/get-started/how-magic-modules-works.md
+++ b/docs/content/get-started/how-magic-modules-works.md
@@ -40,9 +40,8 @@ Handwritten resources and datasources can be grouped by "service", which general
 
 In addition to the core implementation, handwritten resources and datasources will also have documentation, tests, and sweepers (which clean up stray resources left behind by tests). Each type of code is stored in the following locations:
 
-- Resource implementation: In the appropriate service folder inside [`magic-modules/mmv1/third_party/terraform/services`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/services)
+- Resource & datasource implementation: In the appropriate service folder inside [`magic-modules/mmv1/third_party/terraform/services`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/services)
 - Resource documentation: [`magic-modules/mmv1/third_party/terraform/website/docs/r`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/website/docs/r)
-- Datasource implementation: [`magic-modules/mmv1/third_party/terraform/data_sources`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/data_sources)
 - Datasource documentation: [`magic-modules/mmv1/third_party/terraform/webside/docs/d`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/webside/docs/d)
 - Tests: [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests)
 - Sweepers: [`magic-modules/mmv1/third_party/terraform/utils`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/utils)


### PR DESCRIPTION
Set up a parallel construction that goes from broad organizational concepts to more detailed ones and links correctly to common code locations.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

![localhost_1313_magic-modules_get-started_how-magic-modules-works_ (2)](https://github.com/GoogleCloudPlatform/magic-modules/assets/299979/09460a50-68fe-4256-a89c-ac402849ac49)


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
