### PR TITLE
Move gcp_sweeper_test.go to the sweeper package

### DIFF
--- a/mmv1/provider/terraform/common~compile.yaml
+++ b/mmv1/provider/terraform/common~compile.yaml
@@ -100,6 +100,13 @@
 <% end -%>
 
 <%
+  Dir["third_party/terraform/sweeper/*.go.erb"].each do |file_path|
+    fname = file_path.split('/')[-1]
+-%>
+'<%= dir -%>/sweeper/<%= fname.delete_suffix(".erb") -%>': 'third_party/terraform/sweeper/<%= fname -%>'
+<% end -%>
+
+<%
   Dir["third_party/terraform/transport/*.go.erb"].each do |file_path|
     fname = file_path.split('/')[-1]
 -%>

--- a/mmv1/third_party/terraform/.teamcity/components/generated/packages.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/packages.erb
@@ -77,6 +77,6 @@ var sweepers = mapOf(
     "sweeper" to mapOf(
         "name" to "sweeper",
         "displayName" to "Sweeper",
-        "path" to "<%= "./google#{version_string}" -%>"
+        "path" to "<%= "./google#{version_string}/sweeper" -%>"
     )
 )

--- a/mmv1/third_party/terraform/sweeper/gcp_sweeper_test.go.erb
+++ b/mmv1/third_party/terraform/sweeper/gcp_sweeper_test.go.erb
@@ -1,6 +1,6 @@
 <% autogen_exception -%>
 
-package google
+package sweeper_test
 
 import (
 	"testing"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The file gcp_sweeper_test.go.erb is moved from the google package to the sweeper_test package in the folder sweeper.

With this change, the command to run the sweepers in the teamcity settings need to change, too.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
