### PR TITLE
Promote cloudbuildv2_connection and cloudbuildv2_repository to GA

### DIFF
--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -64,7 +64,6 @@ examples:
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_trigger_repo'
-    min_version: beta
     primary_resource_id: 'repo-trigger'
     vars:
       installation_id: '123123'
@@ -92,7 +91,6 @@ examples:
     primary_resource_id: 'allow-exit-codes-trigger'
   - !ruby/object:Provider::Terraform::Examples
     name: "cloudbuild_trigger_pubsub_with_repo"
-    min_version: beta
     primary_resource_id: "pubsub-with-repo-trigger"
     vars:
       installation_id: "123123"
@@ -209,7 +207,6 @@ properties:
           invocation originated is assumed to be the repo from which to read the specified path.
       - !ruby/object:Api::Type::String
         name: 'repository'
-        min_version: beta
         description: |
           The fully qualified resource name of the Repo API repository. The fully qualified resource name of the Repo API repository.
           If unspecified, the repo from which the trigger invocation originated is assumed to be the repo from which to read the specified path.
@@ -237,7 +234,6 @@ properties:
           Format: projects/{project}/locations/{location}/githubEnterpriseConfigs/{id}. projects/{project}/githubEnterpriseConfigs/{id}.
   - !ruby/object:Api::Type::NestedObject
     name: 'repositoryEventConfig'
-    min_version: beta
     description: |
       The configuration of a trigger that creates a build whenever an event from Repo API is received.
     at_least_one_of:
@@ -338,7 +334,6 @@ properties:
           The URI of the repo.
       - !ruby/object:Api::Type::String
         name: 'repository'
-        min_version: beta
         description: |
           The qualified resource name of the Repo API repository.
           Either uri or repository can be specified and is required.

--- a/mmv1/products/cloudbuild/product.yaml
+++ b/mmv1/products/cloudbuild/product.yaml
@@ -19,9 +19,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://cloudbuild.googleapis.com/v1/
-  - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://cloudbuild.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:

--- a/mmv1/products/cloudbuildv2/Connection.yaml
+++ b/mmv1/products/cloudbuildv2/Connection.yaml
@@ -15,14 +15,12 @@
 name: 'Connection'
 base_url: projects/{{project}}/locations/{{location}}/connections
 self_link: projects/{{project}}/locations/{{location}}/connections/{{name}}
-min_version: beta
 exclude_resource: true
 description: |
   Only used to generate IAM resources.
 exclude_validator: true
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   skip_import_test: true
-  min_version: beta
   method_name_separator: ':'
   fetch_iam_policy_verb: :GET
   allowed_iam_role: 'roles/cloudbuild.connectionViewer'
@@ -36,7 +34,6 @@ import_format:
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuildv2_connection'
-    min_version: beta
     primary_resource_id: 'my-connection'
     primary_resource_name: "fmt.Sprintf(\"tf-test-connection%s\",
       context[\"random_suffix\"\

--- a/mmv1/products/cloudbuildv2/product.yaml
+++ b/mmv1/products/cloudbuildv2/product.yaml
@@ -16,9 +16,6 @@ name: Cloudbuildv2
 display_name: Cloud Build v2
 versions:
   - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://cloudbuild.googleapis.com/v2/
-  - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://cloudbuild.googleapis.com/v2/
 scopes:

--- a/mmv1/products/cloudbuildv2/product.yaml
+++ b/mmv1/products/cloudbuildv2/product.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://cloudbuild.googleapis.com/v2/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://cloudbuild.googleapis.com/v2/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_pubsub_with_repo.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_pubsub_with_repo.tf.erb
@@ -1,5 +1,4 @@
 resource "google_cloudbuildv2_connection" "my-connection" {
-  provider = google-beta
   location = "us-central1"
   name = "my-connection"
 
@@ -12,19 +11,16 @@ resource "google_cloudbuildv2_connection" "my-connection" {
 }
 
 resource "google_cloudbuildv2_repository" "my-repository" {
-  provider = google-beta
   name = "my-repo"
   parent_connection = google_cloudbuildv2_connection.my-connection.id
   remote_uri = "<%= ctx[:vars]['repo_uri'] %>"
 }
 
 resource "google_pubsub_topic" "mytopic" {
-  provider = google-beta
   name = "mytopic"
 }
 
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name = "pubsub-with-repo-trigger"
   location = "us-central1"
 

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_repo.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_repo.tf.erb
@@ -1,5 +1,4 @@
 resource "google_cloudbuildv2_connection" "my-connection" {
-  provider = google-beta
   location = "us-central1"
   name = "my-connection"
 
@@ -12,14 +11,12 @@ resource "google_cloudbuildv2_connection" "my-connection" {
 }
 
 resource "google_cloudbuildv2_repository" "my-repository" {
-  provider = google-beta
   name = "my-repo"
   parent_connection = google_cloudbuildv2_connection.my-connection.id
   remote_uri = "<%= ctx[:vars]['repo_uri'] %>"
 }
 
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   location = "us-central1"
 
   repository_event_config {

--- a/mmv1/templates/terraform/examples/cloudbuildv2_connection.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuildv2_connection.tf.erb
@@ -1,5 +1,4 @@
 resource "google_cloudbuildv2_connection" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   location = "us-central1"
   name = "<%= ctx[:vars]['connection_name'] %>"
 

--- a/tpgtools/api/cloudbuildv2/samples/ghe_complete_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/ghe_complete_connection.yaml
@@ -15,7 +15,7 @@ name: ghe_complete_connection
 description: Creates a GitHub Enterprise connection.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/ghe_complete.connection.json
 variables:
 - name: connection

--- a/tpgtools/api/cloudbuildv2/samples/ghe_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/ghe_connection.yaml
@@ -15,7 +15,7 @@ name: ghe_connection
 description: Creates and updates a GitHub Enterprise connection.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/ghe_initial.connection.json
 updates:
 - resource: samples/ghe_complete.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/ghe_priv_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/ghe_priv_connection.yaml
@@ -15,7 +15,7 @@ name: ghe_priv_connection
 description: Creates a connection to a private server using Service Directory.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/ghe_priv.connection.json
 variables:
 - name: connection

--- a/tpgtools/api/cloudbuildv2/samples/ghe_priv_update_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/ghe_priv_update_connection.yaml
@@ -15,7 +15,7 @@ name: ghe_priv_update_connection
 description: Creates and updates a connection to a private server using Service Directory.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/ghe_initial.connection.json
 updates:
 - resource: samples/ghe_priv.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/ghe_repository.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/ghe_repository.yaml
@@ -15,7 +15,7 @@ name: ghe_repository
 description: Creates a GitHub repository.
 type: repository
 versions:
-- beta
+- ga
 resource: samples/ghe.repository.json
 dependencies:
 - samples/ghe_complete.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/github_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/github_connection.yaml
@@ -15,7 +15,7 @@ name: github_connection
 description: Creates and updates a GitHub connection.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/github_initial.connection.json
 updates:
 - resource: samples/github_update.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/github_repository.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/github_repository.yaml
@@ -15,7 +15,7 @@ name: github_repository
 description: Creates a GitHub repository.
 type: repository
 versions:
-- beta
+- ga
 resource: samples/github.repository.json
 dependencies:
 - samples/github_update.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/gitlab_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab_connection.yaml
@@ -15,7 +15,7 @@ name: gitlab_connection
 description: Creates a gitlab.com connection.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/gitlab.connection.json
 variables:
 - name: connection

--- a/tpgtools/api/cloudbuildv2/samples/gitlab_repository.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gitlab_repository.yaml
@@ -15,7 +15,7 @@ name: gitlab_repository
 description: Creates a gitlab repository.
 type: repository
 versions:
-- beta
+- ga
 resource: samples/gitlab.repository.json
 dependencies:
 - samples/gitlab.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/gle_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_connection.yaml
@@ -15,7 +15,7 @@ name: gle_connection
 description: Creates a GLE connection then update to an older version.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/gle.connection.json
 updates:
 - resource: samples/gle_old.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/gle_old_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_old_connection.yaml
@@ -15,7 +15,7 @@ name: gle_old_connection
 description: Creates a GLE connection on an old version then update to a newer version.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/gle_old.connection.json
 updates:
 - resource: samples/gle.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/gle_priv_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_priv_connection.yaml
@@ -15,7 +15,7 @@ name: gle_priv_connection
 description: Creates a connection to a private server using Service Directory.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/gle_priv.connection.json
 variables:
 - name: connection

--- a/tpgtools/api/cloudbuildv2/samples/gle_priv_update_connection.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_priv_update_connection.yaml
@@ -15,7 +15,7 @@ name: gle_priv_update_connection
 description: Creates and updates a connection to a private server using Service Directory.
 type: connection
 versions:
-- beta
+- ga
 resource: samples/gle.connection.json
 updates:
 - resource: samples/gle_priv.connection.json

--- a/tpgtools/api/cloudbuildv2/samples/gle_repository.yaml
+++ b/tpgtools/api/cloudbuildv2/samples/gle_repository.yaml
@@ -15,7 +15,7 @@ name: gle_repository
 description: Creates a GLE repository.
 type: repository
 versions:
-- beta
+- ga
 resource: samples/gle.repository.json
 dependencies:
 - samples/gle.connection.json

--- a/tpgtools/overrides/cloudbuildv2/repository.yaml
+++ b/tpgtools/overrides/cloudbuildv2/repository.yaml
@@ -1,0 +1,18 @@
+- type: CUSTOM_NAME
+  # Rename to parent_connection as connection is a reserved word in terraform.
+  field: connection
+  details:
+    name: parent_connection
+# TODO: remove once DCL is updpated to not have these fields required.
+- type: CUSTOM_SCHEMA_VALUES
+  field: project
+  details:
+    required: false
+    optional: true
+    computed: true
+- type: CUSTOM_SCHEMA_VALUES
+  field: location
+  details:
+    required: false
+    optional: true
+    computed: true

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_secret_manager_secret" "private-key-secret" {
-  provider = google-beta
   secret_id = "ghe-pk-secret"
 
   replication {
@@ -8,13 +7,11 @@ resource "google_secret_manager_secret" "private-key-secret" {
 }
 
 resource "google_secret_manager_secret_version" "private-key-secret-version" {
-  provider = google-beta
   secret = google_secret_manager_secret.private-key-secret.id
   secret_data = file("private-key.pem")
 }
 
 resource "google_secret_manager_secret" "webhook-secret-secret" {
-  provider = google-beta
   secret_id = "github-token-secret"
 
   replication {
@@ -23,13 +20,11 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
 }
 
 resource "google_secret_manager_secret_version" "webhook-secret-secret-version" {
-  provider = google-beta
   secret = google_secret_manager_secret.webhook-secret-secret.id
   secret_data = "<webhook-secret-data>"
 }
 
 data "google_iam_policy" "p4sa-secretAccessor" {
-  provider = google-beta
   binding {
     role = "roles/secretmanager.secretAccessor"
     // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
@@ -38,19 +33,16 @@ data "google_iam_policy" "p4sa-secretAccessor" {
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-pk" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.private-key-secret.secret_id
   policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-whs" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
   policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_cloudbuildv2_connection" "my-connection" {
-  provider = google-beta
   location = "us-central1"
   name = "my-terraform-ghe-connection"
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_secret_manager_secret" "github-token-secret" {
-  provider = google-beta
   secret_id = "github-token-secret"
 
   replication {
@@ -8,13 +7,11 @@ resource "google_secret_manager_secret" "github-token-secret" {
 }
 
 resource "google_secret_manager_secret_version" "github-token-secret-version" {
-  provider = google-beta
   secret = google_secret_manager_secret.github-token-secret.id
   secret_data = file("my-github-token.txt")
 }
 
 data "google_iam_policy" "p4sa-secretAccessor" {
-  provider = google-beta
   binding {
     role = "roles/secretmanager.secretAccessor"
     // Here, {{projectNum}} is the Google Cloud project number for {{project}}.
@@ -23,13 +20,11 @@ data "google_iam_policy" "p4sa-secretAccessor" {
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.github-token-secret.secret_id
   policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_cloudbuildv2_connection" "my-connection" {
-  provider = google-beta
   location = "{{region}}"
   name = "my-connection"
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_secret_manager_secret" "private-key-secret" {
-  provider = google-beta
   secret_id = "ghe-pk-secret"
 
   replication {
@@ -8,13 +7,11 @@ resource "google_secret_manager_secret" "private-key-secret" {
 }
 
 resource "google_secret_manager_secret_version" "private-key-secret-version" {
-  provider = google-beta
   secret = google_secret_manager_secret.private-key-secret.id
   secret_data = file("private-key.pem")
 }
 
 resource "google_secret_manager_secret" "webhook-secret-secret" {
-  provider = google-beta
   secret_id = "github-token-secret"
 
   replication {
@@ -23,13 +20,11 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
 }
 
 resource "google_secret_manager_secret_version" "webhook-secret-secret-version" {
-  provider = google-beta
   secret = google_secret_manager_secret.webhook-secret-secret.id
   secret_data = "<webhook-secret-data>"
 }
 
 data "google_iam_policy" "p4sa-secretAccessor" {
-  provider = google-beta
   binding {
     role = "roles/secretmanager.secretAccessor"
     // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
@@ -38,19 +33,16 @@ data "google_iam_policy" "p4sa-secretAccessor" {
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-pk" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.private-key-secret.secret_id
   policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy-whs" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.webhook-secret-secret.secret_id
   policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_cloudbuildv2_connection" "my-connection" {
-  provider = google-beta
   location = "us-central1"
   name = "my-terraform-ghe-connection"
 
@@ -70,7 +62,6 @@ resource "google_cloudbuildv2_connection" "my-connection" {
 }
 
 resource "google_cloudbuildv2_repository" "my-repository" {
-  provider = google-beta
   name = "my-terraform-ghe-repo"
   location = "us-central1"
   parent_connection = google_cloudbuildv2_connection.my-connection.id

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_secret_manager_secret" "github-token-secret" {
-  provider = google-beta
   secret_id = "github-token-secret"
 
   replication {
@@ -8,13 +7,11 @@ resource "google_secret_manager_secret" "github-token-secret" {
 }
 
 resource "google_secret_manager_secret_version" "github-token-secret-version" {
-  provider = google-beta
   secret = google_secret_manager_secret.github-token-secret.id
   secret_data = file("my-github-token.txt")
 }
 
 data "google_iam_policy" "p4sa-secretAccessor" {
-  provider = google-beta
   binding {
     role = "roles/secretmanager.secretAccessor"
     // Here, {{projectNum}} is the Google Cloud project number for {{project}}.
@@ -23,13 +20,11 @@ data "google_iam_policy" "p4sa-secretAccessor" {
 }
 
 resource "google_secret_manager_secret_iam_policy" "policy" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.github-token-secret.secret_id
   policy_data = data.google_iam_policy.p4sa-secretAccessor.policy_data
 }
 
 resource "google_cloudbuildv2_connection" "my-connection" {
-  provider = google-beta
   location = "{{region}}"
   name = "my-connection"
 
@@ -42,7 +37,6 @@ resource "google_cloudbuildv2_connection" "my-connection" {
 }
 
 resource "google_cloudbuildv2_repository" "my-repository" {
-  provider = google-beta
   location = "{{region}}"
   name = "my-repo"
   parent_connection = google_cloudbuildv2_connection.my-connection.name

--- a/tpgtools/overrides/cloudbuildv2/tpgtools_product.yaml
+++ b/tpgtools/overrides/cloudbuildv2/tpgtools_product.yaml
@@ -1,0 +1,9 @@
+## product level overrides
+
+- type: PRODUCT_DOCS_SECTION
+  details:
+    docssection: Cloud Build v2
+
+- type: PRODUCT_BASE_PATH
+  details:
+    skip: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The Cloud Build repositories API is becoming GA.
This PR promotes the cloudbuildv2 connection and repository resources to GA, along with the cloudbuild_trigger field that makes use of those resources.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_cloudbuildv2_connection` (ga)
```

```release-note:new-resource
`google_cloudbuildv2_repository` (ga)
```

```release-note:enhancement
cloudbuild: added `repository_event_config` field to `google_cloudbuild_trigger` resource (ga)
```