### PR TITLE
Enable public ca api

### DIFF
--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -382,13 +382,6 @@ resource "google_project_iam_member" "aiplatform_agent_encrypter_decrypter" {
   member  = "serviceAccount:service-${google_project.proj.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
 }
 
-# TestAccCertificateManagerPublicCAExternalAccountKey_certificateManagerPublicCaExternalAccountKeyExample
-resource "google_project_iam_member" "sa_public_ca_ext_account_key_creator" {
-  project = google_project.proj.project_id
-  role   = "roles/publicca.externalAccountKeyCreator"
-  member = google_service_account.sa.member
-}
-
 data "google_organization" "org2" {
   organization = var.org2_id
 }

--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -382,6 +382,7 @@ resource "google_project_iam_member" "aiplatform_agent_encrypter_decrypter" {
   member  = "serviceAccount:service-${google_project.proj.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
 }
 
+# TestAccCertificateManagerPublicCAExternalAccountKey_certificateManagerPublicCaExternalAccountKeyExample
 resource "google_project_iam_member" "sa_public_ca_ext_account_key_creator" {
   project = google_project.proj.project_id
   role   = "roles/publicca.externalAccountKeyCreator"

--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -271,6 +271,7 @@ module "project-services" {
     "privateca.googleapis.com",
     "pubsub.googleapis.com",
     "pubsublite.googleapis.com",
+    "publicca.googleapis.com",
     "recaptchaenterprise.googleapis.com",
     "redis.googleapis.com",
     "replicapool.googleapis.com",
@@ -379,6 +380,12 @@ resource "google_project_iam_member" "aiplatform_agent_encrypter_decrypter" {
   project = google_project.proj.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${google_project.proj.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "sa_public_ca_ext_account_key_creator" {
+  project = google_project.proj.project_id
+  role   = "roles/publicca.externalAccountKeyCreator"
+  member = google_service_account.sa.member
 }
 
 data "google_organization" "org2" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Enabling the public CA api and adding required permissions to create external account keys.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

```release-note:none

```
