### PR TITLE
Fix Filestore quota usage

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -44,7 +44,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_instance_enterprise'
     primary_resource_id: 'instance'
-    skip_test: true
+    skip_test: true # https://github.com/GoogleCloudPlatform/magic-modules/pull/5875#discussion_r844285335
     vars:
       instance_name: 'test-instance'
 custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/products/filestore/Snapshot.yaml
+++ b/mmv1/products/filestore/Snapshot.yaml
@@ -40,7 +40,6 @@ examples:
     vars:
       snapshot_name: 'test-snapshot'
       instance_name: 'test-instance-for-snapshot'
-
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'

--- a/mmv1/templates/terraform/examples/filestore_backup_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_backup_basic.tf.erb
@@ -1,28 +1,27 @@
-
 resource "google_filestore_instance" "instance" {
-  name = "<%= ctx[:vars]["instance_name"] %>"
+  name     = "<%= ctx[:vars]["instance_name"] %>"
   location = "us-central1-b"
-  tier = "BASIC_SSD"
+  tier     = "BASIC_HDD"
 
   file_shares {
-    capacity_gb = 2560
+    capacity_gb = 1024
     name        = "share1"
   }
 
   networks {
-    network = "default"
-    modes   = ["MODE_IPV4"]
+    network      = "default"
+    modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
   }
 }
 
 resource "google_filestore_backup" "<%= ctx[:primary_resource_id] %>" {
-  name        = "<%= ctx[:vars]["backup_name"] %>"
-  location    = "us-central1"
+  name              = "<%= ctx[:vars]["backup_name"] %>"
+  location          = "us-central1"
+  description       = "This is a filestore backup for the test instance"
   source_instance   = google_filestore_instance.instance.id
   source_file_share = "share1"
 
-  description = "This is a filestore backup for the test instance"
   labels = {
     "files":"label1",
     "other-label": "label2"

--- a/mmv1/templates/terraform/examples/filestore_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_basic.tf.erb
@@ -1,10 +1,10 @@
 resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
-  name = "<%= ctx[:vars]["instance_name"] %>"
+  name     = "<%= ctx[:vars]["instance_name"] %>"
   location = "us-central1-b"
-  tier = "PREMIUM"
+  tier     = "BASIC_HDD"
 
   file_shares {
-    capacity_gb = 2660
+    capacity_gb = 1024
     name        = "share1"
   }
 

--- a/mmv1/templates/terraform/examples/filestore_instance_enterprise.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_enterprise.tf.erb
@@ -1,10 +1,10 @@
 resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
-  name = "<%= ctx[:vars]["instance_name"] %>"
+  name     = "<%= ctx[:vars]["instance_name"] %>"
   location = "us-central1"
-  tier = "ENTERPRISE"
+  tier     = "ENTERPRISE"
 
   file_shares {
-    capacity_gb = 2560
+    capacity_gb = 1024
     name        = "share1"
   }
 
@@ -12,6 +12,7 @@ resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
     network = "default"
     modes   = ["MODE_IPV4"]
   }
+
   kms_key_name = google_kms_crypto_key.filestore_key.id
 }
 

--- a/mmv1/templates/terraform/examples/filestore_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_full.tf.erb
@@ -1,30 +1,30 @@
 resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
-  name = "<%= ctx[:vars]["instance_name"] %>"
+  name     = "<%= ctx[:vars]["instance_name"] %>"
   location = "us-central1-b"
-  tier = "BASIC_SSD"
+  tier     = "BASIC_SSD"
 
   file_shares {
-    capacity_gb = 2660
+    capacity_gb = 2560
     name        = "share1"
 
     nfs_export_options {
-      ip_ranges = ["10.0.0.0/24"]
+      ip_ranges   = ["10.0.0.0/24"]
       access_mode = "READ_WRITE"
       squash_mode = "NO_ROOT_SQUASH"
-   }
+    }
 
-   nfs_export_options {
-      ip_ranges = ["10.10.0.0/24"]
+    nfs_export_options {
+      ip_ranges   = ["10.10.0.0/24"]
       access_mode = "READ_ONLY"
       squash_mode = "ROOT_SQUASH"
-      anon_uid = 123
-      anon_gid = 456
-   }
+      anon_uid    = 123
+      anon_gid    = 456
+    }
   }
 
   networks {
-    network = "default"
-    modes   = ["MODE_IPV4"]
+    network      = "default"
+    modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
   }
 }

--- a/mmv1/templates/terraform/examples/filestore_snapshot_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_snapshot_basic.tf.erb
@@ -1,12 +1,12 @@
 resource "google_filestore_snapshot" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]["snapshot_name"] %>"
   instance = google_filestore_instance.instance.name
-  location = "us-central1"
+  location = "us-east1"
 }
 
 resource "google_filestore_instance" "instance" {
   name     = "<%= ctx[:vars]["instance_name"] %>"
-  location = "us-central1"
+  location = "us-east1"
   tier     = "ENTERPRISE"
 
   file_shares {

--- a/mmv1/templates/terraform/examples/filestore_snapshot_full.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_snapshot_full.tf.erb
@@ -1,7 +1,7 @@
 resource "google_filestore_snapshot" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]["snapshot_name"] %>"
   instance = google_filestore_instance.instance.name
-  location = "us-central1"
+  location = "us-west1"
 
   description = "Snapshot of <%= ctx[:vars]["instance_name"] %>"
 
@@ -12,7 +12,7 @@ resource "google_filestore_snapshot" "<%= ctx[:primary_resource_id] %>" {
 
 resource "google_filestore_instance" "instance" {
   name     = "<%= ctx[:vars]["instance_name"] %>"
-  location = "us-central1"
+  location = "us-west1"
   tier     = "ENTERPRISE"
 
   file_shares {

--- a/mmv1/third_party/terraform/tests/resource_filestore_backup_test.go
+++ b/mmv1/third_party/terraform/tests/resource_filestore_backup_test.go
@@ -44,21 +44,21 @@ func TestAccFilestoreBackup_update(t *testing.T) {
 func testAccFilestoreBackup_create(instName string, bkupName string) string {
 	return fmt.Sprintf(`
 resource "google_filestore_instance" "instance" {
-  name = "%s"
-  location = "us-central1-b"
-  tier = "BASIC_SSD"
+  name        = "%s"
+  location    = "us-central1-b"
+  tier        = "BASIC_HDD"
+  description = "An instance created during testing."
 
   file_shares {
-    capacity_gb = 2560
+    capacity_gb = 1024
     name        = "share22"
   }
 
   networks {
-    network = "default"
-    modes   = ["MODE_IPV4"]
+    network      = "default"
+    modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
   }
-  description = "An instance created during testing."
 }
 
 resource "google_filestore_backup" "backup" {
@@ -76,27 +76,26 @@ resource "google_filestore_backup" "backup" {
 func testAccFilestoreBackup_update(instName string, bkupName string) string {
 	return fmt.Sprintf(`
 resource "google_filestore_instance" "instance" {
-  name = "%s"
-  location = "us-central1-b"
-  tier = "BASIC_SSD"
+  name        = "%s"
+  location    = "us-central1-b"
+  tier        = "BASIC_HDD"
+  description = "A modified instance during testing."
 
   file_shares {
-    capacity_gb = 2560
+    capacity_gb = 1024
     name        = "share22"
   }
 
   networks {
-    network = "default"
-    modes   = ["MODE_IPV4"]
+    network      = "default"
+    modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
   }
 
   labels = {
-	"files":"label1",
-	"other-label": "update"
+	  "files"      : "label1",
+	  "other-label": "update"
   }
-
-  description = "A modified instance during testing."
 }
 
 resource "google_filestore_backup" "backup" {

--- a/mmv1/third_party/terraform/tests/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_filestore_instance_test.go
@@ -74,21 +74,24 @@ func TestAccFilestoreInstance_update(t *testing.T) {
 func testAccFilestoreInstance_update(name string) string {
 	return fmt.Sprintf(`
 resource "google_filestore_instance" "instance" {
-  name = "tf-instance-%s"
-  zone = "us-central1-b"
+  name        = "tf-instance-%s"
+  zone        = "us-central1-b"
+  tier        = "BASIC_HDD"
+  description = "An instance created during testing."
+
   file_shares {
-    capacity_gb = 2660
+    capacity_gb = 1024
     name        = "share"
   }
+
   networks {
     network = "default"
     modes   = ["MODE_IPV4"]
   }
+
   labels = {
     baz = "qux"
   }
-  tier        = "PREMIUM"
-  description = "An instance created during testing."
 }
 `, name)
 }
@@ -96,18 +99,20 @@ resource "google_filestore_instance" "instance" {
 func testAccFilestoreInstance_update2(name string) string {
 	return fmt.Sprintf(`
 resource "google_filestore_instance" "instance" {
-  name = "tf-instance-%s"
-  zone = "us-central1-b"
+  name        = "tf-instance-%s"
+  zone        = "us-central1-b"
+  tier        = "BASIC_HDD"
+  description = "A modified instance created during testing."
+
   file_shares {
-    capacity_gb = 2760
+    capacity_gb = 1536
     name        = "share"
   }
+
   networks {
     network = "default"
     modes   = ["MODE_IPV4"]
   }
-  tier        = "PREMIUM"
-  description = "A modified instance created during testing."
 }
 `, name)
 }
@@ -149,7 +154,7 @@ func testAccFilestoreInstance_reservedIpRange_update(name string) string {
 resource "google_filestore_instance" "instance" {
   name = "tf-instance-%s"
   zone = "us-central1-b"
-  tier    = "BASIC_HDD"
+  tier = "BASIC_HDD"
 
   file_shares {
     capacity_gb = 1024
@@ -170,7 +175,7 @@ func testAccFilestoreInstance_reservedIpRange_update2(name string) string {
 resource "google_filestore_instance" "instance" {
   name = "tf-instance-%s"
   zone = "us-central1-b"
-  tier    = "BASIC_HDD"
+  tier = "BASIC_HDD"
 
   file_shares {
     capacity_gb = 1024


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Our test project has, in us-central1:
* 1024gb of ENTERPRISE regional quota
* 5120gb of BASIC_SSD/PREMUM regional quota
* 92,160gb of BASIC_HDD/STANDARD regional quota

The minimum size for BASIC_HDD & ENTERPRISE is 1024gb, and for BASIC_SSD it's 2560gb.

We were using primarily BASIC_SSD and provisioning more than our quota for that tier, randomly succeeding or failing depending on the specific execution order of the Filestore tests. With this change I've moved us mostly to BASIC_HDD (and less of it!) which should eliminate that source of quota pressure. Only a single test uses BASIC_SSD now, and it uses half our quota for that tier (the minimum instance size).

I've preserved the Filestore instance ENTERPRISE example/test. However, Filestore snapshots require ENTERPRISE- so I've moved those test to other `us-` regions, to ensure that they're able to execute in parallel successfully.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
