### PR TITLE
Parallelize mmv1 build time

### DIFF
--- a/mmv1/Gemfile
+++ b/mmv1/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gem 'activesupport'
 gem 'binding_of_caller'
-gem 'rake'
 gem 'parallel'
+gem 'rake'
 
 group :test do
   gem 'mocha', '~> 1.3.0'

--- a/mmv1/Gemfile
+++ b/mmv1/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'activesupport'
 gem 'binding_of_caller'
 gem 'rake'
+gem 'parallel'
 
 group :test do
   gem 'mocha', '~> 1.3.0'

--- a/mmv1/Gemfile.lock
+++ b/mmv1/Gemfile.lock
@@ -63,6 +63,7 @@ DEPENDENCIES
   activesupport
   binding_of_caller
   mocha (~> 1.3.0)
+  parallel
   rake
   rspec
   rubocop (>= 0.77.0)

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -295,7 +295,7 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
 
   # provider_config is mutated by instantiating a provider.
   # we need to preserve a single provider instance to use outside of this loop.
-  { definitions: product_api, overrides: provider_config, provider: provider }
+  { definitions: product_api, overrides: provider_config, provider }
 end
 
 products_for_version = products_for_version.compact # remove any nil values

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -277,7 +277,6 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
       override_providers[force_provider].new(provider_config, product_api, version, start_time)
   end
 
-
   unless products_to_generate.include?(product_name)
     Google::LOGGER.info "#{product_name}: Not specified, skipping generation"
     next
@@ -298,10 +297,12 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
   { definitions: product_api, overrides: provider_config }
 end
 
+products_for_version = products_for_version.compact # remove any nil values
+
 # In order to only copy/compile files once per provider this must be called outside
 # of the products loop. This will get called with the provider from the final iteration
 # of the loop
-final_product = products_for_version.compact.last # added compact to remove nils
+final_product = products_for_version.compact.last
 final_provider_config = final_product[:overrides] # access the hash values with keys
 final_product_api = final_product[:definitions]
 provider = \

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -295,7 +295,7 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
 
   # provider_config is mutated by instantiating a provider.
   # we need to preserve a single provider instance to use outside of this loop.
-  { definitions: product_api, overrides: provider_config, provider }
+  { definitions: product_api, overrides: provider_config, provider: provider } # rubocop:disable Style/HashSyntax
 end
 
 products_for_version = products_for_version.compact # remove any nil values


### PR DESCRIPTION
Local testing decreased build time from 663 seconds to 280 seconds. (11m to 5m)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
