### PR TITLE
Added E2_MEDIUM as machine_type for CloudBuild triggers

### DIFF
--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -1108,17 +1108,10 @@ properties:
             values:
               - :NOT_VERIFIED
               - :VERIFIED
-          - !ruby/object:Api::Type::Enum
+          - !ruby/object:Api::Type::String
             name: 'machineType'
             description: |
               Compute Engine machine type on which to run the build.
-            values:
-              - :UNSPECIFIED
-              - :N1_HIGHCPU_8
-              - :N1_HIGHCPU_32
-              - :E2_HIGHCPU_8
-              - :E2_HIGHCPU_32
-              - :E2_MEDIUM
           - !ruby/object:Api::Type::Integer
             name: 'diskSizeGb'
             description: |

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -1118,6 +1118,7 @@ properties:
               - :N1_HIGHCPU_32
               - :E2_HIGHCPU_8
               - :E2_HIGHCPU_32
+              - :E2_MEDIUM
           - !ruby/object:Api::Type::Integer
             name: 'diskSizeGb'
             description: |

--- a/mmv1/templates/terraform/state_migrations/cloud_build_trigger.go.erb
+++ b/mmv1/templates/terraform/state_migrations/cloud_build_trigger.go.erb
@@ -373,8 +373,8 @@ The elements are of the form "KEY=VALUE" for the environment variable "KEY" bein
 									"machine_type": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: verify.ValidateEnum([]string{"UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", ""}),
-										Description:  `Compute Engine machine type on which to run the build. Possible values: ["UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32"]`,
+										ValidateFunc: verify.ValidateEnum([]string{"UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", "E2_MEDIUM", ""}),
+										Description:  `Compute Engine machine type on which to run the build. Possible values: ["UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", "E2_MEDIUM"]`,
 									},
 									"requested_verify_option": {
 										Type:         schema.TypeString,

--- a/mmv1/templates/terraform/state_migrations/cloud_build_trigger.go.erb
+++ b/mmv1/templates/terraform/state_migrations/cloud_build_trigger.go.erb
@@ -373,7 +373,8 @@ The elements are of the form "KEY=VALUE" for the environment variable "KEY" bein
 									"machine_type": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										Description:  `Compute Engine machine type on which to run the build.`,
+										ValidateFunc: verify.ValidateEnum([]string{"UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", ""}),
+										Description:  `Compute Engine machine type on which to run the build. Possible values: ["UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32"]`,
 									},
 									"requested_verify_option": {
 										Type:         schema.TypeString,

--- a/mmv1/templates/terraform/state_migrations/cloud_build_trigger.go.erb
+++ b/mmv1/templates/terraform/state_migrations/cloud_build_trigger.go.erb
@@ -373,8 +373,7 @@ The elements are of the form "KEY=VALUE" for the environment variable "KEY" bein
 									"machine_type": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: verify.ValidateEnum([]string{"UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", "E2_MEDIUM", ""}),
-										Description:  `Compute Engine machine type on which to run the build. Possible values: ["UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", "E2_MEDIUM"]`,
+										Description:  `Compute Engine machine type on which to run the build.`,
 									},
 									"requested_verify_option": {
 										Type:         schema.TypeString,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: removed the validation function for the values of `machine_type` field on the `google_cloudbuild_trigger` resource
```

Closes: https://github.com/hashicorp/terraform-provider-google/issues/15282
