### PR TITLE
Revert "Subnetnetwork: replaced ipv6CidrRange with internalIpV6Prefix"

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -366,7 +366,7 @@ properties:
       or the first time the subnet is updated into IPV4_IPV6 dual stack. If the ipv6_type is EXTERNAL then this subnet
       cannot enable direct path.
   - !ruby/object:Api::Type::String
-    name: 'internalIpv6Prefix'
+    name: 'ipv6CidrRange'
     output: true
     description: |
       The range of internal IPv6 addresses that are owned by this subnetwork.


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#8370

Listed reason in the original PR

```release-note: none
```