### PR TITLE
Add data source documentation for google_firebase_android_app_config

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/firebase_android_app_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_android_app_config.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Firebase"
+description: |-
+  A Google Cloud Firebase Android application configuration
+---
+
+# google\_firebase\_android\_app\_config
+
+A Google Cloud Firebase Android application configuration
+
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+
+To get more information about androidApp, see:
+
+* [API documentation](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects.androidApps)
+* How-to Guides
+    * [Official Documentation](https://firebase.google.com/)
+
+
+## Argument Reference
+The following arguments are supported:
+
+* `app_id` - (Required) The id of the Firebase Android App.
+
+- - -
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `config_filename` -
+  The filename that the configuration artifact for the AndroidApp is typically saved as.
+  For example: google-services.json
+
+* `config_file_contents` -
+  The contents of the JSON configuration file.
+  A base64-encoded string.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add missing documentation for `google_firebase_android_app_config` even though the data source is already in effect.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Documentation change only
```
