### PR TITLE
Add `enable_strong_affinity` field to `google_compute_region_backend_service` (beta)

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1199,6 +1199,9 @@ properties:
           - :DEFAULT_FOR_PROTOCOL
           - :NEVER_PERSIST
           - :ALWAYS_PERSIST
+      - !ruby/object:Api::Type::Boolean
+        name: enableStrongAffinity
+        description: Enable Strong Session Affinity for Network Load Balancing. This option is not available publicly.
   - !ruby/object:Api::Type::Integer
     name: 'timeoutSec'
     description: |

--- a/mmv1/templates/terraform/examples/region_backend_service_connection_tracking.tf.erb
+++ b/mmv1/templates/terraform/examples/region_backend_service_connection_tracking.tf.erb
@@ -11,6 +11,7 @@ resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] 
     tracking_mode                                = "PER_SESSION"
     connection_persistence_on_unhealthy_backends = "NEVER_PERSIST"
     idle_timeout_sec                             = 60
+    enable_strong_affinity                       = true
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

NOTE: this is blocked because the field is not publicly available.


[Link to field's documentation](https://cloud.google.com/compute/docs/reference/rest/beta/regionBackendServices#BackendService.FIELDS.inlinedField_91), it says:

> **connectionTrackingPolicy.enableStrongAffinity** | boolean   -   Enable Strong Session Affinity for Network Load Balancing. This option is not available publicly.





----
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `enable_strong_affinity` field to `google_compute_region_backend_service` (beta)
```
