### PR TITLE
Add allow_net_admin field to google_container_cluster resource

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -4117,11 +4117,11 @@ func expandPodCidrOverprovisionConfig(configured interface{}) *container.PodCIDR
 	}
 }
 
-func expandIPAllocationPolicy(configured interface{}, networkingMode string, enable_autopilot bool) (*container.IPAllocationPolicy, error) {
+func expandIPAllocationPolicy(configured interface{}, networkingMode string, autopilot bool) (*container.IPAllocationPolicy, error) {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		if networkingMode == "VPC_NATIVE" {
-			if enable_autopilot {
+			if autopilot {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("`ip_allocation_policy` block is required for VPC_NATIVE clusters.")

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2055,6 +2055,13 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	var workloadPolicyConfig *container.WorkloadPolicyConfig
+	if allowed := d.Get("allow_net_admin").(bool); allowed {
+		workloadPolicyConfig = &container.WorkloadPolicyConfig{
+			AllowNetAdmin: allowed,
+		}
+	}
+
 	cluster := &container.Cluster{
 		Name:                           clusterName,
 		InitialNodeCount:               int64(d.Get("initial_node_count").(int)),
@@ -2080,9 +2087,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
 		Autopilot: &container.Autopilot{
 			Enabled:         d.Get("enable_autopilot").(bool),
-			WorkloadPolicyConfig: &container.WorkloadPolicyConfig{
-            	AllowNetAdmin: d.Get("allow_net_admin").(bool),
-            },
+			WorkloadPolicyConfig: workloadPolicyConfig,
 			ForceSendFields: []string{"Enabled"},
 		},
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
@@ -2766,12 +2771,16 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("allow_net_admin") {
+		var workloadPolicyConfig *container.WorkloadPolicyConfig
 		allowed := d.Get("allow_net_admin").(bool)
+		if allowed {
+			workloadPolicyConfig = &container.WorkloadPolicyConfig{
+				AllowNetAdmin: allowed,
+			}
+		}
 		req := &container.UpdateClusterRequest{
 		    Update: &container.ClusterUpdate{
-		        DesiredAutopilotWorkloadPolicyConfig: &container.WorkloadPolicyConfig{
-		        	AllowNetAdmin: allowed,
-		        },
+		        DesiredAutopilotWorkloadPolicyConfig: workloadPolicyConfig,
 		    },
 		}
 		

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2771,8 +2771,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		    Update: &container.ClusterUpdate{
 		        DesiredAutopilotWorkloadPolicyConfig: &container.WorkloadPolicyConfig{
 		        	AllowNetAdmin: allowed,
-		        }
-		    }
+		        },
+		    },
 		}
 		
 	    updateF := updateFunc(req, "updating net admin for GKE autopilot workload policy config")

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2507,8 +2507,8 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		if err := d.Set("enable_autopilot", autopilot.Enabled); err != nil {
 			return fmt.Errorf("Error setting enable_autopilot: %s", err)
 		}
-		if autopilot.WorkloadConfig != nil {
-            if err := d.Set("allow_net_admin", autopilot.WorkloadConfig.AllowNetAdmin); err != nil {
+		if autopilot.WorkloadPolicyConfig != nil {
+            if err := d.Set("allow_net_admin", autopilot.WorkloadPolicyConfig.AllowNetAdmin); err != nil {
                 return fmt.Errorf("Error setting allow_net_admin: %s", err)
             }
         }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -890,7 +890,6 @@ func ResourceContainerCluster() *schema.Resource {
 				Type: schema.TypeBool,
 				Optional: true,
 				Description: `Enable NET_ADMIN for this cluster.`,
-				RequiredWith: []string{"enable_autopilot"},
             },
 
 			"authenticator_groups_config": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -886,6 +886,13 @@ func ResourceContainerCluster() *schema.Resource {
 				// ConflictsWith: many fields, see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison. The conflict is only set one-way, on other fields w/ this field.
 			},
 
+			"allow_net_admin": {
+				Type: schema.TypeBool,
+				Optional: true,
+				Description: `Enable NET_ADMIN for this cluster.`,
+				RequiredWith: []string{"enable_autopilot"},
+            },
+
 			"authenticator_groups_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -2073,6 +2080,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
 		Autopilot: &container.Autopilot{
 			Enabled:         d.Get("enable_autopilot").(bool),
+			WorkloadPolicyConfig: &container.WorkloadPolicyConfig{
+            	AllowNetAdmin: d.Get("allow_net_admin").(bool),
+            },
 			ForceSendFields: []string{"Enabled"},
 		},
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
@@ -2493,10 +2503,15 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
                         return err
                 }
         }
-	if cluster.Autopilot != nil {
-		if err := d.Set("enable_autopilot", cluster.Autopilot.Enabled); err != nil {
+	if autopilot := cluster.Autopilot; autopilot != nil {
+		if err := d.Set("enable_autopilot", autopilot.Enabled); err != nil {
 			return fmt.Errorf("Error setting enable_autopilot: %s", err)
 		}
+		if autopilot.WorkloadConfig != nil {
+            if err := d.Set("allow_net_admin", autopilot.WorkloadConfig.AllowNetAdmin); err != nil {
+                return fmt.Errorf("Error setting allow_net_admin: %s", err)
+            }
+        }
 	}
 	if cluster.ShieldedNodes != nil {
 		if err := d.Set("enable_shielded_nodes", cluster.ShieldedNodes.Enabled); err != nil {
@@ -2748,6 +2763,25 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s's cluster-wide autoscaling has been updated", d.Id())
+	}
+
+	if d.HasChange("allow_net_admin") {
+		allowed := d.Get("allow_net_admin").(bool)
+		req := &container.UpdateClusterRequest{
+		    Update: &container.ClusterUpdate{
+		        DesiredAutopilotWorkloadPolicyConfig: &container.WorkloadPolicyConfig{
+		        	AllowNetAdmin: allowed,
+		        }
+		    }
+		}
+		
+	    updateF := updateFunc(req, "updating net admin for GKE autopilot workload policy config")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		    return err
+	    }
+		
+		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
 	}
 
 	if d.HasChange("enable_binary_authorization") {
@@ -4083,11 +4117,11 @@ func expandPodCidrOverprovisionConfig(configured interface{}) *container.PodCIDR
 	}
 }
 
-func expandIPAllocationPolicy(configured interface{}, networkingMode string, autopilot bool) (*container.IPAllocationPolicy, error) {
+func expandIPAllocationPolicy(configured interface{}, networkingMode string, enable_autopilot bool) (*container.IPAllocationPolicy, error) {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		if networkingMode == "VPC_NATIVE" {
-			if autopilot {
+			if enable_autopilot {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("`ip_allocation_policy` block is required for VPC_NATIVE clusters.")

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2770,16 +2770,12 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("allow_net_admin") {
-		var workloadPolicyConfig *container.WorkloadPolicyConfig
 		allowed := d.Get("allow_net_admin").(bool)
-		if allowed {
-			workloadPolicyConfig = &container.WorkloadPolicyConfig{
-				AllowNetAdmin: allowed,
-			}
-		}
 		req := &container.UpdateClusterRequest{
 		    Update: &container.ClusterUpdate{
-		        DesiredAutopilotWorkloadPolicyConfig: workloadPolicyConfig,
+		        DesiredAutopilotWorkloadPolicyConfig: &container.WorkloadPolicyConfig{
+					AllowNetAdmin: allowed,
+				},
 		    },
 		}
 		

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3695,14 +3695,7 @@ func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 				ResourceName:      "google_container_cluster.primary",
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-			{
-				Config: testAccContainerCluster_autopilot_net_admin(clusterName, false),
-			},
-			{
-				ResourceName:      "google_container_cluster.primary",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportStateVerifyIgnore:	[]string{"min_master_version"},
 			},
 		},
 	})
@@ -7656,6 +7649,7 @@ resource "google_container_cluster" "primary" {
   name             = "%s"
   location         = "us-central1"
   enable_autopilot = true
-  allow_net_admin  = "%t"
+  allow_net_admin  = %t
+  min_master_version = 1.27
 }`, name, enabled)
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3677,6 +3677,37 @@ func TestAccContainerCluster_autopilot_minimal(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
+	t.Parallel()
+
+	// Test that allow_net_admin can be enabled for a new autopilot cluster,
+	// updated to false, then re-enabled.
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, true),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, false),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccContainerCluster_masterAuthorizedNetworksDisabled(t *testing.T, resource_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resource_name]
@@ -7616,5 +7647,15 @@ resource "google_container_cluster" "primary" {
   name             = "%s"
   location         = "us-central1"
   enable_autopilot = true
+}`, name)
+}
+
+func testAccContainerCluster_autopilot_net_admin(name string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name             = "%s"
+  location         = "us-central1"
+  enable_autopilot = true
+  allow_net_admin  = enabled
 }`, name)
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -7656,6 +7656,6 @@ resource "google_container_cluster" "primary" {
   name             = "%s"
   location         = "us-central1"
   enable_autopilot = true
-  allow_net_admin  = enabled
-}`, name)
+  allow_net_admin  = "%t"
+}`, name, enabled)
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3695,6 +3695,24 @@ func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore:	[]string{"min_master_version"},
 			},
+			{
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, false),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore:	[]string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, true),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore:	[]string{"min_master_version"},
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3680,8 +3680,6 @@ func TestAccContainerCluster_autopilot_minimal(t *testing.T) {
 func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 	t.Parallel()
 
-	// Test that allow_net_admin can be enabled for a new autopilot cluster,
-	// updated to false, then re-enabled.
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -121,6 +121,10 @@ preferred.
 * `addons_config` - (Optional) The configuration for addons supported by GKE.
     Structure is [documented below](#nested_addons_config).
 
+* `allow_net_admin` - (Optional) Enable NET_ADMIN for the cluster. Defaults to 
+`false`. This field should only be enabled for Autopilot clusters (`enable_autopilot`
+set to `true`).
+
 * `cluster_ipv4_cidr` - (Optional) The IP address range of the Kubernetes pods
 in this cluster in CIDR notation (e.g. `10.96.0.0/14`). Leave blank to have one
 automatically chosen or specify a `/14` block in `10.0.0.0/8`. This field will


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes issue https://github.com/hashicorp/terraform-provider-google/issues/15136


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `allow_net_admin` field to `google_container_cluster` resource
```
