### PR TITLE
Promote google_dns_response_policy & google_dns_response_policy_rule to GA

### DIFF
--- a/mmv1/products/dns/ResponsePolicy.yaml
+++ b/mmv1/products/dns/ResponsePolicy.yaml
@@ -20,7 +20,6 @@ description: |
 base_url: 'projects/{{project}}/responsePolicies'
 self_link: 'projects/{{project}}/responsePolicies/{{response_policy_name}}'
 update_verb: :PATCH
-min_version: beta
 identity:
   - responsePolicyName
 examples:

--- a/mmv1/products/dns/ResponsePolicyRule.yaml
+++ b/mmv1/products/dns/ResponsePolicyRule.yaml
@@ -22,7 +22,6 @@ description: |
 base_url: 'projects/{{project}}/responsePolicies/{{response_policy}}/rules'
 self_link: 'projects/{{project}}/responsePolicies/{{response_policy}}/rules/{{rule_name}}'
 update_verb: :PATCH
-min_version: beta
 identity:
   - ruleName
 id_format: 'projects/{{project}}/responsePolicies/{{response_policy}}/rules/{{rule_name}}'

--- a/mmv1/templates/terraform/examples/dns_response_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dns_response_policy_basic.tf.erb
@@ -1,21 +1,15 @@
 # [START dns_response_policy_basic]
 resource "google_compute_network" "network-1" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_1_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-2" {
-  provider = google-beta
-  
   name                    = "<%= ctx[:vars]['network_2_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork-1" {
-  provider = google-beta
-
   name                     = google_compute_network.network-1.name
   network                  = google_compute_network.network-1.name
   ip_cidr_range            = "10.0.36.0/24"
@@ -34,8 +28,6 @@ resource "google_compute_subnetwork" "subnetwork-1" {
 }
 
 resource "google_container_cluster" "cluster-1" {
-  provider = google-beta
-
   name               = "<%= ctx[:vars]['cluster_1_name'] %>"
   location           = "us-central1-c"
   initial_node_count = 1
@@ -64,10 +56,8 @@ resource "google_container_cluster" "cluster-1" {
 }
 
 resource "google_dns_response_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-  
   response_policy_name = "<%= ctx[:vars]['response_policy_name'] %>"
-  
+
   networks {
     network_url = google_compute_network.network-1.id
   }

--- a/mmv1/templates/terraform/examples/dns_response_policy_rule_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dns_response_policy_rule_basic.tf.erb
@@ -1,23 +1,17 @@
 # [START dns_response_policy_rule_basic]
 resource "google_compute_network" "network-1" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_1_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-2" {
-  provider = google-beta
-  
   name                    = "<%= ctx[:vars]['network_2_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_dns_response_policy" "response-policy" {
-  provider = google-beta
-
   response_policy_name = "<%= ctx[:vars]['response_policy_name'] %>"
-  
+
   networks {
     network_url = google_compute_network.network-1.id
   }
@@ -27,8 +21,6 @@ resource "google_dns_response_policy" "response-policy" {
 }
 
 resource "google_dns_response_policy_rule" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   response_policy = google_dns_response_policy.response-policy.response_policy_name
   rule_name       = "<%= ctx[:vars]['response_policy_rule_name'] %>"
   dns_name        = "dns.example.com."
@@ -40,7 +32,7 @@ resource "google_dns_response_policy_rule" "<%= ctx[:primary_resource_id] %>" {
       ttl     = 300
       rrdatas = ["192.0.2.91"]
     }
-  }  
+  }
 
 }
 # [END dns_response_policy_rule_basic]


### PR DESCRIPTION
Promote google_dns_response_policy & google_dns_response_policy_rule to GA

Fixes hashicorp/terraform-provider-google/issues/14762

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_dns_response_policy` (ga)
```

```release-note:new-resource
`google_dns_response_policy_rule` (ga)
```
