### PR TITLE
Promote asynchronous disk replication resources to GA

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -81,7 +81,6 @@ examples:
     primary_resource_name: "fmt.Sprintf(\"tf-test-test-disk%s\",
       context[\"random_suffix\"\
       ])"
-    min_version: beta
     vars:
       disk_name: 'async-test-disk'
       secondary_disk_name: 'async-secondary-test-disk'
@@ -450,7 +449,6 @@ properties:
     update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=provisionedThroughput'
   - !ruby/object:Api::Type::NestedObject
     name: 'asyncPrimaryDisk'
-    min_version: 'beta'
     properties:
       - !ruby/object:Api::Type::String
         name: 'disk'

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -81,7 +81,6 @@ examples:
     primary_resource_name: "fmt.Sprintf(\"tf-test-my-region-disk%s\",
       context[\"random_suffix\"\
       ])"
-    min_version: beta
     vars:
       region_disk_name: 'primary-region-disk'
       secondary_region_disk_name: 'secondary-region-disk'
@@ -327,7 +326,6 @@ properties:
     output: true
   - !ruby/object:Api::Type::NestedObject
     name: 'asyncPrimaryDisk'
-    min_version: 'beta'
     properties:
       - !ruby/object:Api::Type::String
         name: 'disk'

--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -72,7 +72,6 @@ examples:
       name: 'gce-policy'
   - !ruby/object:Provider::Terraform::Examples
     name: 'resource_policy_consistency_group'
-    min_version: 'beta'
     primary_resource_id: 'cgroup'
     vars:
       name: 'gce-policy'
@@ -345,7 +344,6 @@ properties:
           The expiration time of the schedule. The timestamp is an RFC3339 string.
   - !ruby/object:Api::Type::NestedObject
     name: 'diskConsistencyGroupPolicy'
-    min_version: 'beta'
     conflicts:
       - 'snapshot_schedule_policy'
       - 'group_placement_policy'

--- a/mmv1/templates/terraform/examples/disk_async.tf.erb
+++ b/mmv1/templates/terraform/examples/disk_async.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_disk" "primary" {
-  provider = google-beta
-
   name  = "<%= ctx[:vars]['disk_name'] %>"
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -9,8 +7,6 @@ resource "google_compute_disk" "primary" {
 }
 
 resource "google_compute_disk" "secondary" {
-  provider = google-beta
-
   name  = "<%= ctx[:vars]['secondary_disk_name'] %>"
   type  = "pd-ssd"
   zone  = "us-east1-c"

--- a/mmv1/templates/terraform/examples/region_disk_async.tf.erb
+++ b/mmv1/templates/terraform/examples/region_disk_async.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_disk" "primary" {
-  provider = google-beta
-
   name                      = "<%= ctx[:vars]['region_disk_name'] %>"
   type                      = "pd-ssd"
   region                    = "us-central1"
@@ -10,8 +8,6 @@ resource "google_compute_region_disk" "primary" {
 }
 
 resource "google_compute_region_disk" "secondary" {
-  provider = google-beta
-
   name                      = "<%= ctx[:vars]['secondary_region_disk_name'] %>"
   type                      = "pd-ssd"
   region                    = "us-east1"

--- a/mmv1/templates/terraform/examples/resource_policy_consistency_group.tf.erb
+++ b/mmv1/templates/terraform/examples/resource_policy_consistency_group.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_resource_policy" "cgroup" {
-  provider = google-beta
-
   name   = "<%= ctx[:vars]['name'] %>"
   region = "europe-west1"
   disk_consistency_group_policy {

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -481,8 +481,8 @@ end     # products.each do
 				"google_composer_environment":                  composer.ResourceComposerEnvironment(),
 				"google_compute_attached_disk":                 compute.ResourceComputeAttachedDisk(),
 				"google_compute_instance":                      compute.ResourceComputeInstance(),
-				<% unless version == 'ga' -%>
 				"google_compute_disk_async_replication":        compute.ResourceComputeDiskAsyncReplication(),
+				<% unless version == 'ga' -%>
 				"google_compute_instance_from_machine_image":   compute.ResourceComputeInstanceFromMachineImage(),
 				<% end -%>
 				"google_compute_instance_from_template":        compute.ResourceComputeInstanceFromTemplate(),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_async_replication.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_async_replication.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package compute
-<% if version != "ga" -%>
 
 import (
 	"fmt"
@@ -303,4 +302,3 @@ func resourceDiskAsyncReplicationDelete(d *schema.ResourceData, meta interface{}
 	}
 	return nil
 }
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_async_replication_test.go.erb
@@ -45,7 +45,7 @@ func TestAccComputeDiskAsyncReplication(t *testing.T) {
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeDiskAsyncReplication_basicZonal(region, secondaryRegion, primaryDisk, secondaryDisk),
@@ -76,8 +76,6 @@ func TestAccComputeDiskAsyncReplication(t *testing.T) {
 func testAccComputeDiskAsyncReplication_basicZonal(region, secondaryRegion, primaryDisk, secondaryDisk string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "primary" {
-	provider = google-beta
-
 	zone = "%s-a"
 	name = "%s"
 	type = "pd-ssd"
@@ -86,8 +84,6 @@ resource "google_compute_disk" "primary" {
 }
 	
 resource "google_compute_disk" "secondary" {
-	provider = google-beta
-	
 	name = "%s"
 	type = "pd-ssd"
 	zone = "%s-b"
@@ -100,8 +96,6 @@ resource "google_compute_disk" "secondary" {
 }
 	
 resource "google_compute_disk_async_replication" "replication" {
-	provider = google-beta
-	
 	primary_disk = google_compute_disk.primary.id
 
 	secondary_disk {
@@ -114,8 +108,6 @@ resource "google_compute_disk_async_replication" "replication" {
 func testAccComputeDiskAsyncReplication_basicRegional(region, secondaryRegion, primaryDisk, secondaryDisk string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_disk" "primary" {
-	provider = google-beta
-	
 	region = "%s"
 	name   = "%s"
 	type   = "pd-ssd"
@@ -129,8 +121,6 @@ resource "google_compute_region_disk" "primary" {
 }
 	
 resource "google_compute_region_disk" "secondary" {
-    provider = google-beta
-	
 	region = "%s"
 	name   = "%s"
 	type   = "pd-ssd"
@@ -148,8 +138,6 @@ resource "google_compute_region_disk" "secondary" {
 }
 	
 resource "google_compute_disk_async_replication" "replication" {
-	provider = google-beta
-	
 	primary_disk = google_compute_region_disk.primary.id
 
 	secondary_disk {

--- a/mmv1/third_party/terraform/website/docs/r/compute_disk_async_replication.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_disk_async_replication.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 Starts and stops asynchronous persistent disk replication. For more information
 see [the official documentation](https://cloud.google.com/compute/docs/disks/async-pd/about)
-and the [API](https://cloud.google.com/compute/docs/reference/rest/beta/disks).
+and the [API](https://cloud.google.com/compute/docs/reference/rest/v1/disks).
 
 ## Example Usage
 


### PR DESCRIPTION
Promotes the Asynchronous PD replication features to GA.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
compute: promoted `google_compute_disk_async_replication` resource to GA.
```

```release-note:note
compute: promoted `async_primary_disk` field in `google_compute_disk` resource to GA.
```

```release-note:note
compute: promoted `async_primary_disk` field in `google_compute_region_disk` resource to GA.
```

```release-note:note
compute: promoted `disk_consistency_group_policy` field in `google_compute_resource_policy` resource to GA.
```
