### PR TITLE
Add support for complexDataTypeReferenceParsing in FHIR Stores

### DIFF
--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -110,6 +110,18 @@ properties:
       - :DSTU2
       - :STU3
       - :R4
+  - !ruby/object:Api::Type::Enum
+    name: complexDataTypeReferenceParsing
+    description: |
+      Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
+    exact_version: ga
+    required: false
+    immutable: false
+    default_value: :DISABLED
+    values:
+      - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED
+      - :DISABLED
+      - :ENABLED
   - !ruby/object:Api::Type::Boolean
     name: 'enableUpdateCreate'
     description: |

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -114,10 +114,7 @@ properties:
     name: complexDataTypeReferenceParsing
     description: |
       Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
-    exact_version: ga
-    required: false
-    immutable: false
-    default_value: :DISABLED
+    default_from_api: true
     values:
       - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED
       - :DISABLED

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -113,7 +113,7 @@ properties:
   - !ruby/object:Api::Type::Enum
     name: complexDataTypeReferenceParsing
     description: |
-      Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
+      Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED by default after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
     default_from_api: true
     values:
       - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED

--- a/mmv1/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
@@ -2,6 +2,7 @@ resource "google_healthcare_fhir_store" "default" {
   name    = "<%= ctx[:vars]['fhir_store_name'] %>"
   dataset = google_healthcare_dataset.dataset.id
   version = "R4"
+  complex_data_type_reference_parsing = "DISABLED"
 
   enable_update_create          = false
   disable_referential_integrity = false


### PR DESCRIPTION
Add support for complexDataTypeReferenceParsing in FHIR Stores

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14829 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added `complex_data_type_reference_parsing ` field to `google_healthcare_fhir_store` resource
```
