### PR TITLE
Allow setting enable_private_endpoint on creation time for PSC Based Clusters

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1592,7 +1592,7 @@ func ResourceContainerCluster() *schema.Resource {
 							Optional:         true,
 							AtLeastOneOf:     privateClusterConfigKeys,
 							DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
-							Description:      `When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true.`,
+							Description:      `When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used.`,
 						},
 						"enable_private_nodes": {
 							Type:             schema.TypeBool,
@@ -2286,6 +2286,14 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.SecurityPostureConfig = expandSecurityPostureConfig(v)
 	}
 
+	// For now PSC based cluster don't support `enable_private_endpoint` on `create`, but only on `update` API call.
+    // If cluster is PSC based and enable_private_endpoint is set to true we will ignore it on `create` call and update cluster right after creation.
+	enablePrivateEndpointPSCCluster := isEnablePrivateEndpointPSCCluster(cluster)
+	if enablePrivateEndpointPSCCluster {
+		cluster.PrivateClusterConfig.EnablePrivateEndpoint = false
+	}
+	
+
 	req := &container.CreateClusterRequest{
 		Cluster: cluster,
 	}
@@ -2373,6 +2381,34 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	if enablePrivateEndpointPSCCluster {
+		name := containerClusterFullName(project, location, clusterName)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredEnablePrivateEndpoint: true,
+				ForceSendFields:              []string{"DesiredEnablePrivateEndpoint"},
+			},
+		}
+
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: func() error {
+				clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+				if config.UserProjectOverride {
+					clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
+				}
+				op, err = clusterUpdateCall.Do()
+				return err
+			},
+		})
+		if err != nil {
+			return errwrap.Wrapf("Error updating enable private endpoint: {{err}}", err)
+		}
+
+		err = ContainerOperationWait(config, op, project, location, "updating enable private endpoint", userAgent, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return errwrap.Wrapf("Error while waiting to enable private endpoint: {{err}}", err)
+		}
+	}
 
 	if err := resourceContainerClusterRead(d, meta); err != nil {
 		return err
@@ -4723,6 +4759,22 @@ func expandNetworkPolicy(configured interface{}) *container.NetworkPolicy {
 		}
 	}
 	return result
+}
+
+func isEnablePrivateEndpointPSCCluster(cluster *container.Cluster) bool {
+	// EnablePrivateEndpoint not provided
+	if cluster == nil || cluster.PrivateClusterConfig == nil {
+		return false
+	}
+	// Not a PSC cluster
+	if cluster.PrivateClusterConfig.EnablePrivateNodes || len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) > 0 {
+		return false
+	}
+	// PSC Cluster with EnablePrivateEndpoint
+	if cluster.PrivateClusterConfig.EnablePrivateEndpoint {
+		return true
+	}
+	return false
 }
 
 func expandPrivateClusterConfig(configured interface{}) *container.PrivateClusterConfig {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -4819,6 +4819,19 @@ resource "google_container_cluster" "with_enable_private_endpoint" {
 `, clusterName, flag)
 }
 
+func testAccContainerCluster_regionalWithNodePool(cluster, nodePool string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "regional" {
+  name     = "%s"
+  location = "us-central1"
+
+  node_pool {
+    name = "%s"
+  }
+}
+`, cluster, nodePool)
+}
+
 func testAccContainerCluster_regionalNodeLocations(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_locations" {

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -4746,15 +4746,6 @@ func TestAccContainerCluster_withEnablePrivateEndpointToggle(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withoutEnablePrivateEndpoint(clusterName),
-			},
-			{
-				ResourceName:				"google_container_cluster.with_enable_private_endpoint",
-				ImportState:				true,
-				ImportStateVerify:			true,
-				ImportStateVerifyIgnore:	[]string{"min_master_version"},
-			},
-			{
 				Config: testAccContainerCluster_withEnablePrivateEndpoint(clusterName, "true"),
 			},
 			{
@@ -4826,39 +4817,6 @@ resource "google_container_cluster" "with_enable_private_endpoint" {
   }
 }
 `, clusterName, flag)
-}
-
-func testAccContainerCluster_withoutEnablePrivateEndpoint(clusterName string) string {
-
-	return fmt.Sprintf(`
-data "google_container_engine_versions" "uscentral1a" {
-  location = "us-central1-a"
-}
-
-resource "google_container_cluster" "with_enable_private_endpoint" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
-  initial_node_count = 1
-
-  master_authorized_networks_config {
-    gcp_public_cidrs_access_enabled = false
-  }
-}
-`, clusterName)
-}
-
-func testAccContainerCluster_regionalWithNodePool(cluster, nodePool string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "regional" {
-  name     = "%s"
-  location = "us-central1"
-
-  node_pool {
-    name = "%s"
-  }
-}
-`, cluster, nodePool)
 }
 
 func testAccContainerCluster_regionalNodeLocations(clusterName string) string {


### PR DESCRIPTION
Currently PSC Based clusters allow setting "enable_private_endpoint" on "update" phase only, this PR allows setting it on cluster initial creation time

Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

```
