### PR TITLE
make uptime check period updatable

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -83,7 +83,6 @@ properties:
   - !ruby/object:Api::Type::String
     name: period
     default_value: '300s'
-    immutable: true
     description:
       How often, in seconds, the uptime check is performed. Currently, the only
       supported values are 60s (1 minute), 300s (5 minutes), 600s (10 minutes),

--- a/mmv1/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
@@ -114,7 +114,7 @@ func TestAccMonitoringUptimeCheckConfig_jsonPathUpdate(t *testing.T) {
 	})
 }
 
-func testAccMonitoringUptimeCheckConfig_update(suffix, perdiod, path, pwd, project, host string) string {
+func testAccMonitoringUptimeCheckConfig_update(suffix, period, path, pwd, project, host string) string {
 	return fmt.Sprintf(`
 resource "google_monitoring_uptime_check_config" "http" {
   display_name = "http-uptime-check-%s"
@@ -144,7 +144,7 @@ resource "google_monitoring_uptime_check_config" "http" {
     matcher = "CONTAINS_STRING"
   }
 }
-`, suffix, path, pwd, project, host,
+`, suffix, period, path, pwd, project, host,
 	)
 }
 

--- a/mmv1/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
@@ -20,7 +20,7 @@ func TestAccMonitoringUptimeCheckConfig_update(t *testing.T) {
 		CheckDestroy:             testAccCheckMonitoringUptimeCheckConfigDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "mypath", "password1", project, host),
+				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "60s", "mypath", "password1", project, host),
 			},
 			{
 				ResourceName:            "google_monitoring_uptime_check_config.http",
@@ -29,7 +29,7 @@ func TestAccMonitoringUptimeCheckConfig_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"http_check.0.auth_info.0.password"},
 			},
 			{
-				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "", "password2", project, host),
+				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "60s", "", "password2", project, host),
 			},
 			{
 				ResourceName:            "google_monitoring_uptime_check_config.http",
@@ -53,7 +53,7 @@ func TestAccMonitoringUptimeCheckConfig_changeNonUpdatableFields(t *testing.T) {
 		CheckDestroy:             testAccCheckMonitoringUptimeCheckConfigDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "mypath", "password1", project, "192.168.1.1"),
+				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "60s", "mypath", "password1", project, "192.168.1.1"),
 			},
 			{
 				ResourceName:            "google_monitoring_uptime_check_config.http",
@@ -62,7 +62,7 @@ func TestAccMonitoringUptimeCheckConfig_changeNonUpdatableFields(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"http_check.0.auth_info.0.password"},
 			},
 			{
-				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "mypath", "password1", project, "192.168.1.2"),
+				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "300s", "mypath", "password1", project, "192.168.1.2"),
 			},
 			{
 				ResourceName:            "google_monitoring_uptime_check_config.http",
@@ -71,7 +71,7 @@ func TestAccMonitoringUptimeCheckConfig_changeNonUpdatableFields(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"http_check.0.auth_info.0.password"},
 			},
 			{
-				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "mypath", "password2", project, "192.168.1.2"),
+				Config: testAccMonitoringUptimeCheckConfig_update(acctest.RandString(t, 4), "60s", "mypath", "password2", project, "192.168.1.2"),
 			},
 			{
 				ResourceName:            "google_monitoring_uptime_check_config.http",
@@ -114,11 +114,12 @@ func TestAccMonitoringUptimeCheckConfig_jsonPathUpdate(t *testing.T) {
 	})
 }
 
-func testAccMonitoringUptimeCheckConfig_update(suffix, path, pwd, project, host string) string {
+func testAccMonitoringUptimeCheckConfig_update(suffix, perdiod, path, pwd, project, host string) string {
 	return fmt.Sprintf(`
 resource "google_monitoring_uptime_check_config" "http" {
   display_name = "http-uptime-check-%s"
   timeout      = "60s"
+  period       = %s
 
   http_check {
     path = "/%s"

--- a/mmv1/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
@@ -119,7 +119,7 @@ func testAccMonitoringUptimeCheckConfig_update(suffix, period, path, pwd, projec
 resource "google_monitoring_uptime_check_config" "http" {
   display_name = "http-uptime-check-%s"
   timeout      = "60s"
-  period       = %s
+  period       = "%s"
 
   http_check {
     path = "/%s"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added update support for `period` in `google_monitoring_uptime_check_config`
```
