### PR TITLE
feat(google_container_node_pool): support gpu driver version

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -109,6 +109,25 @@ func schemaNodeConfig() *schema.Schema {
 								DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 								Description: `The accelerator type resource name.`,
 							},
+							"gpu_driver_installation_config": &schema.Schema{
+								Type:         schema.TypeList,
+								MaxItems:     1,
+								Optional:     true,
+								ForceNew:     true,
+								ConfigMode: schema.SchemaConfigModeAttr,
+								Description:  `Configuration for auto installation of GPU driver.`,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"gpu_driver_version": &schema.Schema{
+											Type:         schema.TypeString,
+											Required:     true,
+											ForceNew:     true,
+											Description:  `Mode for how the GPU driver is installed.`,
+											ValidateFunc: validation.StringInSlice([]string{"GPU_DRIVER_VERSION_UNSPECIFIED", "INSTALLATION_DISABLED", "DEFAULT", "LATEST"}, false),
+										},
+									},
+								},
+							},
 							"gpu_partition_size": &schema.Schema{
 								Type:             schema.TypeString,
 								Optional:         true,
@@ -648,6 +667,13 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 				GpuPartitionSize: data["gpu_partition_size"].(string),
 			}
 
+			if v, ok := data["gpu_driver_installation_config"]; ok && len(v.([]interface{})) > 0 {
+				gpuDriverInstallationConfig := data["gpu_driver_installation_config"].([]interface{})[0].(map[string]interface{})
+				guestAcceleratorConfig.GpuDriverInstallationConfig = &container.GPUDriverInstallationConfig{
+					GpuDriverVersion: gpuDriverInstallationConfig["gpu_driver_version"].(string),
+				}
+			}
+
 			if v, ok := data["gpu_sharing_config"]; ok && len(v.([]interface{})) > 0 {
 				gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
 				guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
@@ -1042,6 +1068,13 @@ func flattenContainerGuestAccelerators(c []*container.AcceleratorConfig) []map[s
 			"count": accel.AcceleratorCount,
 			"type":  accel.AcceleratorType,
 			"gpu_partition_size": accel.GpuPartitionSize,
+		}
+		if accel.GpuDriverInstallationConfig != nil {
+			accelerator["gpu_driver_installation_config"] = []map[string]interface{}{
+				{
+					"gpu_driver_version": accel.GpuDriverInstallationConfig.GpuDriverVersion,
+				},
+			}
 		}
 		if accel.GpuSharingConfig != nil {
 			accelerator["gpu_sharing_config"] = []map[string]interface{}{

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -2739,6 +2739,9 @@ resource "google_container_node_pool" "np_with_gpu" {
       type  = "nvidia-tesla-a100"
       gpu_partition_size = "1g.5gb"
       count = 1
+	  gpu_driver_installation_config {
+		gpu_driver_version = "LATEST"
+	  }
       gpu_sharing_config {
         gpu_sharing_strategy = "TIME_SHARING"
         max_shared_clients_per_gpu = 2

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -948,6 +948,17 @@ sole_tenant_config {
 
 * `count` (Required) - The number of the guest accelerator cards exposed to this instance.
 
+* `gpu_driver_installation_config` (Optional) - Configuration for auto installation of GPU driver. Structure is [documented below](#nested_gpu_driver_installation_config).
+
+<a name="nested_gpu_driver_installation_config"></a>The `gpu_driver_installation_config` block supports:
+
+* `gpu_driver_version` (Required) - Mode for how the GPU driver is installed.
+    Accepted values are:
+    * `"GPU_DRIVER_VERSION_UNSPECIFIED"`: Default value is to not install any GPU driver.
+    * `"INSTALLATION_DISABLED"`: Disable GPU driver auto installation and needs manual installation.
+    * `"DEFAULT"`: "Default" GPU driver in COS and Ubuntu.
+    * `"LATEST"`: "Latest" GPU driver in COS.
+
 * `gpu_partition_size` (Optional) - Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig [user guide](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning).
 
 * `gpu_sharing_config` (Optional) - Configuration for GPU sharing. Structure is [documented below](#nested_gpu_sharing_config).


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15151

This PR added support for GPU driver version to `google_container_node_pool` resource. This allows users to choose which version of the GPU driver they want to install on the nodes. See [Running GPUs](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#create) and corresponding [REST API doc](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/NodeConfig#gpudriverinstallationconfig).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `gpu_driver_installation_config.gpu_driver_version` field to `google_container_node_pool`
```
