### PR TITLE
fix: add updateMask to bqtransfer config updateurl

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -15,9 +15,8 @@
 name: 'Config'
 base_url: projects/{{project}}/locations/{{location}}/transferConfigs?serviceAccountName={{service_account_name}}
 self_link: '{{name}}'
-update_url: "{{name}}?serviceAccountName={{service_account_name}}"
+update_url: "{{name}}?serviceAccountName={{service_account_name}}&updateMask=serviceAccountName,displayName,destinationDatasetId,schedule,scheduleOptions,emailPreferences,notificationPubsubTopic,dataRefreshWindowDays,disabled,params"
 update_verb: :PATCH
-update_mask: true
 description: |
   Represents a data transfer configuration. A transfer configuration
   contains all metadata needed to perform a data transfer.

--- a/mmv1/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
@@ -386,7 +386,6 @@ func testAccCheckBigqueryDataTransferConfigDestroyProducer(t *testing.T) func(s 
 func testAccBigqueryDataTransferConfig_scheduledQuery_update_service_account(t *testing.T) {
 	random_suffix1 := acctest.RandString(t, 10)
 	random_suffix2 := acctest.RandString(t, 10)
-	transferConfigID := ""
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -395,7 +394,6 @@ func testAccBigqueryDataTransferConfig_scheduledQuery_update_service_account(t *
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigqueryDataTransferConfig_scheduledQuery_updateServiceAccount(random_suffix1, random_suffix1),
-				Check:  testAccCheckDataTransferConfigID("google_bigquery_data_transfer_config.query_config", &transferConfigID),
 			},
 			{
 				ResourceName:            "google_bigquery_data_transfer_config.query_config",
@@ -405,7 +403,7 @@ func testAccBigqueryDataTransferConfig_scheduledQuery_update_service_account(t *
 			},
 			{
 				Config: testAccBigqueryDataTransferConfig_scheduledQuery_updateServiceAccount(random_suffix1, random_suffix2),
-				Check:  testAccCheckDataTransferConfigIDChange("google_bigquery_data_transfer_config.query_config", &transferConfigID),
+				Check:  testAccCheckDataTransferServiceAccountNamePrefix("google_bigquery_data_transfer_config.query_config", random_suffix2),
 			},
 			{
 				ResourceName:            "google_bigquery_data_transfer_config.query_config",
@@ -417,8 +415,8 @@ func testAccBigqueryDataTransferConfig_scheduledQuery_update_service_account(t *
 	})
 }
 
-// Retrieve transfer config ID and stores it in transferConfigID
-func testAccCheckDataTransferConfigID(resourceName string, transferConfigID *string) resource.TestCheckFunc {
+// Check if transfer config service account name starts with given prefix
+func testAccCheckDataTransferServiceAccountNamePrefix(resourceName string, prefix string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -426,31 +424,10 @@ func testAccCheckDataTransferConfigID(resourceName string, transferConfigID *str
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Transfer config ID is not set")
+		if !strings.HasPrefix(rs.Primary.Attributes["service_account_name"], "bqwriter"+prefix) {
+			return fmt.Errorf("Transfer config service account not updated")
 		}
 
-		*transferConfigID = rs.Primary.ID
-		return nil
-	}
-}
-
-// Check if transfer config ID matches the one stored in transferConfigID
-func testAccCheckDataTransferConfigIDChange(resourceName string, transferConfigID *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Transfer config ID is not set")
-		}
-
-		if *transferConfigID != rs.Primary.ID {
-			return fmt.Errorf("Transfer config was recreated after changing service account")
-		}
 		return nil
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15080

`update_mask` currently does not work for `url_param_only` properties. This change hardcodes the update mask into the update URL to include all update-able properties.

Debugged the acceptance tests manually to make sure that service account is being updated correctly in cloud console.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed a bug in update support for several fields in `google_bigquery_data_transfer_config`
```
