### PR TITLE
Pin Hugo version to 0.115.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.115.0'
           extended: true
 
       - name: Build


### PR DESCRIPTION
To starve off any instability lets pin this version.

Closes b/284471603

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
