### PR TITLE
Revert "Add Terraform support for L3_DEFAULT (all protocol) L4 ILB (#…

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1210,9 +1210,7 @@ properties:
     description: |
       The protocol this BackendService uses to communicate with backends.
       The default is HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
-      types and may result in errors if used with the GA API. **NOTE**: With protocol “UNSPECIFIED”,
-      the backend service can be used by Layer 4 Internal Load Balancing or Network Load Balancing
-      with TCP/UDP/L3_DEFAULT Forwarding Rule protocol.
+      types and may result in errors if used with the GA API.
     values:
       - :HTTP
       - :HTTPS
@@ -1220,7 +1218,6 @@ properties:
       - :TCP
       - :SSL
       - :GRPC
-      - :UNSPECIFIED
     # TODO: make a ResourceRef to Security Policy
     default_from_api: true
   - !ruby/object:Api::Type::String

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -1182,63 +1182,6 @@ resource "google_compute_http_health_check" "default" {
 `, serviceName, timeout, igName, itName, checkName)
 }
 
-func testAccComputeBackendService_withUnspecifiedProtocol(
-	serviceName, igName, itName, checkName string, timeout int64) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-11"
-  project = "debian-cloud"
-}
-
-resource "google_compute_backend_service" "lipsum" {
-  name        = "%s"
-  description = "Hello World 1234"
-  port_name   = "http"
-  protocol    = "UNSPECIFIED"
-  timeout_sec = %v
-
-  backend {
-    group = google_compute_instance_group_manager.foobar.instance_group
-  }
-
-  health_checks = [google_compute_http_health_check.default.self_link]
-}
-
-resource "google_compute_instance_group_manager" "foobar" {
-  name = "%s"
-  version {
-    instance_template = google_compute_instance_template.foobar.self_link
-    name              = "primary"
-  }
-  base_instance_name = "tf-test-foobar"
-  zone               = "us-central1-f"
-  target_size        = 1
-}
-
-resource "google_compute_instance_template" "foobar" {
-  name         = "%s"
-  machine_type = "e2-medium"
-
-  network_interface {
-    network = "default"
-  }
-
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    boot         = true
-  }
-}
-
-resource "google_compute_http_health_check" "default" {
-  name               = "%s"
-  request_path       = "/"
-  check_interval_sec = 1
-  timeout_sec        = 1
-}
-`, serviceName, timeout, igName, itName, checkName)
-}
-
 func testAccComputeBackendService_withBackendAndMaxUtilization(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
…8445)"

This reverts commit 617d778ca4fa8179857e0647c90141c02c171784.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The original PR does not actually add a test that applies the new config. Upon adding such a test and running it locally I saw the following error:

```json
{
  "error": {
    "code": 400,
    "message": "Invalid value for field 'resource.protocol': 'UNSPECIFIED'. Protocol for a global EXTERNAL backend service must be one of HTTP, HTTPS or HTTP2 (was UNSPECIFIED).",
    "errors": [
      {
        "message": "Invalid value for field 'resource.protocol': 'UNSPECIFIED'. Protocol for a global EXTERNAL backend service must be one of HTTP, HTTPS or HTTP2 (was UNSPECIFIED).",
        "domain": "global",
        "reason": "invalid",
        "debugInfo": "java.lang.Exception\n\tat com.google.cloud.control.common.publicerrors.PublicErrorProtoUtils.newErrorBuilder(PublicErrorProtoUtils.java:1984)\n\tat com.google.cloud.control.common.publicerrors.PublicErrorProtoUtils.createInvalidFieldValue(PublicErrorProtoUtils.java:873)\n\tat com.google.cloud.control.common.publicerrors.RequestValidatorsWithPublicExceptions.validateFieldCondition(RequestValidatorsWithPublicExceptions.java:150)\n\tat com.google.cloud.control.common.publicerrors.RequestValidatorsWithPublicExceptions.validateFieldCondition(RequestValidatorsWithPublicExceptions.java:125)\n\tat com.google.cloud.cluster.manager.networking.services.backendservice.MixerBackendServiceInputValidator.validateProtocol(MixerBackendServiceInputValidator.java:2984)\n\tat com.google.cloud.cluster.manager.networking.services.backendservice.MixerBackendServiceInputValidator.verifyBackendServiceInputInReadOnly(MixerBackendServiceInputValidator.java:1078)\n\tat com.google.cloud.cluster.manager.networking.services.backendservice.MixerBackendServiceInputValidator.verifyBackendServiceInputInReadOnly(MixerBackendServiceInputValidator.java:1061)\n\tat com.google.cloud.cluster.manager.networking.services.backendservice.BackendServiceMutationHelper$ValidationHandler.runAttempt(BackendServiceMutationHelper.java:519)\n\tat com.google.cloud.cluster.manager.networking.services.backendservice.BackendServiceMutationHelper$ValidationHandler.runAttempt(BackendServiceMutationHelper.java:398)\n\tat com.google.cloud.cluster.metastore.RetryingMetastoreTransactionExecutor$1.runAttempt(RetryingMetastoreTransactionExecutor.java:79)\n\tat com.google.cloud.cluster.metastore.MetastoreRetryLoop.runHandler(MetastoreRetryLoop.java:523)\n\t...Stack trace is shortened.\n"
      }
    ]
  }
}
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
