### PR TITLE
Marked google_compute_router_peer.peer_ip_address as default from api

### DIFF
--- a/mmv1/products/compute/RouterBgpPeer.yaml
+++ b/mmv1/products/compute/RouterBgpPeer.yaml
@@ -142,8 +142,8 @@ properties:
     name: 'peerIpAddress'
     description: |
       IP address of the BGP interface outside Google Cloud Platform.
-      Only IPv4 is supported.
-    required: true
+      Only IPv4 is supported. Required if `ip_address` is set.
+    default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: 'peerAsn'
     description: |

--- a/mmv1/templates/terraform/examples/router_peer_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/router_peer_basic.tf.erb
@@ -2,7 +2,6 @@ resource "google_compute_router_peer" "<%= ctx[:primary_resource_id] %>" {
   name                      = "<%= ctx[:vars]['peer_name'] %>"
   router                    = "<%= ctx[:vars]['router_name'] %>"
   region                    = "us-central1"
-  peer_ip_address           = "169.254.1.2"
   peer_asn                  = 65513
   advertised_route_priority = 100
   interface                 = "interface-1"

--- a/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
@@ -480,7 +480,6 @@ resource "google_compute_router_interface" "foobar" {
   name       = "%s"
   router     = google_compute_router.foobar.name
   region     = google_compute_router.foobar.region
-  ip_range   = "169.254.3.1/30"
   vpn_tunnel = google_compute_vpn_tunnel.foobar.name
 }
 
@@ -488,8 +487,6 @@ resource "google_compute_router_peer" "foobar" {
   name                      = "%s"
   router                    = google_compute_router.foobar.name
   region                    = google_compute_router.foobar.region
-  ip_address                = "169.254.3.1"
-  peer_ip_address           = "169.254.3.2"
   peer_asn                  = 65515
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name
@@ -556,7 +553,6 @@ resource "google_compute_router_interface" "foobar" {
   name       = "%s"
   router     = google_compute_router.foobar.name
   region     = google_compute_router.foobar.region
-  ip_range   = "169.254.3.1/30"
   vpn_tunnel = google_compute_vpn_tunnel.foobar.name
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
@@ -886,7 +882,6 @@ resource "google_compute_router_interface" "foobar" {
   name       = "%s"
   router     = google_compute_router.foobar.name
   region     = google_compute_router.foobar.region
-  ip_range   = "169.254.3.1/30"
   vpn_tunnel = google_compute_vpn_tunnel.foobar.name
 }
 
@@ -894,7 +889,6 @@ resource "google_compute_router_peer" "foobar" {
   name                      = "%s"
   router                    = google_compute_router.foobar.name
   region                    = google_compute_router.foobar.region
-  peer_ip_address           = "169.254.3.2"
   peer_asn                  = 65515
   advertised_route_priority = 100  
   interface = google_compute_router_interface.foobar.name
@@ -962,7 +956,6 @@ resource "google_compute_router_interface" "foobar" {
   name       = "%s"
   router     = google_compute_router.foobar.name
   region     = google_compute_router.foobar.region
-  ip_range   = "169.254.3.1/30"
   vpn_tunnel = google_compute_vpn_tunnel.foobar.name
 }
 
@@ -970,8 +963,6 @@ resource "google_compute_router_peer" "foobar" {
   name                      = "%s"
   router                    = google_compute_router.foobar.name
   region                    = google_compute_router.foobar.region
-  ip_address                = "169.254.3.1"
-  peer_ip_address           = "169.254.3.2"
   peer_asn                  = 65515
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/14981

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: made `google_compute_router_peer.peer_ip_address` optional
```
