### PR TITLE
Add support for locking to google_logging_project_bucket_config

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -202,7 +202,6 @@ func resourceLoggingBucketConfigCreate(d *schema.ResourceData, meta interface{},
 	obj["name"] = d.Get("name")
 	obj["description"] = d.Get("description")
 	obj["retentionDays"] = d.Get("retention_days")
-	obj["locked"] = d.Get("locked")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
 
 	url, err := tpgresource.ReplaceVars(d, config, "{{LoggingBasePath}}projects/{{project}}/locations/{{location}}/buckets?bucketId={{bucket_id}}")

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -42,6 +42,11 @@ var loggingProjectBucketConfigSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: `An optional description for this bucket.`,
 	},
+	"locked": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: `Whether the bucket is locked. The retention period on a locked bucket cannot be changed. Locked buckets may only be deleted if they are empty.`,
+	},
 	"retention_days": {
 		Type:        schema.TypeInt,
 		Optional:    true,
@@ -183,9 +188,9 @@ func resourceLoggingProjectBucketConfigCreate(d *schema.ResourceData, meta inter
 	obj := make(map[string]interface{})
 	obj["name"] = d.Get("name")
 	obj["description"] = d.Get("description")
+	obj["locked"] = d.Get("locked")
 	obj["retentionDays"] = d.Get("retention_days")
 	obj["analyticsEnabled"] = d.Get("enable_analytics")
-	obj["locked"] = d.Get("locked")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
 
 	url, err := tpgresource.ReplaceVars(d, config, "{{LoggingBasePath}}projects/{{project}}/locations/{{location}}/buckets?bucketId={{bucket_id}}")
@@ -259,6 +264,9 @@ func resourceLoggingProjectBucketConfigRead(d *schema.ResourceData, meta interfa
 	}
 	if err := d.Set("description", res["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("locked", res["locked"]); err != nil {
+		return fmt.Errorf("Error setting locked: %s", err)
 	}
 	if err := d.Set("lifecycle_state", res["lifecycleState"]); err != nil {
 		return fmt.Errorf("Error setting lifecycle_state: %s", err)
@@ -343,6 +351,32 @@ func resourceLoggingProjectBucketConfigUpdate(d *schema.ResourceData, meta inter
 	}
 	if err != nil {
 		return fmt.Errorf("Error updating Logging Bucket Config %q: %s", d.Id(), err)
+	}
+
+	// Check if locked is being changed (although removal will fail). Locking is
+	// an atomic operation and can not be performed while other fields.
+	// update locked last so that we lock *after* setting the right settings
+	if d.HasChange("locked") {
+		updateMaskLocked := []string{"locked"}
+		objLocked := map[string]interface{}{
+			"locked": d.Get("locked"),
+		}
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMaskLocked, ",")})
+		if err != nil {
+			return err
+		}
+
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "PATCH",
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      objLocked,
+			Timeout:   d.Timeout(schema.TimeoutUpdate),
+		})
+		if err != nil {
+			return fmt.Errorf("Error updating Logging Bucket Config %q: %s", d.Id(), err)
+		}
 	}
 
 	return resourceLoggingProjectBucketConfigRead(d, meta)

--- a/mmv1/third_party/terraform/tests/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_bucket_config_test.go
@@ -122,6 +122,42 @@ func TestAccLoggingBucketConfigProject_analyticsEnabled(t *testing.T) {
 	})
 }
 
+func TestAccLoggingBucketConfigProject_locked(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":   RandString(t, 10),
+		"project_name":    "tf-test-" + RandString(t, 10),
+		"org_id":          acctest.GetTestOrgFromEnv(t),
+		"billing_account": acctest.GetTestBillingAccountFromEnv(t),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBucketConfigProject_locked(context, false),
+			},
+			{
+				ResourceName:            "google_logging_project_bucket_config.variable_locked",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+			{
+				Config: testAccLoggingBucketConfigProject_locked(context, true),
+			},
+			{
+				ResourceName:            "google_logging_project_bucket_config.variable_locked",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+		},
+	})
+}
+
 func TestAccLoggingBucketConfigProject_cmekSettings(t *testing.T) {
 	t.Parallel()
 
@@ -283,6 +319,32 @@ resource "google_logging_project_bucket_config" "basic" {
 `, context), analytics)
 }
 
+func testAccLoggingBucketConfigProject_locked(context map[string]interface{}, locked bool) string {
+	return fmt.Sprintf(Nprintf(`
+resource "google_project" "default" {
+	project_id = "%{project_name}"
+	name       = "%{project_name}"
+	org_id     = "%{org_id}"
+	billing_account = "%{billing_account}"
+}
+
+resource "google_logging_project_bucket_config" "fixed_locked" {
+	project    = google_project.default.name
+	location  = "global"
+	locked = true
+	bucket_id = "fixed-locked"
+}
+
+resource "google_logging_project_bucket_config" "variable_locked" {
+	project    = google_project.default.name
+	location  = "global"
+	description = "lock status is %v" # test simultaneous update
+	locked = %t
+	bucket_id = "variable-locked"
+}
+`, context), locked, locked)
+}
+
 func testAccLoggingBucketConfigProject_preCmekSettings(context map[string]interface{}, keyRingName, cryptoKeyName, cryptoKeyNameUpdate string) string {
 	return fmt.Sprintf(Nprintf(`
 resource "google_project" "default" {
@@ -442,7 +504,6 @@ resource "google_logging_organization_bucket_config" "basic" {
 }
 
 func getLoggingBucketConfigs(context map[string]interface{}) map[string]string {
-
 	return map[string]string{
 		"project": Nprintf(`resource "google_project" "default" {
 				project_id = "%{project_name}"

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -105,6 +105,8 @@ The following arguments are supported:
 
 * `description` - (Optional) Describes this bucket.
 
+* `locked` - (Optional) Whether the bucket is locked. The retention period on a locked bucket cannot be changed. Locked buckets may only be deleted if they are empty.
+
 * `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used.
 
 * `enable_analytics` - (Optional) Whether or not Log Analytics is enabled. Logs for buckets with Log Analytics enabled can be queried in the **Log Analytics** page using SQL queries. Cannot be disabled once enabled.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9772

There was a stray check for `locked` in these files that didn't work before- remove the unused one from the org+folder resource.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added support for `locked` to `google_logging_project_bucket_config`
```
