### PR TITLE
Add long form project property

### DIFF
--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -221,6 +221,12 @@ module Api
       # instead of a project field to use User Project Overrides
       attr_reader :supports_indirect_user_project_override
 
+      # If true, the resource's project field can be specified as either the short form project
+      # id or the long form projects/project-id. The extra projects/ string will be removed from
+      # urls and ids. This should only be used for resources that previously supported long form
+      # project ids for backwards compatibility.
+      attr_reader :long_form_project
+
       # Function to transform a read error so that handleNotFound recognises
       # it as a 404. This should be added as a handwritten fn that takes in
       # an error and returns one.
@@ -314,6 +320,7 @@ module Api
       check :skip_delete, type: :boolean, default: false
       check :skip_read, type: :boolean, default: false
       check :supports_indirect_user_project_override, type: :boolean, default: false
+      check :long_form_project, type: :boolean, default: false
       check :read_error_transform, type: String
       check :taint_resource_on_failed_create, type: :boolean, default: false
       check :skip_sweeper, type: :boolean, default: false

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -225,7 +225,7 @@ module Api
       # id or the long form projects/project-id. The extra projects/ string will be removed from
       # urls and ids. This should only be used for resources that previously supported long form
       # project ids for backwards compatibility.
-      attr_reader :long_form_project
+      attr_reader :legacy_long_form_project
 
       # Function to transform a read error so that handleNotFound recognises
       # it as a 404. This should be added as a handwritten fn that takes in
@@ -320,7 +320,7 @@ module Api
       check :skip_delete, type: :boolean, default: false
       check :skip_read, type: :boolean, default: false
       check :supports_indirect_user_project_override, type: :boolean, default: false
-      check :long_form_project, type: :boolean, default: false
+      check :legacy_long_form_project, type: :boolean, default: false
       check :read_error_transform, type: String
       check :taint_resource_on_failed_create, type: :boolean, default: false
       check :skip_sweeper, type: :boolean, default: false

--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -26,6 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules'
   api: 'https://cloud.google.com/compute/docs/reference/v1/forwardingRules'
 immutable: true
+long_form_project: true
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     kind: 'compute#operation'

--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -26,7 +26,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules'
   api: 'https://cloud.google.com/compute/docs/reference/v1/forwardingRules'
 immutable: true
-long_form_project: true
+legacy_long_form_project: true
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     kind: 'compute#operation'

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -17,6 +17,7 @@ kind: 'compute#forwardingRule'
 base_url: projects/{{project}}/global/forwardingRules
 immutable: true
 has_self_link: true
+long_form_project: true
 collection_url_key: 'items'
 description: |
   Represents a GlobalForwardingRule resource. Global forwarding rules are

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -17,7 +17,7 @@ kind: 'compute#forwardingRule'
 base_url: projects/{{project}}/global/forwardingRules
 immutable: true
 has_self_link: true
-long_form_project: true
+legacy_long_form_project: true
 collection_url_key: 'items'
 description: |
   Represents a GlobalForwardingRule resource. Global forwarding rules are

--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -19,7 +19,7 @@ update_url: projects/{{project}}/locations/{{location}}/features/{{name}}
 self_link: projects/{{project}}/locations/{{location}}/features/{{name}}
 update_verb: :PATCH
 update_mask: true
-long_form_project: true
+legacy_long_form_project: true
 description: |
   Feature represents the settings and status of any Hub Feature.
 references: !ruby/object:Api::Resource::ReferenceLinks

--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -19,6 +19,7 @@ update_url: projects/{{project}}/locations/{{location}}/features/{{name}}
 self_link: projects/{{project}}/locations/{{location}}/features/{{name}}
 update_verb: :PATCH
 update_mask: true
+long_form_project: true
 description: |
   Feature represents the settings and status of any Hub Feature.
 references: !ruby/object:Api::Resource::ReferenceLinks

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -232,7 +232,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
-<%    if object.long_form_project -%>
+<%    if object.legacy_long_form_project -%>
     url = strings.ReplaceAll(url, "projects/projects/", "projects/")
 <%    end -%>
 
@@ -257,7 +257,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
-<%      if object.long_form_project -%>
+<%      if object.legacy_long_form_project -%>
     billingProject = strings.TrimPrefix(project, "projects/")
 <%      else -%>
     billingProject = project
@@ -313,7 +313,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error constructing id: %s", err)
     }
-<%    if object.long_form_project -%>
+<%    if object.legacy_long_form_project -%>
     id = strings.ReplaceAll(id, "projects/projects/", "projects/")
 <%    end -%>
     d.SetId(id)
@@ -374,7 +374,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error constructing id: %s", err)
     }
-<%          if object.long_form_project -%>
+<%          if object.legacy_long_form_project -%>
     id = strings.ReplaceAll(id, "projects/projects/", "projects/")
 <%          end -%>
     d.SetId(id)
@@ -436,7 +436,7 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
         if err != nil {
             return nil, err
         }
-<%      if object.long_form_project -%>
+<%      if object.legacy_long_form_project -%>
         url = strings.ReplaceAll(url, "projects/projects/", "projects/")
 <%      end -%>
 
@@ -447,7 +447,7 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
         if err != nil {
             return nil, fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
         }
-<%        if object.long_form_project -%>
+<%        if object.legacy_long_form_project -%>
         billingProject = strings.TrimPrefix(project, "projects/")
 <%        else -%>
         billingProject = project
@@ -528,7 +528,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
     if err != nil {
         return err
     }
-<%  if object.long_form_project -%>
+<%  if object.legacy_long_form_project -%>
     url = strings.ReplaceAll(url, "projects/projects/", "projects/")
 <%  end -%>
 
@@ -539,7 +539,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
-<%    if object.long_form_project -%>
+<%    if object.legacy_long_form_project -%>
     billingProject = strings.TrimPrefix(project, "projects/")
 <%    else -%>
     billingProject = project
@@ -690,7 +690,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
-<%      if object.long_form_project -%>
+<%      if object.legacy_long_form_project -%>
     billingProject = strings.TrimPrefix(project, "projects/")
 <%      else -%>
     billingProject = project
@@ -743,7 +743,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
-<%      if object.long_form_project -%>
+<%      if object.legacy_long_form_project -%>
     url = strings.ReplaceAll(url, "projects/projects/", "projects/")
 <%      end -%>
 
@@ -920,7 +920,7 @@ if len(updateMask) > 0 {
         if err != nil {
             return err
         }
-<%        if object.long_form_project -%>
+<%        if object.legacy_long_form_project -%>
     url = strings.ReplaceAll(url, "projects/projects/", "projects/")
 <%        end -%>
 
@@ -1017,7 +1017,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
-<%        if object.long_form_project -%>
+<%        if object.legacy_long_form_project -%>
     billingProject = strings.TrimPrefix(project, "projects/")
 <%        else -%>
     billingProject = project
@@ -1037,7 +1037,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
-<%      if object.long_form_project -%>
+<%      if object.legacy_long_form_project -%>
     url = strings.ReplaceAll(url, "projects/projects/", "projects/")
 <%      end -%>
 
@@ -1137,7 +1137,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     if err != nil {
         return nil, fmt.Errorf("Error constructing id: %s", err)
     }
-<%      if object.long_form_project -%>
+<%      if object.legacy_long_form_project -%>
     id = strings.ReplaceAll(id, "projects/projects/", "projects/")
 <%      end -%>
     d.SetId(id)

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -190,7 +190,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  if object.custom_code.custom_create -%>
     <%= lines(compile(pwd + '/' + object.custom_code.custom_create))  -%>
 <%  else  -%>
-    userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+    userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
         return err
     }
@@ -232,6 +232,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
+<%    if object.long_form_project -%>
+    url = strings.ReplaceAll(url, "projects/projects/", "projects/")
+<%    end -%>
 
     log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
 <%    if object.nested_query&.modify_by_patch -%>
@@ -254,7 +257,11 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
+<%      if object.long_form_project -%>
+    billingProject = strings.TrimPrefix(project, "projects/")
+<%      else -%>
     billingProject = project
+<%      end -%>
 <%    end -%>
 
 <%    if object.supports_indirect_user_project_override -%>
@@ -306,6 +313,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error constructing id: %s", err)
     }
+<%    if object.long_form_project -%>
+    id = strings.ReplaceAll(id, "projects/projects/", "projects/")
+<%    end -%>
     d.SetId(id)
 
 <%    if object.async&.allow?('create') -%>
@@ -324,7 +334,8 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%          unless object.taint_resource_on_failed_create -%>
         // The resource didn't actually create
         d.SetId("")
-<%          end -%>         
+
+<%          end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
 
@@ -363,6 +374,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error constructing id: %s", err)
     }
+<%          if object.long_form_project -%>
+    id = strings.ReplaceAll(id, "projects/projects/", "projects/")
+<%          end -%>
     d.SetId(id)
 
 <%        else # if object.async.is_a? Api::OpAsync -%>
@@ -422,6 +436,9 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
         if err != nil {
             return nil, err
         }
+<%      if object.long_form_project -%>
+        url = strings.ReplaceAll(url, "projects/projects/", "projects/")
+<%      end -%>
 
         billingProject := ""
 
@@ -430,7 +447,11 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
         if err != nil {
             return nil, fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
         }
+<%        if object.long_form_project -%>
+        billingProject = strings.TrimPrefix(project, "projects/")
+<%        else -%>
         billingProject = project
+<%        end -%>
 <%      end -%>
 
 <%      if object.supports_indirect_user_project_override -%>
@@ -444,7 +465,7 @@ func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interfac
         billingProject = bp
         }
 
-        userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+        userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
         if err != nil {
             return nil, err
         }
@@ -498,7 +519,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
   return nil
 <%  else  -%>
     config := meta.(*transport_tpg.Config)
-    userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+    userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
         return err
     }
@@ -507,6 +528,9 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
     if err != nil {
         return err
     }
+<%  if object.long_form_project -%>
+    url = strings.ReplaceAll(url, "projects/projects/", "projects/")
+<%  end -%>
 
     billingProject := ""
 
@@ -515,7 +539,11 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
+<%    if object.long_form_project -%>
+    billingProject = strings.TrimPrefix(project, "projects/")
+<%    else -%>
     billingProject = project
+<%    end -%>
 <%  end -%>
 
 <%  if object.supports_indirect_user_project_override -%>
@@ -650,7 +678,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 <%  if object.custom_code.custom_update -%>
     <%= lines(compile(pwd + '/' + object.custom_code.custom_update))  -%>
 <%  else  -%>
-    userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+    userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
         return err
     }
@@ -662,7 +690,11 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
+<%      if object.long_form_project -%>
+    billingProject = strings.TrimPrefix(project, "projects/")
+<%      else -%>
     billingProject = project
+<%      end -%>
 <%    end -%>
 
 
@@ -711,6 +743,9 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
+<%      if object.long_form_project -%>
+    url = strings.ReplaceAll(url, "projects/projects/", "projects/")
+<%      end -%>
 
     log.Printf("[DEBUG] Updating <%= object.name -%> %q: %#v", d.Id(), obj)
 <%= lines(compile(pwd + '/templates/terraform/update_mask.erb')) if object.update_mask -%>
@@ -885,6 +920,9 @@ if len(updateMask) > 0 {
         if err != nil {
             return err
         }
+<%        if object.long_form_project -%>
+    url = strings.ReplaceAll(url, "projects/projects/", "projects/")
+<%        end -%>
 
 <%= lines(compile(pwd + '/' + object.custom_code.pre_update)) if object.custom_code.pre_update -%>
 <%        if object.supports_indirect_user_project_override -%>
@@ -963,7 +1001,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     return nil
 <%  else -%>
     config := meta.(*transport_tpg.Config)
-    userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+    userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
         return err
     }
@@ -979,7 +1017,11 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
         return fmt.Errorf("Error fetching project for <%= object.name -%>: %s", err)
     }
+<%        if object.long_form_project -%>
+    billingProject = strings.TrimPrefix(project, "projects/")
+<%        else -%>
     billingProject = project
+<%        end -%>
 <%      end -%>
 
 <%      if object.mutex -%>
@@ -995,6 +1037,9 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
+<%      if object.long_form_project -%>
+    url = strings.ReplaceAll(url, "projects/projects/", "projects/")
+<%      end -%>
 
 <%# If the deletion of the object requires sending a request body, the custom code will set 'obj' -%>
     var obj map[string]interface{}
@@ -1092,6 +1137,9 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     if err != nil {
         return nil, fmt.Errorf("Error constructing id: %s", err)
     }
+<%      if object.long_form_project -%>
+    id = strings.ReplaceAll(id, "projects/projects/", "projects/")
+<%      end -%>
     d.SetId(id)
 
 <%-     unless object.virtual_fields.empty? -%>

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
@@ -9,65 +9,65 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
-  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 <% unless version == 'ga' -%>
 func TestAccGKEHubFeature_gkehubFeatureFleetObservability(t *testing.T) {
-  // VCR fails to handle batched project services
-  acctest.SkipIfVcr(t)
-  t.Parallel()
+	// VCR fails to handle batched project services
+	acctest.SkipIfVcr(t)
+	t.Parallel()
 
-  context := map[string]interface{}{
-    "random_suffix":   RandString(t, 10),
-    "org_id":          acctest.GetTestOrgFromEnv(t),
-    "billing_account": acctest.GetTestBillingAccountFromEnv(t),
-  }
+	context := map[string]interface{}{
+		"random_suffix":   RandString(t, 10),
+		"org_id":          acctest.GetTestOrgFromEnv(t),
+		"billing_account": acctest.GetTestBillingAccountFromEnv(t),
+	}
 
-  VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
-    CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
-    ExternalProviders: map[string]resource.ExternalProvider{
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
 			"time":   {},
 		},
-    Steps: []resource.TestStep{
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureFleetObservability(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate1(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate2(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-    },
-  })
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureFleetObservability(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate1(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate2(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func testAccGKEHubFeature_gkehubFeatureFleetObservability(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetup(context) + Nprintf(`
+	return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "time_sleep" "wait_for_gkehub_enablement" {
   create_duration = "150s"
   depends_on = [google_project_service.gkehub]
 }
-  
+
 resource "google_gke_hub_feature" "feature" {
   name = "fleetobservability"
   location = "global"
@@ -76,7 +76,7 @@ resource "google_gke_hub_feature" "feature" {
     fleetobservability {
       logging_config {
         default_config {
-	  mode = "MOVE"
+    mode = "MOVE"
         }
         fleet_scope_logs_config {
           mode = "COPY"
@@ -91,7 +91,7 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate1(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetup(context) + Nprintf(`
+	return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "time_sleep" "wait_for_gkehub_enablement" {
   create_duration = "150s"
   depends_on = [google_project_service.gkehub]
@@ -105,7 +105,7 @@ resource "google_gke_hub_feature" "feature" {
     fleetobservability {
       logging_config {
         default_config {
-	  mode = "MOVE"
+    mode = "MOVE"
         }
       }
     }
@@ -117,7 +117,7 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate2(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetup(context) + Nprintf(`
+	return gkeHubFeatureProjectSetup(context) + Nprintf(`
 resource "time_sleep" "wait_for_gkehub_enablement" {
   create_duration = "150s"
   depends_on = [google_project_service.gkehub]
@@ -143,7 +143,7 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func gkeHubFeatureProjectSetup(context map[string]interface{}) string {
-  return Nprintf(`
+	return Nprintf(`
 resource "google_project" "project" {
   name            = "tf-test-gkehub%{random_suffix}"
   project_id      = "tf-test-gkehub%{random_suffix}"
@@ -201,45 +201,45 @@ resource "google_project_service" "gkehub" {
 <% end -%>
 
 func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
-  // VCR fails to handle batched project services
-  acctest.SkipIfVcr(t)
-  t.Parallel()
+	// VCR fails to handle batched project services
+	acctest.SkipIfVcr(t)
+	t.Parallel()
 
-  context := map[string]interface{}{
-    "random_suffix":   RandString(t, 10),
-    "org_id":          acctest.GetTestOrgFromEnv(t),
-    "billing_account": acctest.GetTestBillingAccountFromEnv(t),
-  }
+	context := map[string]interface{}{
+		"random_suffix":   RandString(t, 10),
+		"org_id":          acctest.GetTestOrgFromEnv(t),
+		"billing_account": acctest.GetTestBillingAccountFromEnv(t),
+	}
 
-  VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-    CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
-    Steps: []resource.TestStep{
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureMciUpdateStart(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"update_time"},
-      },
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureMciChangeMembership(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"update_time"},
-      },
-    },
-  })
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureMciUpdateStart(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"update_time"},
+			},
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureMciChangeMembership(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"update_time"},
+			},
+		},
+	})
 }
 
 func testAccGKEHubFeature_gkehubFeatureMciUpdateStart(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
 
 resource "google_container_cluster" "primary" {
   name               = "tf-test%{random_suffix}"
@@ -291,7 +291,7 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func testAccGKEHubFeature_gkehubFeatureMciChangeMembership(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
 resource "google_container_cluster" "primary" {
   name               = "tf-test%{random_suffix}"
   location           = "us-central1-a"
@@ -345,47 +345,48 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
-  // VCR fails to handle batched project services
-  acctest.SkipIfVcr(t)
-  t.Parallel()
+	// VCR fails to handle batched project services
+	acctest.SkipIfVcr(t)
+	t.Parallel()
 
-  context := map[string]interface{}{
-    "random_suffix":   RandString(t, 10),
-    "org_id":          acctest.GetTestOrgFromEnv(t),
-    "billing_account": acctest.GetTestBillingAccountFromEnv(t),
-  }
+	context := map[string]interface{}{
+		"random_suffix":   RandString(t, 10),
+		"org_id":          acctest.GetTestOrgFromEnv(t),
+		"billing_account": acctest.GetTestBillingAccountFromEnv(t),
+	}
 
-  VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-    CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
-    Steps: []resource.TestStep{
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureMcsd(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-      {
-        Config: testAccGKEHubFeature_gkehubFeatureMcsdUpdate(context),
-      },
-      {
-        ResourceName:      "google_gke_hub_feature.feature",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-    },
-  })
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureMcsd(context),
+			},
+			{
+				ResourceName:            "google_gke_hub_feature.feature",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+			{
+				Config: testAccGKEHubFeature_gkehubFeatureMcsdUpdate(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func testAccGKEHubFeature_gkehubFeatureMcsd(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
 resource "google_gke_hub_feature" "feature" {
   name = "multiclusterservicediscovery"
   location = "global"
-  project = google_project.project.project_id
+  project = "projects/${google_project.project.project_id}"
   labels = {
     foo = "bar"
   }
@@ -395,7 +396,7 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func testAccGKEHubFeature_gkehubFeatureMcsdUpdate(context map[string]interface{}) string {
-  return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + Nprintf(`
 resource "google_gke_hub_feature" "feature" {
   name = "multiclusterservicediscovery"
   location = "global"
@@ -410,7 +411,7 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 func gkeHubFeatureProjectSetupForGA(context map[string]interface{}) string {
-  return Nprintf(`
+	return Nprintf(`
 resource "google_project" "project" {
   name            = "tf-test-gkehub%{random_suffix}"
   project_id      = "tf-test-gkehub%{random_suffix}"
@@ -459,40 +460,40 @@ resource "google_project_service" "gkehub" {
 }
 
 func testAccCheckGKEHubFeatureDestroyProducer(t *testing.T) func(s *terraform.State) error {
-  return func(s *terraform.State) error {
-    for name, rs := range s.RootModule().Resources {
-      if rs.Type != "google_gke_hub_feature" {
-        continue
-      }
-      if strings.HasPrefix(name, "data.") {
-        continue
-      }
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_gke_hub_feature" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
 
-      config := GoogleProviderConfig(t)
+			config := GoogleProviderConfig(t)
 
-      url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{GKEHub2BasePath}}projects/{{project}}/locations/{{location}}/features/{{name}}")
-      if err != nil {
-        return err
-      }
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{GKEHub2BasePath}}projects/{{project}}/locations/{{location}}/features/{{name}}")
+			if err != nil {
+				return err
+			}
 
-      billingProject := ""
+			billingProject := ""
 
-      if config.BillingProject != "" {
-        billingProject = config.BillingProject
-      }
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
 
-      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-          Config: config,
-          Method: "GET",
-          Project: billingProject,
-          RawURL: url,
-          UserAgent: config.UserAgent,
-      })
-      if err == nil {
-        return fmt.Errorf("GKEHubFeature still exists at %s", url)
-      }
-    }
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config: config,
+				Method: "GET",
+				Project: billingProject,
+				RawURL: url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("GKEHubFeature still exists at %s", url)
+			}
+		}
 
-    return nil
-  }
+		return nil
+	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This fixes a backwards compatibility issue with some of the former DCL resources so that they continue to support long form project ids (`projects/project-id` instead of just `project-id`).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue with setting project field to long form in `google_compute_forwarding_rule` and `google_compute_global_forwarding_rule`
```
```release-note:bug
gkehub: fixed an issue with setting project field to long form in `google_gke_hub_feature`
```
