### PR TITLE
Enforce mutual exclusivity among view, materialized view, and schema in BigQuery table config

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -492,6 +492,7 @@ func ResourceBigQueryTable() *schema.Resource {
 						// Schema: Optional] The schema for the  data.
 						// Schema is required for CSV and JSON formats if autodetect is not on.
 						// Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, Avro, Iceberg, ORC, and Parquet formats.
+						// Schema is mutually exclusive with View and Materialized View.
 						"schema": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -502,7 +503,8 @@ func ResourceBigQueryTable() *schema.Resource {
 								json, _ := structure.NormalizeJsonString(v)
 								return json
 							},
-							Description: `A JSON schema for the external table. Schema is required for CSV and JSON formats and is disallowed for Google Cloud Bigtable, Cloud Datastore backups, and Avro formats when using external tables.`,
+							Description:   `A JSON schema for the external table. Schema is required for CSV and JSON formats and is disallowed for Google Cloud Bigtable, Cloud Datastore backups, and Avro formats when using external tables.`,
+							ConflictsWith: []string{"view", "materialized_view"},
 						},
 						// CsvOptions: [Optional] Additional properties to set if
 						// sourceFormat is set to CSV.
@@ -774,6 +776,7 @@ func ResourceBigQueryTable() *schema.Resource {
 				Description:      `A JSON schema for the table.`,
 			},
 			// View: [Optional] If specified, configures this table as a view.
+			// View is mutually exclusive with Schema and Materialized View.
 			"view": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -800,9 +803,11 @@ func ResourceBigQueryTable() *schema.Resource {
 						},
 					},
 				},
+				ConflictsWith: []string{"schema", "materialized_view"},
 			},
 
 			// Materialized View: [Optional] If specified, configures this table as a materialized view.
+			// Materialized View is mutually exclusive with Schema and View.
 			"materialized_view": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -839,6 +844,7 @@ func ResourceBigQueryTable() *schema.Resource {
 						},
 					},
 				},
+				ConflictsWith: []string{"schema", "view"},
 			},
 
 			// TimePartitioning: [Experimental] If specified, configures time-based
@@ -1170,40 +1176,15 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	datasetID := d.Get("dataset_id").(string)
 
-	if table.View != nil && table.Schema != nil {
+	log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
 
-		log.Printf("[INFO] Removing schema from table definition because big query does not support setting schema on view creation")
-		schemaBack := table.Schema
-		table.Schema = nil
-
-		log.Printf("[INFO] Creating BigQuery table: %s without schema", table.TableReference.TableId)
-
-		res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
-		if err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] BigQuery table %s has been created", res.Id)
-		d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
-
-		table.Schema = schemaBack
-		log.Printf("[INFO] Updating BigQuery table: %s with schema", table.TableReference.TableId)
-		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, res.TableReference.TableId, table).Do(); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] BigQuery table %s has been update with schema", res.Id)
-	} else {
-		log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
-
-		res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
-		if err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] BigQuery table %s has been created", res.Id)
-		d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
+	res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
+	if err != nil {
+		return err
 	}
+
+	log.Printf("[INFO] BigQuery table %s has been created", res.Id)
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 
 	return resourceBigQueryTableRead(d, meta)
 }

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -367,27 +367,8 @@ func TestAccBigQueryTable_WithViewAndSchema(t *testing.T) {
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-<<<<<<< HEAD
-				Config: testAccBigQueryTableWithViewAndSchema(datasetID, tableID, "table description1"),
-			},
-			{
-				ResourceName:            "google_bigquery_table.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccBigQueryTableWithViewAndSchema(datasetID, tableID, "table description2"),
-			},
-			{
-				ResourceName:            "google_bigquery_table.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-=======
 				Config:      testAccBigQueryTableWithViewAndSchema(datasetID, tableID, "table description"),
 				ExpectError: regexp.MustCompile("\"view\": conflicts with schema"),
->>>>>>> 5471308bd (add ConflictsWith to resource_bigquery_table)
 			},
 		},
 	})
@@ -492,8 +473,6 @@ func TestAccBigQueryTable_MaterializedView_DailyTimePartioning_Update(t *testing
 	})
 }
 
-<<<<<<< HEAD
-=======
 func TestAccBigQueryTable_MaterializedView_WithSchema(t *testing.T) {
 	t.Parallel()
 
@@ -536,7 +515,6 @@ func TestAccBigQueryTable_MaterializedView_WithView(t *testing.T) {
 	})
 }
 
->>>>>>> 5471308bd (add ConflictsWith to resource_bigquery_table)
 func TestAccBigQueryExternalDataTable_parquet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14220.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
bigquery: fixed view and materialized view creation when schema is specified
```
