### PR TITLE
cloud_tasks_queue: supress permadiffs on backoff settings

### DIFF
--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -172,6 +172,7 @@ properties:
           maxBackoff duration after it fails, if the queue's RetryConfig
           specifies that the task should be retried.
         default_from_api: true
+        diff_suppress_func: 'tpgresource.DurationDiffSuppress'
       - !ruby/object:Api::Type::String
         name: 'maxBackoff'
         description: |
@@ -179,6 +180,7 @@ properties:
           maxBackoff duration after it fails, if the queue's RetryConfig
           specifies that the task should be retried.
         default_from_api: true
+        diff_suppress_func: 'tpgresource.DurationDiffSuppress'
       - !ruby/object:Api::Type::Integer
         name: 'maxDoublings'
         description: |

--- a/mmv1/templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go
+++ b/mmv1/templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go
@@ -1,7 +1,7 @@
-func suppressOmittedMaxDuration(_, old, new string, _ *schema.ResourceData) bool {
+func suppressOmittedMaxDuration(k, old, new string, d *schema.ResourceData) bool {
 	if old == "" && new == "0s" {
 		log.Printf("[INFO] max retry is 0s and api omitted field, suppressing diff")
 		return true
 	}
-	return false
+	return tpgresource.DurationDiffSuppress(k, old, new, d)
 }

--- a/mmv1/third_party/terraform/tests/resource_cloud_tasks_queue_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_tasks_queue_test.go.erb
@@ -91,6 +91,29 @@ func TestAccCloudTasksQueue_MaxRetryDiffSuppress0s(t *testing.T) {
 	})
 }
 
+// Make sure the diff suppression function handles the situation where an
+// unexpected time unit is used, e.g., 2.0s instead of 2s or 2.0s instead of
+// 2.000s
+func TestAccCloudTasksQueue_TimeUnitDiff(t *testing.T) {
+	t.Parallel()
+	testID := acctest.RandString(t, 10)
+	cloudTaskName := fmt.Sprintf("tf-test-%s", testID)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudtasksQueueTimeUnitDiff(cloudTaskName),
+			},
+			{
+				ResourceName:      "google_cloud_tasks_queue.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCloudTasksQueue_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_tasks_queue" "default" {
@@ -183,5 +206,22 @@ func testAccCloudtasksQueueMaxRetry0s(cloudTaskName string) string {
 							min_backoff        = "0.100s"
 		}
 	}
+`, cloudTaskName)
+}
+
+func testAccCloudtasksQueueTimeUnitDiff(cloudTaskName string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_tasks_queue" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  retry_config {
+    max_attempts       = -1
+    max_backoff        = "5.000s"
+    max_doublings      = 16
+    max_retry_duration = "1.0s"
+    min_backoff        = "0.10s"
+  }
+}
 `, cloudTaskName)
 }


### PR DESCRIPTION
Add `tpgresource.DurationDiffSuppress` to min / max backoff
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15166

h/t to @edwardmedia for the pointer

Note: `maxRetryDuration` already has a custom diff function: `suppressOmittedMaxDuration()` - for now, I didn't touch that one

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloud_tasks: suppressed time-unit permadiffs on `google_cloud_tasks_queue` min and max backoff settings
```
