### PR TITLE
Simplify network reference in AlloyDB examples

### DIFF
--- a/mmv1/templates/terraform/examples/alloydb_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_basic.tf.erb
@@ -1,7 +1,7 @@
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+  network    = google_compute_network.default.id
 }
 
 data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
@@ -1,7 +1,7 @@
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id   = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location     = "us-central1"
-  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+  network      = google_compute_network.default.id
 
   initial_user {
     user     = "<%= ctx[:vars]['alloydb_cluster_name'] %>"

--- a/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
@@ -13,7 +13,7 @@ resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+  network    = google_compute_network.default.id
 
   initial_user {
     password = "<%= ctx[:vars]['alloydb_cluster_name'] %>"

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_alloydb.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_alloydb.tf.erb
@@ -11,16 +11,12 @@ resource "google_compute_global_address" "private_ip_alloc" {
   purpose       = "VPC_PEERING"
   prefix_length = 16
   network       = google_compute_network.default.id
-
-  depends_on    = [google_compute_network.default]
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
   network                 = google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
-
-  depends_on = [google_compute_global_address.private_ip_alloc]
 }
 
 
@@ -38,7 +34,7 @@ resource "google_database_migration_service_connection_profile" "<%= ctx[:primar
         user = "alloyuser%{random_suffix}"
         password = "alloypass%{random_suffix}"
       }
-      vpc_network = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+      vpc_network = google_compute_network.default.id
       labels  = { 
         alloyfoo = "alloybar" 
       }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
* Use network.id instead of custom string templates
* remove explicit `depends_on` when dependency is already defined implicitly

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```