### PR TITLE
chore: remove unused doc region tags

### DIFF
--- a/mmv1/templates/terraform/examples/cloudfunctions2_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_basic.tf.erb
@@ -1,4 +1,3 @@
-# [START functions_v2_basic]
 locals {
   project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
 }
@@ -41,4 +40,3 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
 output "function_uri" { 
   value = google_cloudfunctions2_function.function.service_config[0].uri
 }
-# [END functions_v2_basic]

--- a/mmv1/templates/terraform/examples/cloudfunctions2_basic_auditlogs.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_basic_auditlogs.tf.erb
@@ -1,4 +1,3 @@
-# [START functions_v2_basic_auditlogs]
 # This example follows the examples shown in this Google Cloud Community blog post
 # https://medium.com/google-cloud/applying-a-path-pattern-when-filtering-in-eventarc-f06b937b4c34
 # and the docs:
@@ -107,4 +106,3 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 }
-# [END functions_v2_basic_auditlogs]

--- a/mmv1/templates/terraform/examples/cloudfunctions2_basic_gcs.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_basic_gcs.tf.erb
@@ -1,5 +1,3 @@
-# [START functions_v2_basic_gcs]
-
 resource "google_storage_bucket" "source-bucket" {
   name     = "<%= ctx[:vars]['bucket_name_source'] %>"
   location = "US"
@@ -103,4 +101,3 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 }
-# [END functions_v2_basic_gcs]

--- a/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
@@ -1,4 +1,3 @@
-# [START functions_v2_full]
 locals {
   project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
 }
@@ -65,4 +64,3 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     retry_policy = "RETRY_POLICY_RETRY"
   }
 }
-# [END functions_v2_full]

--- a/mmv1/templates/terraform/examples/cloudfunctions2_scheduler_auth.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_scheduler_auth.tf.erb
@@ -1,4 +1,3 @@
-# [START function_v2_scheduler_auth]
 locals {
   project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
 }
@@ -77,4 +76,3 @@ resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   }
 }
 
-# [END function_v2_scheduler_auth]

--- a/mmv1/templates/terraform/examples/eventarc_basic_tf.tf.erb
+++ b/mmv1/templates/terraform/examples/eventarc_basic_tf.tf.erb
@@ -1,4 +1,3 @@
-# [START eventarc_terraform_enableapis]
 # Used to retrieve project_number later
 data "google_project" "project" {
   provider = google-beta
@@ -18,10 +17,6 @@ resource "google_project_service" "eventarc" {
   disable_on_destroy = false
 }
 
-# [END eventarc_terraform_enableapis]
-
-# [START cloudrun_terraform_deploy_eventarc]
-  
 # Deploy Cloud Run service
 resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
@@ -52,11 +47,6 @@ resource "google_cloud_run_service_iam_member" "allUsers" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
-
-
-# [END cloudrun_terraform_deploy_eventarc]
-  
-# [START eventarc_terraform_pubsub]
       
 # Create a Pub/Sub trigger
 resource "google_eventarc_trigger" "<%= ctx[:vars]['trigger_pubsub_tf'] %>" {
@@ -76,9 +66,6 @@ resource "google_eventarc_trigger" "<%= ctx[:vars]['trigger_pubsub_tf'] %>" {
 
   depends_on = [google_project_service.eventarc]
 }
-
-# [END eventarc_terraform_pubsub]
-# [START eventarc_terraform_auditlog_storage]
 
 # Give default Compute service account eventarc.eventReceiver role
 resource "google_project_iam_binding" "project" {
@@ -119,6 +106,3 @@ resource "google_eventarc_trigger" "<%= ctx[:vars]['trigger_auditlog_tf'] %>" {
 
   depends_on = [google_project_service.eventarc]
 }
-
-# [END eventarc_terraform_auditlog_storage]
-

--- a/mmv1/templates/terraform/examples/eventarc_workflows.tf.erb
+++ b/mmv1/templates/terraform/examples/eventarc_workflows.tf.erb
@@ -1,4 +1,3 @@
-# [START eventarc_terraform_enableapis]
 # Used to retrieve project_number later
 data "google_project" "project" {
   provider = google-beta
@@ -25,9 +24,7 @@ resource "google_project_service" "workflows" {
   disable_on_destroy = false
 }
 
-# [END eventarc_terraform_enableapis]
 
-# [START eventarc_workflows_create_serviceaccount]
 
 # Create a service account for Eventarc trigger and Workflows
 resource "google_service_account" "eventarc_workflows_service_account" {
@@ -58,9 +55,7 @@ members = ["serviceAccount:${google_service_account.eventarc_workflows_service_a
   depends_on = [google_service_account.eventarc_workflows_service_account]
 }
 
-# [END eventarc_workflows_create_serviceaccount]
 
-# [START eventarc_workflows_deploy]
 # Define and deploy a workflow
 resource "google_workflows_workflow" "workflows_example" {
   name            = "<%= ctx[:vars]['pubsub_workflow_tf'] %>"
@@ -75,9 +70,7 @@ resource "google_workflows_workflow" "workflows_example" {
 google_service_account.eventarc_workflows_service_account]
 }
 
-# [END eventarc_workflows_deploy]
 
-# [START eventarc_create_pubsub_trigger]
 # Create an Eventarc trigger routing Pub/Sub events to Workflows
 resource "google_eventarc_trigger" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['trigger_pubsub_workflow_tf'] %>"
@@ -98,4 +91,3 @@ resource "google_eventarc_trigger" "<%= ctx[:primary_resource_id] %>" {
 google_service_account.eventarc_workflows_service_account]
 }
 
-# [END eventarc_create_pubsub_trigger]

--- a/mmv1/third_party/terraform/tests/resource_cloudfunction2_function_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunction2_function_test.go
@@ -205,7 +205,6 @@ func TestAccCloudFunctions2Function_fullUpdate(t *testing.T) {
 
 func testAccCloudfunctions2function_cloudfunctions2BasicAuditlogsExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-# [START functions_v2_basic_auditlogs]
 # This example follows the examples shown in this Google Cloud Community blog post
 # https://medium.com/google-cloud/applying-a-path-pattern-when-filtering-in-eventarc-f06b937b4c34
 # and the docs:
@@ -312,6 +311,5 @@ resource "google_cloudfunctions2_function" "function" {
       value = google_storage_bucket.audit-log-bucket.name # Update: stops using path pattern operator
     }
   }
-}
-# [END functions_v2_basic_auditlogs]`, context)
+}`, context)
 }


### PR DESCRIPTION
The samples linked in official documentation have been migrated to https://github.com/terraform-google-modules/terraform-docs-samples. These samples are automatically "copied" into other repos like GoogleCloudPlatform/k8s-config-connector, hashicorp/terraform-provider-google-beta, and hashicorp/terraform-provider-google. The copying of the region tags makes conflicts in DevRel services and inappropriately shows examples embedded in Go test code.

I have checked that there are no doc references to magic-modules, hashicorp/terraform-provider-google-beta, or hashicorp/terraform-provider-google


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
 remove unused doc region tags from serverless samples
```
