### PR TITLE
Support project numbers in monitored project

### DIFF
--- a/mmv1/products/monitoring/MonitoredProject.yaml
+++ b/mmv1/products/monitoring/MonitoredProject.yaml
@@ -36,6 +36,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: templates/terraform/decoders/monitoring_monitored_project.go.erb
   pre_read: templates/terraform/pre_read/monitoring_monitored_project.go.erb
   test_check_destroy: templates/terraform/custom_check_destroy/monitoring_monitored_project.go.erb
+  constants: templates/terraform/constants/monitoring_monitored_project.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'monitoring_monitored_project_basic'
@@ -67,7 +68,7 @@ properties:
     name: name
     description: 'Immutable. The resource name of the `MonitoredProject`. On input, the resource name includes the scoping project ID and monitored project ID. On output, it contains the equivalent project numbers. Example: `locations/global/metricsScopes/{SCOPING_PROJECT_ID_OR_NUMBER}/projects/{MONITORED_PROJECT_ID_OR_NUMBER}`'
     required: true
-    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    diff_suppress_func: 'resourceMonitoringMonitoredProjectNameDiffSuppress'
   - !ruby/object:Api::Type::String
     name: createTime
     description: Output only. The time when this `MonitoredProject` was created.

--- a/mmv1/templates/terraform/constants/monitoring_monitored_project.go.erb
+++ b/mmv1/templates/terraform/constants/monitoring_monitored_project.go.erb
@@ -1,0 +1,26 @@
+func ResourceMonitoringMonitoredProjectNameDiffSuppressFunc(k, old, new string, d tpgresource.TerraformResourceDataChange) bool {
+	// Don't suppress if values are empty strings
+	if old == "" || new == "" {
+		return false
+	}
+
+	oldShort := tpgresource.GetResourceNameFromSelfLink(old)
+	newShort := tpgresource.GetResourceNameFromSelfLink(new)
+
+	// Suppress if short names are equal
+	if oldShort == newShort {
+		return true
+	}
+
+	_, isOldNumErr := tpgresource.StringToFixed64(oldShort)
+	isOldNumber := isOldNumErr == nil
+	_, isNewNumErr := tpgresource.StringToFixed64(newShort)
+	isNewNumber := isNewNumErr == nil
+
+	// Suppress if comparing a project number to project id
+	return isOldNumber != isNewNumber
+}
+
+func resourceMonitoringMonitoredProjectNameDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return ResourceMonitoringMonitoredProjectNameDiffSuppressFunc(k, old, new, d)
+}

--- a/mmv1/templates/terraform/decoders/monitoring_monitored_project.go.erb
+++ b/mmv1/templates/terraform/decoders/monitoring_monitored_project.go.erb
@@ -13,9 +13,18 @@
 	# limitations under the License.
 -%>
 config := meta.(*transport_tpg.Config)
+
+expectedName, _ := expandNestedMonitoringMonitoredProjectName(d.Get("name"), d, config)
+expectedFlattenedName := flattenNestedMonitoringMonitoredProjectName(expectedName, d, config)
+_, isNumErr := tpgresource.StringToFixed64(expectedFlattenedName.(string))
+expectProjectNumber := isNumErr == nil
+
 name := res["name"].(string)
 name = tpgresource.GetResourceNameFromSelfLink(name)
-if name != "" {
+
+if expectProjectNumber {
+	res["name"] = name
+} else if name != "" {
 	project, err := config.NewResourceManagerClient(config.UserAgent).Projects.Get(name).Do()
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/tests/resource_monitoring_monitored_project_test.go
+++ b/mmv1/third_party/terraform/tests/resource_monitoring_monitored_project_test.go
@@ -1,0 +1,291 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/monitoring"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+)
+
+func TestAccMonitoringMonitoredProject_projectNumLongForm(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMonitoringMonitoredProjectDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitoringMonitoredProject_projectNumLongForm(context),
+			},
+			{
+				ResourceName:            "google_monitoring_monitored_project.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metrics_scope"},
+			},
+		},
+	})
+}
+
+func TestAccMonitoringMonitoredProject_projectNumShortForm(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMonitoringMonitoredProjectDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitoringMonitoredProject_projectNumShortForm(context),
+			},
+			{
+				ResourceName:            "google_monitoring_monitored_project.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metrics_scope"},
+			},
+		},
+	})
+}
+
+func testAccMonitoringMonitoredProject_projectNumLongForm(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_monitoring_monitored_project" "primary" {
+  metrics_scope = "%{project_id}"
+  name          = "locations/global/metricsScopes/%{project_id}/projects/${google_project.basic.number}"
+}
+
+resource "google_project" "basic" {
+  project_id = "tf-test-m-id%{random_suffix}"
+  name       = "tf-test-m-id%{random_suffix}-display"
+  org_id     = "%{org_id}"
+}
+`, context)
+}
+
+func testAccMonitoringMonitoredProject_projectNumShortForm(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_monitoring_monitored_project" "primary" {
+  metrics_scope = "%{project_id}"
+  name          = "${google_project.basic.number}"
+}
+
+resource "google_project" "basic" {
+  project_id = "tf-test-m-id%{random_suffix}"
+  name       = "tf-test-m-id%{random_suffix}-display"
+  org_id     = "%{org_id}"
+}
+`, context)
+}
+
+func TestUnitMonitoringMonitoredProject_nameDiffSuppress(t *testing.T) {
+	for _, tc := range monitoringMonitoredProjectDiffSuppressTestCases {
+		tc.Test(t)
+	}
+}
+
+type MonitoringMonitoredProjectDiffSuppressTestCase struct {
+	Name           string
+	KeysToSuppress []string
+	Before         map[string]interface{}
+	After          map[string]interface{}
+}
+
+var monitoringMonitoredProjectDiffSuppressTestCases = []MonitoringMonitoredProjectDiffSuppressTestCase{
+	// Project Id -> project Id
+	{
+		Name:           "short project id to long project id suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "sameId",
+		},
+		After: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/sameId",
+		},
+	},
+	{
+		Name:           "long project id to short project id suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/sameId",
+		},
+		After: map[string]interface{}{
+			"name": "sameId",
+		},
+	},
+	{
+		Name:           "short project id to long project id show diff",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"name": "oldId",
+		},
+		After: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/newId",
+		},
+	},
+	{
+		Name:           "long project id to short project id show diff",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/oldId",
+		},
+		After: map[string]interface{}{
+			"name": "newId",
+		},
+	},
+
+	// Project Num -> Project Num
+	{
+		Name:           "short project num to long project num suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "000000000000",
+		},
+		After: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/000000000000",
+		},
+	},
+	{
+		Name:           "long project num to short project num suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/000000000000",
+		},
+		After: map[string]interface{}{
+			"name": "000000000000",
+		},
+	},
+	{
+		Name:           "short project num to long project num show diff",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"name": "000000000000",
+		},
+		After: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/111111111111",
+		},
+	},
+	{
+		Name:           "long project num to short project num show diff",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/000000000000",
+		},
+		After: map[string]interface{}{
+			"name": "111111111111",
+		},
+	},
+
+	// Project id <--> Project num
+	// Every variation of this should be suppressed. We cannot detect
+	// if the project number matches the id within a diff suppress
+	{
+		Name:           "short project id to long project num suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "oldId",
+		},
+		After: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/111111111111",
+		},
+	},
+	{
+		Name:           "long project id to short project num suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/oldId",
+		},
+		After: map[string]interface{}{
+			"name": "111111111111",
+		},
+	},
+	{
+		Name:           "short project num to long project id suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "000000000000",
+		},
+		After: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/newId",
+		},
+	},
+	{
+		Name:           "long project num to short project id suppressed",
+		KeysToSuppress: []string{"name"},
+		Before: map[string]interface{}{
+			"name": "locations/global/metricsScopes/projectId/projects/000000000000",
+		},
+		After: map[string]interface{}{
+			"name": "newId",
+		},
+	},
+
+	// Empty -> anything (resource creation)
+	{
+		Name:           "empty name to anything shows diff",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"name": "",
+		},
+		After: map[string]interface{}{
+			"name": "newId",
+		},
+	},
+}
+
+func (tc *MonitoringMonitoredProjectDiffSuppressTestCase) Test(t *testing.T) {
+	mockResourceDiff := &tpgresource.ResourceDiffMock{
+		Before: tc.Before,
+		After:  tc.After,
+	}
+
+	keySuppressionMap := map[string]bool{}
+	for key := range tc.Before {
+		keySuppressionMap[key] = false
+	}
+	for key := range tc.After {
+		keySuppressionMap[key] = false
+	}
+
+	for _, key := range tc.KeysToSuppress {
+		keySuppressionMap[key] = true
+	}
+
+	for key, tcSuppress := range keySuppressionMap {
+		oldValue, ok := tc.Before[key]
+		if !ok {
+			oldValue = ""
+		}
+		newValue, ok := tc.After[key]
+		if !ok {
+			newValue = ""
+		}
+		suppressed := monitoring.ResourceMonitoringMonitoredProjectNameDiffSuppressFunc(key, fmt.Sprintf("%v", oldValue), fmt.Sprintf("%v", newValue), mockResourceDiff)
+		if suppressed != tcSuppress {
+			var expectation string
+			if tcSuppress {
+				expectation = "be"
+			} else {
+				expectation = "not be"
+			}
+			t.Errorf("Test %s: expected key `%s` to %s suppressed", tc.Name, key, expectation)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/15211

- needed a diff suppress for short & long versions with project name and number
- modified the decoder to look for a project number instead of project id when given a project number
- added two acceptance tests for short and long form project number creation
- added unit tests for diff suppress function

Completed the following manual upgrade tests:

- created w/ long id in 4.70 -> upgraded to built provider successfully
- created w/ short id in 4.70 -> upgraded to built provider successfully
- created w/ long num in 4.70 -> upgraded to built provider successfully
- created w/ short num in 4.70 -> upgraded to built provider successfully

- created w/ long id in 4.75 -> upgraded to built provider successfully
- created w/ short id in 4.75 -> upgraded to built provider successfully
- created w/ long num in 4.75 & failed as expected, could not upgrade without importing
- created w/ short num in 4.75 & failed as expected, could not upgrade without importing

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed an issue in `google_monitoring_monitored_project` where project numbers were not accepted for `name`
```
