### PR TITLE
[fix] Location tag binding example for compute instances in documentation

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
@@ -69,7 +69,7 @@ resource "google_tags_tag_value" "value" {
 resource "google_tags_location_tag_binding" "binding" {
 	parent    = "//compute.googleapis.com/projects/${google_project.project.number}/zones/us-central1-a/instances/${google_compute_instance.instance.instance_id}"
 	tag_value = "tagValues/${google_tags_tag_value.value.name}"
-	location  = "us-central1"
+	location  = "us-central1-a"
 }
 ```
 


### PR DESCRIPTION
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

```release-note:bug
Fixed the "location" argument in the usage example of google_tags_location_tag_binding for compute instances.
```
