### PR TITLE
Add traffic status field to cloud run v1 service.

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -920,6 +920,44 @@ properties:
           stamped out from this Service's Configuration that has had its "Ready" condition become
           "True".
         output: true
+      - !ruby/object:Api::Type::Array
+        name: traffic
+        description: |-
+          Traffic specifies how to distribute traffic over a collection of Knative Revisions
+          and Configurations
+        output: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: revisionName
+              description: |-
+                RevisionName of a specific revision to which to send this portion of traffic.
+              output: true
+            - !ruby/object:Api::Type::Integer
+              name: percent
+              output: true
+              description: |-
+                Percent specifies percent of the traffic to this Revision or Configuration.
+            - !ruby/object:Api::Type::String
+              name: tag
+              output: true
+              description: |-
+                Tag is optionally used to expose a dedicated url for referencing this target exclusively.
+            - !ruby/object:Api::Type::Boolean
+              name: latestRevision
+              output: true
+              description: |-
+                LatestRevision may be optionally provided to indicate that the latest ready
+                Revision of the Configuration should be used for this traffic target. When
+                provided LatestRevision must be true if RevisionName is empty; it must be
+                false when RevisionName is non-empty.
+            - !ruby/object:Api::Type::String
+              name: url
+              output: true
+              description: |-
+                URL displays the URL for accessing tagged traffic targets. URL is displayed in status,
+                and is disallowed on spec. URL must contain a scheme (e.g. http://) and a hostname,
+                but may not contain anything else (e.g. basic auth, url path, etc.)
 
   - !ruby/object:Api::Type::NestedObject
     name: metadata

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -42,6 +42,31 @@ func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
 	})
 }
 
+// test that the status fields are propagated correctly
+func TestAccCloudRunService_cloudRunServiceCreateHasStatus(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	name := "tftest-cloudrun-" + acctest.RandString(t, 6)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
+        Check: resource.TestCheckResourceAttrSet("google_cloud_run_service.default", "status.0.traffic.0.revision_name"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+		},
+	})
+}
+
 // this test checks that Terraform does not fail with a 409 recreating the same service
 func TestAccCloudRunService_foregroundDeletion(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is an output-only field so it's not generally important for the managed resource, but it can be useful in the data source to get the current traffic.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15153

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloud-run: added `status.traffic` output fields to `google_cloud_run_service` resource 
```
