### PR TITLE
Re-added ignoring diffs on asset.Resource version and doc uri

### DIFF
--- a/mmv1/third_party/validator/tests/source/init_test.go
+++ b/mmv1/third_party/validator/tests/source/init_test.go
@@ -157,6 +157,12 @@ func normalizeAssets(t *testing.T, assets []caiasset.Asset, offline bool) []caia
 				asset.Resource.Data["name"] = re.ReplaceAllString(name, "/placeholder-foobar")
 			}
 		}
+		// skip comparing version, DiscoveryDocumentURI,
+		// since switching to beta generates version difference
+		if asset.Resource != nil {
+			asset.Resource.Version = ""
+			asset.Resource.DiscoveryDocumentURI = ""
+		}
 		ret[i] = asset
 	}
 	sort.Slice(ret, func(i, j int) bool {


### PR DESCRIPTION
Change to hopefully resolve spurious TGC test failures on older PRs related to the beta change

```release-note:none

```
