### PR TITLE
Upgrade to DCL Version 1.44.0; add cloudbuildv2 gitlab_config samples

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -5,7 +5,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/bigtable v1.17.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.42.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -15,8 +15,8 @@ cloud.google.com/go/iam v0.13.0/go.mod h1:ljOg+rcNfzZ5d6f1nAUJ8ZIxOaZUVoS14bKCta
 cloud.google.com/go/longrunning v0.4.1 h1:v+yFJOfKC3yZdY6ZUI933pIYdhyhV8S3NpWrXWmg7jM=
 cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.42.0 h1:ClnwLCqnr8/exvPWhBLJOj16oa8bvw8Fhu45wCjvQbU=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.42.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0 h1:hASUAck0/5j84kejIHGJjipjUzFHiN5edNMobKwj2HA=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/tpgtools/api/cloudbuildv2/samples/gitlab.connection.json
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab.connection.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{connection}}",
+  "gitlabConfig": {
+    "authorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gitlab-api-pat/versions/latest"
+    },
+    "readAuthorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gitlab-read-pat/versions/latest"
+    },
+    "webhookSecretSecretVersion":"projects/407304063574/secrets/gle-webhook-secret/versions/latest"
+  },
+  "project": "{{project}}",
+  "location": "us-west1"
+}

--- a/tpgtools/api/cloudbuildv2/samples/gitlab.repository.json
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab.repository.json
@@ -1,0 +1,10 @@
+{
+  "project": "{{project}}",
+  "location": "us-west1",
+  "connection": "projects/{{project}}/locations/us-west1/connections/{{ref:gitlab.connection.json:name}}",
+  "name": "{{repository}}",
+  "remoteUri": "https://gitlab.com/proctor-eng-team/terraform-testing.git",
+  "annotations": {
+    "some-key": "some-value"
+  }
+}

--- a/tpgtools/api/cloudbuildv2/samples/gitlab.repository.json
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab.repository.json
@@ -1,7 +1,7 @@
 {
   "project": "{{project}}",
   "location": "us-west1",
-  "connection": "projects/{{project}}/locations/us-west1/connections/{{ref:gitlab.connection.json:name}}",
+  "connection": "{{ref:gitlab.connection.json:name}}",
   "name": "{{repository}}",
   "remoteUri": "https://gitlab.com/proctor-eng-team/terraform-testing.git",
   "annotations": {

--- a/tpgtools/api/cloudbuildv2/samples/gitlab_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab_connection.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gitlab_connection
+description: Creates a gitlab.com connection.
+type: connection
+versions:
+- beta
+resource: samples/gitlab.connection.json
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project

--- a/tpgtools/api/cloudbuildv2/samples/gitlab_repository.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab_repository.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gitlab_repository
+description: Creates a gitlab repository.
+type: repository
+versions:
+- beta
+resource: samples/gitlab.repository.json
+dependencies:
+- samples/gitlab.connection.json
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project
+- name: repository
+  type: resource_name

--- a/tpgtools/api/cloudbuildv2/samples/gle.connection.json
+++ b/tpgtools/api/cloudbuildv2/samples/gle.connection.json
@@ -1,0 +1,15 @@
+{
+  "name": "{{connection}}",
+  "gitlabConfig": {
+    "hostUri": "https://gle-us-central1.gcb-test.com",
+    "authorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gle-api-token/versions/latest"
+    },
+    "readAuthorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gle-read-token/versions/latest"
+    },
+    "webhookSecretSecretVersion":"projects/407304063574/secrets/gle-webhook-secret/versions/latest"
+  },
+  "project": "{{project}}",
+  "location": "us-west1"
+}

--- a/tpgtools/api/cloudbuildv2/samples/gle.repository.json
+++ b/tpgtools/api/cloudbuildv2/samples/gle.repository.json
@@ -1,0 +1,10 @@
+{
+  "project": "{{project}}",
+  "location": "us-west1",
+  "connection": "projects/{{project}}/locations/us-west1/connections/{{ref:gle.connection.json:name}}",
+  "name": "{{repository}}",
+  "remoteUri": "https://gle-us-central1.gcb-test.com/proctor-test/smoketest.git",
+  "annotations": {
+    "some-key": "some-value"
+  }
+}

--- a/tpgtools/api/cloudbuildv2/samples/gle.repository.json
+++ b/tpgtools/api/cloudbuildv2/samples/gle.repository.json
@@ -1,7 +1,7 @@
 {
   "project": "{{project}}",
   "location": "us-west1",
-  "connection": "projects/{{project}}/locations/us-west1/connections/{{ref:gle.connection.json:name}}",
+  "connection": "{{ref:gle.connection.json:name}}",
   "name": "{{repository}}",
   "remoteUri": "https://gle-us-central1.gcb-test.com/proctor-test/smoketest.git",
   "annotations": {

--- a/tpgtools/api/cloudbuildv2/samples/gle_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_connection.yaml
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gle_connection
+description: Creates a GLE connection then update to an older version.
+type: connection
+versions:
+- beta
+resource: samples/gle.connection.json
+updates:
+- resource: samples/gle_old.connection.json
+  dependencies: []
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project

--- a/tpgtools/api/cloudbuildv2/samples/gle_old.connection.json
+++ b/tpgtools/api/cloudbuildv2/samples/gle_old.connection.json
@@ -1,0 +1,15 @@
+{
+  "name": "{{connection}}",
+  "gitlabConfig": {
+    "hostUri": "https://gle-old.gcb-test.com",
+    "authorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gle-old-api-token/versions/2"
+    },
+    "readAuthorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gle-old-read-token/versions/3"
+    },
+    "webhookSecretSecretVersion":"projects/407304063574/secrets/gle-webhook-secret/versions/latest"
+  },
+  "project": "{{project}}",
+  "location": "us-west1"
+}

--- a/tpgtools/api/cloudbuildv2/samples/gle_old_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_old_connection.yaml
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gle_old_connection
+description: Creates a GLE connection on an old version then update to a newer version.
+type: connection
+versions:
+- beta
+resource: samples/gle_old.connection.json
+updates:
+- resource: samples/gle.connection.json
+  dependencies: []
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project

--- a/tpgtools/api/cloudbuildv2/samples/gle_priv.connection.json
+++ b/tpgtools/api/cloudbuildv2/samples/gle_priv.connection.json
@@ -1,0 +1,19 @@
+{
+  "name": "{{connection}}",
+  "gitlabConfig": {
+    "hostUri": "https://gle-test.proctor-staging-test.com",
+    "serviceDirectoryConfig": {
+      "service": "projects/proctor-gitlab-enterprise/locations/us-west1/namespaces/gle-uw-1/services/private-smoketest"
+    },
+    "sslCa": "-----BEGIN CERTIFICATE-----\nMIIDajCCAlKgAwIBAgIUedXFQAw0eUDTe6gmPKVyRvBlDi8wDQYJKoZIhvcNAQEL\nBQAwVjELMAkGA1UEBhMCVVMxGzAZBgNVBAoMEkdvb2dsZSBDbG91ZCBCdWlsZDEq\nMCgGA1UEAwwhZ2xlLXRlc3QucHJvY3Rvci1zdGFnaW5nLXRlc3QuY29tMB4XDTIy\nMDcyNTE3Mzg0MFoXDTIzMDcyNTE3Mzg0MFowVjELMAkGA1UEBhMCVVMxGzAZBgNV\nBAoMEkdvb2dsZSBDbG91ZCBCdWlsZDEqMCgGA1UEAwwhZ2xlLXRlc3QucHJvY3Rv\nci1zdGFnaW5nLXRlc3QuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC\nAQEAr7H0J4nZBL0ed3duVDbOdlnqJuLHZVBWIOp0DBVWPzdx+4eDCi86czxzXmVG\nuZXSpvg3az4QHGWs2HwlBCDk6tp2QT6F1gR6TE8S2yp+04BDhtg1DUopWY+f+Xi7\ni1tXQG7OTDByez3V6MR0t0bVv/LOJlvOngWbJ32qZqfbj5W8MACR/3u7KBjGs/bm\nrbDMga3YOOIa+DVLdLCwzc7kFlM9W7sezkUM/FhhellaxLu4i5O86sywJYMEo7VG\nj3FUS3XiDyKW68xOpE4svW7LiZEAnnLSsPdELO2bzhR/md84Jjvm99i6yP0StrMB\n+X2EwPYmTLMktdJyMUn/vhFYzQIDAQABozAwLjAsBgNVHREEJTAjgiFnbGUtdGVz\ndC5wcm9jdG9yLXN0YWdpbmctdGVzdC5jb20wDQYJKoZIhvcNAQELBQADggEBAJ+6\nH7WI9+hqrT4zpyc/CpH6VuviYezo1qd4/6M496dKlrHd11+xAXkBRZ4FFyoDFMgz\nO7YihNTBuONwiv21YN3OV9xoTExGx/IIkHNaueL2ZPkbVcJWQEWtEITp9Mo0qDIj\nkKjEQ5A+I4T4CiQ/OAhqtN8gR8ZUKGRJw+s2sE+yCIvRfoeJ4YU7NfUL1vSXxKfy\nHz3awR7t5qnCsvcShZtmiZ4xsc6o/tKqL5nAwNk1M6rPMY/+/PY70juLf1GNNDoZ\nA2Co+g6uI/FwAFAO5ZYKRLlstgNcPXerNdxXhpRZKMxGj8WfQ3z0Eu4cGtTUmDz5\npTam4bqToj22/MN2IhA=\n-----END CERTIFICATE-----\n",
+    "authorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gle-api-token/versions/latest"
+    },
+    "readAuthorizerCredential": {
+      "userTokenSecretVersion": "projects/407304063574/secrets/gle-read-token/versions/latest"
+    },
+    "webhookSecretSecretVersion":"projects/407304063574/secrets/gle-webhook-secret/versions/latest"
+  },
+  "project": "{{project}}",
+  "location": "us-west1"
+}

--- a/tpgtools/api/cloudbuildv2/samples/gle_priv_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_priv_connection.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gle_priv_connection
+description: Creates a connection to a private server using Service Directory.
+type: connection
+versions:
+- beta
+resource: samples/gle_priv.connection.json
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project

--- a/tpgtools/api/cloudbuildv2/samples/gle_priv_update_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_priv_update_connection.yaml
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gle_priv_update_connection
+description: Creates and updates a connection to a private server using Service Directory.
+type: connection
+versions:
+- beta
+resource: samples/gle.connection.json
+updates:
+- resource: samples/gle_priv.connection.json
+  dependencies: []
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project

--- a/tpgtools/api/cloudbuildv2/samples/gle_repository.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_repository.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: gle_repository
+description: Creates a GLE repository.
+type: repository
+versions:
+- beta
+resource: samples/gle.repository.json
+dependencies:
+- samples/gle.connection.json
+variables:
+- name: connection
+  type: resource_name
+- name: project
+  type: project
+- name: repository
+  type: resource_name

--- a/tpgtools/api/cloudbuildv2/samples/gle_update.connection.json
+++ b/tpgtools/api/cloudbuildv2/samples/gle_update.connection.json
@@ -1,0 +1,13 @@
+{
+  "name": "{{connection}}",
+  "gitlabConfig": {
+    "hostUri": "https://gle-us-central1.gcb-test.com",
+    "authorizerCredential": {
+      "userTokenSecretVersion": "projects/212465313333/secrets/proctor-repo-gle-api-token/versions/latest"
+    },
+    "webhookSecretSecretVersion":"projects/407304063574/secrets/gle-webhook-secret/versions/latest"
+  },
+  "project": "{{project}}",
+  "annotations": {"somekey": "somevalue"},
+  "location": "{{region}}"
+}

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.42.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/hcl v1.0.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -35,8 +35,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.42.0 h1:ClnwLCqnr8/exvPWhBLJOj16oa8bvw8Fhu45wCjvQbU=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.42.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0 h1:hASUAck0/5j84kejIHGJjipjUzFHiN5edNMobKwj2HA=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/tpgtools/overrides/cloudbuildv2/beta/repository.yaml
+++ b/tpgtools/overrides/cloudbuildv2/beta/repository.yaml
@@ -3,3 +3,16 @@
   field: connection
   details:
     name: parent_connection
+# TODO: remove once DCL is updpated to not have these fields required.
+- type: CUSTOM_SCHEMA_VALUES
+  field: project
+  details:
+    required: false
+    optional: true
+    computed: true
+- type: CUSTOM_SCHEMA_VALUES
+  field: location
+  details:
+    required: false
+    optional: true
+    computed: true

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/meta.yaml
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/meta.yaml
@@ -13,3 +13,8 @@ doc_hide:
 - ghe_complete_connection.yaml
 - ghe_priv_connection.yaml
 - ghe_priv_update_connection.yaml
+- gitlab_connection.yaml
+- gle_connection.yaml
+- gle_old_connection.yaml
+- gle_priv_connection.yaml
+- gle_priv_update_connection.yaml

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/meta.yaml
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/meta.yaml
@@ -10,3 +10,5 @@ doc_hide:
 # to show them in the docs.
 - ghe_repository.yaml
 - github_repository.yaml
+- gitlab_repository.yaml
+- gle_repository.yaml


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR upgrades DCL to v1.44.0 which includes a new field for cloudbuildv2 connection resource. It also includes the samples for that new field.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuildv2: added `gitlab_config` field to `google_cloudbuildv2_connection` resource (beta)
```
