### PR TITLE
[DO NOT MERGE] Composer network config

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -546,7 +546,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 										Optional: true,
 										Computed: true,
 										AtLeastOneOf: composerPrivateEnvironmentConfig,
-										DiffSuppressFunc: testDiffSupressFunc,
 										ForceNew: true,
 										Description: `When enabled, IPs from public (non-RFC1918) ranges can be used for ip_allocation_policy.cluster_ipv4_cidr_block and ip_allocation_policy.service_ipv4_cidr_block.`,
 									},
@@ -2418,23 +2417,6 @@ func validateServiceAccountRelativeNameOrEmail(v interface{}, k string) (ws []st
 	}
 
 	return
-}
-
-func isComposer25(imageVersion string) bool {
-	composerVersion := strings.Split(imageVersion, "-")[1]
-	if composerVersion == "1" || composerVersion == "2" {
-		return false
-	}
-	composerVersionDetails := strings.Split(composerVersion, ".")
-	major, minor := composerVersionDetails[0], composerVersionDetails[1]
-	minorInt, _ := strconv.Atoi(minor)
-	return major == "2" && minorInt >= 50
-}
-
-func testDiffSupressFunc(k, old, new string, d *schema.ResourceData) bool {
-	var image_version = d.Get("config").([]interface{})[0].(map[string]interface{})["software_config"].([]interface{})[0].(map[string]interface{})["image_version"]
-	fmt.Printf("resource data %T, %s\n", image_version, image_version)
-	return true
 }
 
 func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -89,6 +89,7 @@ var (
 	}
 
 	composerPrivateEnvironmentConfig = []string{
+		"config.0.private_environment_config.0.connection_type",
 		"config.0.private_environment_config.0.enable_private_endpoint",
 		"config.0.private_environment_config.0.master_ipv4_cidr_block",
 		"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
@@ -478,29 +479,15 @@ func ResourceComposerEnvironment() *schema.Resource {
 							Description:  `The configuration used for the Private IP Cloud Composer environment.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"network_configuration_store": {
-										Type:         schema.TypeList,
-										Optional:     true,
-										Computed:     true,
-										AtLeastOneOf: composerConfigKeys,
-										MaxItems:     1,
-										ForceNew:     true,
-										Description:  `The configuration used for the Private IP Cloud Composer environment.`
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"connection_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-													Computed: true,
-													AtLeastOneOf: composerPrivateEnvironmentConfig,
-													ForceNew: true,
-													DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
-													ValidateFunc: validation.StringInSlice([]string{"VPC_PERRING", "PSC"}, false),
-													Description: `When specified, the environment will use Private Service Connect instead of VPC peerings to connect to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP address from this subnetwork. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
-												},
-											}
-
-
+									"connection_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										AtLeastOneOf: composerPrivateEnvironmentConfig,
+										ForceNew: true,
+										ValidateFunc: validation.StringInSlice([]string{"VPC_PEERING", "PRIVATE_SERVICE_CONNECT"}, false),
+										Description: `When specified, the environment will use Private Service Connect instead of VPC peerings to connect to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP address from this subnetwork. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
+									},
 									"enable_private_endpoint": {
 										Type:     schema.TypeBool,
 										Optional: true,
@@ -1533,7 +1520,7 @@ func flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg *composer.P
 	}
 
 	transformed := make(map[string]interface{})
-	transformed["network_configuration_store"] = flattenNetworkConfigurationStore(envCfg)
+	transformed["connection_type"] = envCfg.NetworkingConfig.ConnectionType
 	transformed["enable_private_endpoint"] = envCfg.PrivateClusterConfig.EnablePrivateEndpoint
 	transformed["master_ipv4_cidr_block"] = envCfg.PrivateClusterConfig.MasterIpv4CidrBlock
 	transformed["cloud_sql_ipv4_cidr_block"] = envCfg.CloudSqlIpv4CidrBlock
@@ -1987,6 +1974,11 @@ func expandComposerEnvironmentConfigPrivateEnvironmentConfig(v interface{}, d *s
 	}
 
 	subBlock := &composer.PrivateClusterConfig{}
+	networkConfig := &composer.NetworkingConfig{}
+
+	if v, ok := original["connection_type"]; ok {
+		networkConfig.ConnectionType = v.(string)
+	}
 
 	if v, ok := original["enable_private_endpoint"]; ok {
 		subBlock.EnablePrivateEndpoint = v.(bool)
@@ -2015,6 +2007,7 @@ func expandComposerEnvironmentConfigPrivateEnvironmentConfig(v interface{}, d *s
 	}
 
 	transformed.PrivateClusterConfig = subBlock
+	transformed.NetworkingConfig = networkConfig
 
 	return transformed, nil
 }

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -523,6 +523,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 										Optional: true,
 										Computed: true,
 										AtLeastOneOf: composerPrivateEnvironmentConfig,
+										DiffSuppressFunc: testDiffSupressFunc,
 										ForceNew: true,
 										Description: `When enabled, IPs from public (non-RFC1918) ranges can be used for ip_allocation_policy.cluster_ipv4_cidr_block and ip_allocation_policy.service_ipv4_cidr_block.`,
 									},
@@ -2393,6 +2394,23 @@ func validateServiceAccountRelativeNameOrEmail(v interface{}, k string) (ws []st
 	}
 
 	return
+}
+
+func isComposer25(imageVersion string) bool {
+	composerVersion := strings.Split(imageVersion, "-")[1]
+	if composerVersion == "1" || composerVersion == "2" {
+		return false
+	}
+	composerVersionDetails := strings.Split(composerVersion, ".")
+	major, minor := composerVersionDetails[0], composerVersionDetails[1]
+	minorInt, _ := strconv.Atoi(minor)
+	return major == "2" && minorInt >= 50
+}
+
+func testDiffSupressFunc(k, old, new string, d *schema.ResourceData) bool {
+	var image_version = d.Get("config").([]interface{})[0].(map[string]interface{})["software_config"].([]interface{})[0].(map[string]interface{})["image_version"]
+	fmt.Printf("resource data %T, %s\n", image_version, image_version)
+	return true
 }
 
 func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -486,7 +486,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 										AtLeastOneOf: composerPrivateEnvironmentConfig,
 										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{"VPC_PEERING", "PRIVATE_SERVICE_CONNECT"}, false),
-										Description: `When specified, the environment will use Private Service Connect instead of VPC peerings to connect to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP address from this subnetwork. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
+										Description: `Configuration options for networking connections in the Composer 2 environment. Indicates the user requested specific connection type between Tenant and Customer projects. You cannot set networking connection type in public IP environment. Must be either: "VPC_PEERING" or "PRIVATE_SERVICE_CONNECT".`,
 									},
 									"enable_private_endpoint": {
 										Type:     schema.TypeBool,

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -478,6 +478,29 @@ func ResourceComposerEnvironment() *schema.Resource {
 							Description:  `The configuration used for the Private IP Cloud Composer environment.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"network_configuration_store": {
+										Type:         schema.TypeList,
+										Optional:     true,
+										Computed:     true,
+										AtLeastOneOf: composerConfigKeys,
+										MaxItems:     1,
+										ForceNew:     true,
+										Description:  `The configuration used for the Private IP Cloud Composer environment.`
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"connection_type": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+													AtLeastOneOf: composerPrivateEnvironmentConfig,
+													ForceNew: true,
+													DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
+													ValidateFunc: validation.StringInSlice([]string{"VPC_PERRING", "PSC"}, false),
+													Description: `When specified, the environment will use Private Service Connect instead of VPC peerings to connect to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP address from this subnetwork. This field is supported for Cloud Composer environments in versions composer-2.*.*-airflow-*.*.* and newer.`,
+												},
+											}
+
+
 									"enable_private_endpoint": {
 										Type:     schema.TypeBool,
 										Optional: true,
@@ -1511,6 +1534,7 @@ func flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg *composer.P
 	}
 
 	transformed := make(map[string]interface{})
+	transformed["network_configuration_store"] = flattenNetworkConfigurationStore(envCfg)
 	transformed["enable_private_endpoint"] = envCfg.PrivateClusterConfig.EnablePrivateEndpoint
 	transformed["master_ipv4_cidr_block"] = envCfg.PrivateClusterConfig.MasterIpv4CidrBlock
 	transformed["cloud_sql_ipv4_cidr_block"] = envCfg.CloudSqlIpv4CidrBlock

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1183,6 +1183,7 @@ resource "google_composer_environment" "test" {
       image_version  = "composer-2-airflow-2"
     }
     private_environment_config {
+      connection_type = "VPC_PEERING"
       enable_private_endpoint = true
       enable_privately_used_public_ips = true
   	}

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -469,6 +469,14 @@ The following arguments are supported:
 
 See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. <a name="nested_private_environment_config"></a>The `private_environment_config` block supports:
 
+* `connection_type` -
+  (Optional, Cloud Composer 2 only)
+  Configuration options for networking connections in the Composer 2 
+  environment. Indicates the user requested specific connection type between
+  Tenant and Customer projects. You cannot set networking connection type in
+  public IP environment. Must be either: `"VPC_PEERING"` or
+  `"PRIVATE_SERVICE_CONNECT"`.
+ 
 * `enable_private_endpoint` -
   If true, access to the public endpoint of the GKE cluster is denied.
   If this field is set to true, the `ip_allocation_policy.use_ip_aliases` field must


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Adding support for connection type in private environments for Cloud Composer.
```
