### PR TITLE
Adding custom_audiences field for cloud run v2 service.

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -207,6 +207,13 @@ properties:
         name: 'useDefault'
         description: |
           If True, indicates to use the default project's binary authorization policy. If False, binary authorization will be disabled.
+  - !ruby/object:Api::Type::Array
+    name: 'custom_audiences'
+    min_version: beta
+    description: |
+      One or more custom audiences that you want this service to support. Specify each custom audience as the full URL in a string. The custom audiences are encoded in the token and used to authenticate requests.
+      For more information, see https://cloud.google.com/run/docs/configuring/custom-audiences.
+    item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'template'
     required: true

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_custom_audiences.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_custom_audiences.tf.erb
@@ -1,0 +1,20 @@
+resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+  location = "us-central1"
+  launch_stage = "BETA"
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    custom_audiences = ["aud1"]
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
@@ -128,7 +128,6 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-update"
   client_version = "client-version-update"
-  custom_audiences = ["aud1"]
 
   template {
     labels = {

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_v2_service_test.go
@@ -128,6 +128,7 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-update"
   client_version = "client-version-update"
+  custom_audiences = ["aud1"]
 
   template {
     labels = {


### PR DESCRIPTION
Cloud Run V2 API just removed a visibility label from repeated string field "custom_audiences"
Adding the same field to be supported in Terraform for Cloud Run V2

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added field `custom_audiences` to resource `google_cloud_run_v2_service `
```
