### PR TITLE
Breaking changes for Firebase apps deletion policy

### DIFF
--- a/mmv1/products/firebase/AndroidApp.yaml
+++ b/mmv1/products/firebase/AndroidApp.yaml
@@ -64,7 +64,6 @@ examples:
     vars:
       display_name: 'Display Name Basic'
     test_env_vars:
-      org_id: :ORG_ID
       project_id: :PROJECT_NAME
     test_vars_overrides:
       package_name: '"android.package.app" + acctest.RandString(t, 4)'
@@ -73,14 +72,16 @@ examples:
       - project
       - deletion_policy
 virtual_fields:
-  # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
-  - !ruby/object:Api::Type::String
+  - !ruby/object:Api::Type::Enum
     name: 'deletion_policy'
     description: |
       (Optional) Set to `ABANDON` to allow the AndroidApp to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful because the AndroidApp may be
       serving traffic. Set to `DELETE` to delete the AndroidApp. Defaults to `DELETE`.
-    default_value: DELETE
+    default_value: :DELETE
+    values:
+      - :DELETE
+      - :ABANDON
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:

--- a/mmv1/products/firebase/AppleApp.yaml
+++ b/mmv1/products/firebase/AppleApp.yaml
@@ -65,7 +65,6 @@ examples:
       display_name: 'Display Name Basic'
       bundle_id: 'apple.app.12345'
     test_env_vars:
-      org_id: :ORG_ID
       project_id: :PROJECT_NAME
     test_vars_overrides:
       display_name: '"tf-test Display Name Basic"'
@@ -79,7 +78,6 @@ examples:
       app_store_id: '12345'
       team_id: '9987654321'  # Has to be a 10-digit number.
     test_env_vars:
-      org_id: :ORG_ID
       project_id: :PROJECT_NAME
     test_vars_overrides:
       app_store_id: '12345'
@@ -89,14 +87,16 @@ examples:
       - project
       - deletion_policy
 virtual_fields:
-  # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
-  - !ruby/object:Api::Type::String
+  - !ruby/object:Api::Type::Enum
     name: 'deletion_policy'
     description: |
       (Optional) Set to `ABANDON` to allow the Apple to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful because the Apple may be
       serving traffic. Set to `DELETE` to delete the Apple. Defaults to `DELETE`.
-    default_value: DELETE
+    default_value: :DELETE
+    values:
+      - :DELETE
+      - :ABANDON
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:

--- a/mmv1/products/firebase/WebApp.yaml
+++ b/mmv1/products/firebase/WebApp.yaml
@@ -65,23 +65,24 @@ examples:
     vars:
       display_name: 'Display Name Basic'
       bucket_name: 'fb-webapp-'
-      project_name: "my-project"
     test_env_vars:
-      org_id: :ORG_ID
+      project_id: :PROJECT_NAME
     test_vars_overrides:
       display_name: '"tf-test Display Name Basic"'
     ignore_read_extra:
       - project
       - deletion_policy
 virtual_fields:
-  # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
-  - !ruby/object:Api::Type::String
+  - !ruby/object:Api::Type::Enum
     name: 'deletion_policy'
     description: |
       Set to `ABANDON` to allow the WebApp to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful becaue the WebApp may be
-      serving traffic. Set to `DELETE` to delete the WebApp. Default to `ABANDON`
-    default_value: ABANDON
+      serving traffic. Set to `DELETE` to delete the WebApp. Default to `DELETE`
+    default_value: :DELETE
+    values:
+      - :DELETE
+      - :ABANDON
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:

--- a/mmv1/templates/terraform/examples/firebase_web_app_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_web_app_basic.tf.erb
@@ -1,27 +1,7 @@
-resource "google_project" "default" {
-	provider = google-beta
-
-	project_id = "<%= ctx[:vars]['project_name'] %>"
-	name       = "<%= ctx[:vars]['project_name'] %>"
-	org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
-
-	labels = {
-		"firebase" = "enabled"
-	}
-}
-
-resource "google_firebase_project" "default" {
-	provider = google-beta
-	project  = google_project.default.project_id
-}
-
 resource "google_firebase_web_app" "<%= ctx[:primary_resource_id] %>" {
 	provider = google-beta
-	project = google_project.default.project_id
+	project = "<%= ctx[:test_env_vars]['project_id'] %>"
 	display_name = "<%= ctx[:vars]['display_name'] %>"
-	deletion_policy = "DELETE"
-
-	depends_on = [google_firebase_project.default]
 }
 
 data "google_firebase_web_app_config" "basic" {

--- a/mmv1/templates/terraform/examples/firebasehosting_site_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebasehosting_site_full.tf.erb
@@ -2,7 +2,6 @@ resource "google_firebase_web_app" "default" {
   provider = google-beta
   project  = "<%= ctx[:test_env_vars]['project_id'] %>"
   display_name = "<%= ctx[:vars]['display_name'] %>"
-  deletion_policy = "DELETE"
 }
 
 resource "google_firebase_hosting_site" "full" {

--- a/mmv1/third_party/terraform/tests/data_source_google_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_google_firebase_web_app_test.go.erb
@@ -44,7 +44,6 @@ func testAccDataSourceGoogleFirebaseWebApp(context map[string]interface{}) strin
 resource "google_firebase_web_app" "my_app" {
   project = "%{project_id}"
   display_name = "%{display_name}"
-  deletion_policy = "DELETE"
 }
 
 data "google_firebase_web_app" "my_app" {

--- a/mmv1/third_party/terraform/tests/resource_firebase_hosting_site_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_hosting_site_test.go.erb
@@ -52,7 +52,6 @@ resource "google_firebase_web_app" "before" {
   provider = google-beta
   project  = "%{project_id}"
   display_name = "tf-test Test web app before for Firebase Hosting"
-  deletion_policy = "DELETE"
 }
 
 resource "google_firebase_hosting_site" "update" {
@@ -70,7 +69,6 @@ resource "google_firebase_web_app" "after" {
   provider = google-beta
   project  = "%{project_id}"
   display_name = "tf-test Test web app after for Firebase Hosting"
-  deletion_policy = "DELETE"
 }
 
 resource "google_firebase_hosting_site" "update" {

--- a/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
@@ -22,30 +22,19 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 		"display_name":  "tf-test Display Name N",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"google": {
-						VersionConstraint: "4.58.0",
-						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
-					},
-				},
 				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, ""),
 			},
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"google": {
-						VersionConstraint: "4.58.0",
-						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
-					},
-				},
 				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "api_key"),
@@ -54,11 +43,9 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, ""),
 			},
 			{
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "api_key"),
@@ -73,28 +60,11 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 func testAccFirebaseWebApp_firebaseWebAppFull(context map[string]interface{}, update string) string {
 	context["display_name"] = context["display_name"].(string) + update
 	return acctest.Nprintf(`
-resource "google_project" "default" {
-	provider = google-beta
-
-	project_id = "tf-test%{random_suffix}"
-	name       = "tf-test%{random_suffix}"
-	org_id     = "%{org_id}"
-	labels     = {
-		"firebase" = "enabled"
-	}
-}
-
-resource "google_firebase_project" "default" {
-	provider = google-beta
-	project  = google_project.default.project_id
-}
-
 resource "google_firebase_web_app" "default" {
 	provider = google-beta
-	project = google_project.default.project_id
+	project = "%{project_id}"
 	display_name = "%{display_name} %{random_suffix}"
-
-	depends_on = [google_firebase_project.default]
+	deletion_policy = "DELETE"
 }
 
 data "google_firebase_web_app_config" "default" {
@@ -108,7 +78,7 @@ func TestAccFirebaseWebApp_firebaseWebAppSkipDelete(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id": envvar.GetTestProjectFromEnv(),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 		"display_name":  "tf-test Display Name N",
 	}
@@ -132,11 +102,29 @@ func TestAccFirebaseWebApp_firebaseWebAppSkipDelete(t *testing.T) {
 }
 
 func testAccFirebaseWebApp_firebaseWebAppSkipDelete(context map[string]interface{}, update string) string {
+	// Create a new project so we can clean up the project entirely
 	return acctest.Nprintf(`
+resource "google_project" "default" {
+	provider = google-beta
+
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "%{org_id}"
+	labels     = {
+		"firebase" = "enabled"
+	}
+}
+
+resource "google_firebase_project" "default" {
+	provider = google-beta
+	project  = google_project.default.project_id
+}
+
 resource "google_firebase_web_app" "skip_delete" {
 	provider = google-beta
-	project = "%{project_id}"
+	project = google_firebase_project.default.project
 	display_name = "%{display_name} %{random_suffix}"
+	deletion_policy = "ABANDON"
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Make breaking changes related to `deletion_policy` for `google_firebase_android_app`, `google_firebase_apple_app` and `google_firebase_web_app`.
- Make it into an enum
- Fixes https://github.com/hashicorp/terraform-provider-google/issues/12810
- Tidy up tests

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
firebase: changed `deletion_policy` default to `DELETE` for `google_firebase_web_app`.
```
