### PR TITLE
Add support for policy_name field in Placement Policy

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -191,6 +191,12 @@ var schemaNodePool = map[string]*schema.Schema{
 					Required:     true,
 					Description:  `Type defines the type of placement policy`,
 				},
+				"policy_name": {
+					Type:         schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description:  `If set, refers to the name of a custom resource policy supplied by the user. The resource policy must be in the same project and region as the node pool. If not found, InvalidArgument error is returned.`,
+				},
 <% unless version == 'ga' -%>
 				"tpu_topology": {
 					Type:        schema.TypeString,
@@ -937,6 +943,7 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 			placement_policy := v.([]interface{})[0].(map[string]interface{})
 			np.PlacementPolicy = &container.PlacementPolicy{
 				Type: placement_policy["type"].(string),
+				PolicyName: placement_policy["policy_name"].(string),
 <% unless version == 'ga' -%>
 				TpuTopology: placement_policy["tpu_topology"].(string),
 <% end -%>
@@ -1131,6 +1138,7 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		nodePool["placement_policy"] = []map[string]interface{}{
 			{
 				"type": np.PlacementPolicy.Type,
+				"policy_name": np.PlacementPolicy.PolicyName,
 <% unless version == 'ga' -%>
 				"tpu_topology": np.PlacementPolicy.TpuTopology,
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -7884,3 +7884,64 @@ resource "google_container_cluster" "primary" {
   min_master_version = 1.27
 }`, name, enabled)
 }
+
+
+func TestAccContainerCluster_customPlacementPolicy(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+	policy := fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_customPlacementPolicy(cluster, np, policy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.cluster", "node_pool.0.placement_policy.0.type", "COMPACT"),
+					resource.TestCheckResourceAttr("google_container_cluster.cluster", "node_pool.0.placement_policy.0.policy_name", policy),
+					resource.TestCheckResourceAttr("google_container_cluster.cluster", "node_pool.0.node_config.0.machine_type", "c2-standard-4"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_customPlacementPolicy(cluster, np, policyName string) string {
+	return fmt.Sprintf(`
+
+resource "google_compute_resource_policy" "policy" {
+  name = "%s"
+  region = "us-central1"
+  group_placement_policy {
+    collocation = "COLLOCATED"
+  }
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  
+  node_pool {
+    name               = "%s"
+    initial_node_count = 2
+
+    node_config {
+      machine_type = "c2-standard-4"
+    }
+
+    placement_policy {
+      type = "COMPACT"
+      policy_name = google_compute_resource_policy.policy.name
+    }
+  }
+}`, policyName, cluster, np)
+}

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1556,6 +1556,68 @@ resource "google_container_node_pool" "np" {
 `, cluster, np, placementType)
 }
 
+func TestAccContainerNodePool_customPlacementPolicy(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+	policy := fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_customPlacementPolicy(cluster, np, policy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_config.0.machine_type", "c2-standard-4"),
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "placement_policy.0.policy_name", policy),
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "placement_policy.0.type", "COMPACT"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_customPlacementPolicy(cluster, np, policyName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+}
+
+resource "google_compute_resource_policy" "policy" {
+  name = "%s"
+  region = "us-central1"
+  group_placement_policy {
+    collocation = "COLLOCATED"
+  }
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 2
+
+  node_config {
+    machine_type = "c2-standard-4"
+  }
+  placement_policy {
+	type = "COMPACT"
+    policy_name = google_compute_resource_policy.policy.name
+  }
+}
+`, cluster, policyName, np)
+}
+
 func TestAccContainerNodePool_threadsPerCore(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -262,6 +262,10 @@ cluster.
   Specifying COMPACT placement policy type places node pool's nodes in a closer
   physical proximity in order to reduce network latency between nodes.
 
+* `policy_name` - (Optional) If set, refers to the name of a custom resource policy supplied by the user.
+  The resource policy must be in the same project and region as the node pool.
+  If not found, InvalidArgument error is returned.
+
 * `tpu_topology` - (Optional, Beta) The [TPU placement topology](https://cloud.google.com/tpu/docs/types-topologies#tpu_topologies) for pod slice node pool.
 
 ## Attributes Reference


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
[Custom Placement Policy](https://cloud.google.com/kubernetes-engine/docs/how-to/compact-placement#create_node_pools_using_a_shared_custom_placement_policy) is a GKE node pool feature that allows users to use a custom resource placement policy.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `placement_policy.policy_name` field to `google_container_node_pool` resource
```
**Note: I've run the added acceptance tests successfully**, but the `make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool'` is partially failing. I'm running into some issues related to my project, e.g. `INVALID_ARGUMENT: disabling pod cidr overprovision is not allowed for this project` or ` Error: Error waiting for creating GKE cluster: The network "default" does not have available private IP space in 10.0.0.0/8 to reserve a /14 block for containers for cluster...`.