### PR TITLE
Fix condition to fetch id token from API

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_id_token.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_id_token.go
@@ -77,12 +77,13 @@ func dataSourceGoogleServiceAccountIdTokenRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error calling getCredentials(): %v", err)
 	}
 
-	// If the source credential is not a service account key, use the API to generate the idToken
-	if creds.JSON == nil {
+	targetServiceAccount := d.Get("target_service_account").(string)
+	// If a target service account is provided, use the API to generate the idToken
+	if targetServiceAccount != "" {
 		// Use
 		// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken
 		service := config.NewIamCredentialsClient(userAgent)
-		name := fmt.Sprintf("projects/-/serviceAccounts/%s", d.Get("target_service_account").(string))
+		name := fmt.Sprintf("projects/-/serviceAccounts/%s", targetServiceAccount)
 		tokenRequest := &iamcredentials.GenerateIdTokenRequest{
 			Audience:     targetAudience,
 			IncludeEmail: d.Get("include_email").(bool),
@@ -93,7 +94,7 @@ func dataSourceGoogleServiceAccountIdTokenRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("error calling iamcredentials.GenerateIdToken: %v", err)
 		}
 
-		d.SetId(d.Get("target_service_account").(string))
+		d.SetId(targetServiceAccount)
 		if err := d.Set("id_token", at.Token); err != nil {
 			return fmt.Errorf("Error setting id_token: %s", err)
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
I use GCE metadata server to authenticate and want to get id token.

```
  data "google_service_account_id_token" "oidc" {
    target_audience = "https://foo.bar/"
  }
```

The condition `if creds.JSON == nil` prevents me from passing the line `idtoken.NewTokenSource()` and returns incomprehensible error message below: 

```
Error: error calling iamcredentials.GenerateIdToken: googleapi: got HTTP response code 404 with body: 

  with data.google_service_account_id_token.oidc,
  on provider.tf line 6, in data "google_service_account_id_token" "oidc":
   6: data "google_service_account_id_token" "oidc" {
```

I think this can be fixed by that the API is called only if target_service_account is provided.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
resourcemanager: fixed handling of `google_service_account_id_token` when authenticated with GCE metadata credentials
```
