### PR TITLE
Fix .erb warning about `=` used in conditional

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -552,7 +552,7 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 		},
 	})
 }
-<% unless version = 'ga' -%>
+<% unless version == 'ga' -%>
 func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -552,17 +552,20 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 		},
 	})
 }
+
 <% unless version == 'ga' -%>
 func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
 	t.Parallel()
 
 
 	context := map[string]interface{}{
-		"random_suffix":        RandString(t, 10),
-		"kms":                  BootstrapKMSKey(t),
+		"random_suffix":        acctest.RandString(t, 10),
+		"kms":                  acctest.BootstrapKMSKey(t).CryptoKey.Name, // global KMS key
 		"disk_size":            64,
 		"confidential_compute": true,
 	}
+
+	var disk compute.Disk
 
 	VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -571,10 +574,12 @@ func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeDisk_pdHyperDiskEnableConfidentialCompute(context),
-				Check: resource.ComposeTestCheckFunc( 
-					testAccCheckEncryptionKey(t, "google_compute_disk.foobar", &disk),
-			),
-				
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeDiskExists(
+						t, "google_compute_disk.foobar", envvar.GetTestProjectFromEnv(), &disk),
+					testAccCheckEncryptionKey(
+						t, "google_compute_disk.foobar", &disk),
+				),
 			},
 			{
 				ResourceName:      "google_compute_disk.foobar",
@@ -1151,7 +1156,7 @@ resource "google_compute_disk" "foobar" {
 <% end -%>
 
 <% unless version == 'ga' -%>
-func testAccComputeDisk_multiWriter(instance string,  diskName string, enableMultiwriter bool) string {
+func testAccComputeDisk_multiWriter(instance string, diskName string, enableMultiwriter bool) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -733,7 +733,7 @@ func TestAccComputeDisk_resourcePolicies(t *testing.T) {
 func TestAccComputeDisk_multiWriter(t *testing.T) {
 	t.Parallel()
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	diskName := fmt.Sprintf("tf-testd-%s", acctest.RandString(t, 10))
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is to address a warning when you generate the downstream that looks like:

```
I, [2023-07-18T20:37:51.818200 #93534]  INFO -- : Copying common files for terraform
I, [2023-07-18T20:37:54.216687 #93534]  INFO -- : Compiling common files for terraform
(erb):555: warning: found `= literal' in conditional, should be ==
make tpgtools
make serialize
cd tpgtools;\
		... rest omitted
```

I tracked it to this file using `git bisect`, because the error isn't super informative

---
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
