### PR TITLE
mark redis instance maintenanceSchedule block as output only

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -336,6 +336,7 @@ properties:
                     function: 'validation.IntBetween(0,999999999)'
   - !ruby/object:Api::Type::NestedObject
     name: maintenanceSchedule
+    output: true
     description: Upcoming maintenance schedule.
     properties:
       - !ruby/object:Api::Type::String


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

For some reason `maintenance_schedule` is being set (to NULL) even though the whole block is output-only.  

I haven't been able to figure out with 100% certainty why, but me and others, are suddenly suffering from this.

I think it might have to do with a slight change in the gcloud API regarding scheduled upcoming maintenance...

for instances that are due for an upgrade the gcloud API will return the `maintenance_schedule` for the scheduled upcoming maintenance, and then terraform incorrectly NULLs the 3 properties because they're output only, leaving an empty `maintenance_schedule` object that it will use apply.

for a freshly creation redis instance I don't get a `maintenanceSchedule` in the `GET GET /v1beta1/projects/my-instance/locations/europe-west4/instances/aurora-redis?alt=json` while for an older one it is present.

note how it nulls the properties, not the whole object;
```
      - maintenance_schedule {
          - end_time               = "2023-07-08T05:00:00Z" -> null
          - schedule_deadline_time = "2023-07-15T04:00:00Z" -> null
          - start_time             = "2023-07-08T04:00:00Z" -> null
        }
```

This PR marks the whole block as `output: true` to by-pass this problem entirely.

Fixes [11871](https://github.com/hashicorp/terraform-provider-google/issues/11871)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

*Note:* I wasn't able to run the acceptance test because I'm struggling with the authentication ... will try to resolve ...

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
fixed issue with `google_redis_instance` populating output-only field `maintenance_schedule`. 
```
