### PR TITLE
Made make-in-container script always use latest container

### DIFF
--- a/.ci/containers/magic-modules-dev/Dockerfile
+++ b/.ci/containers/magic-modules-dev/Dockerfile
@@ -1,3 +1,0 @@
-FROM gcr.io/graphite-docker-images/downstream-builder:latest
-WORKDIR /magic-modules
-ENTRYPOINT ["/usr/bin/make"]

--- a/docs/content/reference/make-commands.md
+++ b/docs/content/reference/make-commands.md
@@ -55,14 +55,30 @@ git checkout -- . && git clean -f google/ google-beta/ website/
 
 For ease of contribution, we provide containers with the required dependencies for building magic-modules, as well as the option to build them yourself.
 
-[scripts/make-in-container.sh](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/scripts/make-in-container.sh) acts as a drop-in replacement for magic-modules `make` commands by setting up the containers and running `make` inside the container.
+[`./scripts/make-in-container.sh`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/scripts/make-in-container.sh) acts as a drop-in replacement for magic-modules `make` commands by setting up the containers and running `make` inside the container. The script uses [Docker](https://docker.io/) if available and [Podman](https://podman.io/) otherwise. If you run into any problems, please [file an issue](https://github.com/hashicorp/terraform-provider-google/issues/new/choose).
 
-For example, to build the `google` provider:
+#### Before you begin
+
+1. Ensure that `GOPATH` is set on your host machine.
+
+   ```bash
+   printenv | grep GOPATH
+   ```
+
+   If not, add `export GOPATH=$HOME/go` to your terminal's startup script.
+1. Clone the `google` and `google-beta` provider repositories with the following commands:
+
+   ```bash
+   git clone https://github.com/hashicorp/terraform-provider-google.git $GOPATH/src/github.com/hashicorp/terraform-provider-google
+   git clone https://github.com/hashicorp/terraform-provider-google-beta.git $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
+   ```
+
+#### Example
+
+To build the `google` provider:
 
 ```bash
 ./scripts/make-in-container.sh \
   terraform VERSION=ga \
   OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"
 ```
-
-`make-in-container.sh` will use [Docker](https://docker.io/) if available and otherwise attempt to fall back to [Podman](https://podman.io/). If you run into any problems, try pulling the latest version of `gcr.io/graphite-docker-images/downstream-builder`. If that doesn't resolve your problem, please [file an issue](https://github.com/hashicorp/terraform-provider-google/issues/new/choose).

--- a/docs/content/reference/make-commands.md
+++ b/docs/content/reference/make-commands.md
@@ -53,9 +53,9 @@ git checkout -- . && git clean -f google/ google-beta/ website/
 
 {{< hint warning >}}This approach is in beta and still collecting feedback. Please [file an issue](https://github.com/hashicorp/terraform-provider-google/issues/new/choose) if you encounter challenges.{{< /hint >}}
 
-For ease of contribution, we provide containers with the required dependencies for building magic-modules, as well as the option to build them yourself.
+[`./scripts/make-in-container.sh`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/scripts/make-in-container.sh) runs `make` with the provided arguments inside a container with all necessary dependencies preinstalled. It uses [Docker](https://docker.io/) if available and [Podman](https://podman.io/) otherwise. Like `make`, this script must be run in the root of a `magic-modules` repository clone.
 
-[`./scripts/make-in-container.sh`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/scripts/make-in-container.sh) acts as a drop-in replacement for magic-modules `make` commands by setting up the containers and running `make` inside the container. The script uses [Docker](https://docker.io/) if available and [Podman](https://podman.io/) otherwise. If you run into any problems, please [file an issue](https://github.com/hashicorp/terraform-provider-google/issues/new/choose).
+If you run into any problems, please [file an issue](https://github.com/hashicorp/terraform-provider-google/issues/new/choose).
 
 #### Before you begin
 
@@ -65,7 +65,7 @@ For ease of contribution, we provide containers with the required dependencies f
    printenv | grep GOPATH
    ```
 
-   If not, add `export GOPATH=$HOME/go` to your terminal's startup script.
+   If not, add `export GOPATH=$HOME/go` to your terminal's startup script and restart your terminal.
 1. Clone the `google` and `google-beta` provider repositories with the following commands:
 
    ```bash
@@ -75,7 +75,7 @@ For ease of contribution, we provide containers with the required dependencies f
 
 #### Example
 
-To build the `google` provider:
+To build the `google` provider, run the following command in the root of a `magic-modules` repository clone:
 
 ```bash
 ./scripts/make-in-container.sh \

--- a/scripts/make-in-container.sh
+++ b/scripts/make-in-container.sh
@@ -6,44 +6,74 @@
 set -e
 
 BUILDER_IMAGE="gcr.io/graphite-docker-images/downstream-builder:latest"
-DEV_IMAGE="gcr.io/graphite-docker-images/magic-modules-dev:latest"
 
-main() {
-    if which docker > /dev/null; then
-        CONTAINER_EXECUTABLE="docker"
-    elif which podman > /dev/null; then
-        CONTAINER_EXECUTABLE="podman"
-    else
-        echo "Unable to find podman or docker executable. Please install podman or docker and try again." && exit 1;
-    fi
+if [ -t 1 ]; then
+    red=$'\e[1;31m'
+    grn=$'\e[1;32m'
+    yel=$'\e[1;33m'
+    blu=$'\e[1;34m'
+    mag=$'\e[1;35m'
+    cyn=$'\e[1;36m'
+    end=$'\e[0m'
+else
+    red=''
+    grn=''
+    yel=''
+    blu=''
+    mag=''
+    cyn=''
+    end=''
+fi
 
-    echo "Found ${CONTAINER_EXECUTABLE}, using it to run commands."
-
-    if ! ${CONTAINER_EXECUTABLE} images | grep "gcr.io/graphite-docker-images/magic-modules-dev" > /dev/null; then
-        echo "unable to find magic-modules-dev container"
-        build_dev_container
-    fi
-
-    ${CONTAINER_EXECUTABLE} run --rm \
-    -v "$PWD:/magic-modules" -v "$GOPATH:$GOPATH" \
-    -it "${DEV_IMAGE}" "$@"
+warn() {
+    printf "%s\n" "${!1}${2}${end}"
 }
 
+main() {
+    exitcode=0
 
-build_dev_container() {
-    echo "building containers...."
-    echo "NOTE: this may take a while."
-    sleep 1
-    if ! ${CONTAINER_EXECUTABLE} images | grep "${BUILDER_IMAGE}" > /dev/null; then
-        if ! ${CONTAINER_EXECUTABLE} pull "${BUILDER_IMAGE}"; then
-            ${CONTAINER_EXECUTABLE} build \
-                .ci/containers/downstream-builder/ \
-                -t "${BUILDER_IMAGE}"
-        fi
+    if [[ -z "${GOPATH}" ]]; then
+        warn "red" "GOPATH is not set on the host machine. Add 'export GOPATH=\$HOME/go' to your terminal's startup script and restart your terminal."
+        exitcode=1
+    else
+        echo "Host GOPATH=${GOPATH}"
     fi
-    ${CONTAINER_EXECUTABLE} build \
-        .ci/containers/magic-modules-dev/ \
-        -t "${DEV_IMAGE}"
+
+
+    if which docker > /dev/null || which podman > /dev/null; then
+        if which docker > /dev/null; then
+            CONTAINER_EXECUTABLE="docker"
+        else
+            CONTAINER_EXECUTABLE="podman"
+        fi
+        echo "Found ${CONTAINER_EXECUTABLE}, using it to run commands."
+
+        echo "Updating containers..."
+        echo "NOTE: this may take a while."
+        sleep 1
+        if ! ${CONTAINER_EXECUTABLE} images | grep "${BUILDER_IMAGE}" > /dev/null; then
+            if ! ${CONTAINER_EXECUTABLE} pull "${BUILDER_IMAGE}"; then
+                ${CONTAINER_EXECUTABLE} build \
+                    .ci/containers/downstream-builder/ \
+                    -t "${BUILDER_IMAGE}"
+            fi
+        fi
+    else
+        warn "red" "Unable to find podman or docker executable. Please install podman or docker and try again.";
+        exitcode=1
+    fi
+
+    if [ $exitcode -eq 0 ]; then
+        ${CONTAINER_EXECUTABLE} run --rm \
+            -v "$PWD:/magic-modules" -v "$GOPATH:$GOPATH" \
+            --entrypoint "/usr/bin/make" \
+            -w "/magic-modules" \
+            -it "${BUILDER_IMAGE}" "$@"
+    else
+        warn "red" "Found errors; exiting"
+    fi
+
+    exit $exitcode
 }
 
 main "$@"


### PR DESCRIPTION
Previously there was a wrapper to override the workdir and entrypoint; however, this means that the latest version of the builder container image being pulled doesn't actually update the user's environment if they have a magic-modules-dev build based on a previous builder container image. We can use the builder image directly instead and override the entrypoint and workdir in the script, since docker and podman use the same argument names for these.

I've made the following changes:

1. Eliminated wrapper container and made the script use the builder image directly, with command-line overrides for the entrypoint and workdir (which is possible since the arguments are called the same for [docker](https://docs.docker.com/engine/reference/commandline/run/) and [podman](https://docs.podman.io/en/latest/markdown/podman-run.1.html))
2. Made downstream-builder get updated on every run. This adds a few seconds most of the time but ensures that the image does not get outdated.
3. Added a check to ensure GOPATH is set on the host, since that is necessary for the container mounted directories to be set up correctly
4. Updated docs to reflect these changes.

yaqs/7430975669045035008

```release-note:none

```
