### PR TITLE
Properly handle AutomatedBackupPolicy midnight start time (hours = 0)

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -212,6 +212,7 @@ properties:
           - !ruby/object:Api::Type::Array
             name: 'startTimes'
             required: true
+            custom_flatten: 'templates/terraform/custom_flatten/alloydb_cluster_input_automated_backup_policy_start_times_flatten.go.erb'
             description: |
               The times during the day to start a backup. At least one start time must be provided. The start times are assumed to be in UTC and to be an exact hour (e.g., 04:00:00).
             item_type: !ruby/object:Api::Type::NestedObject

--- a/mmv1/templates/terraform/custom_flatten/alloydb_cluster_input_automated_backup_policy_start_times_flatten.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/alloydb_cluster_input_automated_backup_policy_start_times_flatten.go.erb
@@ -22,12 +22,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		original := raw.(map[string]interface{})
 		if len(original) < 1 {
 			// If no start times exist, that means we take backups at midnight. This is represented as 0's all around.
-            return append(transformed, map[string]interface{}{
-                "hours":   0,
-                "minutes": 0,
-                "seconds": 0,
-                "nanos":   0,
-            })
+			return append(transformed, map[string]interface{}{})
 		}
 		transformed = append(transformed, map[string]interface{}{
 			"hours":   flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesHours(original["hours"], d, config),

--- a/mmv1/templates/terraform/custom_flatten/alloydb_cluster_input_automated_backup_policy_start_times_flatten.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/alloydb_cluster_input_automated_backup_policy_start_times_flatten.go.erb
@@ -1,0 +1,108 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// If no start times exist, that means we take backups at midnight. This is represented as 0's all around.
+            return append(transformed, map[string]interface{}{
+                "hours":   0,
+                "minutes": 0,
+                "seconds": 0,
+                "nanos":   0,
+            })
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"hours":   flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesHours(original["hours"], d, config),
+			"minutes": flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesMinutes(original["minutes"], d, config),
+			"seconds": flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesSeconds(original["seconds"], d, config),
+			"nanos":   flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesNanos(original["nanos"], d, config),
+		})
+	}
+	return transformed
+}
+
+func flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesHours(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// Handles the string fixed64 format
+	if strVal, ok := v.(string); ok {
+		if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+			return intVal
+		}
+	}
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
+}
+
+func flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesMinutes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// Handles the string fixed64 format
+	if strVal, ok := v.(string); ok {
+		if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+			return intVal
+		}
+	}
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
+}
+
+func flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesSeconds(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// Handles the string fixed64 format
+	if strVal, ok := v.(string); ok {
+		if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+			return intVal
+		}
+	}
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
+}
+
+func flattenAlloydbClusterAutomatedBackupPolicyWeeklyScheduleStartTimesNanos(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// Handles the string fixed64 format
+	if strVal, ok := v.(string); ok {
+		if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+			return intVal
+		}
+	}
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
+}

--- a/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
@@ -167,16 +167,8 @@ func TestAccAlloydbCluster_AutomatedBackupPolicyHandlesMidnight(t *testing.T) {
 		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlloydbCluster_withoutInitialUserAndAutomatedBackupPolicy(context),
-			},
-			{
-				ResourceName:            "google_alloydb_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location"},
-			},
-			{
-				Config: testAccAlloydbCluster_withInitialUserAndAutomatedBackupPolicy(context),
+				Config:             testAccAlloydbCluster_withInitialUserAndAutomatedBackupPolicy(context),
+				ExpectNonEmptyPlan: false,
 			},
 			{
 				ResourceName:            "google_alloydb_cluster.default",

--- a/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
@@ -167,8 +167,7 @@ func TestAccAlloydbCluster_AutomatedBackupPolicyHandlesMidnight(t *testing.T) {
 		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccAlloydbCluster_withInitialUserAndAutomatedBackupPolicy(context),
-				ExpectNonEmptyPlan: false,
+				Config: testAccAlloydbCluster_withInitialUserAndAutomatedBackupPolicy(context),
 			},
 			{
 				ResourceName:            "google_alloydb_cluster.default",

--- a/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/resource_alloydb_cluster_test.go
@@ -77,6 +77,7 @@ func TestAccAlloydbCluster_addAutomatedBackupPolicyAndInitialUser(t *testing.T) 
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
+		"hour":          23,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -117,6 +118,7 @@ func TestAccAlloydbCluster_deleteAutomatedBackupPolicyAndInitialUser(t *testing.
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
+		"hour":          23,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -135,6 +137,46 @@ func TestAccAlloydbCluster_deleteAutomatedBackupPolicyAndInitialUser(t *testing.
 			},
 			{
 				Config: testAccAlloydbCluster_withoutInitialUserAndAutomatedBackupPolicy(context),
+			},
+			{
+				ResourceName:            "google_alloydb_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location"},
+			},
+			{
+				Config: testAccAlloydbCluster_alloydbClusterBasicExample(context),
+			},
+		},
+	})
+}
+
+// Test if automatedBackupPolicy properly handles a startTime of 0 (aka midnight). Calling terraform plan
+// after creating the cluster should not bring anything up.
+func TestAccAlloydbCluster_AutomatedBackupPolicyHandlesMidnight(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"hour":          0,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbCluster_withoutInitialUserAndAutomatedBackupPolicy(context),
+			},
+			{
+				ResourceName:            "google_alloydb_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location"},
+			},
+			{
+				Config: testAccAlloydbCluster_withInitialUserAndAutomatedBackupPolicy(context),
 			},
 			{
 				ResourceName:            "google_alloydb_cluster.default",
@@ -170,7 +212,7 @@ resource "google_alloydb_cluster" "default" {
       days_of_week = ["MONDAY"]
 
       start_times {
-        hours   = 23
+        hours   = %{hour}
         minutes = 0
         seconds = 0
         nanos   = 0


### PR DESCRIPTION
Currently, if you set Hours = 0 in Cluster.AutomatedBackupPolicy, the change will properly be applied, but when the resource is read, it treats 0 as an empty configuration. This leads to `terraform plan` returning incorrect output, stating that it will update the weekly schedule, even though it is already set.

I consider this a small bug-fix, so I did not open an issue in [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues).

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fix automated backup policy handling of 0 start time (midnight)
```
