### PR TITLE
Support named databases for Firestore

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -18,8 +18,7 @@ create_url: 'projects/{{project}}/databases?databaseId={{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
-  A Cloud Firestore Database. Currently only one database is allowed per
-  Cloud project; this database must have a `database_id` of '(default)'.
+  A Cloud Firestore Database.
 
   If you wish to use Firestore with App Engine, use the
   [`google_app_engine_application`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/app_engine_application)
@@ -55,7 +54,7 @@ import_format:
   - '{{name}}'
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'firestore_database'
+    name: 'firestore_default_database'
     primary_resource_id: 'database'
     pull_external: true
     test_env_vars:
@@ -66,11 +65,35 @@ examples:
     vars:
       project_id: 'my-project'
   - !ruby/object:Provider::Terraform::Examples
-    name: 'firestore_database_datastore_mode'
+    name: 'firestore_database'
+    primary_resource_id: 'database'
+    pull_external: true
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    ignore_read_extra:
+      - project
+      - etag
+    vars:
+      project_id: 'my-project'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firestore_default_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
     pull_external: true
     test_env_vars:
       org_id: :ORG_ID
+    ignore_read_extra:
+      - project
+      - etag
+    vars:
+      project_id: 'my-project'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firestore_database_in_datastore_mode'
+    primary_resource_id: 'database'
+    pull_external: true
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
     ignore_read_extra:
       - project
       - etag

--- a/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
@@ -1,12 +1,12 @@
 resource "google_project" "project" {
-  project_id = "<%= ctx[:vars]['project_id'] %>"
-  name       = "<%= ctx[:vars]['project_id'] %>"
-  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+  project_id      = "<%= ctx[:vars]['project_id'] %>"
+  name            = "<%= ctx[:vars]['project_id'] %>"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
 }
 
 resource "time_sleep" "wait_60_seconds" {
   depends_on = [google_project.project]
-
   create_duration = "60s"
 }
 
@@ -19,12 +19,13 @@ resource "google_project_service" "firestore" {
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project = google_project.project.project_id
-
-  name = "(default)"
-
-  location_id = "nam5"
-  type        = "DATASTORE_MODE"
+  project                     = google_project.project.project_id
+  name                        = "datastore-mode-database"
+  location_id                 = "nam5"
+  type                        = "DATASTORE_MODE"
+  concurrency_mode            = "OPTIMISTIC"
+  app_engine_integration_mode = "DISABLED"
 
   depends_on = [google_project_service.firestore]
 }
+

--- a/mmv1/templates/terraform/examples/firestore_default_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_default_database.tf.erb
@@ -1,8 +1,7 @@
 resource "google_project" "project" {
-  project_id      = "<%= ctx[:vars]['project_id'] %>"
-  name            = "<%= ctx[:vars]['project_id'] %>"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+  project_id = "<%= ctx[:vars]['project_id'] %>"
+  name       = "<%= ctx[:vars]['project_id'] %>"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
 }
 
 resource "time_sleep" "wait_60_seconds" {
@@ -14,18 +13,15 @@ resource "time_sleep" "wait_60_seconds" {
 resource "google_project_service" "firestore" {
   project = google_project.project.project_id
   service = "firestore.googleapis.com"
-
   # Needed for CI tests for permissions to propagate, should not be needed for actual usage
   depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                     = google_project.project.project_id
-  name                        = "my-database"
-  location_id                 = "nam5"
-  type                        = "FIRESTORE_NATIVE"
-  concurrency_mode            = "OPTIMISTIC"
-  app_engine_integration_mode = "DISABLED"
+  project     = google_project.project.project_id
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
 
   depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_default_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_default_database_in_datastore_mode.tf.erb
@@ -1,0 +1,28 @@
+resource "google_project" "project" {
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_project.project]
+  create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+  project = google_project.project.project_id
+  service = "firestore.googleapis.com"
+  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+    project = google_project.project.project_id
+
+    name = "(default)"
+
+    location_id = "nam5"
+    type        = "DATASTORE_MODE"
+
+    depends_on = [google_project_service.firestore]
+}


### PR DESCRIPTION
This adds named database support for Firestore databases.
No actual Terraform code needs to be changed for this to occur, this is purely a matter of documentation and testing.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes). *Just documentation/testing, so not needed*
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). *N/A*
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). *Tests not yet passing locally*
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
