### PR TITLE
Removed references to installing bundler because it is preinstalled for modern ruby versions

### DIFF
--- a/docs/content/get-started/generate-providers.md
+++ b/docs/content/get-started/generate-providers.md
@@ -35,7 +35,6 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
    ```bash
    rbenv install 3.1.0
    ```
-1. [Install bundler](https://bundler.io/guides/getting_started.html)
 1. [Install go](https://go.dev/doc/install)
 1. Install goimports
    ```bash
@@ -58,8 +57,6 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
  
    ```
    Check for ruby in path...
-      found!
-   Check for bundle in path...
       found!
    Check for go in path...
       found!

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -39,24 +39,6 @@ if [ $found -eq 0 ] || ! ruby -e "exit Gem::Version.new(RUBY_VERSION) >= Gem::Ve
     warn "yel" "   ruby version needs to be at least 3.1.0. See https://github.com/rbenv/rbenv for information on installing it."
 else
     warn "grn" "   found!"
-
-    count_in_path "bundle"
-    if [ $found -eq 0 ]; then
-        exitcode=1
-        warn "yel" "   bundler not found. Run 'gem install bundler' to install it."
-    else
-        if grep -qi "^Bundler" <<< "$(bundle version)"; then
-            if cd mmv1 && bundle check &> /dev/null; then
-                warn "grn" "   found!"
-            else
-                exitcode=1
-                warn "yel" "   bundle gems outdated. Run 'bundle install' from the mmv1 directory to correct"
-            fi
-        else
-            exitcode=1
-            warn "yel" "   wrong bundle found. You may have something incompatible overriding 'bundle'."
-        fi
-    fi
 fi
 
 count_in_path "go"


### PR DESCRIPTION
See https://bundler.io/guides/getting_started.html#getting-started. Note that installing packages _using_ bundler happens automatically as part of `make provider`

yaqs/8830557214180638720

```release-note:none

```
