### PR TITLE
fix osconfig validation func issue

### DIFF
--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
@@ -379,8 +379,8 @@ Remote: A checksum must be specified. Cloud Storage: An object generation number
 															"state": {
 																Type:         schema.TypeString,
 																Required:     true,
-																ValidateFunc: verify.ValidateEnum([]string{"OS_POLICY_COMPLIANCE_STATE_UNSPECIFIED", "COMPLIANT", "NON_COMPLIANT", "UNKNOWN", "NO_OS_POLICIES_APPLICABLE"}),
-																Description:  `Desired state of the file. Possible values: ["OS_POLICY_COMPLIANCE_STATE_UNSPECIFIED", "COMPLIANT", "NON_COMPLIANT", "UNKNOWN", "NO_OS_POLICIES_APPLICABLE"]`,
+																ValidateFunc: verify.ValidateEnum([]string{"DESIRED_STATE_UNSPECIFIED", "PRESENT", "ABSENT", "CONTENTS_MATCH"}),
+																Description:  `Desired state of the file. Possible values: ["DESIRED_STATE_UNSPECIFIED", "PRESENT", "ABSENT", "CONTENTS_MATCH"]`,
 															},
 															"content": {
 																Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/website/docs/r/os_config_os_policy_assignment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/os_config_os_policy_assignment.html.markdown
@@ -550,8 +550,8 @@ The following arguments are supported:
 *   `path` - (Required) The absolute path of the file within the VM.
 
 *   `state` - (Required) Desired state of the file. Possible values are:
-    `OS_POLICY_COMPLIANCE_STATE_UNSPECIFIED`, `COMPLIANT`, `NON_COMPLIANT`,
-    `UNKNOWN`, `NO_OS_POLICIES_APPLICABLE`.
+    `DESIRED_STATE_UNSPECIFIED`, `PRESENT`, `ABSENT`,
+    `CONTENTS_MATCH`.
 
 *   `permissions` - (Output) Consists of three octal digits which represent, in
     order, the permissions of the owner, group, and other users for the file


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
