### PR TITLE
Fix tpg-transport unit tests for local runs

### DIFF
--- a/mmv1/third_party/terraform/transport/config_test.go
+++ b/mmv1/third_party/terraform/transport/config_test.go
@@ -39,6 +39,9 @@ func TestHandleSDKDefaults_BillingProject(t *testing.T) {
 			ExpectedValue: "my-billing-project-from-env",
 		},
 		"when no values are provided via config or environment variables, the field remains unset without error": {
+			EnvVariables: map[string]string{
+				"GOOGLE_BILLING_PROJECT": "", // GOOGLE_BILLING_PROJECT unset
+			},
 			ValueNotProvided: true,
 		},
 	}
@@ -101,13 +104,17 @@ func TestHandleSDKDefaults_Region(t *testing.T) {
 		"region value set in the provider config is not overridden by ENVs": {
 			ConfigValue: "region-from-config",
 			EnvVariables: map[string]string{
-				"GOOGLE_REGION": "region-from-env",
+				"GOOGLE_REGION":           "region-from-env",
+				"GCLOUD_REGION":           "", // GCLOUD_REGION unset
+				"CLOUDSDK_COMPUTE_REGION": "", // CLOUDSDK_COMPUTE_REGION unset
 			},
 			ExpectedValue: "region-from-config",
 		},
 		"region can be set by environment variable, when no value supplied via the config": {
 			EnvVariables: map[string]string{
-				"GOOGLE_REGION": "region-from-env",
+				"GOOGLE_REGION":           "region-from-env",
+				"GCLOUD_REGION":           "", // GCLOUD_REGION unset
+				"CLOUDSDK_COMPUTE_REGION": "", // CLOUDSDK_COMPUTE_REGION unset
 			},
 			ExpectedValue: "region-from-env",
 		},
@@ -121,7 +128,7 @@ func TestHandleSDKDefaults_Region(t *testing.T) {
 		},
 		"when multiple region environment variables are provided, `GCLOUD_REGION` is used second": {
 			EnvVariables: map[string]string{
-				// GOOGLE_REGION unset
+				"GOOGLE_REGION":           "", // GOOGLE_REGION unset
 				"GCLOUD_REGION":           "project-from-GCLOUD_REGION",
 				"CLOUDSDK_COMPUTE_REGION": "project-from-CLOUDSDK_COMPUTE_REGION",
 			},
@@ -129,13 +136,18 @@ func TestHandleSDKDefaults_Region(t *testing.T) {
 		},
 		"when multiple region environment variables are provided, `CLOUDSDK_COMPUTE_REGION` is the last-used ENV": {
 			EnvVariables: map[string]string{
-				// GOOGLE_REGION unset
-				// GCLOUD_REGION unset
+				"GOOGLE_REGION":           "", // GOOGLE_REGION unset
+				"GCLOUD_REGION":           "", // GCLOUD_REGION unset
 				"CLOUDSDK_COMPUTE_REGION": "project-from-CLOUDSDK_COMPUTE_REGION",
 			},
 			ExpectedValue: "project-from-CLOUDSDK_COMPUTE_REGION",
 		},
 		"when no values are provided via config or environment variables, the field remains unset without error": {
+			EnvVariables: map[string]string{
+				"GOOGLE_REGION":           "", // GOOGLE_REGION unset
+				"GCLOUD_REGION":           "", // GCLOUD_REGION unset
+				"CLOUDSDK_COMPUTE_REGION": "", // CLOUDSDK_COMPUTE_REGION unset
+			},
 			ValueNotProvided: true,
 		},
 	}
@@ -198,13 +210,17 @@ func TestHandleSDKDefaults_Zone(t *testing.T) {
 		"region value set in the provider config is not overridden by ENVs": {
 			ConfigValue: "zone-from-config",
 			EnvVariables: map[string]string{
-				"GOOGLE_ZONE": "zone-from-env",
+				"GOOGLE_ZONE":           "zone-from-env",
+				"GCLOUD_ZONE":           "", // GCLOUD_ZONE unset
+				"CLOUDSDK_COMPUTE_ZONE": "", // CLOUDSDK_COMPUTE_ZONE unset
 			},
 			ExpectedValue: "zone-from-config",
 		},
 		"zone can be set by environment variable, when no value supplied via the config": {
 			EnvVariables: map[string]string{
-				"GOOGLE_ZONE": "zone-from-env",
+				"GOOGLE_ZONE":           "zone-from-env",
+				"GCLOUD_ZONE":           "", // GCLOUD_ZONE unset
+				"CLOUDSDK_COMPUTE_ZONE": "", // CLOUDSDK_COMPUTE_ZONE unset
 			},
 			ExpectedValue: "zone-from-env",
 		},
@@ -218,7 +234,7 @@ func TestHandleSDKDefaults_Zone(t *testing.T) {
 		},
 		"when multiple zone environment variables are provided, `GCLOUD_ZONE` is used second": {
 			EnvVariables: map[string]string{
-				// GOOGLE_ZONE unset
+				"GOOGLE_ZONE":           "", // GOOGLE_ZONE unset
 				"GCLOUD_ZONE":           "zone-from-GCLOUD_ZONE",
 				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
 			},
@@ -226,13 +242,18 @@ func TestHandleSDKDefaults_Zone(t *testing.T) {
 		},
 		"when multiple zone environment variables are provided, `CLOUDSDK_COMPUTE_ZONE` is the last-used ENV": {
 			EnvVariables: map[string]string{
-				// GOOGLE_ZONE unset
-				// GCLOUD_ZONE unset
+				"GOOGLE_ZONE":           "", // GOOGLE_ZONE unset
+				"GCLOUD_ZONE":           "", // GCLOUD_ZONE unset
 				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
 			},
 			ExpectedValue: "zone-from-CLOUDSDK_COMPUTE_ZONE",
 		},
 		"when no values are provided via config or environment variables, the field remains unset without error": {
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE":           "", // GOOGLE_ZONE unset
+				"GCLOUD_ZONE":           "", // GCLOUD_ZONE unset
+				"CLOUDSDK_COMPUTE_ZONE": "", // CLOUDSDK_COMPUTE_ZONE unset
+			},
 			ValueNotProvided: true,
 		},
 	}
@@ -334,6 +355,9 @@ func TestHandleSDKDefaults_UserProjectOverride(t *testing.T) {
 			ExpectError: true,
 		},
 		"when no values are provided via config or environment variables, the field remains unset without error": {
+			EnvVariables: map[string]string{
+				"USER_PROJECT_OVERRIDE": "", // USER_PROJECT_OVERRIDE unset
+			},
 			ValueNotProvided: true,
 		},
 	}
@@ -405,6 +429,9 @@ func TestHandleSDKDefaults_RequestReason(t *testing.T) {
 			ExpectedValue: "request-reason-from-env",
 		},
 		"when no values are provided via config or environment variables, the field remains unset without error": {
+			EnvVariables: map[string]string{
+				"CLOUDSDK_CORE_REQUEST_REASON": "", // CLOUDSDK_CORE_REQUEST_REASON unset
+			},
 			ValueNotProvided: true,
 		},
 	}


### PR DESCRIPTION
A github contributor [noted that our unit tests were failing locally](https://github.com/GoogleCloudPlatform/magic-modules/pull/8317#issuecomment-1631646071) for them. Looks like we aren't unsetting the environment variables before performing tests that rely on them to be in a certain state. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
