### PR TITLE
compute_external_vpn_gateway - allow updating labels

### DIFF
--- a/mmv1/products/compute/ExternalVpnGateway.yaml
+++ b/mmv1/products/compute/ExternalVpnGateway.yaml
@@ -66,6 +66,8 @@ properties:
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'labels'
     description: 'Labels for the external VPN gateway resource.'
+    update_verb: :POST
+    update_url: 'projects/{{project}}/global/externalVpnGateways/{{name}}/setLabels'
   - !ruby/object:Api::Type::String
     name: 'name'
     description: |

--- a/mmv1/products/compute/ExternalVpnGateway.yaml
+++ b/mmv1/products/compute/ExternalVpnGateway.yaml
@@ -68,6 +68,13 @@ properties:
     description: 'Labels for the external VPN gateway resource.'
     update_verb: :POST
     update_url: 'projects/{{project}}/global/externalVpnGateways/{{name}}/setLabels'
+  - !ruby/object:Api::Type::Fingerprint
+    name: 'labelFingerprint'
+    description: |
+      The fingerprint used for optimistic locking of this resource.  Used
+      internally during updates.
+    update_url: 'projects/{{project}}/global/externalVpnGateways/{{name}}/setLabels'
+    update_verb: :POST
   - !ruby/object:Api::Type::String
     name: 'name'
     description: |

--- a/mmv1/third_party/terraform/tests/resource_compute_external_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_external_vpn_gateway_test.go
@@ -1,0 +1,65 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccComputeExternalVPNGateway_updateLabels(t *testing.T) {
+	t.Parallel()
+
+	rnd := acctest.RandString(t, 10)
+	resourceName := "google_compute_external_vpn_gateway.external_gateway"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeExternalVPNGateway_updateLabels(rnd, "test", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeExternalVPNGateway_updateLabels(rnd, "test-updated", "test-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test-updated", "test-updated"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeExternalVPNGateway_updateLabels(suffix, key, value string) string {
+	return fmt.Sprintf(`
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "tf-test-external-gateway-%s"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+
+  labels = {
+    %s = "%s"
+  }
+}
+`, suffix, key, value)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for updating labels in `google_compute_external_vpn_gateway`
```

Closes https://github.com/hashicorp/terraform-provider-google/issues/13759