### PR TITLE
Add Update Connector Support for VPC Access Connectors

### DIFF
--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -15,13 +15,14 @@
 name: 'Connector'
 kind: 'vpcaccess#Connector'
 description: 'Serverless VPC Access connector resource.'
-immutable: true
 base_url: projects/{{project}}/locations/{{region}}/connectors
 create_url: projects/{{project}}/locations/{{region}}/connectors?connectorId={{name}}
+update_verb: :PATCH
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Configuring Serverless VPC Access': 'https://cloud.google.com/vpc/docs/configure-serverless-vpc-access'
   api: 'https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1/projects.locations.connectors'
+update_mask: true
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
@@ -55,6 +56,8 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/no_send_name.go.erb
   post_create: templates/terraform/post_create/sleep.go.erb
   decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
+  constants: templates/terraform/constants/connector.erb
+  resource_definition: templates/terraform/resource_definition/connector.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'
@@ -68,6 +71,7 @@ properties:
     name: name
     description: |
       The name of the resource (Max 25 characters).
+    immutable: true
     required: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
@@ -77,6 +81,7 @@ properties:
     exactly_one_of:
       - network
       - subnet.0.name
+    immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
     custom_expand: 'templates/terraform/custom_expand/resource_from_self_link.go.erb'
     diff_suppress_func: 'tpgresource.CompareResourceNames'
@@ -87,6 +92,7 @@ properties:
       The range of internal addresses that follows RFC 4632 notation. Example: `10.132.0.0/28`.
     required_with:
       - network
+    immutable: true
   - !ruby/object:Api::Type::Enum
     name: state
     description: |
@@ -102,34 +108,36 @@ properties:
     name: machineType
     description: |
       Machine type of VM Instance underlying connector. Default is e2-micro
+    immutable: false
     default_value: e2-micro
   - !ruby/object:Api::Type::Integer
     name: minThroughput
     description: |
       Minimum throughput of the connector in Mbps. Default and min is 200.
-    default_value: 200
+    immutable: true
+    default_from_api: true
     validation: !ruby/object:Provider::Terraform::Validation
-      function: 'validation.IntBetween(200, 1000)'
+      function: 'validation.IntBetween(200, 900)'
   - !ruby/object:Api::Type::Integer
     name: minInstances
     description: |
       Minimum value of instances in autoscaling group underlying the connector.
+    immutable: false
     default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: maxInstances
     description: |
       Maximum value of instances in autoscaling group underlying the connector.
+    immutable: false
     default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: maxThroughput
-    # The API documentation says this will default to 200, but when I tried that I got an error that the minimum
-    # throughput must be lower than the maximum. The console defaults to 1000, so I changed it to that.
-    # API returns 300 if it is not sent
     description: |
-      Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
-    default_value: 300
+      Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 1000.
+    immutable: true
+    default_from_api: true
     validation: !ruby/object:Provider::Terraform::Validation
-      function: 'validation.IntBetween(200, 1000)'
+      function: 'validation.IntBetween(300, 1000)'
   - !ruby/object:Api::Type::String
     name: 'selfLink'
     description: |
@@ -147,6 +155,7 @@ properties:
     immutable: true
     description: |
       The subnet in which to house the connector
+    immutable: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -155,7 +155,6 @@ properties:
     immutable: true
     description: |
       The subnet in which to house the connector
-    immutable: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/mmv1/templates/terraform/constants/connector.erb
+++ b/mmv1/templates/terraform/constants/connector.erb
@@ -1,0 +1,4 @@
+// Are the number of min/max instances reduced?
+func AreInstancesReduced(_ context.Context, old, new, _ interface{}) bool {
+	return new.(int) < old.(int)
+}

--- a/mmv1/templates/terraform/examples/vpc_access_connector.tf.erb
+++ b/mmv1/templates/terraform/examples/vpc_access_connector.tf.erb
@@ -2,4 +2,6 @@ resource "google_vpc_access_connector" "connector" {
   name          = "<%= ctx[:vars]['name'] %>"
   ip_cidr_range = "10.8.0.0/28"
   network       = "default"
+  min_instances  = 2
+  max_instances  = 3
 }

--- a/mmv1/templates/terraform/examples/vpc_access_connector.tf.erb
+++ b/mmv1/templates/terraform/examples/vpc_access_connector.tf.erb
@@ -1,6 +1,6 @@
 resource "google_vpc_access_connector" "connector" {
   name          = "<%= ctx[:vars]['name'] %>"
-  ip_cidr_range = "10.8.0.0/28"
+  ip_cidr_range = "10.18.0.0/28"
   network       = "default"
   min_instances  = 2
   max_instances  = 3

--- a/mmv1/templates/terraform/examples/vpc_access_connector_shared_vpc.tf.erb
+++ b/mmv1/templates/terraform/examples/vpc_access_connector_shared_vpc.tf.erb
@@ -4,6 +4,8 @@ resource "google_vpc_access_connector" "connector" {
     name = google_compute_subnetwork.custom_test.name
   }
   machine_type = "e2-standard-4"
+  min_instances = 2
+  max_instances = 3
 }
 
 resource "google_compute_subnetwork" "custom_test" {

--- a/mmv1/templates/terraform/resource_definition/connector.erb
+++ b/mmv1/templates/terraform/resource_definition/connector.erb
@@ -1,0 +1,3 @@
+CustomizeDiff: customdiff.All(
+  customdiff.ForceNewIfChange("min_instances", AreInstancesReduced),
+  customdiff.ForceNewIfChange("max_instances", AreInstancesReduced)),

--- a/mmv1/third_party/terraform/tests/data_source_vpc_access_connector_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_vpc_access_connector_test.go
@@ -40,6 +40,8 @@ resource "google_vpc_access_connector" "connector" {
   ip_cidr_range = "10.8.0.0/28"
   network       = "default"
   region        = "us-central1"
+  min_instances = 2
+  max_instances = 3
 }
 
 data "google_vpc_access_connector" "connector" {

--- a/mmv1/third_party/terraform/tests/resource_app_engine_standard_app_version_test.go
+++ b/mmv1/third_party/terraform/tests/resource_app_engine_standard_app_version_test.go
@@ -176,6 +176,8 @@ resource "google_vpc_access_connector" "bar" {
   region = "us-central1"
   ip_cidr_range = "10.8.0.0/28"
   network = "default"
+  min_instances = 3
+  max_instances = 10
 }
 
 resource "google_app_engine_standard_app_version" "foo" {

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -1044,6 +1044,8 @@ resource "google_vpc_access_connector" "%s" {
   region        = "us-central1"
   ip_cidr_range = "%s"
   network       = google_compute_network.vpc.name
+  min_instances = 3
+  max_instances = 10
 }
 
 resource "google_storage_bucket" "bucket" {

--- a/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go
@@ -91,13 +91,13 @@ resource "google_compute_network" "custom_test" {
 }
 
 func testAccVPCAccessConnector_vpcAccessConnectorMachineAndInstancesChanged(context map[string]interface{}) string {
-        return Nprintf(`
+	return Nprintf(`
 resource "google_vpc_access_connector" "connector" {
   name          = "tf-test-vpc-con%{random_suffix}"
   subnet {
     name = google_compute_subnetwork.custom_test.name
   }
-  machine_type = "e2-micro"
+  machine_type  = "e2-micro"
   min_instances = 3
   max_instances = 5
   region        = "us-central1"

--- a/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go
+++ b/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go
@@ -31,6 +31,38 @@ func TestAccVPCAccessConnector_vpcAccessConnectorThroughput(t *testing.T) {
 	})
 }
 
+func TestAccVPCAccessConnector_vpcAccessConnectorMachineAndInstancesChanged(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": RandString(t, 10),
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVPCAccessConnectorDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCAccessConnector_vpcAccessConnectorThroughput(context),
+			},
+			{
+				ResourceName:      "google_vpc_access_connector.connector",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccVPCAccessConnector_vpcAccessConnectorMachineAndInstancesChanged(context),
+			},
+			{
+				ResourceName:      "google_vpc_access_connector.connector",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccVPCAccessConnector_vpcAccessConnectorThroughput(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_vpc_access_connector" "connector" {
@@ -41,6 +73,33 @@ resource "google_vpc_access_connector" "connector" {
   machine_type = "e2-standard-4"
   min_instances = 2
   max_instances = 3
+  region        = "us-central1"
+}
+
+resource "google_compute_subnetwork" "custom_test" {
+  name          = "tf-test-vpc-con%{random_suffix}"
+  ip_cidr_range = "10.2.0.0/28"
+  region        = "us-central1"
+  network       = google_compute_network.custom_test.id
+}
+
+resource "google_compute_network" "custom_test" {
+  name                    = "tf-test-vpc-con%{random_suffix}"
+  auto_create_subnetworks = false
+}
+`, context)
+}
+
+func testAccVPCAccessConnector_vpcAccessConnectorMachineAndInstancesChanged(context map[string]interface{}) string {
+        return Nprintf(`
+resource "google_vpc_access_connector" "connector" {
+  name          = "tf-test-vpc-con%{random_suffix}"
+  subnet {
+    name = google_compute_subnetwork.custom_test.name
+  }
+  machine_type = "e2-micro"
+  min_instances = 3
+  max_instances = 5
   region        = "us-central1"
 }
 

--- a/mmv1/third_party/validator/tests/data/example_vpc_access_connector.tf
+++ b/mmv1/third_party/validator/tests/data/example_vpc_access_connector.tf
@@ -27,8 +27,10 @@ provider "google" {
 }
 
 resource "google_vpc_access_connector" "connector" {
-  name          = "vpc-con"
-  ip_cidr_range = "10.8.0.0/28"
-  network       = "default"
-  region        = "us-central1"
+  name           = "vpc-con"
+  ip_cidr_range  = "10.8.0.0/28"
+  network        = "default"
+  region         = "us-central1"
+  max_throughput = 300
+  min_throughput = 200
 }


### PR DESCRIPTION
Adds support for updating Serverless VPC Connectors.



If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement


Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vpcaccess: added support for updates to `google_vpc_access_connector` resource
```
