### PR TITLE
Support for lastUpdatedPartitionConfig in Terraform

### DIFF
--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -270,6 +270,7 @@ properties:
                   properties:
                     - !ruby/object:Api::Type::Enum
                       name: type
+                      required: true
                       description: |
                         Type of partitioning.
                       default_value: :PARTITION_TYPE_UNSPECIFIED

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -263,6 +263,27 @@ properties:
                     resource is a recursive structure; when the depth is 2, the CodeSystem table will have a column called
                     concept.concept but not concept.concept.concept. If not specified or set to 0, the server will use the default
                     value 2. The maximum depth allowed is 5.
+                - !ruby/object:Api::Type::NestedObject
+                  name: lastUpdatedPartitionConfig
+                  description: |
+                    The configuration for exported BigQuery tables to be partitioned by FHIR resource's last updated time column.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: type
+                      description: |
+                        Type of partitioning.
+                      default_value: :PARTITION_TYPE_UNSPECIFIED
+                      values:
+                        - :PARTITION_TYPE_UNSPECIFIED	
+                        - :HOUR
+                        - :DAY
+                        - :MONTH
+                        - :YEAR
+                    - !ruby/object:Api::Type::String
+                      name: expirationMs
+                      description: |
+                        Number of milliseconds for which to keep the storage for a partition.
+
   - !ruby/object:Api::Type::Array
     name: notificationConfigs
     description: |-

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -273,7 +273,6 @@ properties:
                       required: true
                       description: |
                         Type of partitioning.
-                      default_value: :PARTITION_TYPE_UNSPECIFIED
                       values:
                         - :PARTITION_TYPE_UNSPECIFIED
                         - :HOUR

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -1,4 +1,17 @@
-!ruby/object:Api::Resource
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
 name: 'FhirStore'
 kind: 'healthcare#fhirStore'
 base_url: '{{dataset}}/fhirStores?fhirStoreId={{name}}'
@@ -16,281 +29,283 @@ id_format: '{{dataset}}/fhirStores/{{name}}'
 import_format: ['{{dataset}}/fhirStores/{{name}}']
 skip_sweeper: true
 examples:
-- !ruby/object:Provider::Terraform::Examples
-  name: 'healthcare_fhir_store_basic'
-  primary_resource_id: 'default'
-  vars:
-    dataset_name: 'example-dataset'
-    fhir_store_name: 'example-fhir-store'
-    pubsub_topic: 'fhir-notifications'
-- !ruby/object:Provider::Terraform::Examples
-  name: 'healthcare_fhir_store_streaming_config'
-  primary_resource_id: 'default'
-  vars:
-    dataset_name: 'example-dataset'
-    fhir_store_name: 'example-fhir-store'
-    pubsub_topic: 'fhir-notifications'
-    bq_dataset_name: 'bq_example_dataset'
-  test_vars_overrides:
-    policyChanged: ' acctest.BootstrapPSARoles(t, "service-", "gcp-sa-healthcare",
-      []string{"roles/bigquery.dataEditor", "roles/bigquery.jobUser"})'
-- !ruby/object:Provider::Terraform::Examples
-  name: 'healthcare_fhir_store_notification_config'
-  primary_resource_id: 'default'
-  vars:
-    dataset_name: 'example-dataset'
-    fhir_store_name: 'example-fhir-store'
-    pubsub_topic: 'fhir-notifications'
-- !ruby/object:Provider::Terraform::Examples
-  name: 'healthcare_fhir_store_notification_configs'
-  min_version: beta
-  primary_resource_id: 'default'
-  vars:
-    dataset_name: 'example-dataset'
-    fhir_store_name: 'example-fhir-store'
-    pubsub_topic: 'fhir-notifications'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'healthcare_fhir_store_basic'
+    primary_resource_id: 'default'
+    vars:
+      dataset_name: 'example-dataset'
+      fhir_store_name: 'example-fhir-store'
+      pubsub_topic: 'fhir-notifications'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'healthcare_fhir_store_streaming_config'
+    primary_resource_id: 'default'
+    vars:
+      dataset_name: 'example-dataset'
+      fhir_store_name: 'example-fhir-store'
+      pubsub_topic: 'fhir-notifications'
+      bq_dataset_name: 'bq_example_dataset'
+    test_vars_overrides:
+      policyChanged:
+        ' acctest.BootstrapPSARoles(t, "service-", "gcp-sa-healthcare",
+        []string{"roles/bigquery.dataEditor", "roles/bigquery.jobUser"})'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'healthcare_fhir_store_notification_config'
+    primary_resource_id: 'default'
+    vars:
+      dataset_name: 'example-dataset'
+      fhir_store_name: 'example-fhir-store'
+      pubsub_topic: 'fhir-notifications'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'healthcare_fhir_store_notification_configs'
+    min_version: beta
+    primary_resource_id: 'default'
+    vars:
+      dataset_name: 'example-dataset'
+      fhir_store_name: 'example-fhir-store'
+      pubsub_topic: 'fhir-notifications'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
   custom_import: templates/terraform/custom_import/healthcare_fhir_store.go.erb
 parameters:
-- !ruby/object:Api::Type::ResourceRef
-  name: 'dataset'
-  description: |
-    Identifies the dataset addressed by this request. Must be in the format
-    'projects/{project}/locations/{location}/datasets/{dataset}'
-  required: true
-  immutable: true
-  resource: 'Dataset'
-  imports: 'selfLink'
-  url_param_only: true
-properties:
-- !ruby/object:Api::Type::String
-  name: 'name'
-  description: |
-    The resource name for the FhirStore.
-
-    ** Changing this property may recreate the FHIR store (removing all data) **
-  required: true
-  immutable: true
-- !ruby/object:Api::Type::Enum
-  name: version
-  description: |
-    The FHIR specification version.
-  exact_version: beta
-  required: false
-  immutable: true
-  default_value: :STU3
-  values:
-  - :DSTU2
-  - :STU3
-  - :R4
-- !ruby/object:Api::Type::Enum
-  name: version
-  description: |
-    The FHIR specification version.
-  exact_version: ga
-  required: true
-  immutable: true
-  values:
-  - :DSTU2
-  - :STU3
-  - :R4
-- !ruby/object:Api::Type::Enum
-  name: complexDataTypeReferenceParsing
-  description: |
-    Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED by default after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
-  default_from_api: true
-  values:
-  - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED
-  - :DISABLED
-  - :ENABLED
-- !ruby/object:Api::Type::Boolean
-  name: 'enableUpdateCreate'
-  description: |
-    Whether this FHIR store has the updateCreate capability. This determines if the client can use an Update
-    operation to create a new resource with a client-specified ID. If false, all IDs are server-assigned through
-    the Create operation and attempts to Update a non-existent resource will return errors. Please treat the audit
-    logs with appropriate levels of care if client-specified resource IDs contain sensitive data such as patient
-    identifiers, those IDs will be part of the FHIR resource path recorded in Cloud audit logs and Cloud Pub/Sub
-    notifications.
-  required: false
-- !ruby/object:Api::Type::Boolean
-  name: 'disableReferentialIntegrity'
-  description: |
-    Whether to disable referential integrity in this FHIR store. This field is immutable after FHIR store
-    creation. The default value is false, meaning that the API will enforce referential integrity and fail the
-    requests that will result in inconsistent state in the FHIR store. When this field is set to true, the API
-    will skip referential integrity check. Consequently, operations that rely on references, such as
-    Patient.get$everything, will not return all the results if broken references exist.
-
-    ** Changing this property may recreate the FHIR store (removing all data) **
-  required: false
-  immutable: true
-- !ruby/object:Api::Type::Boolean
-  name: 'disableResourceVersioning'
-  description: |
-    Whether to disable resource versioning for this FHIR store. This field can not be changed after the creation
-    of FHIR store. If set to false, which is the default behavior, all write operations will cause historical
-    versions to be recorded automatically. The historical versions can be fetched through the history APIs, but
-    cannot be updated. If set to true, no historical versions will be kept. The server will send back errors for
-    attempts to read the historical versions.
-
-    ** Changing this property may recreate the FHIR store (removing all data) **
-  required: false
-  immutable: true
-- !ruby/object:Api::Type::Boolean
-  name: 'enableHistoryImport'
-  description: |
-    Whether to allow the bulk import API to accept history bundles and directly insert historical resource
-    versions into the FHIR store. Importing resource histories creates resource interactions that appear to have
-    occurred in the past, which clients may not want to allow. If set to false, history bundles within an import
-    will fail with an error.
-
-    ** Changing this property may recreate the FHIR store (removing all data) **
-
-    ** This property can be changed manually in the Google Cloud Healthcare admin console without recreating the FHIR store **
-  required: false
-  immutable: true
-- !ruby/object:Api::Type::KeyValuePairs
-  name: labels
-  required: false
-  description: |
-    User-supplied key-value pairs used to organize FHIR stores.
-
-    Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes, and must
-    conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
-
-    Label values are optional, must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128
-    bytes, and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
-
-    No more than 64 labels can be associated with a given store.
-
-    An object containing a list of "key": value pairs.
-    Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
-
-- !ruby/object:Api::Type::NestedObject
-  name: notificationConfig
-  required: false
-  properties:
-  - !ruby/object:Api::Type::String
-    name: pubsubTopic
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'dataset'
     description: |
-      The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
-      PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
-      It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
-      was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
-      project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
-      Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
+      Identifies the dataset addressed by this request. Must be in the format
+      'projects/{project}/locations/{location}/datasets/{dataset}'
     required: true
-- !ruby/object:Api::Type::String
-  name: 'selfLink'
-  description: |
-    The fully qualified name of this dataset
-  output: true
-  ignore_read: true
-- !ruby/object:Api::Type::Array
-  name: streamConfigs
-  description: |-
-    A list of streaming configs that configure the destinations of streaming export for every resource mutation in
-    this FHIR store. Each store is allowed to have up to 10 streaming configs. After a new config is added, the next
-    resource mutation is streamed to the new location in addition to the existing ones. When a location is removed
-    from the list, the server stops streaming to that location. Before adding a new config, you must add the required
-    bigquery.dataEditor role to your project's Cloud Healthcare Service Agent service account. Some lag (typically on
-    the order of dozens of seconds) is expected before the results show up in the streaming destination.
-  item_type: !ruby/object:Api::Type::NestedObject
+    immutable: true
+    resource: 'Dataset'
+    imports: 'selfLink'
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: |
+      The resource name for the FhirStore.
+
+      ** Changing this property may recreate the FHIR store (removing all data) **
+    required: true
+    immutable: true
+  # Version is duplicated because it is optional in beta but required in GA.
+  - !ruby/object:Api::Type::Enum
+    name: version
+    description: |
+      The FHIR specification version.
+    exact_version: beta
+    required: false
+    immutable: true
+    default_value: :STU3
+    values:
+      - :DSTU2
+      - :STU3
+      - :R4
+  - !ruby/object:Api::Type::Enum
+    name: version
+    description: |
+      The FHIR specification version.
+    exact_version: ga
+    required: true
+    immutable: true
+    values:
+      - :DSTU2
+      - :STU3
+      - :R4
+  - !ruby/object:Api::Type::Enum
+    name: complexDataTypeReferenceParsing
+    description: |
+      Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED by default after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
+    default_from_api: true
+    values:
+      - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED
+      - :DISABLED
+      - :ENABLED
+  - !ruby/object:Api::Type::Boolean
+    name: 'enableUpdateCreate'
+    description: |
+      Whether this FHIR store has the updateCreate capability. This determines if the client can use an Update
+      operation to create a new resource with a client-specified ID. If false, all IDs are server-assigned through
+      the Create operation and attempts to Update a non-existent resource will return errors. Please treat the audit
+      logs with appropriate levels of care if client-specified resource IDs contain sensitive data such as patient
+      identifiers, those IDs will be part of the FHIR resource path recorded in Cloud audit logs and Cloud Pub/Sub
+      notifications.
+    required: false
+  - !ruby/object:Api::Type::Boolean
+    name: 'disableReferentialIntegrity'
+    description: |
+      Whether to disable referential integrity in this FHIR store. This field is immutable after FHIR store
+      creation. The default value is false, meaning that the API will enforce referential integrity and fail the
+      requests that will result in inconsistent state in the FHIR store. When this field is set to true, the API
+      will skip referential integrity check. Consequently, operations that rely on references, such as
+      Patient.get$everything, will not return all the results if broken references exist.
+
+      ** Changing this property may recreate the FHIR store (removing all data) **
+    required: false
+    immutable: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'disableResourceVersioning'
+    description: |
+      Whether to disable resource versioning for this FHIR store. This field can not be changed after the creation
+      of FHIR store. If set to false, which is the default behavior, all write operations will cause historical
+      versions to be recorded automatically. The historical versions can be fetched through the history APIs, but
+      cannot be updated. If set to true, no historical versions will be kept. The server will send back errors for
+      attempts to read the historical versions.
+
+      ** Changing this property may recreate the FHIR store (removing all data) **
+    required: false
+    immutable: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'enableHistoryImport'
+    description: |
+      Whether to allow the bulk import API to accept history bundles and directly insert historical resource
+      versions into the FHIR store. Importing resource histories creates resource interactions that appear to have
+      occurred in the past, which clients may not want to allow. If set to false, history bundles within an import
+      will fail with an error.
+
+      ** Changing this property may recreate the FHIR store (removing all data) **
+
+      ** This property can be changed manually in the Google Cloud Healthcare admin console without recreating the FHIR store **
+    required: false
+    immutable: true
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: labels
+    required: false
+    description: |
+      User-supplied key-value pairs used to organize FHIR stores.
+
+      Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes, and must
+      conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
+
+      Label values are optional, must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128
+      bytes, and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
+
+      No more than 64 labels can be associated with a given store.
+
+      An object containing a list of "key": value pairs.
+      Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+
+  - !ruby/object:Api::Type::NestedObject
+    name: notificationConfig
+    required: false
     properties:
-    - !ruby/object:Api::Type::Array
-      name: 'resourceTypes'
-      description: |
-        Supply a FHIR resource type (such as "Patient" or "Observation"). See
-        https://www.hl7.org/fhir/valueset-resource-types.html for a list of all FHIR resource types. The server treats
-        an empty list as an intent to stream all the supported resource types in this FHIR store.
-      item_type: Api::Type::String
-    - !ruby/object:Api::Type::NestedObject
-      name: bigqueryDestination
-      required: true
-      description: |
-        The destination BigQuery structure that contains both the dataset location and corresponding schema config.
-        The output is organized in one table per resource type. The server reuses the existing tables (if any) that
-        are named after the resource types, e.g. "Patient", "Observation". When there is no existing table for a given
-        resource type, the server attempts to create one.
-        See the [streaming config reference](https://cloud.google.com/healthcare/docs/reference/rest/v1beta1/projects.locations.datasets.fhirStores#streamconfig) for more details.
-      properties:
       - !ruby/object:Api::Type::String
-        name: datasetUri
-        required: true
+        name: pubsubTopic
         description: |
-          BigQuery URI to a dataset, up to 2000 characters long, in the format bq://projectId.bqDatasetId
-      - !ruby/object:Api::Type::NestedObject
-        name: schemaConfig
+          The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
+          PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
+          It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
+          was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
+          project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
+          Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
         required: true
-        description: |
-          The configuration for the exported BigQuery schema.
-        properties:
-        - !ruby/object:Api::Type::Enum
-          name: schemaType
+  - !ruby/object:Api::Type::String
+    name: 'selfLink'
+    description: |
+      The fully qualified name of this dataset
+    output: true
+    ignore_read: true
+  - !ruby/object:Api::Type::Array
+    name: streamConfigs
+    description: |-
+      A list of streaming configs that configure the destinations of streaming export for every resource mutation in
+      this FHIR store. Each store is allowed to have up to 10 streaming configs. After a new config is added, the next
+      resource mutation is streamed to the new location in addition to the existing ones. When a location is removed
+      from the list, the server stops streaming to that location. Before adding a new config, you must add the required
+      bigquery.dataEditor role to your project's Cloud Healthcare Service Agent service account. Some lag (typically on
+      the order of dozens of seconds) is expected before the results show up in the streaming destination.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::Array
+          name: 'resourceTypes'
           description: |
-            Specifies the output schema type.
-             * ANALYTICS: Analytics schema defined by the FHIR community.
-              See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md.
-             * ANALYTICS_V2: Analytics V2, similar to schema defined by the FHIR community, with added support for extensions with one or more occurrences and contained resources in stringified JSON.
-             * LOSSLESS: A data-driven schema generated from the fields present in the FHIR data being exported, with no additional simplification.
-          default_value: :ANALYTICS
-          values:
-          - :ANALYTICS
-          - :ANALYTICS_V2
-          - :LOSSLESS
-        - !ruby/object:Api::Type::Integer
-          name: recursiveStructureDepth
+            Supply a FHIR resource type (such as "Patient" or "Observation"). See
+            https://www.hl7.org/fhir/valueset-resource-types.html for a list of all FHIR resource types. The server treats
+            an empty list as an intent to stream all the supported resource types in this FHIR store.
+          item_type: Api::Type::String
+        - !ruby/object:Api::Type::NestedObject
+          name: bigqueryDestination
           required: true
           description: |
-            The depth for all recursive structures in the output analytics schema. For example, concept in the CodeSystem
-            resource is a recursive structure; when the depth is 2, the CodeSystem table will have a column called
-            concept.concept but not concept.concept.concept. If not specified or set to 0, the server will use the default
-            value 2. The maximum depth allowed is 5.
-        - !ruby/object:Api::Type::NestedObject
-          name: lastUpdatedPartitionConfig
-          description: |
-            The configuration for exported BigQuery tables to be partitioned by FHIR resource's last updated time column.
+            The destination BigQuery structure that contains both the dataset location and corresponding schema config.
+            The output is organized in one table per resource type. The server reuses the existing tables (if any) that
+            are named after the resource types, e.g. "Patient", "Observation". When there is no existing table for a given
+            resource type, the server attempts to create one.
+            See the [streaming config reference](https://cloud.google.com/healthcare/docs/reference/rest/v1beta1/projects.locations.datasets.fhirStores#streamconfig) for more details.
           properties:
-          - !ruby/object:Api::Type::Enum
-            name: type
-            description: |
-              Type of partitioning.
-            default_value: :PARTITION_TYPE_UNSPECIFIED
-            values:
-            - :PARTITION_TYPE_UNSPECIFIED
-            - :HOUR
-            - :DAY
-            - :MONTH
-            - :YEAR
-          - !ruby/object:Api::Type::String
-            name: expirationMs
-            description: |
-              Number of milliseconds for which to keep the storage for a partition.
+            - !ruby/object:Api::Type::String
+              name: datasetUri
+              required: true
+              description: |
+                BigQuery URI to a dataset, up to 2000 characters long, in the format bq://projectId.bqDatasetId
+            - !ruby/object:Api::Type::NestedObject
+              name: schemaConfig
+              required: true
+              description: |
+                The configuration for the exported BigQuery schema.
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: schemaType
+                  description: |
+                    Specifies the output schema type.
+                     * ANALYTICS: Analytics schema defined by the FHIR community.
+                      See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md.
+                     * ANALYTICS_V2: Analytics V2, similar to schema defined by the FHIR community, with added support for extensions with one or more occurrences and contained resources in stringified JSON.
+                     * LOSSLESS: A data-driven schema generated from the fields present in the FHIR data being exported, with no additional simplification.
+                  default_value: :ANALYTICS
+                  values:
+                    - :ANALYTICS
+                    - :ANALYTICS_V2
+                    - :LOSSLESS
+                - !ruby/object:Api::Type::Integer
+                  name: recursiveStructureDepth
+                  required: true
+                  description: |
+                    The depth for all recursive structures in the output analytics schema. For example, concept in the CodeSystem
+                    resource is a recursive structure; when the depth is 2, the CodeSystem table will have a column called
+                    concept.concept but not concept.concept.concept. If not specified or set to 0, the server will use the default
+                    value 2. The maximum depth allowed is 5.
+                - !ruby/object:Api::Type::NestedObject
+                  name: lastUpdatedPartitionConfig
+                  description: |
+                    The configuration for exported BigQuery tables to be partitioned by FHIR resource's last updated time column.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: type
+                      description: |
+                        Type of partitioning.
+                      default_value: :PARTITION_TYPE_UNSPECIFIED
+                      values:
+                        - :PARTITION_TYPE_UNSPECIFIED
+                        - :HOUR
+                        - :DAY
+                        - :MONTH
+                        - :YEAR
+                    - !ruby/object:Api::Type::String
+                      name: expirationMs
+                      description: |
+                        Number of milliseconds for which to keep the storage for a partition.
 
-- !ruby/object:Api::Type::Array
-  name: notificationConfigs
-  description: |-
-    A list of notifcation configs that configure the notification for every resource mutation in this FHIR store.
-  min_version: beta
-  item_type: !ruby/object:Api::Type::NestedObject
-    properties:
-    - !ruby/object:Api::Type::String
-      name: pubsubTopic
-      required: true
-      description: |
-        The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
-        PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
-        It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
-        was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
-        project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
-        Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
-    - !ruby/object:Api::Type::Boolean
-      name: sendFullResource
-      description: |
-        Whether to send full FHIR resource to this Pub/Sub topic for Create and Update operation.
-        Note that setting this to true does not guarantee that all resources will be sent in the format of
-        full FHIR resource. When a resource change is too large or during heavy traffic, only the resource name will be
-        sent. Clients should always check the "payloadType" label from a Pub/Sub message to determine whether
-        it needs to fetch the full resource as a separate operation.
+  - !ruby/object:Api::Type::Array
+    name: notificationConfigs
+    description: |-
+      A list of notifcation configs that configure the notification for every resource mutation in this FHIR store.
+    min_version: beta
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: pubsubTopic
+          required: true
+          description: |
+            The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
+            PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
+            It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
+            was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
+            project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
+            Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
+        - !ruby/object:Api::Type::Boolean
+          name: sendFullResource
+          description: |
+            Whether to send full FHIR resource to this Pub/Sub topic for Create and Update operation.
+            Note that setting this to true does not guarantee that all resources will be sent in the format of
+            full FHIR resource. When a resource change is too large or during heavy traffic, only the resource name will be
+            sent. Clients should always check the "payloadType" label from a Pub/Sub message to determine whether
+            it needs to fetch the full resource as a separate operation.

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -1,17 +1,4 @@
-# Copyright 2023 Google Inc.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
---- !ruby/object:Api::Resource
+!ruby/object:Api::Resource
 name: 'FhirStore'
 kind: 'healthcare#fhirStore'
 base_url: '{{dataset}}/fhirStores?fhirStoreId={{name}}'
@@ -29,283 +16,281 @@ id_format: '{{dataset}}/fhirStores/{{name}}'
 import_format: ['{{dataset}}/fhirStores/{{name}}']
 skip_sweeper: true
 examples:
-  - !ruby/object:Provider::Terraform::Examples
-    name: 'healthcare_fhir_store_basic'
-    primary_resource_id: 'default'
-    vars:
-      dataset_name: 'example-dataset'
-      fhir_store_name: 'example-fhir-store'
-      pubsub_topic: 'fhir-notifications'
-  - !ruby/object:Provider::Terraform::Examples
-    name: 'healthcare_fhir_store_streaming_config'
-    primary_resource_id: 'default'
-    vars:
-      dataset_name: 'example-dataset'
-      fhir_store_name: 'example-fhir-store'
-      pubsub_topic: 'fhir-notifications'
-      bq_dataset_name: 'bq_example_dataset'
-    test_vars_overrides:
-      policyChanged:
-        ' acctest.BootstrapPSARoles(t, "service-", "gcp-sa-healthcare",
-        []string{"roles/bigquery.dataEditor", "roles/bigquery.jobUser"})'
-  - !ruby/object:Provider::Terraform::Examples
-    name: 'healthcare_fhir_store_notification_config'
-    primary_resource_id: 'default'
-    vars:
-      dataset_name: 'example-dataset'
-      fhir_store_name: 'example-fhir-store'
-      pubsub_topic: 'fhir-notifications'
-  - !ruby/object:Provider::Terraform::Examples
-    name: 'healthcare_fhir_store_notification_configs'
-    min_version: beta
-    primary_resource_id: 'default'
-    vars:
-      dataset_name: 'example-dataset'
-      fhir_store_name: 'example-fhir-store'
-      pubsub_topic: 'fhir-notifications'
+- !ruby/object:Provider::Terraform::Examples
+  name: 'healthcare_fhir_store_basic'
+  primary_resource_id: 'default'
+  vars:
+    dataset_name: 'example-dataset'
+    fhir_store_name: 'example-fhir-store'
+    pubsub_topic: 'fhir-notifications'
+- !ruby/object:Provider::Terraform::Examples
+  name: 'healthcare_fhir_store_streaming_config'
+  primary_resource_id: 'default'
+  vars:
+    dataset_name: 'example-dataset'
+    fhir_store_name: 'example-fhir-store'
+    pubsub_topic: 'fhir-notifications'
+    bq_dataset_name: 'bq_example_dataset'
+  test_vars_overrides:
+    policyChanged: ' acctest.BootstrapPSARoles(t, "service-", "gcp-sa-healthcare",
+      []string{"roles/bigquery.dataEditor", "roles/bigquery.jobUser"})'
+- !ruby/object:Provider::Terraform::Examples
+  name: 'healthcare_fhir_store_notification_config'
+  primary_resource_id: 'default'
+  vars:
+    dataset_name: 'example-dataset'
+    fhir_store_name: 'example-fhir-store'
+    pubsub_topic: 'fhir-notifications'
+- !ruby/object:Provider::Terraform::Examples
+  name: 'healthcare_fhir_store_notification_configs'
+  min_version: beta
+  primary_resource_id: 'default'
+  vars:
+    dataset_name: 'example-dataset'
+    fhir_store_name: 'example-fhir-store'
+    pubsub_topic: 'fhir-notifications'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
   custom_import: templates/terraform/custom_import/healthcare_fhir_store.go.erb
 parameters:
-  - !ruby/object:Api::Type::ResourceRef
-    name: 'dataset'
-    description: |
-      Identifies the dataset addressed by this request. Must be in the format
-      'projects/{project}/locations/{location}/datasets/{dataset}'
-    required: true
-    immutable: true
-    resource: 'Dataset'
-    imports: 'selfLink'
-    url_param_only: true
+- !ruby/object:Api::Type::ResourceRef
+  name: 'dataset'
+  description: |
+    Identifies the dataset addressed by this request. Must be in the format
+    'projects/{project}/locations/{location}/datasets/{dataset}'
+  required: true
+  immutable: true
+  resource: 'Dataset'
+  imports: 'selfLink'
+  url_param_only: true
 properties:
+- !ruby/object:Api::Type::String
+  name: 'name'
+  description: |
+    The resource name for the FhirStore.
+
+    ** Changing this property may recreate the FHIR store (removing all data) **
+  required: true
+  immutable: true
+- !ruby/object:Api::Type::Enum
+  name: version
+  description: |
+    The FHIR specification version.
+  exact_version: beta
+  required: false
+  immutable: true
+  default_value: :STU3
+  values:
+  - :DSTU2
+  - :STU3
+  - :R4
+- !ruby/object:Api::Type::Enum
+  name: version
+  description: |
+    The FHIR specification version.
+  exact_version: ga
+  required: true
+  immutable: true
+  values:
+  - :DSTU2
+  - :STU3
+  - :R4
+- !ruby/object:Api::Type::Enum
+  name: complexDataTypeReferenceParsing
+  description: |
+    Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED by default after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
+  default_from_api: true
+  values:
+  - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED
+  - :DISABLED
+  - :ENABLED
+- !ruby/object:Api::Type::Boolean
+  name: 'enableUpdateCreate'
+  description: |
+    Whether this FHIR store has the updateCreate capability. This determines if the client can use an Update
+    operation to create a new resource with a client-specified ID. If false, all IDs are server-assigned through
+    the Create operation and attempts to Update a non-existent resource will return errors. Please treat the audit
+    logs with appropriate levels of care if client-specified resource IDs contain sensitive data such as patient
+    identifiers, those IDs will be part of the FHIR resource path recorded in Cloud audit logs and Cloud Pub/Sub
+    notifications.
+  required: false
+- !ruby/object:Api::Type::Boolean
+  name: 'disableReferentialIntegrity'
+  description: |
+    Whether to disable referential integrity in this FHIR store. This field is immutable after FHIR store
+    creation. The default value is false, meaning that the API will enforce referential integrity and fail the
+    requests that will result in inconsistent state in the FHIR store. When this field is set to true, the API
+    will skip referential integrity check. Consequently, operations that rely on references, such as
+    Patient.get$everything, will not return all the results if broken references exist.
+
+    ** Changing this property may recreate the FHIR store (removing all data) **
+  required: false
+  immutable: true
+- !ruby/object:Api::Type::Boolean
+  name: 'disableResourceVersioning'
+  description: |
+    Whether to disable resource versioning for this FHIR store. This field can not be changed after the creation
+    of FHIR store. If set to false, which is the default behavior, all write operations will cause historical
+    versions to be recorded automatically. The historical versions can be fetched through the history APIs, but
+    cannot be updated. If set to true, no historical versions will be kept. The server will send back errors for
+    attempts to read the historical versions.
+
+    ** Changing this property may recreate the FHIR store (removing all data) **
+  required: false
+  immutable: true
+- !ruby/object:Api::Type::Boolean
+  name: 'enableHistoryImport'
+  description: |
+    Whether to allow the bulk import API to accept history bundles and directly insert historical resource
+    versions into the FHIR store. Importing resource histories creates resource interactions that appear to have
+    occurred in the past, which clients may not want to allow. If set to false, history bundles within an import
+    will fail with an error.
+
+    ** Changing this property may recreate the FHIR store (removing all data) **
+
+    ** This property can be changed manually in the Google Cloud Healthcare admin console without recreating the FHIR store **
+  required: false
+  immutable: true
+- !ruby/object:Api::Type::KeyValuePairs
+  name: labels
+  required: false
+  description: |
+    User-supplied key-value pairs used to organize FHIR stores.
+
+    Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes, and must
+    conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
+
+    Label values are optional, must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128
+    bytes, and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
+
+    No more than 64 labels can be associated with a given store.
+
+    An object containing a list of "key": value pairs.
+    Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+
+- !ruby/object:Api::Type::NestedObject
+  name: notificationConfig
+  required: false
+  properties:
   - !ruby/object:Api::Type::String
-    name: 'name'
+    name: pubsubTopic
     description: |
-      The resource name for the FhirStore.
-
-      ** Changing this property may recreate the FHIR store (removing all data) **
+      The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
+      PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
+      It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
+      was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
+      project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
+      Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
     required: true
-    immutable: true
-  # Version is duplicated because it is optional in beta but required in GA.
-  - !ruby/object:Api::Type::Enum
-    name: version
-    description: |
-      The FHIR specification version.
-    exact_version: beta
-    required: false
-    immutable: true
-    default_value: :STU3
-    values:
-      - :DSTU2
-      - :STU3
-      - :R4
-  - !ruby/object:Api::Type::Enum
-    name: version
-    description: |
-      The FHIR specification version.
-    exact_version: ga
-    required: true
-    immutable: true
-    values:
-      - :DSTU2
-      - :STU3
-      - :R4
-  - !ruby/object:Api::Type::Enum
-    name: complexDataTypeReferenceParsing
-    description: |
-      Enable parsing of references within complex FHIR data types such as Extensions. If this value is set to ENABLED, then features like referential integrity and Bundle reference rewriting apply to all references. If this flag has not been specified the behavior of the FHIR store will not change, references in complex data types will not be parsed. New stores will have this value set to ENABLED by default after a notification period. Warning: turning on this flag causes processing existing resources to fail if they contain references to non-existent resources.
-    default_from_api: true
-    values:
-      - :COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED
-      - :DISABLED
-      - :ENABLED
-  - !ruby/object:Api::Type::Boolean
-    name: 'enableUpdateCreate'
-    description: |
-      Whether this FHIR store has the updateCreate capability. This determines if the client can use an Update
-      operation to create a new resource with a client-specified ID. If false, all IDs are server-assigned through
-      the Create operation and attempts to Update a non-existent resource will return errors. Please treat the audit
-      logs with appropriate levels of care if client-specified resource IDs contain sensitive data such as patient
-      identifiers, those IDs will be part of the FHIR resource path recorded in Cloud audit logs and Cloud Pub/Sub
-      notifications.
-    required: false
-  - !ruby/object:Api::Type::Boolean
-    name: 'disableReferentialIntegrity'
-    description: |
-      Whether to disable referential integrity in this FHIR store. This field is immutable after FHIR store
-      creation. The default value is false, meaning that the API will enforce referential integrity and fail the
-      requests that will result in inconsistent state in the FHIR store. When this field is set to true, the API
-      will skip referential integrity check. Consequently, operations that rely on references, such as
-      Patient.get$everything, will not return all the results if broken references exist.
-
-      ** Changing this property may recreate the FHIR store (removing all data) **
-    required: false
-    immutable: true
-  - !ruby/object:Api::Type::Boolean
-    name: 'disableResourceVersioning'
-    description: |
-      Whether to disable resource versioning for this FHIR store. This field can not be changed after the creation
-      of FHIR store. If set to false, which is the default behavior, all write operations will cause historical
-      versions to be recorded automatically. The historical versions can be fetched through the history APIs, but
-      cannot be updated. If set to true, no historical versions will be kept. The server will send back errors for
-      attempts to read the historical versions.
-
-      ** Changing this property may recreate the FHIR store (removing all data) **
-    required: false
-    immutable: true
-  - !ruby/object:Api::Type::Boolean
-    name: 'enableHistoryImport'
-    description: |
-      Whether to allow the bulk import API to accept history bundles and directly insert historical resource
-      versions into the FHIR store. Importing resource histories creates resource interactions that appear to have
-      occurred in the past, which clients may not want to allow. If set to false, history bundles within an import
-      will fail with an error.
-
-      ** Changing this property may recreate the FHIR store (removing all data) **
-
-      ** This property can be changed manually in the Google Cloud Healthcare admin console without recreating the FHIR store **
-    required: false
-    immutable: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
-    required: false
-    description: |
-      User-supplied key-value pairs used to organize FHIR stores.
-
-      Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes, and must
-      conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
-
-      Label values are optional, must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128
-      bytes, and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
-
-      No more than 64 labels can be associated with a given store.
-
-      An object containing a list of "key": value pairs.
-      Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
-
-  - !ruby/object:Api::Type::NestedObject
-    name: notificationConfig
-    required: false
+- !ruby/object:Api::Type::String
+  name: 'selfLink'
+  description: |
+    The fully qualified name of this dataset
+  output: true
+  ignore_read: true
+- !ruby/object:Api::Type::Array
+  name: streamConfigs
+  description: |-
+    A list of streaming configs that configure the destinations of streaming export for every resource mutation in
+    this FHIR store. Each store is allowed to have up to 10 streaming configs. After a new config is added, the next
+    resource mutation is streamed to the new location in addition to the existing ones. When a location is removed
+    from the list, the server stops streaming to that location. Before adding a new config, you must add the required
+    bigquery.dataEditor role to your project's Cloud Healthcare Service Agent service account. Some lag (typically on
+    the order of dozens of seconds) is expected before the results show up in the streaming destination.
+  item_type: !ruby/object:Api::Type::NestedObject
     properties:
+    - !ruby/object:Api::Type::Array
+      name: 'resourceTypes'
+      description: |
+        Supply a FHIR resource type (such as "Patient" or "Observation"). See
+        https://www.hl7.org/fhir/valueset-resource-types.html for a list of all FHIR resource types. The server treats
+        an empty list as an intent to stream all the supported resource types in this FHIR store.
+      item_type: Api::Type::String
+    - !ruby/object:Api::Type::NestedObject
+      name: bigqueryDestination
+      required: true
+      description: |
+        The destination BigQuery structure that contains both the dataset location and corresponding schema config.
+        The output is organized in one table per resource type. The server reuses the existing tables (if any) that
+        are named after the resource types, e.g. "Patient", "Observation". When there is no existing table for a given
+        resource type, the server attempts to create one.
+        See the [streaming config reference](https://cloud.google.com/healthcare/docs/reference/rest/v1beta1/projects.locations.datasets.fhirStores#streamconfig) for more details.
+      properties:
       - !ruby/object:Api::Type::String
-        name: pubsubTopic
-        description: |
-          The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
-          PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
-          It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
-          was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
-          project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
-          Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
+        name: datasetUri
         required: true
-  - !ruby/object:Api::Type::String
-    name: 'selfLink'
-    description: |
-      The fully qualified name of this dataset
-    output: true
-    ignore_read: true
-  - !ruby/object:Api::Type::Array
-    name: streamConfigs
-    description: |-
-      A list of streaming configs that configure the destinations of streaming export for every resource mutation in
-      this FHIR store. Each store is allowed to have up to 10 streaming configs. After a new config is added, the next
-      resource mutation is streamed to the new location in addition to the existing ones. When a location is removed
-      from the list, the server stops streaming to that location. Before adding a new config, you must add the required
-      bigquery.dataEditor role to your project's Cloud Healthcare Service Agent service account. Some lag (typically on
-      the order of dozens of seconds) is expected before the results show up in the streaming destination.
-    item_type: !ruby/object:Api::Type::NestedObject
-      properties:
-        - !ruby/object:Api::Type::Array
-          name: 'resourceTypes'
+        description: |
+          BigQuery URI to a dataset, up to 2000 characters long, in the format bq://projectId.bqDatasetId
+      - !ruby/object:Api::Type::NestedObject
+        name: schemaConfig
+        required: true
+        description: |
+          The configuration for the exported BigQuery schema.
+        properties:
+        - !ruby/object:Api::Type::Enum
+          name: schemaType
           description: |
-            Supply a FHIR resource type (such as "Patient" or "Observation"). See
-            https://www.hl7.org/fhir/valueset-resource-types.html for a list of all FHIR resource types. The server treats
-            an empty list as an intent to stream all the supported resource types in this FHIR store.
-          item_type: Api::Type::String
+            Specifies the output schema type.
+             * ANALYTICS: Analytics schema defined by the FHIR community.
+              See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md.
+             * ANALYTICS_V2: Analytics V2, similar to schema defined by the FHIR community, with added support for extensions with one or more occurrences and contained resources in stringified JSON.
+             * LOSSLESS: A data-driven schema generated from the fields present in the FHIR data being exported, with no additional simplification.
+          default_value: :ANALYTICS
+          values:
+          - :ANALYTICS
+          - :ANALYTICS_V2
+          - :LOSSLESS
+        - !ruby/object:Api::Type::Integer
+          name: recursiveStructureDepth
+          required: true
+          description: |
+            The depth for all recursive structures in the output analytics schema. For example, concept in the CodeSystem
+            resource is a recursive structure; when the depth is 2, the CodeSystem table will have a column called
+            concept.concept but not concept.concept.concept. If not specified or set to 0, the server will use the default
+            value 2. The maximum depth allowed is 5.
         - !ruby/object:Api::Type::NestedObject
-          name: bigqueryDestination
-          required: true
+          name: lastUpdatedPartitionConfig
           description: |
-            The destination BigQuery structure that contains both the dataset location and corresponding schema config.
-            The output is organized in one table per resource type. The server reuses the existing tables (if any) that
-            are named after the resource types, e.g. "Patient", "Observation". When there is no existing table for a given
-            resource type, the server attempts to create one.
-            See the [streaming config reference](https://cloud.google.com/healthcare/docs/reference/rest/v1beta1/projects.locations.datasets.fhirStores#streamconfig) for more details.
+            The configuration for exported BigQuery tables to be partitioned by FHIR resource's last updated time column.
           properties:
-            - !ruby/object:Api::Type::String
-              name: datasetUri
-              required: true
-              description: |
-                BigQuery URI to a dataset, up to 2000 characters long, in the format bq://projectId.bqDatasetId
-            - !ruby/object:Api::Type::NestedObject
-              name: schemaConfig
-              required: true
-              description: |
-                The configuration for the exported BigQuery schema.
-              properties:
-                - !ruby/object:Api::Type::Enum
-                  name: schemaType
-                  description: |
-                    Specifies the output schema type.
-                     * ANALYTICS: Analytics schema defined by the FHIR community.
-                      See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md.
-                     * ANALYTICS_V2: Analytics V2, similar to schema defined by the FHIR community, with added support for extensions with one or more occurrences and contained resources in stringified JSON.
-                     * LOSSLESS: A data-driven schema generated from the fields present in the FHIR data being exported, with no additional simplification.
-                  default_value: :ANALYTICS
-                  values:
-                    - :ANALYTICS
-                    - :ANALYTICS_V2
-                    - :LOSSLESS
-                - !ruby/object:Api::Type::Integer
-                  name: recursiveStructureDepth
-                  required: true
-                  description: |
-                    The depth for all recursive structures in the output analytics schema. For example, concept in the CodeSystem
-                    resource is a recursive structure; when the depth is 2, the CodeSystem table will have a column called
-                    concept.concept but not concept.concept.concept. If not specified or set to 0, the server will use the default
-                    value 2. The maximum depth allowed is 5.
-                - !ruby/object:Api::Type::NestedObject
-                  name: lastUpdatedPartitionConfig
-                  description: |
-                    The configuration for exported BigQuery tables to be partitioned by FHIR resource's last updated time column.
-                  properties:
-                    - !ruby/object:Api::Type::Enum
-                      name: type
-                      description: |
-                        Type of partitioning.
-                      default_value: :PARTITION_TYPE_UNSPECIFIED
-                      values:
-                        - :PARTITION_TYPE_UNSPECIFIED	
-                        - :HOUR
-                        - :DAY
-                        - :MONTH
-                        - :YEAR
-                    - !ruby/object:Api::Type::String
-                      name: expirationMs
-                      description: |
-                        Number of milliseconds for which to keep the storage for a partition.
+          - !ruby/object:Api::Type::Enum
+            name: type
+            description: |
+              Type of partitioning.
+            default_value: :PARTITION_TYPE_UNSPECIFIED
+            values:
+            - :PARTITION_TYPE_UNSPECIFIED
+            - :HOUR
+            - :DAY
+            - :MONTH
+            - :YEAR
+          - !ruby/object:Api::Type::String
+            name: expirationMs
+            description: |
+              Number of milliseconds for which to keep the storage for a partition.
 
-  - !ruby/object:Api::Type::Array
-    name: notificationConfigs
-    description: |-
-      A list of notifcation configs that configure the notification for every resource mutation in this FHIR store.
-    min_version: beta
-    item_type: !ruby/object:Api::Type::NestedObject
-      properties:
-        - !ruby/object:Api::Type::String
-          name: pubsubTopic
-          required: true
-          description: |
-            The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
-            PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
-            It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
-            was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
-            project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
-            Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
-        - !ruby/object:Api::Type::Boolean
-          name: sendFullResource
-          description: |
-            Whether to send full FHIR resource to this Pub/Sub topic for Create and Update operation.
-            Note that setting this to true does not guarantee that all resources will be sent in the format of
-            full FHIR resource. When a resource change is too large or during heavy traffic, only the resource name will be
-            sent. Clients should always check the "payloadType" label from a Pub/Sub message to determine whether
-            it needs to fetch the full resource as a separate operation.
+- !ruby/object:Api::Type::Array
+  name: notificationConfigs
+  description: |-
+    A list of notifcation configs that configure the notification for every resource mutation in this FHIR store.
+  min_version: beta
+  item_type: !ruby/object:Api::Type::NestedObject
+    properties:
+    - !ruby/object:Api::Type::String
+      name: pubsubTopic
+      required: true
+      description: |
+        The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
+        PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
+        It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
+        was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
+        project. service-PROJECT_NUMBER@gcp-sa-healthcare.iam.gserviceaccount.com must have publisher permissions on the given
+        Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
+    - !ruby/object:Api::Type::Boolean
+      name: sendFullResource
+      description: |
+        Whether to send full FHIR resource to this Pub/Sub topic for Create and Update operation.
+        Note that setting this to true does not guarantee that all resources will be sent in the format of
+        full FHIR resource. When a resource change is too large or during heavy traffic, only the resource name will be
+        sent. Clients should always check the "payloadType" label from a Pub/Sub message to determine whether
+        it needs to fetch the full resource as a separate operation.

--- a/mmv1/templates/terraform/examples/healthcare_fhir_store_streaming_config.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_fhir_store_streaming_config.tf.erb
@@ -18,6 +18,10 @@ resource "google_healthcare_fhir_store" "default" {
       dataset_uri = "bq://${google_bigquery_dataset.bq_dataset.project}.${google_bigquery_dataset.bq_dataset.dataset_id}"
       schema_config {
         recursive_structure_depth = 3
+        last_updated_partition_config {
+          type = "HOUR"
+          expiration_ms = 1000000
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Support for lastUpdatedPartitionConfig in SchemaConfig of FHIR stores in Terraform

Link: https://cloud.google.com/healthcare-api/docs/reference/rest/v1/projects.locations.datasets.fhirStores#schemaconfig

This solves https://github.com/hashicorp/terraform-provider-google/issues/15185

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added `last_updated_partition_config` field to `google_healthcare_fhir_store` resource
```
