### PR TITLE
fixed update_policy.max_surge_fixed

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -21,6 +21,20 @@ import (
 	compute "google.golang.org/api/compute/v0.beta"
 <% end -%>
 )
+func EmptyOrAllowedListSuppress(vals []string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return (old == "" && contains(vals, new)) || (new == "" && contains(vals, old))
+	}
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
 
 func ResourceComputeInstanceGroupManager() *schema.Resource {
 	return &schema.Resource{
@@ -239,6 +253,9 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Computed:      true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return (old == "1" && new == "0")
+							},
 							ConflictsWith: []string{"update_policy.0.max_surge_percent"},
 							Description:   `The maximum number of instances that can be created above the specified targetSize during the update process. Conflicts with max_surge_percent. If neither is set, defaults to 1`,
 						},
@@ -279,7 +296,7 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							Type:             schema.TypeString,
 							Optional:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"RECREATE", "SUBSTITUTE", ""}, false),
-							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("SUBSTITUTE"),
+							DiffSuppressFunc: EmptyOrAllowedListSuppress([]string{"RECREATE", "SUBSTITUTE"}),
 							Description:      `The instance replacement method for managed instance groups. Valid values are: "RECREATE", "SUBSTITUTE". If SUBSTITUTE (default), the group replaces VM instances with new instances that have randomly generated names. If RECREATE, instance names are preserved.  You must also set max_unavailable_fixed or max_unavailable_percent to be greater than 0.`,
 						},
 					},
@@ -1255,8 +1272,12 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 				NullFields: []string{"Fixed"},
 			}
 		} else {
+			v := 1 // conditioanl default
+			if data["max_surge_fixed"] != nil {
+				v = data["max_surge_fixed"].(int)
+			}
 			updatePolicy.MaxSurge = &compute.FixedOrPercent{
-				Fixed: int64(data["max_surge_fixed"].(int)),
+				Fixed: int64(v),
 				// allow setting this value to 0
 				ForceSendFields: []string{"Fixed"},
 				NullFields:      []string{"Percent"},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -23,7 +23,7 @@ import (
 )
 func EmptyOrAllowedListSuppress(vals []string) schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
-		return (old == "" && contains(vals, new)) || (new == "" && contains(vals, old))
+		return (old == "" && contains(vals, new)) || (new == "" && contains(vals, old)) || (new == old)
 	}
 }
 
@@ -34,6 +34,10 @@ func contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func EmptyNewSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return (old == "1" && new == "0") || (old == new)
 }
 
 func ResourceComputeInstanceGroupManager() *schema.Resource {
@@ -253,9 +257,7 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Computed:      true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return (old == "1" && new == "0")
-							},
+							DiffSuppressFunc: EmptyNewSuppress,
 							ConflictsWith: []string{"update_policy.0.max_surge_percent"},
 							Description:   `The maximum number of instances that can be created above the specified targetSize during the update process. Conflicts with max_surge_percent. If neither is set, defaults to 1`,
 						},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -310,9 +310,7 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							ConflictsWith: []string{"update_policy.0.max_surge_fixed"},
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return (old == "1" && new == "0")
-							},
+							DiffSuppressFunc: EmptyNewSuppress,
 							Description:   `The maximum number of instances(calculated as percentage) that can be created above the specified targetSize during the update process. Conflicts with max_surge_fixed. Percent value is only allowed for regional managed instance groups with size at least 10.`,
 							ValidateFunc:  validation.IntBetween(0, 100),
 						},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -310,6 +310,9 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							ConflictsWith: []string{"update_policy.0.max_surge_fixed"},
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return (old == "1" && new == "0")
+							},
 							Description:   `The maximum number of instances(calculated as percentage) that can be created above the specified targetSize during the update process. Conflicts with max_surge_fixed. Percent value is only allowed for regional managed instance groups with size at least 10.`,
 							ValidateFunc:  validation.IntBetween(0, 100),
 						},
@@ -349,7 +352,7 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:             schema.TypeString,
 							Optional:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"RECREATE", "SUBSTITUTE", ""}, false),
-							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("SUBSTITUTE"),
+							DiffSuppressFunc: EmptyOrAllowedListSuppress([]string{"RECREATE", "SUBSTITUTE"}),
 							Description:      `The instance replacement method for regional managed instance groups. Valid values are: "RECREATE", "SUBSTITUTE". If SUBSTITUTE (default), the group replaces VM instances with new instances that have randomly generated names. If RECREATE, instance names are preserved.  You must also set max_unavailable_fixed or max_unavailable_percent to be greater than 0.`,
 						},
 					},
@@ -1005,8 +1008,12 @@ func expandRegionUpdatePolicy(configured []interface{}) *compute.InstanceGroupMa
 				NullFields: []string{"Fixed"},
 			}
 		} else {
+			v := 1 // conditioanl default
+			if data["max_surge_fixed"] != nil {
+				v = data["max_surge_fixed"].(int)
+			}
 			updatePolicy.MaxSurge = &compute.FixedOrPercent{
-				Fixed: int64(data["max_surge_fixed"].(int)),
+				Fixed: int64(v),
 				// allow setting this value to 0
 				ForceSendFields: []string{"Fixed"},
 				NullFields:      []string{"Percent"},

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 )
 
 func TestAccInstanceGroupManager_basic(t *testing.T) {
@@ -995,106 +996,6 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 `, igm)
 }
 
-func testAccInstanceGroupManager_rollingUpdatePolicy6(igm string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-11"
-  project = "debian-cloud"
-}
-
-resource "google_compute_instance_template" "igm-rolling-update-policy" {
-  machine_type   = "e2-medium"
-  can_ip_forward = false
-  tags           = ["terraform-testing"]
-
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    boot         = true
-  }
-
-  network_interface {
-    network = "default"
-  }
-
-  service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
-  description = "Terraform test instance group manager"
-  name        = "%s"
-  version {
-    name              = "prod"
-    instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
-  }
-  base_instance_name = "tf-test-igm-rolling-update-policy"
-  zone               = "us-central1-c"
-  target_size        = 3
-  update_policy {
-    type                    = "PROACTIVE"
-    minimal_action          = "REPLACE"
-  }
-  named_port {
-    name = "customhttp"
-    port = 8080
-  }
-}
-`, igm)
-}
-
-resource "google_compute_instance_template" "igm-rolling-update-policy" {
-  machine_type   = "e2-medium"
-  can_ip_forward = false
-  tags           = ["terraform-testing"]
-
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    boot         = true
-  }
-
-  network_interface {
-    network = "default"
-  }
-
-  service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
-  description = "Terraform test instance group manager"
-  name        = "%s"
-  version {
-    name              = "prod"
-    instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
-  }
-  base_instance_name = "tf-test-igm-rolling-update-policy"
-  zone               = "us-central1-c"
-  target_size        = 3
-  update_policy {
-    type                    = "PROACTIVE"
-    minimal_action          = "REPLACE"
-    max_surge_fixed         = 0
-  }
-  named_port {
-    name = "customhttp"
-    port = 8080
-  }
-}
-`, igm)
-}
-
 func testAccInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1286,6 +1187,113 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     max_surge_fixed       = 0
     max_unavailable_fixed = 2
     replacement_method    = "RECREATE"
+  }
+  named_port {
+    name = "customhttp"
+    port = 8080
+  }
+}
+`, igm)
+}
+
+func testAccInstanceGroupManager_rollingUpdatePolicy6(igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-rolling-update-policy" {
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["terraform-testing"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
+  description = "Terraform test instance group manager"
+  name        = "%s"
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
+  }
+  base_instance_name = "tf-test-igm-rolling-update-policy"
+  zone               = "us-central1-c"
+  target_size        = 3
+  update_policy {
+    type                    = "PROACTIVE"
+    minimal_action          = "REPLACE"
+  }
+  named_port {
+    name = "customhttp"
+    port = 8080
+  }
+}
+`, igm)
+}
+
+func testAccInstanceGroupManager_rollingUpdatePolicy7(igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-rolling-update-policy" {
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["terraform-testing"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
+  description = "Terraform test instance group manager"
+  name        = "%s"
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
+  }
+  base_instance_name = "tf-test-igm-rolling-update-policy"
+  zone               = "us-central1-c"
+  target_size        = 3
+  update_policy {
+    type                    = "PROACTIVE"
+    minimal_action          = "REPLACE"
+    max_surge_fixed         = 0
   }
   named_port {
     name = "customhttp"
@@ -1930,4 +1938,101 @@ resource "google_compute_per_instance_config" "per-instance" {
 	}
 }
 `, template, target, igm, perInstanceConfig)
+}
+
+func TestEmptyOrAllowedListSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		Key                []string
+		ExpectDiffSuppress bool
+	}{
+		"empty with 1st of the list": {
+			Old:                "",
+			New:                "v1",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: true,
+		},
+		"empty with 2nd of the list": {
+			Old:                "",
+			New:                "v2",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: true,
+		},
+		"same values": {
+			Old:                "v1",
+			New:                "v1",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: true,
+		},
+		"1st of the list with empty": {
+			Old:                "",
+			New:                "v1",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: true,
+		},
+		"2nd of the list with empty": {
+			Old:                "",
+			New:                "v2",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: true,
+		},
+		"empty with none of the list": {
+			Old:                "",
+			New:                "v3",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: false,
+		},
+		"none of the list with empty": {
+			Old:                "v3",
+			New:                "",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: false,
+		},
+		"differnt ones in the list": {
+			Old:                "v1",
+			New:                "v2",
+			Key:                []string{"v1", "v2"},
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if tpgcompute.EmptyOrAllowedListSuppress(tc.Key)("", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
+func TestEmptyNewSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"1 with 0": {
+			Old:                "1",
+			New:                "0",
+			ExpectDiffSuppress: true,
+		},
+		"0 with 1": {
+			Old:                "0",
+			New:                "1",
+			ExpectDiffSuppress: false,
+		},
+		"same cases": {
+			Old:                "1",
+			New:                "1",
+			ExpectDiffSuppress: true,
+		},
+		"none 1 with 0": {
+			Old:                "2",
+			New:                "0",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if tpgcompute.EmptyNewSuppress("key", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -239,6 +239,24 @@ func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"status"},
 			},
+      {
+			Config: testAccInstanceGroupManager_rollingUpdatePolicy6(igm),
+			},
+			{
+				ResourceName:            "google_compute_instance_group_manager.igm-rolling-update-policy",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+      {
+			Config: testAccInstanceGroupManager_rollingUpdatePolicy7(igm),
+			},
+			{
+				ResourceName:            "google_compute_instance_group_manager.igm-rolling-update-policy",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
 		},
 	})
 }
@@ -968,6 +986,106 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
     minimal_action          = "REPLACE"
     max_surge_percent       = 50
     max_unavailable_percent = 50
+  }
+  named_port {
+    name = "customhttp"
+    port = 8080
+  }
+}
+`, igm)
+}
+
+func testAccInstanceGroupManager_rollingUpdatePolicy6(igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-rolling-update-policy" {
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["terraform-testing"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
+  description = "Terraform test instance group manager"
+  name        = "%s"
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
+  }
+  base_instance_name = "tf-test-igm-rolling-update-policy"
+  zone               = "us-central1-c"
+  target_size        = 3
+  update_policy {
+    type                    = "PROACTIVE"
+    minimal_action          = "REPLACE"
+  }
+  named_port {
+    name = "customhttp"
+    port = 8080
+  }
+}
+`, igm)
+}
+
+resource "google_compute_instance_template" "igm-rolling-update-policy" {
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["terraform-testing"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
+  description = "Terraform test instance group manager"
+  name        = "%s"
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.igm-rolling-update-policy.self_link
+  }
+  base_instance_name = "tf-test-igm-rolling-update-policy"
+  zone               = "us-central1-c"
+  target_size        = 3
+  update_policy {
+    type                    = "PROACTIVE"
+    minimal_action          = "REPLACE"
+    max_surge_fixed         = 0
   }
   named_port {
     name = "customhttp"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15202


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed the error when neither `update_policy.max_surge_fixed` nor `update_policy.max_surge_percent` is provided  on `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```
