### PR TITLE
Handle case of no call expression in config function

### DIFF
--- a/tools/missing-test-detector/reader.go
+++ b/tools/missing-test-detector/reader.go
@@ -187,6 +187,9 @@ func readConfigFunc(configFunc *ast.FuncDecl) (Step, error) {
 	for _, stmt := range configFunc.Body.List {
 		if returnStmt, ok := stmt.(*ast.ReturnStmt); ok {
 			for _, result := range returnStmt.Results {
+				if basicLit, ok := result.(*ast.BasicLit); ok && basicLit.Kind == token.STRING {
+					return readConfigBasicLit(basicLit)
+				}
 				if callExpr, ok := result.(*ast.CallExpr); ok {
 					return readConfigFuncCallExpr(callExpr)
 				}
@@ -203,10 +206,8 @@ func readConfigFuncCallExpr(configFuncCallExpr *ast.CallExpr) (Step, error) {
 	if len(configFuncCallExpr.Args) == 0 {
 		return nil, fmt.Errorf("no arguments found for call expression %v", configFuncCallExpr)
 	}
-	if basicLit, ok := configFuncCallExpr.Args[0].(*ast.BasicLit); ok {
-		if basicLit.Kind == token.STRING {
-			return readConfigBasicLit(basicLit)
-		}
+	if basicLit, ok := configFuncCallExpr.Args[0].(*ast.BasicLit); ok && basicLit.Kind == token.STRING {
+		return readConfigBasicLit(basicLit)
 	} else if nestedCallExpr, ok := configFuncCallExpr.Args[0].(*ast.CallExpr); ok {
 		return readConfigFuncCallExpr(nestedCallExpr)
 	}

--- a/tools/missing-test-detector/testdata/covered_resource_test.go
+++ b/tools/missing-test-detector/testdata/covered_resource_test.go
@@ -36,7 +36,7 @@ resource "covered_resource" "resource" {
 }
 
 func testAccCoveredResource_update() string {
-	return acctest.Nprintf(`
+	return `
 resource "covered_resource" "resource" {
   field_two {
     field_three = "value-two"
@@ -47,5 +47,5 @@ resource "covered_resource" "resource" {
     }
   }
 }
-`, context)
+`
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
