### PR TITLE
Remove generation lines from generate downstream, fix link

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -155,11 +155,6 @@ else
         fi
         pushd ../
         make tpgtools OUTPUT_PATH=$LOCAL_PATH VERSION=$VERSION
-        pushd ./tools/breaking-change-detector
-        set +e
-        go run . -docs -providerFolder="${LOCAL_PATH}/.github/"
-        set -e
-        popd
         popd
     fi
 fi

--- a/docs/content/develop/breaking-changes.md
+++ b/docs/content/develop/breaking-changes.md
@@ -1,5 +1,5 @@
 ---
-title: "Understanding breaking changes"
+title: "Understand breaking changes"
 summary: "This page discusses provider versioning, handling of breaking changes, and rare exceptions within Terraform development."
 weight: 12
 ---

--- a/tools/breaking-change-detector/constants/constants.go
+++ b/tools/breaking-change-detector/constants/constants.go
@@ -3,7 +3,7 @@ package constants
 const BreakingChangeRelativeLocation = "develop/"
 const BreakingChangeFileName = "breaking-changes"
 
-var docsite = "https://googlecloudplatform.github.io/magic-modules"
+var docsite = "https://googlecloudplatform.github.io/magic-modules/"
 
 func GetFileUrl(identifier string) string {
 	return docsite + BreakingChangeRelativeLocation + BreakingChangeFileName + "#" + identifier


### PR DESCRIPTION
Documentation has already been migrated [to the github docs site](https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/#resource-schema-field-removal-or-rename). This is just clean up of unneeded code and a small href fix.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
