### PR TITLE
Move regional SSL policies to GA

### DIFF
--- a/mmv1/products/compute/RegionSslPolicy.yaml
+++ b/mmv1/products/compute/RegionSslPolicy.yaml
@@ -18,14 +18,13 @@ base_url: projects/{{project}}/regions/{{region}}/sslPolicies
 collection_url_key: 'items'
 update_verb: :PATCH
 has_self_link: true
-min_version: beta
 description: |
   Represents a Regional SSL policy. SSL policies give you the ability to control the
   features of SSL that your SSL proxy or HTTPS load balancer negotiates.
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Using SSL Policies': 'https://cloud.google.com/compute/docs/load-balancing/ssl-policies'
-  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionSslPolicies'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionSslPolicies'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     kind: 'compute#operation'

--- a/mmv1/third_party/terraform/tests/resource_compute_region_ssl_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_ssl_policy_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -230,4 +229,3 @@ resource "google_compute_region_ssl_policy" "update" {
 }
 `, resourceName)
 }
-<% end -%>


### PR DESCRIPTION
Move `google_compute_region_ssl_policy` to GA.



If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_region_ssl_policy` (GA)

```
