### PR TITLE
Bump swp to ga

### DIFF
--- a/mmv1/products/networksecurity/GatewaySecurityPolicies.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPolicies.yaml
@@ -16,14 +16,13 @@ name: 'GatewaySecurityPolicy'
 base_url: 'projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies'
 create_url: 'projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies?gatewaySecurityPolicyId={{name}}'
 self_link: 'projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
   The GatewaySecurityPolicy resource contains a collection of GatewaySecurityPolicyRules and associated metadata.
 references:
   !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1beta1/projects.locations.gatewaySecurityPolicies'
+  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.gatewaySecurityPolicies'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
@@ -51,7 +50,6 @@ import_format:
   ]
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_gateway_security_policy_basic'
     primary_resource_id: 'default'
     vars:
@@ -109,3 +107,4 @@ properties:
     ignore_read: true
     description: |
       Name of a TlsInspectionPolicy resource that defines how TLS inspection is performed for any rule that enables it.
+    min_version: beta

--- a/mmv1/products/networksecurity/GatewaySecurityPoliciesRules.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPoliciesRules.yaml
@@ -16,15 +16,14 @@ name: 'GatewaySecurityPolicyRule'
 base_url: 'projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{gateway_security_policy}}/rules'
 create_url: 'projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{gateway_security_policy}}/rules?gatewaySecurityPolicyRuleId={{name}}'
 self_link: 'projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{gateway_security_policy}}/rules/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
   The GatewaySecurityPolicyRule resource is in a nested collection within a GatewaySecurityPolicy and represents
   a traffic matching condition and associated action to perform.
 references:
-  !ruby/object:Api::Resource::ReferenceLinks  # TODO(felipegc): change the url to beta once it is available.
-  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1alpha1/projects.locations.gatewaySecurityPolicies.rules'
+  !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.gatewaySecurityPolicies.rules'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
@@ -52,14 +51,12 @@ import_format:
   ]
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_gateway_security_policy_rules_basic'
     primary_resource_id: 'default'
     vars:
       gateway_security_policy_id: 'my-gateway-security-policy'
       resource_name: 'my-gateway-security-policy-rule'
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_gateway_security_policy_rules_advanced'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/networksecurity/UrlLists.yaml
+++ b/mmv1/products/networksecurity/UrlLists.yaml
@@ -16,17 +16,16 @@ name: 'UrlLists'
 base_url: 'projects/{{project}}/locations/{{location}}/urlLists'
 create_url: 'projects/{{project}}/locations/{{location}}/urlLists?urlListId={{name}}'
 self_link: 'projects/{{project}}/locations/{{location}}/urlLists/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
   UrlList proto helps users to set reusable, independently manageable lists of hosts, host patterns, URLs, URL patterns.
 references:
-  !ruby/object:Api::Resource::ReferenceLinks  # TODO(diogoesteves): change the url to beta once it is available.
+  !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Use UrlLists':
       ' https://cloud.google.com/secure-web-proxy/docs/use-url-list'
-  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1alpha1/projects.locations.urlLists'
+  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.urlLists'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
@@ -51,13 +50,11 @@ autogen_async: true
 import_format: ['projects/{{project}}/locations/{{location}}/urlLists/{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_url_lists_basic'
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-url-lists'
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_url_lists_advanced'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/networksecurity/product.yaml
+++ b/mmv1/products/networksecurity/product.yaml
@@ -17,6 +17,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://networksecurity.googleapis.com/v1beta1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://networksecurity.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:

--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -16,7 +16,6 @@ name: 'Gateway'
 base_url: 'projects/{{project}}/locations/{{location}}/gateways'
 create_url: 'projects/{{project}}/locations/{{location}}/gateways?gatewayId={{name}}'
 self_link: 'projects/{{project}}/locations/{{location}}/gateways/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -25,7 +24,7 @@ description: |
   along with any policy configurations. Routes have reference to to Gateways
   to dictate how requests should be routed by this Gateway.
 references: !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.gateways'
+  api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1/projects.locations.gateways'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
@@ -50,19 +49,16 @@ autogen_async: true
 import_format: ['projects/{{project}}/locations/{{location}}/gateways/{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_services_gateway_basic'
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-gateway'
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_services_gateway_advanced'
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-gateway'
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_services_gateway_secure_web_proxy'
     primary_resource_id: 'default'
     vars:
@@ -77,7 +73,6 @@ examples:
     ignore_read_extra:
       - 'delete_swg_autogen_router_on_destroy'
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_services_gateway_multiple_swp_same_network'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/templates/terraform/examples/network_security_gateway_security_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_gateway_security_policy_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_gateway_security_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name'] %>"
   location    = "us-central1"
   description = "my description"

--- a/mmv1/templates/terraform/examples/network_security_gateway_security_policy_rules_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_gateway_security_policy_rules_advanced.tf.erb
@@ -1,12 +1,10 @@
 resource "google_network_security_gateway_security_policy" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['gateway_security_policy_id'] %>"
   location    = "us-central1"
   description = "gateway security policy created to be used as reference by the rule."
 }
 
 resource "google_network_security_gateway_security_policy_rule" "<%= ctx[:primary_resource_id] %>" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['resource_name'] %>"
   location                = "us-central1"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name

--- a/mmv1/templates/terraform/examples/network_security_gateway_security_policy_rules_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_gateway_security_policy_rules_basic.tf.erb
@@ -1,12 +1,10 @@
 resource "google_network_security_gateway_security_policy" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['gateway_security_policy_id'] %>"
   location    = "us-central1"
   description = "gateway security policy created to be used as reference by the rule."
 }
 
 resource "google_network_security_gateway_security_policy_rule" "<%= ctx[:primary_resource_id] %>" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['resource_name'] %>"
   location                = "us-central1"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name

--- a/mmv1/templates/terraform/examples/network_security_url_lists_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_url_lists_advanced.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_url_lists" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name'] %>"
   location    = "us-central1"
   description = "my description"

--- a/mmv1/templates/terraform/examples/network_security_url_lists_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_url_lists_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_url_lists" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name'] %>"
   location    = "us-central1"
   values = ["www.example.com"]

--- a/mmv1/templates/terraform/examples/network_services_gateway_advanced.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_gateway_advanced.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name'] %>"
   labels      = {
     foo = "bar"

--- a/mmv1/templates/terraform/examples/network_services_gateway_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_gateway_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['resource_name'] %>"
   scope    = "default-scope-basic"
   type     = "OPEN_MESH"

--- a/mmv1/templates/terraform/examples/network_services_gateway_multiple_swp_same_network.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_gateway_multiple_swp_same_network.tf.erb
@@ -1,5 +1,4 @@
 resource "google_certificate_manager_certificate" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['certificate_name'] %>"
   location    = "us-south1"
   self_managed {
@@ -9,14 +8,12 @@ resource "google_certificate_manager_certificate" "default" {
 }
 
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   routing_mode            = "REGIONAL"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['subnetwork_name'] %>"
   purpose       = "PRIVATE"
   ip_cidr_range = "10.128.0.0/20"
@@ -26,7 +23,6 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_subnetwork" "proxyonlysubnet" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['proxy_only_subnetwork_name'] %>"
   purpose       = "REGIONAL_MANAGED_PROXY"
   ip_cidr_range = "192.168.0.0/23"
@@ -36,13 +32,11 @@ resource "google_compute_subnetwork" "proxyonlysubnet" {
 }
 
 resource "google_network_security_gateway_security_policy" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['policy_name'] %>"
   location    = "us-south1"
 }
 
 resource "google_network_security_gateway_security_policy_rule" "default" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['policy_rule_name'] %>"
   location                = "us-south1"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name
@@ -53,7 +47,6 @@ resource "google_network_security_gateway_security_policy_rule" "default" {
 }
 
 resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
-  provider                             = google-beta
   name                                 = "<%= ctx[:vars]['gateway_name_1'] %>"
   location                             = "us-south1"
   addresses                            = ["10.128.0.99"]
@@ -69,7 +62,6 @@ resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_network_services_gateway" "gateway2" {
-  provider                             = google-beta
   name                                 = "<%= ctx[:vars]['gateway_name_2'] %>"
   location                             = "us-south1"
   addresses                            = ["10.128.0.98"]

--- a/mmv1/templates/terraform/examples/network_services_gateway_secure_web_proxy.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_gateway_secure_web_proxy.tf.erb
@@ -1,5 +1,4 @@
 resource "google_certificate_manager_certificate" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['certificate_name'] %>"
   location    = "us-central1"
   self_managed {
@@ -9,14 +8,12 @@ resource "google_certificate_manager_certificate" "default" {
 }
 
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   routing_mode            = "REGIONAL"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['subnetwork_name'] %>"
   purpose       = "PRIVATE"
   ip_cidr_range = "10.128.0.0/20"
@@ -26,7 +23,6 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_subnetwork" "proxyonlysubnet" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['proxy_only_subnetwork_name'] %>"
   purpose       = "REGIONAL_MANAGED_PROXY"
   ip_cidr_range = "192.168.0.0/23"
@@ -36,13 +32,11 @@ resource "google_compute_subnetwork" "proxyonlysubnet" {
 }
 
 resource "google_network_security_gateway_security_policy" "default" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['policy_name'] %>"
   location    = "us-central1"
 }
 
 resource "google_network_security_gateway_security_policy_rule" "default" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['policy_rule_name'] %>"
   location                = "us-central1"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name
@@ -53,7 +47,6 @@ resource "google_network_security_gateway_security_policy_rule" "default" {
 }
 
 resource "google_network_services_gateway" "<%= ctx[:primary_resource_id] %>" {
-  provider                             = google-beta
   name                                 = "<%= ctx[:vars]['gateway_name_1'] %>"
   location                             = "us-central1"
   addresses                            = ["10.128.0.99"]

--- a/mmv1/third_party/terraform/tests/resource_network_security_gateway_security_policies_rule_test.go
+++ b/mmv1/third_party/terraform/tests/resource_network_security_gateway_security_policies_rule_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -17,9 +15,9 @@ func TestAccNetworkSecurityGatewaySecurityPolicyRule_update(t *testing.T) {
 	gatewaySecurityPolicyRuleName := fmt.Sprintf("tf-test-gateway-sp-rule-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckNetworkSecurityGatewaySecurityPolicyRuleDestroyProducer(t),
+		CheckDestroy:             testAccCheckNetworkSecurityGatewaySecurityPolicyRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityGatewaySecurityPolicyRule_basic(gatewaySecurityPolicyName, gatewaySecurityPolicyRuleName),
@@ -93,5 +91,3 @@ resource "google_network_security_gateway_security_policy_rule" "foobar" {
 }
 `, gatewaySecurityPolicyName, gatewaySecurityPolicyRuleName)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_network_security_gateway_security_policies_test.go
+++ b/mmv1/third_party/terraform/tests/resource_network_security_gateway_security_policies_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -16,9 +14,9 @@ func TestAccNetworkSecurityGatewaySecurityPolicy_update(t *testing.T) {
 	gatewaySecurityPolicyName := fmt.Sprintf("tf-test-gateway-sp-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckNetworkSecurityGatewaySecurityPolicyDestroyProducer(t),
+		CheckDestroy:             testAccCheckNetworkSecurityGatewaySecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityGatewaySecurityPolicy_basic(gatewaySecurityPolicyName),
@@ -59,5 +57,3 @@ resource "google_network_security_gateway_security_policy" "foobar" {
 }
 `, gatewaySecurityPolicyName)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_network_security_url_lists_test.go
+++ b/mmv1/third_party/terraform/tests/resource_network_security_url_lists_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -10,15 +8,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNetworkSecurityUrlLists_update(t *testing.T){
-    t.Parallel()
+func TestAccNetworkSecurityUrlLists_update(t *testing.T) {
+	t.Parallel()
 
-    urlListsName := fmt.Sprintf("tf-test-url-lists-%s", acctest.RandString(t, 10))
+	urlListsName := fmt.Sprintf("tf-test-url-lists-%s", acctest.RandString(t, 10))
 
-    acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckNetworkSecurityUrlListsDestroyProducer(t),
+		CheckDestroy:             testAccCheckNetworkSecurityUrlListsDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityUrlLists_basic(urlListsName),
@@ -41,7 +39,7 @@ func TestAccNetworkSecurityUrlLists_update(t *testing.T){
 }
 
 func testAccNetworkSecurityUrlLists_basic(urlListsName string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_network_security_url_lists" "foobar" {
     name        = "%s"
     location    = "us-central1"
@@ -51,7 +49,7 @@ resource "google_network_security_url_lists" "foobar" {
 }
 
 func testAccNetworkSecurityUrlLists_update(urlListsName string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_network_security_url_lists" "foobar" {
     name        = "%s"
     location    = "us-central1"
@@ -60,5 +58,3 @@ resource "google_network_security_url_lists" "foobar" {
 }
 `, urlListsName)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_network_services_gateway_test.go
+++ b/mmv1/third_party/terraform/tests/resource_network_services_gateway_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -16,9 +14,9 @@ func TestAccNetworkServicesGateway_update(t *testing.T) {
 	gatewayName := fmt.Sprintf("tf-test-gateway-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckNetworkServicesGatewayDestroyProducer(t),
+		CheckDestroy:             testAccCheckNetworkServicesGatewayDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkServicesGateway_basic(gatewayName),
@@ -153,12 +151,12 @@ resource "google_network_services_gateway" "foobar" {
 //  name                    = "%s"
 //  location                = "us-east1"
 //  gateway_security_policy = google_network_security_gateway_security_policy.default.name
-//  enabled                 = true  
+//  enabled                 = true
 //  priority                = 1
 //  session_matcher         = "host() == 'example.com'"
 //  basic_profile           = "ALLOW"
 //}
-//	  
+//
 //resource "google_network_services_gateway" "foobar" {
 //  name                                 = "%s"
 //  location                             = "us-east1"
@@ -231,7 +229,7 @@ resource "google_network_services_gateway" "foobar" {
 //  name                    = "%s"
 //  location                = "us-east1"
 //  gateway_security_policy = google_network_security_gateway_security_policy.default.name
-//  enabled                 = true  
+//  enabled                 = true
 //  priority                = 1
 //  session_matcher         = "host() == 'example.com'"
 //  basic_profile           = "ALLOW"
@@ -247,12 +245,12 @@ resource "google_network_services_gateway" "foobar" {
 //#   name                    = "%s"
 //#   location                = "us-east1"
 //#   gateway_security_policy = google_network_security_gateway_security_policy.newpolicy.name
-//#   enabled                 = true  
+//#   enabled                 = true
 //#   priority                = 1
 //#   session_matcher         = "host() == 'example.com'"
 //#   basic_profile           = "ALLOW"
 //# }
-//	  
+//
 //resource "google_network_services_gateway" "foobar" {
 //  name                                 = "%s"
 //  location                             = "us-east1"
@@ -733,5 +731,3 @@ resource "google_compute_subnetwork" "proxyonlysubnet2" {
 
 `, cmName, netName, subnetName, pSubnetName, policyName, ruleName, gatewayName, gatewayScope, net2Name, subnet2Name, pSubnet2Name)
 }
-
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes:
https://github.com/hashicorp/terraform-provider-google/issues/15067

Bumping SWP and related resources to G.A

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
NetworkServices: added `google_network_services_gateway` resource(ga)
```

```release-note:enhancement
NetworkSecurity: added `google_network_security_url_lists` resource(ga)
```

```release-note:enhancement
NetworkSecurity: added `google_network_security_gateway_security_policy` resource(ga)
```

```release-note:enhancement
NetworkSecurity: added `google_network_security_gateway_security_policy_rule` resource(ga)
```
