### PR TITLE
Add future limit to quota exceeded error for gce operations

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_operation.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_operation.go.erb
@@ -185,6 +185,13 @@ func writeOperationError(w io.StringWriter, opError *compute.OperationErrorError
                 if opError.Code == "QUOTA_EXCEEDED" && ed.QuotaInfo != nil {
 			w.WriteString("\tmetric name = " + ed.QuotaInfo.MetricName + "\n")
 			w.WriteString("\tlimit name = " + ed.QuotaInfo.LimitName + "\n")
+			if ed.QuotaInfo.Limit != 0 {
+				w.WriteString("\tlimit = " + fmt.Sprint(ed.QuotaInfo.Limit) + "\n")
+			}
+			if ed.QuotaInfo.FutureLimit != 0 {
+				w.WriteString("\tfuture limit = " + fmt.Sprint(ed.QuotaInfo.FutureLimit) + "\n")
+				w.WriteString("\trollout status = in progress\n")
+			}
 			if ed.QuotaInfo.Dimensions != nil {
 				w.WriteString("\tdimensions = " + fmt.Sprint(ed.QuotaInfo.Dimensions) + "\n")
 			}

--- a/mmv1/third_party/terraform/services/compute/compute_operation_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_operation_test.go.erb
@@ -60,7 +60,7 @@ func buildOperationError(numLocalizedMsg int, numHelpWithLinks []int) compute.Op
 
 }
 
-func buildOperationErrorQuotaExceeded(withDetails bool, withDimensions bool) compute.OperationError {
+func buildOperationErrorQuotaExceeded(withDetails bool, withDimensions bool, withFutureLimit bool) compute.OperationError {
 	opError := &compute.OperationErrorErrors{Message: quotaExceededMsg, Code: quotaExceededCode}
 	opErrorErrors := []*compute.OperationErrorErrors{opError}
 	if withDetails {
@@ -68,6 +68,9 @@ func buildOperationErrorQuotaExceeded(withDetails bool, withDimensions bool) com
 			MetricName: quotaMetricName,
 			LimitName:  quotaLimitName,
 			Limit:      1100,
+		}
+		if withFutureLimit {
+			quotaInfo.FutureLimit = 2200
 		}
 		if withDimensions {
 			quotaInfo.Dimensions = map[string]string{"region": "us-central1"}
@@ -210,21 +213,23 @@ func TestComputeOperationError_Error(t *testing.T) {
                 },
                 {
 			name:  "QuotaMessageOnly",
-			input: buildOperationErrorQuotaExceeded(false, false),
+			input: buildOperationErrorQuotaExceeded(false, false, false),
 			expectContains: []string{
 				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
 			},
 			expectOmits: append(omitAlways(0, []int{}), []string{
 				"metric name = compute.googleapis.com/disks_total_storage",
+				"limit = 1100",
 			}...),
 		},
 		{
 			name:  "QuotaMessageWithDetailsNoDimensions",
-			input: buildOperationErrorQuotaExceeded(true, false),
+			input: buildOperationErrorQuotaExceeded(true, false, false),
 			expectContains: []string{
 				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
 				"metric name = compute.googleapis.com/disks_total_storage",
 				"limit name = DISKS-TOTAL-GB-per-project-region",
+				"limit = 1100",
 			},
 			expectOmits: append(omitAlways(0, []int{}), []string{
 				"dimensions = map[region:us-central1]",
@@ -232,11 +237,47 @@ func TestComputeOperationError_Error(t *testing.T) {
 		},
 		{
 			name:  "QuotaMessageWithDetailsWithDimensions",
-			input: buildOperationErrorQuotaExceeded(true, true),
+			input: buildOperationErrorQuotaExceeded(true, true, false),
 			expectContains: []string{
 				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
 				"metric name = compute.googleapis.com/disks_total_storage",
 				"limit name = DISKS-TOTAL-GB-per-project-region",
+				"limit = 1100",
+				"dimensions = map[region:us-central1]",
+			},
+			expectOmits: append(omitAlways(0, []int{}), []string{
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			}...),
+		},
+		{
+			name:  "QuotaMessageWithDetailsWithFutureLimit",
+			input: buildOperationErrorQuotaExceeded(true, false, true),
+			expectContains: []string{
+				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
+				"metric name = compute.googleapis.com/disks_total_storage",
+				"limit name = DISKS-TOTAL-GB-per-project-region",
+				"limit = 1100",
+				"future limit = 2200",
+				"rollout status = in progress",
+			},
+			expectOmits: append(omitAlways(0, []int{}), []string{
+				"LocalizedMessage1",
+				"Help1Link1 Description",
+				"https://help1.com/link1",
+			}...),
+		},
+		{
+			name:  "QuotaMessageWithDetailsWithDimensionsWithFutureLimit",
+			input: buildOperationErrorQuotaExceeded(true, true, true),
+			expectContains: []string{
+				"Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1.",
+				"metric name = compute.googleapis.com/disks_total_storage",
+				"limit name = DISKS-TOTAL-GB-per-project-region",
+				"limit = 1100",
+				"future limit = 2200",
+				"rollout status = in progress",
 				"dimensions = map[region:us-central1]",
 			},
 			expectOmits: append(omitAlways(0, []int{}), []string{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Surfacing one more field `future limit` in error details when compute operation has quota exceeded error while creating a GCE resource. This could help user know the status of the ongoing rollout if any and what to expect when the rollout is done.
Quota exceeded error details are provided in quota_info. This change will surface the field in the terraform response.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: add future_limit in quota exceeded error details for Compute Operation.
```
