### PR TITLE
added contributing to 5.0.0 section

### DIFF
--- a/docs/content/develop/make-a-breaking-change.md
+++ b/docs/content/develop/make-a-breaking-change.md
@@ -181,6 +181,21 @@ Example (`google_container_cluster.enable_shielded_nodes`)
 * https://github.com/GoogleCloudPlatform/magic-modules/pull/5263 changed the default value for the field and added an upgrade guide entry
 * Note: In 4.0.0 the upgrade guide was split between main and the major release branch. Going forward, those changes will be made against main exclusively.
 
+## Contributing to the next major release (`5.0.0`)
+
+For the next major release, `5.0.0`, a specific branch named [`FEATURE-BRANCH-major-release-5.0.0`](https://github.com/GoogleCloudPlatform/magic-modules/tree/FEATURE-BRANCH-major-release-5.0.0) will be managed parallel to `main` in the magic-modules repo.
+All breaking changes targeting `5.0.0` must be committed to `FEATURE-BRANCH-major-release-5.0.0`.
+
+A downstream branch with the same name `FEATURE-BRANCH-major-release-5.0.0` will also be created to track the generated `5.0.0` changes in both [`google`](https://github.com/hashicorp/terraform-provider-google/tree/FEATURE-BRANCH-major-release-5.0.0) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta/tree/FEATURE-BRANCH-major-release-5.0.0) provider repos
+
+The process of contributing to the major release `5.0.0` should follow most of the [General contributing steps]({{< ref "/get-started/contributing" >}}), with the following exceptions
+
+1. Use `FEATURE-BRANCH-major-release-5.0.0` branch instead of the `main` branch as the base branch when you
+   * checkout your working branch where you make your code changes.
+   * sync your working branch using `git rebase` or `git merge`.
+   * create a pull request in the magic-modules repo.
+2. Make sure that you checkout to the `FEATURE-BRANCH-major-release-5.0.0` branch in your downstream `google` and `google-beta` repos before generating the providers locally.
+
 ## References
 
 * Terraform (Provider) Plugin Development

--- a/docs/content/develop/make-a-breaking-change.md
+++ b/docs/content/develop/make-a-breaking-change.md
@@ -116,7 +116,7 @@ The process of contributing to the major release `5.0.0` follows most of the [Ge
 3. If your change is a follow-up to a recent commit to main that is not yet contained in the released branch, it is strongly encouraged to wait until the branch sync and resolve any merge conflicts in the PR. 
    For example, if you are removing a field that has been recently deprecated in main. 
 
-   The release branch is synced with main on a weekly basis every Monday.
+The release branch is synced with main on a weekly basis every Monday.
 
 
 ### Renaming a field

--- a/docs/content/develop/make-a-breaking-change.md
+++ b/docs/content/develop/make-a-breaking-change.md
@@ -99,6 +99,21 @@ release series before their removal or change in a major release. Additionally,
 deprecation warnings must be actionable- at the time a deprecation is posted, a
 user must be able to remove the field.
 
+### Contributing to the next major release (`5.0.0`)
+
+For the `5.0.0` major release, the major release branch that you'll contribute to is [`FEATURE-BRANCH-major-release-5.0.0`](https://github.com/GoogleCloudPlatform/magic-modules/tree/FEATURE-BRANCH-major-release-5.0.0).
+All breaking changes targeting `5.0.0` must be committed to this branch.
+
+A downstream branch with the same name `FEATURE-BRANCH-major-release-5.0.0` will be used to track the generated `5.0.0` changes in both [`google`](https://github.com/hashicorp/terraform-provider-google/tree/FEATURE-BRANCH-major-release-5.0.0) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta/tree/FEATURE-BRANCH-major-release-5.0.0) provider repos
+
+The process of contributing to the major release `5.0.0` should follow most of the [General contributing steps]({{< ref "/get-started/contributing" >}}), with the following exceptions
+
+1. Use `FEATURE-BRANCH-major-release-5.0.0` branch instead of the `main` branch as the base branch when you
+   * checkout your working branch where you make your code changes.
+   * sync your working branch using `git rebase` or `git merge`.
+   * create a pull request in the magic-modules repo.
+2. Make sure that you checkout to the `FEATURE-BRANCH-major-release-5.0.0` branch in your downstream `google` and `google-beta` repos before generating the providers locally.
+
 ### Renaming a field
 
 The most common type of breaking change is a field rename, and most guidance is
@@ -180,21 +195,6 @@ than through the upgrade guide.
 Example (`google_container_cluster.enable_shielded_nodes`)
 * https://github.com/GoogleCloudPlatform/magic-modules/pull/5263 changed the default value for the field and added an upgrade guide entry
 * Note: In 4.0.0 the upgrade guide was split between main and the major release branch. Going forward, those changes will be made against main exclusively.
-
-## Contributing to the next major release (`5.0.0`)
-
-For the next major release, `5.0.0`, a specific branch named [`FEATURE-BRANCH-major-release-5.0.0`](https://github.com/GoogleCloudPlatform/magic-modules/tree/FEATURE-BRANCH-major-release-5.0.0) will be managed parallel to `main` in the magic-modules repo.
-All breaking changes targeting `5.0.0` must be committed to `FEATURE-BRANCH-major-release-5.0.0`.
-
-A downstream branch with the same name `FEATURE-BRANCH-major-release-5.0.0` will also be created to track the generated `5.0.0` changes in both [`google`](https://github.com/hashicorp/terraform-provider-google/tree/FEATURE-BRANCH-major-release-5.0.0) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta/tree/FEATURE-BRANCH-major-release-5.0.0) provider repos
-
-The process of contributing to the major release `5.0.0` should follow most of the [General contributing steps]({{< ref "/get-started/contributing" >}}), with the following exceptions
-
-1. Use `FEATURE-BRANCH-major-release-5.0.0` branch instead of the `main` branch as the base branch when you
-   * checkout your working branch where you make your code changes.
-   * sync your working branch using `git rebase` or `git merge`.
-   * create a pull request in the magic-modules repo.
-2. Make sure that you checkout to the `FEATURE-BRANCH-major-release-5.0.0` branch in your downstream `google` and `google-beta` repos before generating the providers locally.
 
 ## References
 

--- a/docs/content/develop/make-a-breaking-change.md
+++ b/docs/content/develop/make-a-breaking-change.md
@@ -104,15 +104,20 @@ user must be able to remove the field.
 For the `5.0.0` major release, the major release branch that you'll contribute to is [`FEATURE-BRANCH-major-release-5.0.0`](https://github.com/GoogleCloudPlatform/magic-modules/tree/FEATURE-BRANCH-major-release-5.0.0).
 All breaking changes targeting `5.0.0` must be committed to this branch.
 
-A downstream branch with the same name `FEATURE-BRANCH-major-release-5.0.0` will be used to track the generated `5.0.0` changes in both [`google`](https://github.com/hashicorp/terraform-provider-google/tree/FEATURE-BRANCH-major-release-5.0.0) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta/tree/FEATURE-BRANCH-major-release-5.0.0) provider repos
+A downstream branch with the same name `FEATURE-BRANCH-major-release-5.0.0` will be used to track the generated `5.0.0` changes in both [`google`](https://github.com/hashicorp/terraform-provider-google/tree/FEATURE-BRANCH-major-release-5.0.0) and [`google-beta`](https://github.com/hashicorp/terraform-provider-google-beta/tree/FEATURE-BRANCH-major-release-5.0.0) provider repos.
 
-The process of contributing to the major release `5.0.0` should follow most of the [General contributing steps]({{< ref "/get-started/contributing" >}}), with the following exceptions
+The process of contributing to the major release `5.0.0` follows most of the [General contributing steps]({{< ref "/get-started/contributing" >}}), with the following exceptions
 
 1. Use `FEATURE-BRANCH-major-release-5.0.0` branch instead of the `main` branch as the base branch when you
    * checkout your working branch where you make your code changes.
    * sync your working branch using `git rebase` or `git merge`.
    * create a pull request in the magic-modules repo.
 2. Make sure that you checkout to the `FEATURE-BRANCH-major-release-5.0.0` branch in your downstream `google` and `google-beta` repos before generating the providers locally.
+3. If your change is a follow-up to a recent commit to main that is not yet contained in the released branch, it is strongly encouraged to wait until the branch sync and resolve any merge conflicts in the PR. 
+   For example, if you are removing a field that has been recently deprecated in main. 
+
+   The release branch is synced with main on a weekly basis every Monday.
+
 
 ### Renaming a field
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->





<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
