### PR TITLE
Adding enableConfidentialCompute field for Hyperdisk

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -422,6 +422,14 @@ properties:
         'A resource policy applied to this disk for automatic snapshot
         creations.'
   - !ruby/object:Api::Type::Boolean
+    name: 'enableConfidentialCompute'
+    description: |
+      Whether this disk is using confidential compute mode.
+      Note: Only supported on hyperdisk skus, disk_encryption_key is required when setting to true
+    min_version: beta
+    required: false
+    default_from_api: true
+  - !ruby/object:Api::Type::Boolean
     name: 'multiWriter'
     description: |
       Indicates whether or not the disk can be read/write attached to more than one instance.
@@ -435,14 +443,6 @@ properties:
     default_from_api: true
     update_verb: :PATCH
     update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=provisionedIops'
-  - !ruby/object:Api::Type::Boolean
-    name: 'enableConfidentialCompute'
-    description: |
-      Indicates how many IOPS must be provisioned for the disk.
-      Note: Update currently only supported by hyperdisk skus, allowing for an update of IOPS every 4 hours
-    min_version: beta
-    required: false
-    default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'asyncPrimaryDisk'
     min_version: 'beta'

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -440,6 +440,7 @@ properties:
     description: |
       Indicates how many IOPS must be provisioned for the disk.
       Note: Update currently only supported by hyperdisk skus, allowing for an update of IOPS every 4 hours
+    min_version: beta
     required: false
     default_from_api: true
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -435,6 +435,13 @@ properties:
     default_from_api: true
     update_verb: :PATCH
     update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=provisionedIops'
+  - !ruby/object:Api::Type::Boolean
+    name: 'enableConfidentialCompute'
+    description: |
+      Indicates how many IOPS must be provisioned for the disk.
+      Note: Update currently only supported by hyperdisk skus, allowing for an update of IOPS every 4 hours
+    required: false
+    default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'asyncPrimaryDisk'
     min_version: 'beta'

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -502,6 +502,41 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 		},
 	})
 }
+<% unless version = 'ga' -%>
+func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
+	t.Parallel()
+
+
+	context := map[string]interface{}{
+		"random_suffix":        RandString(t, 10),
+		"kms":                  BootstrapKMSKey(t),
+		"disk_size":            64,
+		"confidential_compute": true,
+	}
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_pdHyperDiskEnableConfidentialCompute(context),
+				Check: resource.ComposeTestCheckFunc( 
+					testAccCheckEncryptionKey(t, "google_compute_disk.foobar", &disk),
+			),
+				
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
+
 
 func TestAccComputeDisk_deleteDetach(t *testing.T) {
 	t.Parallel()
@@ -973,6 +1008,24 @@ resource "google_compute_instance_group_manager" "manager" {
 }
 `, diskName, mgrName)
 }
+
+func testAccComputeDisk_pdHyperDiskEnableConfidentialCompute(context map[string]interface{}) string {
+	return Nprintf(`
+	resource "google_compute_disk" "foobar" {
+		name                        = "tf-test-ecc-%{random_suffix}"
+		size                        = %{disk_size}
+		type                        = "hyperdisk-balanced"
+		zone                        = "us-central1-a"
+		enable_confidential_compute = %{confidential_compute}
+
+		disk_encryption_key {
+			kms_key_self_link       = "%{kms}"
+		}
+
+	}
+`, context)
+}
+
 
 func testAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(context map[string]interface{}) string {
 	return Nprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adding in ablity to enable Confidential Compute for Hyper disk on beta


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `enableConfidentialCompute` for `google_compute_disk` resource
```