### PR TITLE
Adding TF support for Tenancy API for Membership Binding

### DIFF
--- a/mmv1/products/gkehub2/MembershipBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipBinding.yaml
@@ -1,0 +1,141 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'MembershipBinding'
+base_url: "projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/bindings"
+create_url: "projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/bindings/?membership_binding_id={{membership_binding_id}}"
+update_url: "projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/bindings/{{membership_binding_id}}"
+self_link: "projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/bindings/{{membership_binding_id}}"
+update_verb: :PATCH
+update_mask: true
+description: |
+  MembershipBinding is a subresource of a Membership, representing what Fleet Scopes (or other, future Fleet resources) a Membership is bound to.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Registering a Cluster': 'https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster#register_cluster'
+  api: 'https://cloud.google.com/anthos/fleet-management/docs/reference/rest/v1/projects.locations.memberships.bindings'
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    kind: 'gkehub#operation'
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+    resource_inside_response: true
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: 'true'
+    allowed:
+      - 'true'
+      - 'false'
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error/errors'
+    message: 'message'
+autogen_async: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "gkehub_membership_binding_basic"
+    primary_resource_name: "fmt.Sprintf(\"tf-test-membership%s\", context[\"random_suffix\"]), fmt.Sprintf(\"tf-test-membership-binding%s\", context[\"random_suffix\"])"
+    primary_resource_id: "example"
+    vars:
+      cluster_name: "basiccluster"
+    test_env_vars:
+      project: :PROJECT_NAME
+      location: :REGION
+      membership_id: "fmt.Sprintf(\"tf-test-membership%s\", context[\"random_suffix\"])"
+# Skip sweeper gen since this is a child resource.
+skip_sweeper: true
+id_format: "projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/bindings/{{membership_binding_id}}"
+import_format: ["projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/bindings/{{membership_binding_id}}"]
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'membership_id'
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      Id of the membership
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      Location of the membership
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'membershipBindingId'
+    description: |
+      The client-provided identifier of the membership binding.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    output: true
+    description: |
+      The resource name for the membershipbinding itself
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      Google-generated UUID for this resource.
+  - !ruby/object:Api::Type::String
+    name: 'scope'
+    description: |
+      A Workspace resource name in the format
+      `projects/*/locations/*/scopes/*`.
+    exactly_one_of:
+      - scope
+      - fleet
+  - !ruby/object:Api::Type::Boolean
+    name: 'fleet'
+    description: |
+      Whether the membershipbinding is Fleet-wide; true means that this
+      Membership should be bound to all Namespaces in this entire Fleet.
+    exactly_one_of:
+      - scope
+      - fleet
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    description: |
+      Time the MembershipBinding was created in UTC.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    description: |
+      Time the MembershipBinding was updated in UTC.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'deleteTime'
+    description: |
+      Time the MembershipBinding was deleted in UTC.
+    output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'state'
+    description: |
+      State of the membership binding resource.
+    output: true
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'code'
+        description: Code describes the state of a MembershipBinding resource.
+        output: true
+        values:
+          - :CODE_UNSPECIFIED
+          - :CREATING
+          - :READY
+          - :DELETING
+          - :UPDATING

--- a/mmv1/templates/terraform/examples/gkehub_membership_binding_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_binding_basic.tf.erb
@@ -1,0 +1,24 @@
+resource "google_container_cluster" "primary" {
+  name               = "<%= ctx[:vars]['cluster_name'] %>"
+  location           = "us-central1-a"
+  initial_node_count = 1
+}
+
+resource "google_gke_hub_membership" "<%= ctx[:primary_resource_id] %>" {
+  membership_id = "tf-test-membership%{random_suffix}"
+  endpoint {
+    gke_cluster {
+      resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
+    }
+  }
+  
+  depends_on = [google_container_cluster.primary]
+}
+
+resource "google_gke_hub_membership_binding" "<%= ctx[:primary_resource_id] %>" {
+  membership_binding_id = "tf-test-membership-binding%{random_suffix}"
+  fleet = true
+  membership_id = "tf-test-membership%{random_suffix}"
+  location = "global"
+  depends_on = [google_gke_hub_membership.<%= ctx[:primary_resource_id] %>]
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15167


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: added `MembershipBinding` resource
```
