### PR TITLE
Update Replacement Method on Example

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -174,8 +174,8 @@ update_policy {
   type                           = "PROACTIVE"
   minimal_action                 = "REPLACE"
   most_disruptive_allowed_action = "REPLACE"
-  max_surge_percent              = 20
-  max_unavailable_fixed          = 2
+  max_surge_fixed                = 3
+  max_unavailable_fixed          = 0
   min_ready_sec                  = 50
   replacement_method             = "SUBSTITUTE"
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -177,7 +177,7 @@ update_policy {
   max_surge_fixed                = 0
   max_unavailable_fixed          = 2
   min_ready_sec                  = 50
-  replacement_method             = "SUBSTITUTE"
+  replacement_method             = "RECREATE"
 }
 ```
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -174,8 +174,8 @@ update_policy {
   type                           = "PROACTIVE"
   minimal_action                 = "REPLACE"
   most_disruptive_allowed_action = "REPLACE"
-  max_surge_fixed                = 3
-  max_unavailable_fixed          = 0
+  max_surge_fixed                = 0
+  max_unavailable_fixed          = 2
   min_ready_sec                  = 50
   replacement_method             = "SUBSTITUTE"
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -177,7 +177,7 @@ update_policy {
   max_surge_percent              = 20
   max_unavailable_fixed          = 2
   min_ready_sec                  = 50
-  replacement_method             = "RECREATE"
+  replacement_method             = "SUBSTITUTE"
 }
 ```
 


### PR DESCRIPTION
Using the Example on the Documentation you get the following error 

`│ Error: Error updating region managed group instances: googleapi: Error 400: Invalid value for field 'resource.updatePolicy.maxSurge': '{  "percent": 20}'. maxSurge must be equal to 0 when replacement method is set to RECREATE, invalid`

I have updated the replacement method so that it can be copied directly




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
Updating documentation update_policy block to working value
```
