### PR TITLE
Set instance name

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -278,7 +278,6 @@ func ResourceComputeInstance() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The name of the instance. One of name or self_link must be provided.`,
 			},
 
@@ -2018,7 +2017,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 
-	needToStopInstanceBeforeUpdating := scopesChange || d.HasChange("service_account.0.email") || d.HasChange("machine_type") || d.HasChange("min_cpu_platform") || d.HasChange("enable_display") || d.HasChange("shielded_instance_config") || len(updatesToNIWhileStopped) > 0 || bootRequiredSchedulingChange || d.HasChange("advanced_machine_features")
+	needToStopInstanceBeforeUpdating := scopesChange || d.HasChange("service_account.0.email") || d.HasChange("machine_type") || d.HasChange("min_cpu_platform") || d.HasChange("enable_display") || d.HasChange("shielded_instance_config") || len(updatesToNIWhileStopped) > 0 || bootRequiredSchedulingChange || d.HasChange("advanced_machine_features") || d.HasChange("name")
 
 	if d.HasChange("desired_status") && !needToStopInstanceBeforeUpdating {
 		desiredStatus := d.Get("desired_status").(string)
@@ -2068,6 +2067,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if opErr != nil {
 				return opErr
 			}
+		}
+
+		if d.HasChange("name") {
+			nameV1 := d.Get("name").(string)
+			req := compute.InstancesSetNameRequest{Name: nameV1}
+
+			op, err := config.NewComputeClient(userAgent).Instances.SetName(
+				project, zone, nameV1, &req).Do()
+			if err != nil {
+				return fmt.Errorf("Error updating instance name: %s", err)
+			}
+
+			opErr := ComputeOperationWaitTime(config, op, project, "updating instance name", userAgent, d.Timeout(schema.TimeoutUpdate))
+			if opErr != nil {
+				return opErr
+			}
+
+			d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, nameV1))
 		}
 
 		if d.HasChange("min_cpu_platform") {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -5758,7 +5758,7 @@ resource "google_compute_instance" "foobar" {
 `, instance, instance)
 }
 
-// Set fields that require stopping the instance: machine_type, min_cpu_platform, and service_account
+// Set fields that require stopping the instance: name, machine_type, min_cpu_platform, and service_account
 func testAccComputeInstance_stopInstanceToUpdate(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -5795,7 +5795,7 @@ resource "google_compute_instance" "foobar" {
 `, instance)
 }
 
-// Update fields that require stopping the instance: machine_type, min_cpu_platform, and service_account
+// Update new values for fields that require stopping the instance: name, machine_type, min_cpu_platform, and service_account
 func testAccComputeInstance_stopInstanceToUpdate2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -5804,7 +5804,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_instance" "foobar" {
-  name         = "%s"
+  name         = "%s-new"
   machine_type = "n1-standard-2"   // can't be e2 because of min_cpu_platform
   zone         = "us-central1-a"
 
@@ -5831,7 +5831,7 @@ resource "google_compute_instance" "foobar" {
 `, instance)
 }
 
-// Remove fields that require stopping the instance: min_cpu_platform and service_account (machine_type is Required)
+// Remove fields that require stopping the instance: min_cpu_platform and service_account (name and machine_type are required)
 func testAccComputeInstance_stopInstanceToUpdate3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -5840,7 +5840,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_instance" "foobar" {
-  name         = "%s"
+  name         = "%s-new"
   machine_type = "n1-standard-2"   // can't be e2 because of min_cpu_platform
   zone         = "us-central1-a"
 


### PR DESCRIPTION
It allows users to update google_compute_instance names if the `allow_stopping_for_update` argument is also specified.

Resolves [#15145](https://github.com/hashicorp/terraform-provider-google/issues/15145#issuecomment-1632825110).

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

```release-note:enhancement
compute: added update support for `name` in `google_compute_instance`
```
