### PR TITLE
Put workstation test key ring in workstation location

### DIFF
--- a/mmv1/templates/terraform/examples/workstation_config_encryption_key.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_encryption_key.tf.erb
@@ -1,11 +1,13 @@
 resource "google_compute_network" "default" {
-  provider                = google-beta
+  provider = google-beta
+
   name                    = "<%= ctx[:vars]['workstation_cluster_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  provider      = google-beta
+  provider = google-beta
+
   name          = "<%= ctx[:vars]['workstation_cluster_name'] %>"
   ip_cidr_range = "10.0.0.0/24"
   region        = "us-central1"
@@ -13,7 +15,8 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_workstations_workstation_cluster" "<%= ctx[:primary_resource_id] %>" {
-  provider               = google-beta
+  provider = google-beta
+
   workstation_cluster_id = "<%= ctx[:vars]['workstation_cluster_name'] %>"
   network                = google_compute_network.default.id
   subnetwork             = google_compute_subnetwork.default.id
@@ -29,25 +32,29 @@ resource "google_workstations_workstation_cluster" "<%= ctx[:primary_resource_id
 }
 
 resource "google_kms_key_ring" "default" {
-  name     = "<%= ctx[:vars]['workstation_cluster_name'] %>"
-  location = "global"
   provider = google-beta
+
+  name     = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "default" {
+  provider = google-beta
+
   name            = "<%= ctx[:vars]['workstation_cluster_name'] %>"
   key_ring        = google_kms_key_ring.default.id
-  provider        = google-beta
 }
 
 resource "google_service_account" "default" {
+  provider = google-beta
+
   account_id   = "<%= ctx[:vars]['account_id'] %>"
   display_name = "Service Account"
-  provider = google-beta
 }
 
 resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id] %>" {
   provider               = google-beta
+
   workstation_config_id  = "<%= ctx[:vars]['workstation_config_name'] %>"
   workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
   location   		         = "us-central1"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

> Error: Error creating WorkstationConfig: googleapi: Error 400: encryption_key.kms_key must be located in the same region as the workstation config. Key is located in: global. Config is located in: us-central1


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
