### PR TITLE
fix `Get to know general workflow for VCR tests` details shortcodes for MM docsite

### DIFF
--- a/docs/content/get-started/contributing.md
+++ b/docs/content/get-started/contributing.md
@@ -33,19 +33,18 @@ aliases:
 1. Get approval to start Clould Builder jobs from the reviewer if you're an community contributor
 1. Wait for the the modules magician to generate downstream diff (which should take about 15 mins after creating the PR) to make sure all changes are generated correctly in downstream repos.
 1. Wait for the VCR test results.
-   {{< details "Get to know general workflow for VCR tests" >}}
-
-      1. Submit your change.
-      1. The recorded tests are ran against your changes by the `modular-magician`. Tests will fail if:
-         1. Your PR has changed the HTTP request values sent by the provider
-         1. Your PR does not change the HTTP request values, but fails on the values returned in an old recording
-         1. The recordings are out of sync with the merge-base of your PR, and an unrelated contributor's change has caused a false positive
-      1. The `modular-magician` will leave a message indicating the number of passing and failing VCR tests. If there is a failure, the `modular-magician` user will leave a message indicating the "`Triggering VCR tests in RECORDING mode for the following tests that failed during VCR:`" marking which tests failed.
-         1. If a test does not appear related to your PR, it probably isn't!
-      1. The `modular-magician` will kick off a second test run targeting only the failed tests, this time hitting the live GCP APIs. If there are tests that fail at this point, a message stating `Tests failed during RECORDING mode:` will be left indicating the tests.
-         1. If a test that appears to be related to your change has failed here, it's likely your change has introduced an issue. You can view the debug logs for the test by clicking the "view" link beside the test case to attempt to debug what's going wrong.
-         1. If a test that appears to be completely unrelated has failed, it's possible that a GCP API has changed in a way that broke the provider or our environment capped on a quota.
-   {{< /details >}}
+{{< details "Get to know general workflow for VCR tests" >}}
+   1. Submit your change.
+   1. The recorded tests are ran against your changes by the `modular-magician`. Tests will fail if:
+      * Your PR has changed the HTTP request values sent by the provider
+      * Your PR does not change the HTTP request values, but fails on the values returned in an old recording
+      * The recordings are out of sync with the merge-base of your PR, and an unrelated contributor's change has caused a false positive
+   1. The `modular-magician` will leave a message indicating the number of passing and failing VCR tests. If there is a failure, the `modular-magician` user will leave a message indicating the "`Triggering VCR tests in RECORDING mode for the following tests that failed during VCR:`" marking which tests failed.
+      * If a test does not appear related to your PR, it probably isn't!
+   1. The `modular-magician` will kick off a second test run targeting only the failed tests, this time hitting the live GCP APIs. If there are tests that fail at this point, a message stating `Tests failed during RECORDING mode:` will be left indicating the tests.
+      * If a test that appears to be related to your change has failed here, it's likely your change has introduced an issue. You can view the debug logs for the test by clicking the "view" link beside the test case to attempt to debug what's going wrong.
+      * If a test that appears to be completely unrelated has failed, it's possible that a GCP API has changed in a way that broke the provider or our environment capped on a quota.
+{{< /details >}}
 
    Where possible, take a look at the logs and see if you can figure out what needs to be fixed related to your change.
    The false positive rate on these tests is extremely high between changes in the API, Cloud Build bugs, and eventual consistency issues in test recordings so we don't expect contributors to wholly interpret the results — that's the responsibility of your reviewer.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Happen to find this error while working on some other doc write up and this PR should fix the `Get to know general workflow for VCR tests` details shortcodes in contributing page: https://googlecloudplatform.github.io/magic-modules/get-started/contributing/

result should look like:
<img width="741" alt="Screenshot 2023-06-27 at 5 44 36 PM" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/87669292/e266ca55-b15b-4daf-9eb2-85625e7202c1">



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
