### PR TITLE
feat(vertexai): Add `ignore_read: true` to `featureNormType` because API doesn't return it

### DIFF
--- a/mmv1/products/vertexai/Index.yaml
+++ b/mmv1/products/vertexai/Index.yaml
@@ -147,6 +147,7 @@ properties:
               * UNIT_L2_NORM: Unit L2 normalization type
               * NONE: No normalization type is specified.
             default_value: 'NONE'
+            ignore_read: true
           - !ruby/object:Api::Type::NestedObject
             name: 'algorithmConfig'
             description:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/12818

Add `ignore_read: true` to `featureNormType` because API doesn't return it. I put a sample response from https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.indexes/get.

<details><summary>Details</summary>

```console
$ curl -X GET \
  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
  -H "Content-Type: application/json; charset=utf-8" \
  https://us-west1-aiplatform.googleapis.com/v1/projects/xxxxx/locations/us-west1/indexes/yyyyyy
{
  "name": "projects/xxxxx/locations/us-west1/indexes/yyyyyy",
  "displayName": "image",
  "description": "index for image embeddings",
  "metadataSchemaUri": "gs://google-cloud-aiplatform/schema/matchingengine/metadata/nearest_neighbor_search_1.0.0.yaml",
  "metadata": {
    "config": {
      "dimensions": 512,
      "approximateNeighborsCount": 150,
      "distanceMeasureType": "DOT_PRODUCT_DISTANCE",
      "algorithmConfig": {
        "treeAhConfig": {
          "leafNodeEmbeddingCount": "1000",
          "leafNodesToSearchPercent": 10
        }
      },
      "shardSize": "SHARD_SIZE_MEDIUM"
    }
  },
  "deployedIndexes": [
    {
      "indexEndpoint": "projects/xxxxx/locations/us-west1/indexEndpoints/zzzzzzz",
      "deployedIndexId": "all_items_index"
    }
  ],
  "etag": "AMEw9yMNTVf04pTQQ8AgKhgTuf3EgU0E6kMVg6xXd5SlGegGiQIIhh0Tss2Ko5__bUI=",
  "createTime": "2023-05-24T05:13:10.102697Z",
  "updateTime": "2023-07-06T23:44:31.005485Z",
  "indexStats": {
    "vectorsCount": "59914820",
    "shardsCount": 7
  },
  "indexUpdateMethod": "STREAM_UPDATE"
}
```

</details> 



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vertexai: fixed `feature_norm_type` in `google_vertex_ai_index` to avoid it from appearing repeatedly in terraform plan
```
