### PR TITLE
Adding Cloud Composer Support For Resilience Mode Updates

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -817,7 +817,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 							Computed:     true,
 							ForceNew:     false,
 							AtLeastOneOf: composerConfigKeys,
-							ValidateFunc: validation.StringInSlice([]string{"RESILIENCE_MODE_UNSPECIFIED", "HIGH_RESILIENCE"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"STANDARD_RESILIENCE", "HIGH_RESILIENCE"}, false),
 							Description:  `Whether high resilience is enabled or not. This field is supported for Cloud Composer environments in versions composer-2.1.15-airflow-*.*.* and newer.`,
 						},
 						"master_authorized_networks_config": {
@@ -1189,7 +1189,11 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("config.0.resilience_mode") {
 		patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 		if config != nil {
-			patchObj.Config.ResilienceMode = config.ResilienceMode
+			if config.ResilienceMode == "STANDARD_RESILIENCE" {
+				patchObj.Config.ResilienceMode = "RESILIENCE_MODE_UNSPECIFIED"
+			} else {
+				patchObj.Config.ResilienceMode = config.ResilienceMode
+			}
 		}
 		err = resourceComposerEnvironmentPatchField("config.ResilienceMode", userAgent, patchObj, d, tfConfig)
   		if err != nil {
@@ -1330,7 +1334,11 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["workloads_config"] = flattenComposerEnvironmentConfigWorkloadsConfig(envCfg.WorkloadsConfig)
 	transformed["recovery_config"] = flattenComposerEnvironmentConfigRecoveryConfig(envCfg.RecoveryConfig)
 	transformed["environment_size"] = envCfg.EnvironmentSize
-	transformed["resilience_mode"] = envCfg.ResilienceMode
+	if envCfg.ResilienceMode == "STANDARD_RESILIENCE" {
+		transformed["resilience_mode"] = "RESILIENCE_MODE_UNSPECIFIED"
+	} else {
+		transformed["resilience_mode"] = envCfg.ResilienceMode
+	}
 	transformed["master_authorized_networks_config"] = flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(envCfg.MasterAuthorizedNetworksConfig)
 	return []interface{}{transformed}
 }
@@ -1692,7 +1700,12 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
   	if err != nil {
   		return nil, err
   	}
-  	transformed.ResilienceMode = transformedResilienceMode
+	if transformedResilienceMode == "RESILIENCE_MODE_UNSPECIFIED" {
+		transformed.ResilienceMode = "STANDARD_RESILIENCE"
+	} else {
+		transformed.ResilienceMode = transformedResilienceMode	
+	}
+  	
 
 	transformedMasterAuthorizedNetworksConfig, err := expandComposerEnvironmentConfigMasterAuthorizedNetworksConfig(original["master_authorized_networks_config"], d, config)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1334,7 +1334,7 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["workloads_config"] = flattenComposerEnvironmentConfigWorkloadsConfig(envCfg.WorkloadsConfig)
 	transformed["recovery_config"] = flattenComposerEnvironmentConfigRecoveryConfig(envCfg.RecoveryConfig)
 	transformed["environment_size"] = envCfg.EnvironmentSize
-	if envCfg.ResilienceMode == "RESILIENCE_MODE_UNSPECIFIED" {
+	if envCfg.ResilienceMode == "RESILIENCE_MODE_UNSPECIFIED" || envCfg.ResilienceMode == "" {
 		transformed["resilience_mode"] = "STANDARD_RESILIENCE"
 	} else {
 		transformed["resilience_mode"] = envCfg.ResilienceMode

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1700,8 +1700,8 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
   	if err != nil {
   		return nil, err
   	}
-	if transformedResilienceMode == "RESILIENCE_MODE_UNSPECIFIED" {
-		transformed.ResilienceMode = "STANDARD_RESILIENCE"
+	if transformedResilienceMode == "STANDARD_RESILIENCE" {
+		transformed.ResilienceMode = "RESILIENCE_MODE_UNSPECIFIED"
 	} else {
 		transformed.ResilienceMode = transformedResilienceMode	
 	}

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -815,7 +815,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ForceNew:     true,
+							ForceNew:     false,
 							AtLeastOneOf: composerConfigKeys,
 							ValidateFunc: validation.StringInSlice([]string{"HIGH_RESILIENCE"}, false),
 							Description:  `Whether high resilience is enabled or not. This field is supported for Cloud Composer environments in versions composer-2.1.15-airflow-*.*.* and newer.`,
@@ -1176,7 +1176,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-    if d.HasChange("config.0.environment_size") {
+		if d.HasChange("config.0.environment_size") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {
 				patchObj.Config.EnvironmentSize = config.EnvironmentSize
@@ -1186,6 +1186,16 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
     }
+	if d.HasChange("config.0.resilience_mode") {
+		patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+		if config != nil {
+			patchObj.Config.ResilienceMode = config.ResilienceMode
+		}
+		err = resourceComposerEnvironmentPatchField("config.ResilienceMode", userAgent, patchObj, d, tfConfig)
+  		if err != nil {
+			return err
+		}
+	}
 		if d.HasChange("config.0.master_authorized_networks_config") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -817,7 +817,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 							Computed:     true,
 							ForceNew:     false,
 							AtLeastOneOf: composerConfigKeys,
-							ValidateFunc: validation.StringInSlice([]string{"HIGH_RESILIENCE"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"RESILIENCE_MODE_UNSPECIFIED", "HIGH_RESILIENCE"}, false),
 							Description:  `Whether high resilience is enabled or not. This field is supported for Cloud Composer environments in versions composer-2.1.15-airflow-*.*.* and newer.`,
 						},
 						"master_authorized_networks_config": {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1334,8 +1334,8 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["workloads_config"] = flattenComposerEnvironmentConfigWorkloadsConfig(envCfg.WorkloadsConfig)
 	transformed["recovery_config"] = flattenComposerEnvironmentConfigRecoveryConfig(envCfg.RecoveryConfig)
 	transformed["environment_size"] = envCfg.EnvironmentSize
-	if envCfg.ResilienceMode == "STANDARD_RESILIENCE" {
-		transformed["resilience_mode"] = "RESILIENCE_MODE_UNSPECIFIED"
+	if envCfg.ResilienceMode == "RESILIENCE_MODE_UNSPECIFIED" {
+		transformed["resilience_mode"] = "STANDARD_RESILIENCE"
 	} else {
 		transformed["resilience_mode"] = envCfg.ResilienceMode
 	}

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -598,42 +598,6 @@ func TestAccComposerEnvironment_UpdateComposerV2(t *testing.T) {
 	})
 }
 
-func TestAccComposerEnvironment_UpdateComposerV2ResilienceMode(t *testing.T) {
-	t.Parallel()
-
-	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, RandInt(t))
-	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, RandInt(t))
-	subnetwork := network + "-1"
-
-	VcrTest(t, resource.TestCase{
-		PreCheck:		          func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComposerEnvironment_composerV2HighResilience(envName, network, subnetwork),
-			},
-			{
-				Config: testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
-			},
-			{
-				ResourceName:			"google_composer_environment.test",
-				ImportState:			 true,
-				ImportStateVerify: true,
-			},
-			// This is a terrible clean-up step in order to get destroy to succeed,
-			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
-			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
-			{
-				PlanOnly:					 true,
-				ExpectNonEmptyPlan: false,
-				Config:						 testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
-				Check:							testAccCheckClearComposerEnvironmentFirewalls(t, network),
-			},
-		},
-	})
-}
-
 func TestAccComposerEnvironment_composerV2PrivateServiceConnect(t *testing.T) {
 	t.Parallel()
 
@@ -1746,69 +1710,6 @@ resource "google_composer_environment" "test" {
 		}
 		environment_size = "ENVIRONMENT_SIZE_MEDIUM"
 		resilience_mode = "HIGH_RESILIENCE"
-		private_environment_config {
-			enable_private_endpoint                  = true
-			cloud_composer_network_ipv4_cidr_block   = "10.3.192.0/24"
-			master_ipv4_cidr_block                   = "172.16.194.0/23"
-			cloud_sql_ipv4_cidr_block                = "10.3.224.0/20"
-		}
-	}
-}
-
-resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-east1"
-   network       = google_compute_network.test.self_link
-  private_ip_google_access = true
-}
-
-`, envName, network, subnetwork)
-}
-
-func testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork string) string {
-	return fmt.Sprintf(`
-resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-east1"
-
-	config {
-		node_config {
-			network          = google_compute_network.test.self_link
-			subnetwork       = google_compute_subnetwork.test.self_link
-		}
-
-		software_config {
-			image_version = "composer-2-airflow-2"
-		}
-
-		workloads_config {
-			scheduler {
-				cpu         = 1.25
-				memory_gb   = 2.5
-				storage_gb  = 5.4
-				count       = 2
-			}
-			web_server {
-				cpu         = 1.75
-				memory_gb   = 3.0
-				storage_gb  = 4.4
-			}
-			worker {
-				cpu         = 0.5
-				memory_gb   = 2.0
-				storage_gb  = 3.4
-				min_count   = 2
-				max_count   = 5
-			}
-		}
-		environment_size = "ENVIRONMENT_SIZE_MEDIUM"
-		resilience_mode = "RESILIENCE_MODE_UNSPECIFIED"
 		private_environment_config {
 			enable_private_endpoint                  = true
 			cloud_composer_network_ipv4_cidr_block   = "10.3.192.0/24"

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -488,6 +488,43 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironment_UpdateComposerV2ResilienceMode(t *testing.T) {
+    t.Parallel()
+
+    envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, RandInt(t))
+    network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, RandInt(t))
+    subnetwork := network + "-1"
+
+    VcrTest(t, resource.TestCase{
+        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+        ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+        CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+        Steps: []resource.TestStep{
+            {
+                Config: testAccComposerEnvironment_composerV2HighResilience(envName, network, subnetwork),
+            },
+            {
+                Config: testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
+            },
+            {
+                ResourceName:           "google_composer_environment.test",
+                ImportState:             true,
+                ImportStateVerify: true,
+            },
+            // This is a terrible clean-up step in order to get destroy to succeed,
+            // due to dangling firewall rules left by the Composer Environment blocking network deletion.
+            // TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+            {
+                PlanOnly:					 true,
+				ExpectNonEmptyPlan: false,
+				Config:						 testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
+                Check:                          testAccCheckClearComposerEnvironmentFirewalls(t, network),
+            },
+        },
+    })
+}
+
+
 
 func TestAccComposerEnvironment_ComposerV2HighResilience(t *testing.T) {
 	t.Parallel()
@@ -1815,6 +1852,70 @@ resource "google_compute_subnetwork" "test" {
 }
 
 `, envName, compVersion, airflowVersion, network, subnetwork)
+}
+
+
+func testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork string) string {
+    return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-east1"
+
+    config {
+        node_config {
+            network          = google_compute_network.test.self_link
+            subnetwork       = google_compute_subnetwork.test.self_link
+        }
+
+        software_config {
+            image_version = "composer-2-airflow-2"
+        }
+
+        workloads_config {
+            scheduler {
+                cpu         = 1.25
+                memory_gb   = 2.5
+                storage_gb  = 5.4
+                count       = 2
+            }
+            web_server {
+                cpu         = 1.75
+                memory_gb   = 3.0
+                storage_gb  = 4.4
+            }
+            worker {
+                cpu         = 0.5
+                memory_gb   = 2.0
+                storage_gb  = 3.4
+                min_count   = 2
+                max_count   = 5
+            }
+        }
+        environment_size = "ENVIRONMENT_SIZE_MEDIUM"
+        resilience_mode = "STANDARD_RESILIENCE"
+        private_environment_config {
+            enable_private_endpoint                  = true
+            cloud_composer_network_ipv4_cidr_block   = "10.3.192.0/24"
+            master_ipv4_cidr_block                   = "172.16.194.0/23"
+            cloud_sql_ipv4_cidr_block                = "10.3.224.0/20"
+        }
+    }
+}
+
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-east1"
+   network       = google_compute_network.test.self_link
+  private_ip_google_access = true
+}
+
+`, envName, network, subnetwork)
 }
 
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -598,6 +598,42 @@ func TestAccComposerEnvironment_UpdateComposerV2(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironment_UpdateComposerV2ResilienceMode(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, RandInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, RandInt(t))
+	subnetwork := network + "-1"
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:		          func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_composerV2HighResilience(envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
+			},
+			{
+				ResourceName:			"google_composer_environment.test",
+				ImportState:			 true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:					 true,
+				ExpectNonEmptyPlan: false,
+				Config:						 testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
+				Check:							testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
 func TestAccComposerEnvironment_composerV2PrivateServiceConnect(t *testing.T) {
 	t.Parallel()
 
@@ -1710,6 +1746,69 @@ resource "google_composer_environment" "test" {
 		}
 		environment_size = "ENVIRONMENT_SIZE_MEDIUM"
 		resilience_mode = "HIGH_RESILIENCE"
+		private_environment_config {
+			enable_private_endpoint                  = true
+			cloud_composer_network_ipv4_cidr_block   = "10.3.192.0/24"
+			master_ipv4_cidr_block                   = "172.16.194.0/23"
+			cloud_sql_ipv4_cidr_block                = "10.3.224.0/20"
+		}
+	}
+}
+
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-east1"
+   network       = google_compute_network.test.self_link
+  private_ip_google_access = true
+}
+
+`, envName, network, subnetwork)
+}
+
+func testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-east1"
+
+	config {
+		node_config {
+			network          = google_compute_network.test.self_link
+			subnetwork       = google_compute_subnetwork.test.self_link
+		}
+
+		software_config {
+			image_version = "composer-2-airflow-2"
+		}
+
+		workloads_config {
+			scheduler {
+				cpu         = 1.25
+				memory_gb   = 2.5
+				storage_gb  = 5.4
+				count       = 2
+			}
+			web_server {
+				cpu         = 1.75
+				memory_gb   = 3.0
+				storage_gb  = 4.4
+			}
+			worker {
+				cpu         = 0.5
+				memory_gb   = 2.0
+				storage_gb  = 3.4
+				min_count   = 2
+				max_count   = 5
+			}
+		}
+		environment_size = "ENVIRONMENT_SIZE_MEDIUM"
+		resilience_mode = "RESILIENCE_MODE_UNSPECIFIED"
 		private_environment_config {
 			enable_private_endpoint                  = true
 			cloud_composer_network_ipv4_cidr_block   = "10.3.192.0/24"

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -683,7 +683,7 @@ The `config` block supports:
   (Optional, Cloud Composer 2.1.15 or newer only)
   The resilience mode states whether high resilience is enabled for 
   the environment or not. Values for resilience mode are `HIGH_RESILIENCE` 
-  for high resilience and `RESILIENCE_MODE_UNSPECIFIED` for standard
+  for high resilience and `STANDARD_RESILIENCE` for standard
   resilience.
 
 * `master_authorized_networks_config` -

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -682,8 +682,9 @@ The `config` block supports:
 * `resilience_mode` -
   (Optional, Cloud Composer 2.1.15 or newer only)
   The resilience mode states whether high resilience is enabled for 
-  the environment or not. Value for resilience mode is `HIGH_RESILIENCE`.
-  If unspecified, defaults to standard resilience.
+  the environment or not. Values for resilience mode are `HIGH_RESILIENCE` 
+  for high resilience and `RESILIENCE_MODE_UNSPECIFIED` for standard
+  resilience.
 
 * `master_authorized_networks_config` -
   (Optional)


### PR DESCRIPTION
Adding Cloud Composer Support For Resilience Mode Updates

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added support for updating `resilience_mode` in `google_composer_environment`
```
