### PR TITLE
feat: add most_recent option to google_compute_image datasource

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_image.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_image.go.erb
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_image.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_image.go.erb
@@ -114,6 +114,11 @@ func DataSourceGoogleComputeImage() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -148,6 +153,19 @@ func dataSourceGoogleComputeImageRead(d *schema.ResourceData, meta interface{}) 
 		if len(images.Items) == 1 {
 			for _, im := range images.Items {
 				image = im
+			}
+		} else if mr, ok := d.GetOk("most_recent"); len(images.Items) >= 1 && ok && mr.(bool) {
+			most_recent := time.UnixMicro(0)
+			for _, im := range images.Items {
+				parsedTS, err := time.Parse(time.RFC3339, im.CreationTimestamp)
+				if err != nil {
+					return fmt.Errorf("error parsing creation timestamp: %w", err)
+				}
+
+				if parsedTS.After(most_recent) {
+					most_recent = parsedTS
+					image = im
+				}
 			}
 		} else {
 			return fmt.Errorf("your filter has returned more than one image or no image. Please refine your filter to return exactly one image")

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_image_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_image_test.go
@@ -70,6 +70,19 @@ func TestAccDataSourceComputeImageFilter(t *testing.T) {
 						"self_link"),
 				),
 			},
+			{
+				Config: testAccDataSourceCustomImageFilterWithMostRecent(family, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_compute_image.from_filter",
+						"name", name+"-latest"),
+					resource.TestCheckResourceAttr("data.google_compute_image.from_filter",
+						"family", family),
+					resource.TestCheckResourceAttr("data.google_compute_image.from_filter",
+						"most_recent", "true"),
+					resource.TestCheckResourceAttrSet("data.google_compute_image.from_filter",
+						"self_link"),
+				),
+			},
 		},
 	})
 }
@@ -162,4 +175,39 @@ data "google_compute_image" "from_filter" {
 }
 
 `, family, name, name, name, name)
+}
+
+func testAccDataSourceCustomImageFilterWithMostRecent(family, name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_image" "image-first" {
+  family      = "%s"
+  name        = "%s-first"
+  source_disk = google_compute_disk.disk.self_link
+  labels = {
+	test = "%s"
+  }
+}
+
+resource "google_compute_image" "image-latest" {
+  depends_on  = [ google_compute_image.image-first ]
+  family      = "%s"
+  name        = "%s-latest"
+  source_disk = google_compute_disk.disk.self_link
+  labels = {
+	test = "%s"
+  }
+}
+
+resource "google_compute_disk" "disk" {
+  name = "%s-disk"
+  zone = "us-central1-b"
+}
+
+data "google_compute_image" "from_filter" {
+  project     = google_compute_image.image-latest.project
+  filter      = "labels.test = %s"
+  most_recent = true
+}
+
+`, family, name, name, family, name, name, name, name)
 }

--- a/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
@@ -36,13 +36,17 @@ The following arguments are supported:
 Exactly one of `name`, `family` or `filter` must be specified. If `name` is specified, it will fetch
 the corresponding image. If `family` is specified, it will return the latest image
 that is part of an image family and is not deprecated. If you specify `filter`, your 
-filter must return exactly one image. Filter syntax can be found [here](https://cloud.google.com/compute/docs/reference/rest/v1/images/list) in the filter section.
+filter must return exactly one image unless you use `most_recent`. 
+Filter syntax can be found [here](https://cloud.google.com/compute/docs/reference/rest/v1/images/list) in the filter section.
 
 - - -
 
 * `project` - (Optional) The project in which the resource belongs. If it is not
   provided, the provider project is used. If you are using a
   [public base image][pubimg], be sure to specify the correct Image Project.
+
+* `most_recent` - (Optional) A boolean to indicate either to take to most recent image if your filter
+  returns more than one image.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR aims to add `most_recent` argument the same way [AWS does](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami#most_recent).

I didn't really find where I could add an example, but here it is:

```
data "google_compute_image" "image" {
  project     = "debian-cloud"
  filter      = "architecture:amd64"
}
# ==> Error: your filter has returned more than one image or no image. Please refine your filter to return exactly one image

data "google_compute_image" "image" {
  project     = "debian-cloud"
  filter      = "architecture:amd64"
  most_recent = true
}
# ==> debian-12-bookworm-arm64-v20230711
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `most_recent` argument to `google_compute_image` datasource
```
