### PR TITLE
Add support for creating Apigee Organization without VPC peering

### DIFF
--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -65,6 +65,22 @@ examples:
       # Resource creation race
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_organization_cloud_basic_disable_vpc_peering'
+    skip_test:
+      true
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test.
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_organization_cloud_basic_disable_vpc_peering_test'
+    primary_resource_id: 'org'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_docs:
+      true
+      # Resource creation race
+    skip_vcr: true
+  - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full'
     skip_test:
       true
@@ -74,6 +90,25 @@ examples:
       # identity resource which is only available in the beta provider.
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full_test'
+    primary_resource_id: 'org'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_docs: true
+    min_version:
+      beta
+      # Resource creation race
+    skip_vcr: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_organization_cloud_full_disable_vpc_peering'
+    skip_test:
+      true
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test. While all Apigee
+      # resources in this test are in the GA API, we depend on a service
+      # identity resource which is only available in the beta provider.
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_organization_cloud_full_disable_vpc_peering_test'
     primary_resource_id: 'org'
     test_env_vars:
       org_id: :ORG_ID
@@ -143,6 +178,14 @@ properties:
       Compute Engine network used for Service Networking to be peered with Apigee runtime instances.
       See [Getting started with the Service Networking API](https://cloud.google.com/service-infrastructure/docs/service-networking/getting-started).
       Valid only when `RuntimeType` is set to CLOUD. The value can be updated only when there are no runtime instances. For example: "default".
+  - !ruby/object:Api::Type::Boolean
+    name: 'disableVpcPeering'
+    description: |
+      Flag that specifies whether the VPC Peering through Private Google Access should be
+      disabled between the consumer network and Apigee. Required if an `authorizedNetwork`
+      on the consumer project is not provided, in which case the flag should be set to `true`.
+      Valid only when `RuntimeType` is set to CLOUD. The value must be set before the creation
+      of any Apigee runtime instance and can be updated only when there are no runtime instances.
   - !ruby/object:Api::Type::Enum
     name: 'runtimeType'
     description: |

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering.tf.erb
@@ -1,0 +1,9 @@
+data "google_client_config" "current" {}
+
+resource "google_apigee_organization" "org" {
+  description         = "Terraform-provisioned basic Apigee Org without VPC Peering."
+  analytics_region    = "us-central1"
+  project_id          = data.google_client_config.current.project
+  disable_vpc_peering = true
+}
+

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering_test.tf.erb
@@ -1,0 +1,21 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
+  description         = "Terraform-provisioned basic Apigee Org without VPC Peering."
+  analytics_region    = "us-central1"
+  project_id          = google_project.project.project_id
+  disable_vpc_peering = true
+  depends_on          = [
+    google_project_service.apigee,
+  ]
+}

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering.tf.erb
@@ -1,0 +1,43 @@
+data "google_client_config" "current" {}
+
+resource "google_kms_key_ring" "apigee_keyring" {
+  name     = "apigee-keyring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "apigee_key" {
+  name            = "apigee-key"
+  key_ring        = google_kms_key_ring.apigee_keyring.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_service_identity" "apigee_sa" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  service  = google_project_service.apigee.service
+}
+
+resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+  crypto_key_id = google_kms_crypto_key.apigee_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
+  ]
+}
+
+resource "google_apigee_organization" "org" {
+  analytics_region                     = "us-central1"
+  display_name                         = "apigee-org"
+  description                          = "Terraform-provisioned Apigee Org without VPC Peering."
+  project_id                           = data.google_client_config.current.project
+  disable_vpc_peering                  = true
+  runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+  ]
+}

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering_test.tf.erb
@@ -1,0 +1,89 @@
+resource "google_project" "project" {
+  provider = google-beta
+
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  provider = google-beta
+
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  provider = google-beta
+
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "kms" {
+  provider = google-beta
+
+  project = google_project.project.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "apigee_keyring" {
+  provider = google-beta
+
+  name       = "apigee-keyring"
+  location   = "us-central1"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.kms]
+}
+
+resource "google_kms_crypto_key" "apigee_key" {
+  provider = google-beta
+
+  name            = "apigee-key"
+  key_ring        = google_kms_key_ring.apigee_keyring.id
+}
+
+resource "google_project_service_identity" "apigee_sa" {
+  provider = google-beta
+
+  project = google_project.project.project_id
+  service = google_project_service.apigee.service
+}
+
+resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+  provider = google-beta
+
+  crypto_key_id = google_kms_crypto_key.apigee_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
+  ]
+}
+
+resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  display_name                         = "apigee-org"
+  description                          = "Terraform-provisioned Apigee Org without VPC Peering."
+  analytics_region                     = "us-central1"
+  project_id                           = google_project.project.project_id
+  disable_vpc_peering                  = true
+  billing_type                         = "EVALUATION"
+  runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
+  properties {
+    property {
+      name = "features.mart.connect.enabled"
+      value = "true"
+    }
+    property {
+      name = "features.hybrid.enabled"
+      value = "true"
+    }
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+  ]
+}


### PR DESCRIPTION
This pull request fixes https://github.com/hashicorp/terraform-provider-google/issues/15135

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/get-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests. 
  - `make test` is failing due to known issue. Please check [below comment](https://github.com/GoogleCloudPlatform/magic-modules/pull/8317#issuecomment-1632956475) for more info.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/get-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
  - Acceptance tests for Beta has a known failure. https://github.com/hashicorp/terraform-provider-google/issues/13274
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
apigee: added `disable_vpc_peering` field to `google_apigee_organization` resource
```