### PR TITLE
made some fields of `google_cloudfunctions2_function` O+C

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -375,12 +375,14 @@ properties:
           The function execution timeout. Execution is considered failed and
           can be terminated if the function is not completed at the end of the
           timeout period. Defaults to 60 seconds.
+        default_from_api: true
       - !ruby/object:Api::Type::String
         name: 'availableMemory'
         description: |
           The amount of memory available for a function.
           Defaults to 256M. Supported units are k, M, G, Mi, Gi. If no unit is
           supplied the value is interpreted as bytes.
+        default_from_api: true
       - !ruby/object:Api::Type::Integer
         name: 'maxInstanceRequestConcurrency'
         description:
@@ -403,6 +405,7 @@ properties:
         description: |
           The limit on the maximum number of function instances that may coexist at a
           given time.
+        default_from_api: true
       - !ruby/object:Api::Type::Integer
         name: 'minInstanceCount'
         description: |

--- a/mmv1/third_party/terraform/tests/resource_cloudfunction2_function_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunction2_function_test.go
@@ -121,9 +121,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   }
 
   service_config {
-    max_instance_count  = 1
-    available_memory    = "1536Mi"
-    timeout_seconds     = 30
+    min_instance_count = 1
   }
 }
 `, context)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

reviewing https://github.com/GoogleCloudPlatform/magic-modules/pull/8169 and the test failed due to a provider issue.

fixes: https://github.com/hashicorp/terraform-provider-google/issues/14646


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudfunction2: fixed permadiffs of some fields of `service_config` in `google_cloudfunctions2_function` resource
```
