### PR TITLE
Fix build when building a single product

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -291,7 +291,7 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
 
   unless products_to_generate.include?(product_name)
     Google::LOGGER.info "#{product_name}: Not specified, skipping generation"
-    next
+    next { definitions: product_api, overrides: provider_config, provider: provider } # rubocop:disable Style/HashSyntax
   end
 
   Google::LOGGER.info \


### PR DESCRIPTION
Fixing the build where a single product is defined. The path recently broke due to [parallelization I introduced](https://github.com/GoogleCloudPlatform/magic-modules/pull/8381). I was notified of this by a contributor.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
