### PR TITLE
Promote fleet observability feature in GKE Hub to GA

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -143,7 +143,6 @@ properties:
       - !ruby/object:Api::Type::NestedObject
         name: fleetobservability
         description: Fleet Observability feature spec.
-        min_version: beta
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: loggingConfig

--- a/mmv1/templates/terraform/examples/enable_fleet_observability_for_both_default_and_scope_logs.tf.erb
+++ b/mmv1/templates/terraform/examples/enable_fleet_observability_for_both_default_and_scope_logs.tf.erb
@@ -13,5 +13,4 @@ resource "google_gke_hub_feature" "feature" {
       }
     }
   }
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/enable_fleet_observability_for_default_logs_with_COPY.tf.erb
+++ b/mmv1/templates/terraform/examples/enable_fleet_observability_for_default_logs_with_COPY.tf.erb
@@ -10,5 +10,4 @@ resource "google_gke_hub_feature" "feature" {
       }
     }
   }
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/enable_fleet_observability_for_scope_logs_with_MOVE.tf.erb
+++ b/mmv1/templates/terraform/examples/enable_fleet_observability_for_scope_logs_with_MOVE.tf.erb
@@ -10,5 +10,4 @@ resource "google_gke_hub_feature" "feature" {
       }
     }
   }
-  provider = google-beta
 }

--- a/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gke_hub_feature_test.go.erb
@@ -15,7 +15,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-<% unless version == 'ga' -%>
 func TestAccGKEHubFeature_gkehubFeatureFleetObservability(t *testing.T) {
 	// VCR fails to handle batched project services
 	acctest.SkipIfVcr(t)
@@ -64,7 +63,7 @@ func TestAccGKEHubFeature_gkehubFeatureFleetObservability(t *testing.T) {
 }
 
 func testAccGKEHubFeature_gkehubFeatureFleetObservability(context map[string]interface{}) string {
-	return gkeHubFeatureProjectSetup(context) + acctest.Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
 resource "time_sleep" "wait_for_gkehub_enablement" {
   create_duration = "150s"
   depends_on = [google_project_service.gkehub]
@@ -87,13 +86,12 @@ resource "google_gke_hub_feature" "feature" {
     }
   }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
-  provider = google-beta
 }
 `, context)
 }
 
 func testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate1(context map[string]interface{}) string {
-	return gkeHubFeatureProjectSetup(context) + acctest.Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
 resource "time_sleep" "wait_for_gkehub_enablement" {
   create_duration = "150s"
   depends_on = [google_project_service.gkehub]
@@ -113,13 +111,12 @@ resource "google_gke_hub_feature" "feature" {
     }
   }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
-  provider = google-beta
 }
 `, context)
 }
 
 func testAccGKEHubFeature_gkehubFeatureFleetObservabilityUpdate2(context map[string]interface{}) string {
-	return gkeHubFeatureProjectSetup(context) + acctest.Nprintf(`
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
 resource "time_sleep" "wait_for_gkehub_enablement" {
   create_duration = "150s"
   depends_on = [google_project_service.gkehub]
@@ -139,11 +136,11 @@ resource "google_gke_hub_feature" "feature" {
     }
   }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
-  provider = google-beta
 }
 `, context)
 }
 
+<% unless version == 'ga' -%>
 func gkeHubFeatureProjectSetup(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Promote `fleetobservability` feature to GA

fixes https://github.com/hashicorp/terraform-provider-google/issues/15045.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: promoted the `google_gke_hub_feature` resource's `fleetobservability` block to GA.
```
