### PR TITLE
cloud_tasks_queue: support state field

### DIFF
--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -51,6 +51,11 @@ examples:
       - 'app_engine_routing_override.0.instance'
     vars:
       name: 'instance-name'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloud_tasks_queue_paused'
+    primary_resource_id: 'paused_queue'
+    vars:
+      name: 'cloud-tasks-paused-queue-test'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'
@@ -200,3 +205,11 @@ properties:
           Specifies the fraction of operations to write to Stackdriver Logging.
           This field may contain any value between 0.0 and 1.0, inclusive. 0.0 is the
           default and means that no operations are logged.
+  - !ruby/object:Api::Type::Enum
+    name: 'state'
+    description: |
+      The state for the job. Set to `PAUSED` to pause the job.
+    values:
+      - :PAUSED
+      - :RUNNING
+      - :STATE_UNSPECIFIED

--- a/mmv1/templates/terraform/examples/cloud_tasks_queue_paused.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_tasks_queue_paused.tf.erb
@@ -1,0 +1,5 @@
+resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["name"] %>"
+  location = "us-central1"
+  state = "PAUSED"
+}


### PR DESCRIPTION
Support the `state` attribute for the `google_cloud_tasks_queue` resource

https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#State

Since `DISABLED` can't directly be set, I've omitted it from the list of available values for the enum.

Closes https://github.com/hashicorp/terraform-provider-google/issues/15165

Let me know if we should either add `DISABLED` or remove `STATE_UNSPECIFIED`, since I don't think it would be typical to set that, or if this isn't the right way to handle the default being `RUNNING`.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloud_tasks_queue: Add support for `state` field and paused task queues
```
