### PR TITLE
Use module tpg in go.mod

### DIFF
--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -144,7 +144,9 @@ module Provider
           FileUtils.copy_entry source, target_file
 
           add_hashicorp_copyright_header(output_folder, target) if File.extname(target) == '.go'
-          replace_import_path(output_folder, target) if File.extname(target) == '.go'
+          if File.extname(target) == '.go' || File.extname(target) == '.mod'
+            replace_import_path(output_folder, target)
+          end
         end
       end.map(&:join)
     end
@@ -305,6 +307,12 @@ module Provider
       data = data.gsub(
         "#{TERRAFORM_PROVIDER_GA}/version",
         "#{tpg}/version"
+      )
+
+      Google::LOGGER.info "replace_import_path target #{output_folder}/#{target}"
+      data = data.gsub(
+        "module #{TERRAFORM_PROVIDER_GA}",
+        "module #{tpg}"
       )
       File.write("#{output_folder}/#{target}", data)
     end

--- a/mmv1/provider/core.rb
+++ b/mmv1/provider/core.rb
@@ -309,7 +309,6 @@ module Provider
         "#{tpg}/version"
       )
 
-      Google::LOGGER.info "replace_import_path target #{output_folder}/#{target}"
       data = data.gsub(
         "module #{TERRAFORM_PROVIDER_GA}",
         "module #{tpg}"

--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
-module github.com/hashicorp/terraform-provider-google<%= "-" + version unless version == 'ga' -%>
-
+module github.com/hashicorp/terraform-provider-google
 go 1.19
 
 require (


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14951
The users of EAP do not need to manually replace the module in go.mod file

In the go.mod file in magic module, the module is hardcoded to `github.com/hashicorp/terraform-provider-google`, and it will be replaced during compiling based on version. 
If the version is alpha, it will be replaced with `internal/terraform-next` for EAP. 
If the version is beta, it will be replaced with `github.com/hashicorp/terraform-provider-google-beta`


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
