### PR TITLE
Ensure that the networksecurity p4sa is permissioned in tests

### DIFF
--- a/mmv1/templates/terraform/examples/network_security_gateway_security_policy_tls_inspection_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_gateway_security_policy_tls_inspection_basic.tf.erb
@@ -61,12 +61,26 @@ resource "google_privateca_certificate_authority" "default" {
   }
 }
 
+resource "google_project_service_identity" "ns_sa" {
+  provider = google-beta
+
+  service = "networksecurity.googleapis.com"
+}
+
+resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
+  provider = google-beta
+
+  ca_pool = google_privateca_ca_pool.default.id
+  role = "roles/privateca.certificateManager"
+  member = "serviceAccount:${google_project_service_identity.ns_sa.email}"
+}
+
 resource "google_network_security_tls_inspection_policy" "default" {
   provider = google-beta
   name     = "<%= ctx[:vars]['privateca_ca_tls_name'] %>"
   location = "us-central1"
   ca_pool  = google_privateca_ca_pool.default.id
-  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default]
+  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default, google_privateca_ca_pool_iam_member.tls_inspection_permission]
 }
 
 resource "google_network_security_gateway_security_policy" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
@@ -61,11 +61,25 @@ resource "google_privateca_certificate_authority" "default" {
   }
 }
 
+resource "google_project_service_identity" "ns_sa" {
+  provider = google-beta
+
+  service = "networksecurity.googleapis.com"
+}
+
+resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
+  provider = google-beta
+
+  ca_pool = google_privateca_ca_pool.default.id
+  role = "roles/privateca.certificateManager"
+  member = "serviceAccount:${google_project_service_identity.ns_sa.email}"
+}
+
 resource "google_network_security_tls_inspection_policy" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   name     = "<%= ctx[:vars]['resource_name'] %>"
   location = "us-central1"
   ca_pool  = google_privateca_ca_pool.default.id
   exclude_public_ca_set = false
-  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default]
+  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default, google_privateca_ca_pool_iam_member.tls_inspection_permission]
 }

--- a/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
@@ -105,14 +105,10 @@ resource "google_privateca_certificate_authority" "default" {
 }
 
 resource "google_project_service_identity" "ns_sa" {
-  provider = google-beta
-
   service = "networksecurity.googleapis.com"
 }
 
 resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
-  provider = google-beta
-
   ca_pool = google_privateca_ca_pool.default.id
   role = "roles/privateca.certificateManager"
   member = "serviceAccount:${google_project_service_identity.ns_sa.email}"

--- a/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
@@ -104,11 +104,25 @@ resource "google_privateca_certificate_authority" "default" {
   }
 }
 
+resource "google_project_service_identity" "ns_sa" {
+  provider = google-beta
+
+  service = "networksecurity.googleapis.com"
+}
+
+resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
+  provider = google-beta
+
+  ca_pool = google_privateca_ca_pool.default.id
+  role = "roles/privateca.certificateManager"
+  member = "serviceAccount:${google_project_service_identity.ns_sa.email}"
+}
+
 resource "google_network_security_tls_inspection_policy" "foobar" {
   name     = "%s"
   location = "us-central1"
   ca_pool    = google_privateca_ca_pool.default.id
-  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default]
+  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default, google_privateca_ca_pool_iam_member.tls_inspection_permission]
 }
 `, caPoolName, certificateAuthorityName, tlsInspectionPolicyName)
 }
@@ -176,12 +190,26 @@ resource "google_privateca_certificate_authority" "default" {
   }
 }
 
+resource "google_project_service_identity" "ns_sa" {
+  provider = google-beta
+
+  service = "networksecurity.googleapis.com"
+}
+
+resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
+  provider = google-beta
+
+  ca_pool = google_privateca_ca_pool.default.id
+  role = "roles/privateca.certificateManager"
+  member = "serviceAccount:${google_project_service_identity.ns_sa.email}"
+}
+
 resource "google_network_security_tls_inspection_policy" "foobar" {
   name        = "%s"
   location    = "us-central1"
   description = "my tls inspection policy updated"
   ca_pool     = google_privateca_ca_pool.default.id
-  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default]
+  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default, google_privateca_ca_pool_iam_member.tls_inspection_permission]
 }
 `, caPoolName, certificateAuthorityName, tlsInspectionPolicyName)
 }

--- a/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_network_security_tls_inspection_policy_test.go.erb
@@ -191,14 +191,10 @@ resource "google_privateca_certificate_authority" "default" {
 }
 
 resource "google_project_service_identity" "ns_sa" {
-  provider = google-beta
-
   service = "networksecurity.googleapis.com"
 }
 
 resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
-  provider = google-beta
-
   ca_pool = google_privateca_ca_pool.default.id
   role = "roles/privateca.certificateManager"
   member = "serviceAccount:${google_project_service_identity.ns_sa.email}"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Implements the guidance from https://cloud.google.com/secure-web-proxy/docs/enable-tls-inspection#create-service-account. This could technically be done at environment bootstrap time, but the identity resource is idempotent and the permission is tied to the specific pool, so let's just do it inline.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
