### PR TITLE
Added windows_node_config support for GKE Clusters

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -522,6 +522,24 @@ func schemaNodeConfig() *schema.Schema {
 						},
 					},
 				},
+				"windows_node_config": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: `Parameters that can be configured on Windows nodes.`,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"osversion": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ForceNew:     true,
+								Default:      "OS_VERSION_UNSPECIFIED",
+								Description:  `The OS Version of the windows nodepool.Values are OS_VERSION_UNSPECIFIED,OS_VERSION_LTSC2019 and OS_VERSION_LTSC2022`,
+								ValidateFunc: validation.StringInSlice([]string{"OS_VERSION_UNSPECIFIED", "OS_VERSION_LTSC2019", "OS_VERSION_LTSC2022"}, false),
+							},
+						},
+					},
+				},
 				"node_group": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -843,6 +861,10 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		nc.LinuxNodeConfig = expandLinuxNodeConfig(v)
 	}
 
+	if v, ok := nodeConfig["windows_node_config"]; ok {
+		nc.WindowsNodeConfig = expandWindowsNodeConfig(v)
+	}
+
 	if v, ok := nodeConfig["node_group"]; ok {
 		nc.NodeGroup = v.(string)
 	}
@@ -925,6 +947,24 @@ func expandLinuxNodeConfig(v interface{}) *container.LinuxNodeConfig {
 	}
 	return &container.LinuxNodeConfig{
 		Sysctls: m,
+	}
+}
+
+func expandWindowsNodeConfig(v interface{}) *container.WindowsNodeConfig {
+	if v == nil {
+		return nil
+	}
+	ls := v.([]interface{})
+	if len(ls) == 0 {
+		return nil
+	}
+	cfg := ls[0].(map[string]interface{})
+	osversionRaw, ok := cfg["osversion"]
+	if !ok {
+		return nil
+	}
+	return &container.WindowsNodeConfig{
+		OsVersion: osversionRaw.(string),
 	}
 }
 
@@ -1013,6 +1053,7 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 		"boot_disk_kms_key": 		c.BootDiskKmsKey,
 		"kubelet_config":            flattenKubeletConfig(c.KubeletConfig),
 		"linux_node_config":         flattenLinuxNodeConfig(c.LinuxNodeConfig),
+		"windows_node_config":       flattenWindowsNodeConfig(c.WindowsNodeConfig),
                 "node_group":                c.NodeGroup,
 		"advanced_machine_features": flattenAdvancedMachineFeaturesConfig(c.AdvancedMachineFeatures),
 		"sole_tenant_config":                 flattenSoleTenantConfig(c.SoleTenantConfig),
@@ -1306,6 +1347,16 @@ func flattenLinuxNodeConfig(c *container.LinuxNodeConfig) []map[string]interface
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"sysctls": c.Sysctls,
+		})
+	}
+	return result
+}
+
+func flattenWindowsNodeConfig(c *container.WindowsNodeConfig) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"osversion": c.OsVersion,
 		})
 	}
 	return result

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -1504,6 +1504,39 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 
 			log.Printf("[INFO] Updated linux_node_config for node pool %s", name)
 		}
+		if d.HasChange(prefix + "node_config.0.windows_node_config") {
+			req := &container.UpdateNodePoolRequest{
+				NodePoolId: name,
+				WindowsNodeConfig: expandWindowsNodeConfig(
+					d.Get(prefix + "node_config.0.windows_node_config")),
+			}
+			if req.WindowsNodeConfig == nil {
+				req.ForceSendFields = []string{"WindowsNodeConfig"}
+			}
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name), req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return ContainerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool windows_node_config", userAgent,
+					timeout)
+			}
+
+			if err := tpgresource.RetryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] Updated windows_node_config for node pool %s", name)
+		}
 
 	}
 

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -486,6 +486,38 @@ func TestAccContainerNodePool_withLinuxNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_withWindowsNodeConfig(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withWindowsNodeConfig(cluster, np, "OS_VERSION_LTSC2019"),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_windows_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Perform an update.
+			{
+				Config: testAccContainerNodePool_withWindowsNodeConfig(cluster, np, "OS_VERSION_LTSC2022"),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_windows_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccContainerNodePool_withNetworkConfig(t *testing.T) {
 	t.Parallel()
 
@@ -2498,6 +2530,39 @@ resource "google_container_node_pool" "with_linux_node_config" {
 `, cluster, np, maxBacklog, soMaxConn, tcpMem, tcpMem, twReuse)
 }
 
+func testAccContainerNodePool_withWindowsNodeConfig(cluster, np string, osversion string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+  networking_mode = "VPC_NATIVE"
+  ip_allocation_policy {}
+}
+
+resource "google_container_node_pool" "with_windows_node_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    image_type = "WINDOWS_LTSC_CONTAINERD"
+    windows_node_config {
+		osversion = "%s"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+`, cluster, np, osversion)
+}
 
 func testAccContainerNodePool_withNetworkConfig(cluster, np, network string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -892,6 +892,16 @@ linux_node_config {
 }
 ```
 
+* `windows_node_config` - (Optional)
+Windows node configuration, currently supporting osversion attributes according to [here](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/NodeConfig#osversion) the value must be one of the [OS_VERSION_UNSPECIFIED, OS_VERSION_LTSC2019, OS_VERSION_LTSC2019].
+Example config is below.
+
+```hcl
+windows_node_config {
+  osversion = "OS_VERSION_LTSC2019"
+}
+```
+
 * `node_group` - (Optional) Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on [sole tenant nodes](https://cloud.google.com/compute/docs/nodes/sole-tenant-nodes).
 
 * `sole_tenant_config` (Optional)  Allows specifying multiple [node affinities](https://cloud.google.com/compute/docs/nodes/sole-tenant-nodes#node_affinity_and_anti-affinity) useful for running workloads on [sole tenant nodes](https://cloud.google.com/kubernetes-engine/docs/how-to/sole-tenancy). `node_affinity` structure is [documented below](#nested_node_affinity).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding support for windows_node_config in gke cluster node_pools. This is required to specify windows 2022 as os version for the nodes. The corresponding issue is https://github.com/hashicorp/terraform-provider-google/issues/14979


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
GKE: added `node_config.windows_node_config` field to `google_container_node_pool` resource
```
