### PR TITLE
Revert tc fix to avoid pre- and post-sweepers run for every service package

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
@@ -32,7 +32,7 @@ class packageDetails(name: String, displayName: String, environment: String, bra
                 // - Compile Test Binary
                 // - Run via jen20/teamcity-go-test
                 // - Post-Sweeper
-                RunAcceptanceTests(providerName, path, packageName)
+                RunAcceptanceTests(path, packageName)
             }
 
             failureConditions {

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -55,7 +55,6 @@ fun servicePath(path : String, packageName: String) : String {
 fun BuildSteps.RunAcceptanceTests(providerName : String, path : String, packageName: String) {
     var packagePath = servicePath(path, packageName)
     var withTestsDirectoryPath = "##teamcity[setParameter name='PACKAGE_PATH' value='%s/tests']".format(packagePath)
-    var providerPath = "./%s".format(providerName)
 
     // some packages use a ./tests folder, others don't - conditionally append that if needed
     step(ScriptBuildStep {
@@ -65,7 +64,7 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, path : String, packageN
 
     step(ScriptBuildStep{
         name = "Pre-Sweeper"
-        scriptContent = "go test -v \"$providerPath\" -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m"
+        scriptContent = "go test -v ./%s -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m".format(providerName)
     })
 
     if (useTeamCityGoTest) {
@@ -90,7 +89,7 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, path : String, packageN
 
     step(ScriptBuildStep{
         name = "Post-Sweeper"
-        scriptContent = "go test -v \"$providerPath\" -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m"
+        scriptContent = "go test -v ./%s -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m".format(providerName)
     })
 }
 

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -52,7 +52,7 @@ fun servicePath(path : String, packageName: String) : String {
     return "./%s/%s".format(path, packageName)
 }
 
-fun BuildSteps.RunAcceptanceTests(providerName : String, path : String, packageName: String) {
+fun BuildSteps.RunAcceptanceTests(path : String, packageName: String) {
     var packagePath = servicePath(path, packageName)
     var withTestsDirectoryPath = "##teamcity[setParameter name='PACKAGE_PATH' value='%s/tests']".format(packagePath)
 
@@ -64,7 +64,7 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, path : String, packageN
 
     step(ScriptBuildStep{
         name = "Pre-Sweeper"
-        scriptContent = "go test -v ./%s -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m".format(providerName)
+        scriptContent = "go test -v \"%PACKAGE_PATH%\" -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m"
     })
 
     if (useTeamCityGoTest) {
@@ -89,7 +89,7 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, path : String, packageN
 
     step(ScriptBuildStep{
         name = "Post-Sweeper"
-        scriptContent = "go test -v ./%s -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m".format(providerName)
+        scriptContent = "go test -v \"%PACKAGE_PATH%\" -sweep=\"%SWEEPER_REGIONS%\"  -sweep-allow-failures -sweep-run=\"%SWEEP_RUN%\" -timeout 30m"
     })
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The commit a7c143e86340b51eba3b4a0b69eb447a12dfdc47 actually is working and fixed the original issue in the command line to run the script. The reason to revert it is because of another bug, that the sweepers are run for every package. 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
