### PR TITLE
Deprecate google_firebase_project_location

### DIFF
--- a/mmv1/products/firebase/ProjectLocation.yaml
+++ b/mmv1/products/firebase/ProjectLocation.yaml
@@ -37,6 +37,12 @@ references: !ruby/object:Api::Resource::ReferenceLinks
 import_format: ['projects/{{project}}', '{{project}}']
 skip_delete: true
 skip_sweeper: true
+docs:
+  warning: |
+    google_firebase_project_location is deprecated in favor of explicitly configuring `google_app_engine_application`
+    and `google_firestore_database`. This resource will be removed in the next major release of the provider.
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  resource_definition: templates/terraform/resource_definition/firebase_project_location_deprecation.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firebase_project_location_basic'

--- a/mmv1/products/firebase/ProjectLocation.yaml
+++ b/mmv1/products/firebase/ProjectLocation.yaml
@@ -37,7 +37,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
 import_format: ['projects/{{project}}', '{{project}}']
 skip_delete: true
 skip_sweeper: true
-docs:
+docs: !ruby/object:Provider::Terraform::Docs
   warning: |
     google_firebase_project_location is deprecated in favor of explicitly configuring `google_app_engine_application`
     and `google_firestore_database`. This resource will be removed in the next major release of the provider.

--- a/mmv1/templates/terraform/resource_definition/firebase_project_location_deprecation.go.erb
+++ b/mmv1/templates/terraform/resource_definition/firebase_project_location_deprecation.go.erb
@@ -1,0 +1,17 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+DeprecationMessage: "Instead of using `google_firebase_project_location`, explicitly configure " +
+                    "`google_app_engine_application.location_id` and `google_firestore_database.location_id`" +
+                    "instead",

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -178,12 +178,6 @@ resource "google_firebaserules_ruleset" "firestore" {
 }
 ```
 
-## Resource: `google_firebase_web_app`
-
-### `deletion_policy` now defaults to `DELETE`
-
-Previously, `google_firebase_web_app` deletions default to `ABANDON`, which means to only stop tracking the WebApp in Terraform. The actual app is not deleted from the Firebase project. If you are relying on this behavior, set `deletion_policy` to `ABANDON` explicitly in the new version.
-
 ## Resource: `google_cloud_run_v2_job`
 
 ### `startup_probe` and `liveness_probe` are now removed
@@ -205,6 +199,104 @@ it will use the default value from the API which is `FALSE`. If you want to
 enable endpoint independent mapping, then explicity set the value of
 `enable_endpoint_independent_mapping` field to `TRUE`.
 
+
+## Resource: `google_firebase_project_location`
+
+### `google_firebase_project_location` is now removed
+
+In `4.X`, `google_firebase_project_location` would implicitly trigger creation of an App Engine application with a default Cloud Storage bucket and Firestore database, located in the specified `location_id`. With `5.0.0`, these resources should instead be set up explicitly.
+
+- If you only used `google_firebase_project_location` to create a default Storage bucket, 
+  instead, use `google_firebase_storage_bucket` and `google_app_engine_application` like so
+```hcl
+# Provisions the default Cloud Storage bucket for the project via Google App Engine.
+resource "google_app_engine_application" "default" {
+  provider    = google-beta
+  project     = google_firebase_project.default.project
+  # See available locations: https://firebase.google.com/docs/projects/locations#default-cloud-location
+  # This will set the location for the default Storage bucket and the App Engine App.
+  location_id = "name-of-region-for-default-bucket"
+
+  # If you use Firestore, uncomment this to make sure Firestore is provisioned first.
+  # depends_on = [
+    # google_firestore_database.firestore
+  # ]
+}
+
+# Makes the default Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
+resource "google_firebase_storage_bucket" "default-bucket" {
+  provider  = google-beta
+  project   = google_firebase_project.default.project
+  bucket_id = google_app_engine_application.default.default_bucket
+}
+```
+- If you only used `google_firebase_project_location` to create a Firestore instance, use
+  `google_firestore_database` instead and specify the location in the resource block.
+- If you use `google_firebase_project_location` for both a default Storage bucket and Firestore:
+  - Set `database_type = "CLOUD_FIRESTORE"` in your `google_app_engine_application`
+  - Add the `google_firestore_database` resource to the `depends_on` block in `google_app_engine_application`
+- If you use App Engine intentinally, make sure `google_app_engine_application` and `google_firestore_database`
+  are in compatible locations. A quick way to test is to create `google_firestore_database` first, and
+  `google_app_engine_application` will fail if it's in an incompatible location.
+
+#### Upgrade instructions
+
+If you have existing resources created using `google_firebase_project_location`:
+1. Remove the `google_firebase_project_location` block
+1. Add blocks according to "New config" in this section for any of the following that you need: `google_app_engine_application`, `google_firebase_storage_bucket`, and/or `google_firestore_database`.
+1. Import the existing resources corresponding to the blocks added in the previous step:
+   `terraform import google_app_engine_application.default <project-id>`
+   `terraform import google_firebase_storage_bucket.default-bucket <project-id>/<project-id>.appspot.com`
+   `terraform import google_firestore_database.default "<project-id>/(default)"`
+
+#### Old config
+
+```hcl
+resource "google_firebase_project_location" "basic" {
+    provider = google-beta
+    project = google_firebase_project.default.project
+
+    location_id = "us-central"
+}
+```
+
+#### New config
+
+Assuming you use both the default Storage bucket and Firestore, an equivalent configuration would be:
+
+```hcl
+resource "google_app_engine_application" "default" {
+  provider      = google-beta
+  project       = google_firebase_project.default.project
+  location_id   = "us-central"
+  database_type = "CLOUD_FIRESTORE"
+
+  depends_on = [
+    google_firestore_database.default
+  ]
+}
+
+resource "google_firebase_storage_bucket" "default-bucket" {
+  provider  = google-beta
+  project   = google_firebase_project.default.project
+  bucket_id = google_app_engine_application.default.default_bucket
+}
+
+resource "google_firestore_database" "default" {
+  project     = google_firebase_project.default.project
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+}
+```
+
+For more information on configuring Firebase resources with Terraform, see [Get started with Terraform and Firebase](https://firebase.google.com/docs/projects/terraform/get-started).
+
+## Resource: `google_firebase_web_app`
+
+### `deletion_policy` now defaults to `DELETE`
+
+Previously, `google_firebase_web_app` deletions default to `ABANDON`, which means to only stop tracking the WebApp in Terraform. The actual app is not deleted from the Firebase project. If you are relying on this behavior, set `deletion_policy` to `ABANDON` explicitly in the new version.
 ## Resource: `google_compute_autoscaler` (beta)
 
 ### `metric.filter` now defaults to `resource.type = gce_instance`

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -204,40 +204,9 @@ enable endpoint independent mapping, then explicity set the value of
 
 ### `google_firebase_project_location` is now removed
 
-In `4.X`, `google_firebase_project_location` would implicitly trigger creation of an App Engine application with a default Cloud Storage bucket and Firestore database, located in the specified `location_id`. With `5.0.0`, these resources should instead be set up explicitly.
+In `4.X`, `google_firebase_project_location` would implicitly trigger creation of an App Engine application with a default Cloud Storage bucket and Firestore database, located in the specified `location_id`. In `5.0.0`, these resources should instead be set up explicitly using `google_app_engine_application` `google_firebase_storage_bucket`, and `google_firestore_database`.
 
-- If you only used `google_firebase_project_location` to create a default Storage bucket, 
-  instead, use `google_firebase_storage_bucket` and `google_app_engine_application` like so
-```hcl
-# Provisions the default Cloud Storage bucket for the project via Google App Engine.
-resource "google_app_engine_application" "default" {
-  provider    = google-beta
-  project     = google_firebase_project.default.project
-  # See available locations: https://firebase.google.com/docs/projects/locations#default-cloud-location
-  # This will set the location for the default Storage bucket and the App Engine App.
-  location_id = "name-of-region-for-default-bucket"
-
-  # If you use Firestore, uncomment this to make sure Firestore is provisioned first.
-  # depends_on = [
-    # google_firestore_database.firestore
-  # ]
-}
-
-# Makes the default Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "default-bucket" {
-  provider  = google-beta
-  project   = google_firebase_project.default.project
-  bucket_id = google_app_engine_application.default.default_bucket
-}
-```
-- If you only used `google_firebase_project_location` to create a Firestore instance, use
-  `google_firestore_database` instead and specify the location in the resource block.
-- If you use `google_firebase_project_location` for both a default Storage bucket and Firestore:
-  - Set `database_type = "CLOUD_FIRESTORE"` in your `google_app_engine_application`
-  - Add the `google_firestore_database` resource to the `depends_on` block in `google_app_engine_application`
-- If you use App Engine intentinally, make sure `google_app_engine_application` and `google_firestore_database`
-  are in compatible locations. A quick way to test is to create `google_firestore_database` first, and
-  `google_app_engine_application` will fail if it's in an incompatible location.
+For more information on configuring Firebase resources with Terraform, see [Get started with Terraform and Firebase](https://firebase.google.com/docs/projects/terraform/get-started).
 
 #### Upgrade instructions
 
@@ -289,8 +258,6 @@ resource "google_firestore_database" "default" {
   type        = "FIRESTORE_NATIVE"
 }
 ```
-
-For more information on configuring Firebase resources with Terraform, see [Get started with Terraform and Firebase](https://firebase.google.com/docs/projects/terraform/get-started).
 
 ## Resource: `google_firebase_web_app`
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Deprecate `google_firebase_project_location`. This resource was introduced before `google_firebase_storage_bucket` and `google_firestore_database` were available. The underlying API is being deprecated. The recommended way now is to use either or both of the above mentioned resources with an explicitly specified location.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: deprecation
firebase: deprecated `google_firebase_project_location` in favor of `google_firebase_storage_bucket` and `google_firestore_database`
```