### PR TITLE
Adding test for resilience mode update

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -488,6 +488,42 @@ func TestAccComposerEnvironment_ComposerV2(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironment_UpdateComposerV2ResilienceMode(t *testing.T) {
+    t.Parallel()
+
+    envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, RandInt(t))
+    network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, RandInt(t))
+    subnetwork := network + "-1"
+
+    VcrTest(t, resource.TestCase{
+        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+        ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+        CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+        Steps: []resource.TestStep{
+            {
+                Config: testAccComposerEnvironment_composerV2HighResilience(envName, network, subnetwork),
+            },
+            {
+                Config: testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
+            },
+            {
+                ResourceName:           "google_composer_environment.test",
+                ImportState:             true,
+                ImportStateVerify: true,
+            },
+            // This is a terrible clean-up step in order to get destroy to succeed,
+            // due to dangling firewall rules left by the Composer Environment blocking network deletion.
+            // TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+            {
+                PlanOnly:                    true,
+                ExpectNonEmptyPlan: false,
+                Config:                      testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork),
+                Check:                          testAccCheckClearComposerEnvironmentFirewalls(t, network),
+            },
+        },
+    })
+}
+
 
 func TestAccComposerEnvironment_ComposerV2HighResilience(t *testing.T) {
 	t.Parallel()
@@ -1717,6 +1753,69 @@ resource "google_composer_environment" "test" {
 			cloud_sql_ipv4_cidr_block                = "10.3.224.0/20"
 		}
 	}
+}
+
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-east1"
+   network       = google_compute_network.test.self_link
+  private_ip_google_access = true
+}
+
+`, envName, network, subnetwork)
+}
+
+func testAccComposerEnvironment_updateComposerV2StandardResilience(envName, network, subnetwork string) string {
+    return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-east1"
+
+    config {
+        node_config {
+            network          = google_compute_network.test.self_link
+            subnetwork       = google_compute_subnetwork.test.self_link
+        }
+
+        software_config {
+            image_version = "composer-2-airflow-2"
+        }
+
+        workloads_config {
+            scheduler {
+                cpu         = 1.25
+                memory_gb   = 2.5
+                storage_gb  = 5.4
+                count       = 2
+            }
+            web_server {
+                cpu         = 1.75
+                memory_gb   = 3.0
+                storage_gb  = 4.4
+            }
+            worker {
+                cpu         = 0.5
+                memory_gb   = 2.0
+                storage_gb  = 3.4
+                min_count   = 2
+                max_count   = 5
+            }
+        }
+        environment_size = "ENVIRONMENT_SIZE_MEDIUM"
+        resilience_mode = "RESILIENCE_MODE_UNSPECIFIED"
+        private_environment_config {
+            enable_private_endpoint                  = true
+            cloud_composer_network_ipv4_cidr_block   = "10.3.192.0/24"
+            master_ipv4_cidr_block                   = "172.16.194.0/23"
+            cloud_sql_ipv4_cidr_block                = "10.3.224.0/20"
+        }
+    }
 }
 
 resource "google_compute_network" "test" {


### PR DESCRIPTION
Adding test for resilience mode update in cloud composer

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added test for updating resilience mode
```
