### PR TITLE
Fix names in gkeonprem acceptance tests to allow sweeping and avoid name collision

### DIFF
--- a/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
@@ -30,7 +30,7 @@ examples:
     min_version: beta
     primary_resource_id: "admin-cluster-basic"
     vars:
-      name: "basic"
+      name: "my-cluster"
     test_env_vars:
       project: "fake-backend-360322"
   - !ruby/object:Provider::Terraform::Examples
@@ -38,7 +38,7 @@ examples:
     min_version: beta
     primary_resource_id: "admin-cluster-basic"
     vars:
-      name: "basic"
+      name: "my-cluster"
     test_env_vars:
       project: "fake-backend-360322"
 parameters:

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -31,7 +31,7 @@ examples:
     min_version: beta
     primary_resource_id: "cluster-basic"
     vars:
-      name: "basic"
+      name: "my-cluster"
     test_env_vars:
       project: "fake-backend-360322"
   - !ruby/object:Provider::Terraform::Examples
@@ -39,7 +39,7 @@ examples:
     min_version: beta
     primary_resource_id: "cluster-manuallb"
     vars:
-      name: "manuallb"
+      name: "cluster-manuallb"
     test_env_vars:
       project: "fake-backend-360322"
   - !ruby/object:Provider::Terraform::Examples
@@ -47,7 +47,7 @@ examples:
     min_version: beta
     primary_resource_id: "cluster-bgplb"
     vars:
-      name: "bgplb"
+      name: "cluster-bgplb"
     test_env_vars:
       project: "fake-backend-360322"
 parameters:

--- a/mmv1/products/gkeonprem/BareMetalNodePool.yaml
+++ b/mmv1/products/gkeonprem/BareMetalNodePool.yaml
@@ -34,7 +34,8 @@ examples:
     primary_resource_id: 'nodepool-basic'
     min_version: beta
     vars:
-      name: 'nodepool'
+      name: 'my-nodepool'
+      cluster: 'my-cluster'
     test_env_vars:
       project: 'fake-backend-360322'
   - !ruby/object:Provider::Terraform::Examples
@@ -42,7 +43,8 @@ examples:
     primary_resource_id: 'nodepool-full'
     min_version: beta
     vars:
-      name: 'nodepool'
+      name: 'my-nodepool'
+      cluster: 'my-cluster'
     test_env_vars:
       project: 'fake-backend-360322'
 skip_sweeper: true

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -37,7 +37,7 @@ examples:
     min_version: beta
     primary_resource_id: 'cluster-basic'
     vars:
-      name: 'basic'
+      name: 'cluster-basic'
     test_env_vars:
       project: 'fake-backend-360322'
   - !ruby/object:Provider::Terraform::Examples
@@ -45,7 +45,7 @@ examples:
     min_version: beta
     primary_resource_id: 'cluster-f5lb'
     vars:
-      name: 'f5lb'
+      name: 'cluster-f5lb'
     test_env_vars:
       project: 'fake-backend-360322'
   - !ruby/object:Provider::Terraform::Examples
@@ -53,7 +53,7 @@ examples:
     min_version: beta
     primary_resource_id: 'cluster-manuallb'
     vars:
-      name: 'manuallb'
+      name: 'cluster-manuallb'
     test_env_vars:
       project: 'fake-backend-360322'
 parameters:

--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -34,7 +34,8 @@ examples:
     min_version: beta
     primary_resource_id: "nodepool-basic"
     vars:
-      name: "nodepool"
+      name: "my-nodepool"
+      cluster: "my-cluster"
     test_env_vars:
       project: "fake-backend-360322"
   - !ruby/object:Provider::Terraform::Examples
@@ -42,7 +43,8 @@ examples:
     min_version: beta
     primary_resource_id: "nodepool-full"
     vars:
-      name: "nodepool"
+      name: "my-nodepool"
+      cluster: "my-cluster"
     test_env_vars:
       project: "fake-backend-360322"
 parameters:

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_basic.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_bare_metal_cluster" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name = "cluster-<%= ctx[:vars]['name'] %>"
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   bare_metal_version = "1.12.3"

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_bgplb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_bgplb.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_bare_metal_cluster" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name = "cluster-<%= ctx[:vars]['name'] %>"
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   bare_metal_version = "1.12.3"

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_manuallb.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_bare_metal_cluster" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name = "cluster-<%= ctx[:vars]['name'] %>"
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   bare_metal_version = "1.12.3"

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_node_pool_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_node_pool_basic.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_bare_metal_cluster" "default-basic" {
   provider = google-beta
-  name = "default-basic"
+  name = "<%= ctx[:vars]['cluster'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   bare_metal_version = "1.12.3"
@@ -71,7 +71,7 @@ resource "google_gkeonprem_bare_metal_cluster" "default-basic" {
 
 resource "google_gkeonprem_bare_metal_node_pool" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name =  "np-<%= ctx[:vars]['name'] %>"
+  name =  "<%= ctx[:vars]['name'] %>"
   bare_metal_cluster =  google_gkeonprem_bare_metal_cluster.default-basic.name
   location = "us-west1"
   node_pool_config {

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_node_pool_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_node_pool_full.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_bare_metal_cluster" "default-full" {
   provider = google-beta
-  name = "default-full"
+  name = "<%= ctx[:vars]['cluster'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   bare_metal_version = "1.12.3"
@@ -71,7 +71,7 @@ resource "google_gkeonprem_bare_metal_cluster" "default-full" {
 
 resource "google_gkeonprem_bare_metal_node_pool" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name =  "np-<%= ctx[:vars]['name'] %>"
+  name =  "<%= ctx[:vars]['name'] %>"
   display_name = "test-name"
   bare_metal_cluster =  google_gkeonprem_bare_metal_cluster.default-full.name
   location = "us-west1"

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_basic.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name = "cluster-<%= ctx[:vars]['name'] %>"
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   description = "test cluster"

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_f5lb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_f5lb.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta  
-  name = "cluster-<%= ctx[:vars]['name'] %>"
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   description = "test cluster"

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
@@ -1,6 +1,6 @@
 resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
-  name = "cluster-<%= ctx[:vars]['name'] %>"
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   description = "test cluster"

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_basic.tf.erb
@@ -1,7 +1,7 @@
 resource "google_gkeonprem_vmware_cluster" "default-basic" {
   provider = google-beta
+  name = "<%= ctx[:vars]['cluster'] %>"
   location = "us-west1"
-  name = "default-basic"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   description = "test cluster"
   on_prem_version = "1.13.1-gke.35"
@@ -39,8 +39,8 @@ resource "google_gkeonprem_vmware_cluster" "default-basic" {
 
 resource "google_gkeonprem_vmware_node_pool" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
-  name = "np-<%= ctx[:vars]['name'] %>"
   vmware_cluster = google_gkeonprem_vmware_cluster.default-basic.name
   config {
     replicas = 3

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.erb
@@ -1,7 +1,7 @@
 resource "google_gkeonprem_vmware_cluster" "default-full" {
   provider = google-beta
+  name = "<%= ctx[:vars]['cluster'] %>"
   location = "us-west1"
-  name = "default-full"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   description = "test cluster"
   on_prem_version = "1.13.1-gke.35"
@@ -39,8 +39,8 @@ resource "google_gkeonprem_vmware_cluster" "default-full" {
 
 resource "google_gkeonprem_vmware_node_pool" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
+  name = "<%= ctx[:vars]['name'] %>"
   location = "us-west1"
-  name = "np-<%= ctx[:vars]['name'] %>"
   vmware_cluster = google_gkeonprem_vmware_cluster.default-full.name
   annotations = {}
   config {

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_bare_metal_node_pool_test.go.erb
@@ -11,7 +11,9 @@ import (
 func TestAccGkeonpremBareMetalNodePool_bareMetalNodePoolUpdate(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -43,7 +45,8 @@ func testAccGkeonpremBareMetalNodePool_bareMetalNodePoolUpdateStart(context map[
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster" {
     provider = google-beta
-    name = "cluster"
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -114,8 +117,9 @@ func testAccGkeonpremBareMetalNodePool_bareMetalNodePoolUpdateStart(context map[
 
   resource "google_gkeonprem_bare_metal_node_pool" "nodepool" {
     provider = google-beta
+
+    name = "tf-test-nodepool-%{random_suffix}"
     location = "us-west1"
-    name = "nodepool"
     bare_metal_cluster = google_gkeonprem_bare_metal_cluster.cluster.name
     annotations = {}
     node_pool_config {
@@ -135,7 +139,8 @@ func testAccGkeonpremBareMetalNodePool_bareMetalNodePoolUpdate(context map[strin
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster" {
     provider = google-beta
-    name = "cluster"
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -206,8 +211,9 @@ func testAccGkeonpremBareMetalNodePool_bareMetalNodePoolUpdate(context map[strin
 
   resource "google_gkeonprem_bare_metal_node_pool" "nodepool" {
     provider = google-beta
+
+    name = "tf-test-nodepool-%{random_suffix}"
     location = "us-west1"
-    name = "nodepool"
     bare_metal_cluster = google_gkeonprem_bare_metal_cluster.cluster.name
     annotations = {}
     node_pool_config {

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_cluster_test.go.erb
@@ -11,7 +11,9 @@ import (
 func TestAccGkeonpremVmwareCluster_vmwareClusterUpdateBasic(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -41,7 +43,9 @@ func TestAccGkeonpremVmwareCluster_vmwareClusterUpdateBasic(t *testing.T) {
 func TestAccGkeonpremVmwareCluster_vmwareClusterUpdateF5Lb(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -73,7 +77,9 @@ func TestAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(t *testing.T) {
   acctest.SkipIfVcr(t)
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -104,7 +110,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateMetalLbStart(context map[s
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -142,9 +150,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateMetalLbStart(context map[s
         }
       }
     }
-  
-    provider = google-beta
-    
   }
 `, context)
 }
@@ -153,7 +158,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateMetalLb(context map[string
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster updated"
@@ -191,9 +198,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateMetalLb(context map[string
         }
       }
     }
-  
-    provider = google-beta
-    
   }
 `, context)
 }
@@ -202,7 +206,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateF5LbStart(context map[stri
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -241,9 +247,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateF5LbStart(context map[stri
         snat_pool = "test-snap-pool"
       }
     }
-  
-    provider = google-beta
-    
   }
 `, context)
 }
@@ -252,7 +255,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateF5lb(context map[string]in
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -291,9 +296,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateF5lb(context map[string]in
         snat_pool = "test-snap-pool-updated"
       }
     }
-  
-    provider = google-beta
-    
   }
 `, context)
 }
@@ -302,7 +304,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLbStart(context map[
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -374,9 +378,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLbStart(context map[
     auto_repair_config {
       enabled = true
     }
-  
-    provider = google-beta
-    
   }
 `, context)
 }
@@ -385,7 +386,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(context map[strin
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -457,9 +460,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(context map[strin
     auto_repair_config {
       enabled = true
     }
-  
-    provider = google-beta
-    
   }
 `, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_gkeonprem_vmware_node_pool_test.go.erb
@@ -11,7 +11,9 @@ import (
 func TestAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -42,8 +44,9 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context map[string
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    provider = google-beta  
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -85,8 +88,9 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context map[string
 
   resource "google_gkeonprem_vmware_node_pool" "nodepool" {
     provider = google-beta
+
+    name = "tf-test-nodepool-%{random_suffix}"
     location = "us-west1"
-    name = "nodepool"
     vmware_cluster = google_gkeonprem_vmware_cluster.cluster.name
     annotations = {}
     config {
@@ -115,8 +119,9 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context map[string]inte
   return acctest.Nprintf(`
 
   resource "google_gkeonprem_vmware_cluster" "cluster" {
-    provider = google-beta  
-    name = "cluster"
+    provider = google-beta
+
+    name = "tf-test-cluster-%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
@@ -158,8 +163,9 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context map[string]inte
 
   resource "google_gkeonprem_vmware_node_pool" "nodepool" {
     provider = google-beta
+
+    name = "tf-test-nodepool-%{random_suffix}"
     location = "us-west1"
-    name = "nodepool"
     vmware_cluster = google_gkeonprem_vmware_cluster.cluster.name
     annotations = {}
     config {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15094

Updating generated and handwritten acceptance tests so that the resource names are unique and sweepable (i.e. start with `tf-test-`)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
