### PR TITLE
dnm: display default provider values at plan-time

### DIFF
--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -217,6 +217,10 @@ module Api
       # public ca external account keys
       attr_reader :skip_read
 
+      # Set to true for resources that wish to disable automatic generation of default provider
+      # value customdiff functions
+      attr_reader :skip_default_cdiff
+
       # This enables resources that get their project via a reference to a different resource
       # instead of a project field to use User Project Overrides
       attr_reader :supports_indirect_user_project_override
@@ -319,6 +323,7 @@ module Api
       check :migrate_state, type: String
       check :skip_delete, type: :boolean, default: false
       check :skip_read, type: :boolean, default: false
+      check :skip_default_cdiff, type: :boolean, default: false
       check :supports_indirect_user_project_override, type: :boolean, default: false
       check :legacy_long_form_project, type: :boolean, default: false
       check :read_error_transform, type: String

--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -84,6 +84,7 @@ parameters:
       URL of the zone where the instance group resides.
     required: false
     immutable: true
+    ignore_read: true
     default_from_api: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
 properties:

--- a/mmv1/products/compute/DiskResourcePolicyAttachment.yaml
+++ b/mmv1/products/compute/DiskResourcePolicyAttachment.yaml
@@ -77,6 +77,7 @@ parameters:
     description: 'A reference to the zone where the disk resides.'
     required: false
     url_param_only: true
+    ignore_read: true
     default_from_api: true
 properties:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/compute/NetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/NetworkEndpointGroup.yaml
@@ -78,6 +78,7 @@ parameters:
       Zone where the network endpoint group is located.
     required: false
     default_from_api: true
+    ignore_read: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
 properties:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -65,6 +65,7 @@ parameters:
     required: false
     immutable: true
     default_from_api: true
+    ignore_read: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
 properties:
   - !ruby/object:Api::Type::Time

--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -85,6 +85,7 @@ parameters:
     description: Region where resource policy resides.
     immutable: true
     required: false
+    ignore_read: true
     default_from_api: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
 properties:

--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -93,6 +93,7 @@ parameters:
     required: false
     immutable: true
     default_from_api: true
+    ignore_read: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
 properties:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -28,6 +28,7 @@ timeouts: !ruby/object:Api::Timeouts
   update_minutes: 20
   delete_minutes: 20
 autogen_async: true
+skip_default_cdiff: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/redis_location_id_for_fallback_zone.go.erb
   decoder: templates/terraform/decoders/redis_instance.go.erb
@@ -35,6 +36,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/redis_instance.go
 custom_diff: [
   'customdiff.ForceNewIfChange("redis_version", isRedisVersionDecreasing)',
+  'tpgresource.DefaultProviderProject',
 ]
 examples:
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -65,6 +65,7 @@ import (
     client_name_lower = client_name.downcase
     has_project = object.base_url.include?('{{project}}') || (object.create_url && object.create_url.include?('{{project}}'))
     has_region = object.base_url.include?('{{region}}') && object.parameters.any?{ |p| p.name == 'region' && p.ignore_read }
+    has_zone = object.base_url.include?('{{zone}}') && object.parameters.any?{ |p| p.name == 'zone' && p.ignore_read }
     # In order of preference, use TF override,
     # general defined timeouts, or default Timeouts
     timeouts = object.timeouts
@@ -113,7 +114,7 @@ func Resource<%= resource_name -%>() *schema.Resource {
 <%      end -%>
         },
 <%  end -%>
-<%  if object.custom_diff.any? || object.settable_properties.any? {|p| p.unordered_list}-%>
+<% if has_project || has_region || has_zone || object.custom_diff.any? || object.settable_properties.any? {|p| p.unordered_list}-%>
         CustomizeDiff: customdiff.All(
 <%      if object.settable_properties.any? {|p| p.unordered_list} -%>
         <%=
@@ -126,6 +127,15 @@ func Resource<%= resource_name -%>() *schema.Resource {
 <%          for cdiff in object.custom_diff-%>
         <%= cdiff%>,
 <%          end -%>
+<%      end -%>
+<%      if has_project -%>
+            tpgresource.DefaultProviderProject,
+<%      end -%>
+<%      if has_region -%>
+            tpgresource.DefaultProviderRegion,
+<%      end -%>
+<%      if has_zone -%>
+            tpgresource.DefaultProviderZone,
 <%      end -%>
         ),
 <%  end -%>

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -114,7 +114,7 @@ func Resource<%= resource_name -%>() *schema.Resource {
 <%      end -%>
         },
 <%  end -%>
-<% if has_project || has_region || has_zone || object.custom_diff.any? || object.settable_properties.any? {|p| p.unordered_list}-%>
+<% if ((has_project || has_region || has_zone) && !object.skip_default_cdiff) || object.custom_diff.any? || object.settable_properties.any? {|p| p.unordered_list}-%>
         CustomizeDiff: customdiff.All(
 <%      if object.settable_properties.any? {|p| p.unordered_list} -%>
         <%=
@@ -128,13 +128,13 @@ func Resource<%= resource_name -%>() *schema.Resource {
         <%= cdiff%>,
 <%          end -%>
 <%      end -%>
-<%      if has_project -%>
+<%      if has_project && !object.skip_default_cdiff -%>
             tpgresource.DefaultProviderProject,
 <%      end -%>
-<%      if has_region -%>
+<%      if has_region && !object.skip_default_cdiff  -%>
             tpgresource.DefaultProviderRegion,
 <%      end -%>
-<%      if has_zone -%>
+<%      if has_zone && !object.skip_default_cdiff  -%>
             tpgresource.DefaultProviderZone,
 <%      end -%>
         ),

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -32,6 +32,7 @@ func ResourceAppEngineApplication() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
 			appEngineApplicationLocationIDCustomizeDiff,
 		),
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -373,6 +373,7 @@ func ResourceBigQueryTable() *schema.Resource {
 			State: resourceBigQueryTableImport,
 		},
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
 			resourceBigQueryTableSchemaCustomizeDiff,
 		),
 		Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -34,6 +34,7 @@ func ResourceBigtableInstance() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
 			resourceBigtableInstanceClusterReorderTypeList,
 			resourceBigtableInstanceUniqueClusterID,
 		),

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
@@ -32,6 +32,9 @@ func ResourceBigtableTable() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
 		// ----------------------------------------------------------------------
 		// IMPORTANT: Do not add any additional ForceNew fields to this resource.
 		// Destroying/recreating tables can lead to data loss for users.

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigtable"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
@@ -141,6 +141,11 @@ func ResourceCloudFunctionsFunction() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderRegion,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
@@ -3,6 +3,7 @@ package cloudfunctions
 import (
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -155,6 +155,11 @@ func ResourceComposerEnvironment() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderRegion,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.erb
@@ -35,6 +35,11 @@ func ResourceComputeAttachedDisk() *schema.Resource {
 			Delete: schema.DefaultTimeout(300 * time.Second),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderZone,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"disk": {
 				Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.erb
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -1023,6 +1023,8 @@ be from 0 to 999,999,999 inclusive.`,
 			},
 		},
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderZone,
 			customdiff.If(
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 					return d.HasChange("guest_accelerator")

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
@@ -32,7 +32,11 @@ func ResourceComputeInstanceFromTemplate() *schema.Resource {
 		Timeouts: ResourceComputeInstance().Timeouts,
 
 		Schema:        computeInstanceFromTemplateSchema(),
-		CustomizeDiff: ResourceComputeInstance().CustomizeDiff,
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderProject,
+			ResourceComputeInstance().CustomizeDiff,
+		),
 		UseJSONNumber: true,
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
@@ -35,7 +35,6 @@ func ResourceComputeInstanceFromTemplate() *schema.Resource {
 		Schema:        computeInstanceFromTemplateSchema(),
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
-			tpgresource.DefaultProviderProject,
 			ResourceComputeInstance().CustomizeDiff,
 		),
 		UseJSONNumber: true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.erb
@@ -12,6 +12,7 @@ import (
 
 	"google.golang.org/api/googleapi"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.erb
@@ -36,6 +36,11 @@ func ResourceComputeInstanceGroup() *schema.Resource {
 			Update: schema.DefaultTimeout(6 * time.Minute),
 			Delete: schema.DefaultTimeout(6 * time.Minute),
 		},
+		
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderZone,
+		),
 
 		SchemaVersion: 2,
 		MigrateState:  resourceComputeInstanceGroupMigrateState,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -36,6 +36,10 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 			Update: schema.DefaultTimeout(15 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderZone,
+		),
 		Schema: map[string]*schema.Schema{
 			"base_instance_name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -62,6 +62,7 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 		},
 		SchemaVersion: 1,
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
 			resourceComputeInstanceTemplateSourceImageCustomizeDiff,
 			resourceComputeInstanceTemplateScratchDiskCustomizeDiff,
 			resourceComputeInstanceTemplateBootDiskCustomizeDiff,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_default_network_tier.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_default_network_tier.go.erb
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_default_network_tier.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_default_network_tier.go.erb
@@ -34,6 +34,10 @@ func ResourceComputeProjectDefaultNetworkTier() *schema.Resource {
 			Create: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		SchemaVersion: 0,
 
 		Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata.go.erb
@@ -33,6 +33,10 @@ func ResourceComputeProjectMetadata() *schema.Resource {
 			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		SchemaVersion: 0,
 
 		Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.erb
@@ -35,6 +35,10 @@ func ResourceComputeProjectMetadataItem() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"key": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -37,6 +37,11 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderRegion,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"base_instance_name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -36,6 +36,8 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 		},
 		SchemaVersion: 1,
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderRegion,
 			resourceComputeInstanceTemplateSourceImageCustomizeDiff,
 			resourceComputeInstanceTemplateScratchDiskCustomizeDiff,
 			resourceComputeInstanceTemplateBootDiskCustomizeDiff,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -35,6 +35,11 @@ func ResourceComputeRouterInterface() *schema.Resource {
 			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderRegion,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -35,7 +35,10 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceSecurityPolicyStateImporter,
 		},
-		CustomizeDiff: rulesCustomizeDiff,
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			rulesCustomizeDiff,
+		),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(8 * time.Minute),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_service_project.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_service_project.go.erb
@@ -36,6 +36,10 @@ func ResourceComputeSharedVpcServiceProject() *schema.Resource {
 			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"host_project": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_service_project.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_service_project.go.erb
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/googleapi"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.erb
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.erb
@@ -39,6 +39,11 @@ func ResourceComputeTargetPool() *schema.Resource {
 			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+			tpgresource.DefaultProviderRegion,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_usage_export_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_usage_export_bucket.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_usage_export_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_usage_export_bucket.go.erb
@@ -32,6 +32,10 @@ func ResourceProjectUsageBucket() *schema.Resource {
 			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"bucket_name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -48,6 +48,7 @@ func ResourceContainerNodePool() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
 			resourceNodeConfigEmptyGuestAccelerator,
 		),
 

--- a/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
+++ b/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"

--- a/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
+++ b/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
@@ -16,6 +16,10 @@ func ResourceContainerRegistry() *schema.Resource {
 		Read:   resourceContainerRegistryRead,
 		Delete: resourceContainerRegistryDelete,
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"location": {
 				Type:     schema.TypeString,

--- a/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
+++ b/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
@@ -19,7 +19,7 @@ func ResourceContainerRegistry() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"location": {
 				Type:     schema.TypeString,

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go.erb
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go.erb
@@ -162,6 +162,10 @@ func ResourceDataprocCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(45 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
@@ -11,6 +11,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/dataproc/v1"

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
@@ -30,6 +30,10 @@ func ResourceDataprocJob() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_environment.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_environment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_environment.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_environment.go
@@ -35,7 +35,7 @@ func ResourceDialogflowCXEnvironment() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_environment.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_environment.go
@@ -32,6 +32,10 @@ func ResourceDialogflowCXEnvironment() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_version.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_version.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_version.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_version.go
@@ -33,6 +33,10 @@ func ResourceDialogflowCXVersion() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_version.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_version.go
@@ -36,7 +36,7 @@ func ResourceDialogflowCXVersion() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -8,6 +8,7 @@ import (
 
 	"net"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -81,6 +81,10 @@ func ResourceDnsRecordSet() *schema.Resource {
 			State: resourceDnsRecordSetImportState,
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"managed_zone": {
 				Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -84,7 +84,7 @@ func ResourceDnsRecordSet() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"managed_zone": {
 				Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -105,6 +105,9 @@ func ResourceLoggingBucketConfig(parentType string, parentSpecificSchema map[str
 		},
 		Schema:        tpgresource.MergeSchemas(loggingBucketConfigSchema, parentSpecificSchema),
 		UseJSONNumber: true,
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
 	}
 }
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -133,6 +133,10 @@ func ResourceLoggingProjectBucketConfig() *schema.Resource {
 		},
 		Schema:        loggingProjectBucketConfigSchema,
 		UseJSONNumber: true,
+		
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
 	}
 }
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -134,7 +134,7 @@ func ResourceLoggingProjectBucketConfig() *schema.Resource {
 		},
 		Schema:        loggingProjectBucketConfigSchema,
 		UseJSONNumber: true,
-		
+
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
@@ -51,6 +51,10 @@ func ResourceMonitoringDashboard() *schema.Resource {
 			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"dashboard_json": {
 				Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
@@ -54,7 +54,7 @@ func ResourceMonitoringDashboard() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"dashboard_json": {
 				Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
@@ -30,6 +30,10 @@ func ResourceOSConfigOSPolicyAssignment() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"instance_filter": {
 				Type:        schema.TypeList,

--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
@@ -33,7 +33,7 @@ func ResourceOSConfigOSPolicyAssignment() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"instance_filter": {
 				Type:        schema.TypeList,

--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_default_service_accounts.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_default_service_accounts.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_default_service_accounts.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_default_service_accounts.go
@@ -32,6 +32,10 @@ func ResourceGoogleProjectDefaultServiceAccounts() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
@@ -23,6 +23,10 @@ func ResourceGoogleProjectIamCustomRole() *schema.Resource {
 			State: resourceGoogleProjectIamCustomRoleImport,
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"role_id": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
@@ -26,7 +26,7 @@ func ResourceGoogleProjectIamCustomRole() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"role_id": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	tpgserviceusage "github.com/hashicorp/terraform-provider-google/google/services/serviceusage"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go
@@ -93,6 +93,10 @@ func ResourceGoogleProjectService() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -9,6 +9,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/iam/v1"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -26,6 +26,9 @@ func ResourceGoogleServiceAccount() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
 		Schema: map[string]*schema.Schema{
 			"email": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity.go.erb
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity.go.erb
@@ -29,7 +29,7 @@ func ResourceProjectServiceIdentity() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:     schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity.go.erb
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity.go.erb
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity.go.erb
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity.go.erb
@@ -26,6 +26,10 @@ func ResourceProjectServiceIdentity() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:     schema.TypeString,

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.erb
@@ -10,6 +10,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
 )

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.erb
@@ -30,7 +30,7 @@ func ResourceRuntimeconfigConfig() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.erb
@@ -27,6 +27,10 @@ func ResourceRuntimeconfigConfig() *schema.Resource {
 			State: resourceRuntimeconfigConfigImport,
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.erb
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
 )

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.erb
@@ -24,6 +24,10 @@ func ResourceRuntimeconfigVariable() *schema.Resource {
 			State: resourceRuntimeconfigVariableImport,
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+		
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.erb
@@ -27,7 +27,7 @@ func ResourceRuntimeconfigVariable() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 		),
-		
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/servicenetworking/v1"
 )

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
@@ -30,6 +30,10 @@ func ResourceGoogleServiceNetworkingPeeredDNSDomain() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
@@ -41,6 +41,7 @@ func ResourceGoogleServiceNetworkingPeeredDNSDomain() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 				ForceNew:    true,
+				DiffSuppressFunc: tpgresource.ProjectNumberDiffSuppress,
 				Description: `The ID of the project that the service account will be created in. Defaults to the provider project configuration.`,
 			},
 			"name": {

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
@@ -41,7 +41,6 @@ func ResourceGoogleServiceNetworkingPeeredDNSDomain() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 				ForceNew:    true,
-				DiffSuppressFunc: tpgresource.ProjectNumberDiffSuppress,
 				Description: `The ID of the project that the service account will be created in. Defaults to the provider project configuration.`,
 			},
 			"name": {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -118,6 +118,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
 			customdiff.ForceNewIfChange("settings.0.disk_size", compute.IsDiskShrinkage),
 			customdiff.ForceNewIfChange("master_instance_name", isMasterInstanceNameSet),
 			customdiff.IfValueChange("instance_type", isReplicaPromoteRequested, checkPromoteConfigurationsAndUpdateDiff),

--- a/mmv1/third_party/terraform/services/sql/resource_sql_ssl_cert.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_ssl_cert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )

--- a/mmv1/third_party/terraform/services/sql/resource_sql_ssl_cert.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_ssl_cert.go
@@ -25,6 +25,10 @@ func ResourceSqlSslCert() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"common_name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -10,6 +10,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -56,6 +56,10 @@ func ResourceSqlUser() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		SchemaVersion: 1,
 		MigrateState:  resourceSqlUserMigrateState,
 

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -61,6 +61,10 @@ func ResourceStorageTransferJob() *schema.Resource {
 			State: resourceStorageTransferJobStateImporter,
 		},
 
+		CustomizeDiff: customdiff.All(
+			tpgresource.DefaultProviderProject,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -11,8 +11,8 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/storagetransfer/v1"

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/storagetransfer/v1"

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -1,6 +1,7 @@
 package tpgresource
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/base64"
 	"errors"

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -103,6 +103,34 @@ func GetProjectFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (s
 	return "", fmt.Errorf("%s: required field is not set", "project")
 }
 
+// getRegionFromDiff reads the "region" field from the given diff and falls
+// back to the provider's value if not given. If the provider's value is not
+// given, an error is returned.
+func GetRegionFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (string, error) {
+	res, ok := d.GetOk("region")
+	if ok {
+		return res.(string), nil
+	}
+	if config.Region != "" {
+		return config.Region, nil
+	}
+	return "", fmt.Errorf("%s: required field is not set", "region")
+}
+
+// getZoneFromDiff reads the "zone" field from the given diff and falls
+// back to the provider's value if not given. If the provider's value is not
+// given, an error is returned.
+func GetZoneFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (string, error) {
+	res, ok := d.GetOk("zone")
+	if ok {
+		return res.(string), nil
+	}
+	if config.Zone != "" {
+		return config.Zone, nil
+	}
+	return "", fmt.Errorf("%s: required field is not set", "zone")
+}
+
 func GetRouterLockName(region string, router string) string {
 	return fmt.Sprintf("router/%s/%s", region, router)
 }
@@ -701,4 +729,78 @@ func GetContentMd5Hash(content []byte) string {
 		log.Printf("[WARN] Failed to compute md5 hash for content: %v", err)
 	}
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func DefaultProviderCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+
+	config := meta.(*transport_tpg.Config)
+
+	//project
+	project, err := GetProjectFromDiff(diff, config)
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", project, err)
+	}
+	diff.SetNew("project", project)
+	//region
+	if region := diff.Get("region"); region != nil {
+		region, err := GetRegionFromDiff(diff, config)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve region, pid: %s, err: %s", region, err)
+		}
+		diff.SetNew("region", region)
+	}
+	// zone
+	if zone := diff.Get("zone"); zone != nil {
+		zone, err := GetZoneFromDiff(diff, config)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve zone, pid: %s, err: %s", zone, err)
+		}
+		diff.SetNew("zone", zone)
+	}
+
+	return nil
+}
+
+func DefaultProviderProject(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+
+	config := meta.(*transport_tpg.Config)
+
+	//project
+	project, err := GetProjectFromDiff(diff, config)
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", project, err)
+	}
+	diff.SetNew("project", project)
+
+	return nil
+}
+
+func DefaultProviderRegion(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+
+	config := meta.(*transport_tpg.Config)
+	//region
+	if region := diff.Get("region"); region != nil {
+		region, err := GetRegionFromDiff(diff, config)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve region, pid: %s, err: %s", region, err)
+		}
+		diff.SetNew("region", region)
+	}
+
+	return nil
+}
+
+func DefaultProviderZone(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+
+	config := meta.(*transport_tpg.Config)
+	// zone
+	if zone := diff.Get("zone"); zone != nil {
+		zone, err := GetZoneFromDiff(diff, config)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve zone, pid: %s, err: %s", zone, err)
+		}
+		diff.SetNew("zone", zone)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -98,6 +98,9 @@ func GetProjectFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (s
 	if ok {
 		return res.(string), nil
 	}
+	if d.GetRawConfig().GetAttr("project") == cty.UnknownVal(cty.String) {
+		return res.(string), nil
+	}
 	if config.Project != "" {
 		return config.Project, nil
 	}
@@ -112,6 +115,9 @@ func GetRegionFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (st
 	if ok {
 		return res.(string), nil
 	}
+	if d.GetRawConfig().GetAttr("region") == cty.UnknownVal(cty.String) {
+		return res.(string), nil
+	}
 	if config.Region != "" {
 		return config.Region, nil
 	}
@@ -124,6 +130,9 @@ func GetRegionFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (st
 func GetZoneFromDiff(d *schema.ResourceDiff, config *transport_tpg.Config) (string, error) {
 	res, ok := d.GetOk("zone")
 	if ok {
+		return res.(string), nil
+	}
+	if d.GetRawConfig().GetAttr("zone") == cty.UnknownVal(cty.String) {
 		return res.(string), nil
 	}
 	if config.Zone != "" {

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -767,12 +767,13 @@ func DefaultProviderProject(_ context.Context, diff *schema.ResourceDiff, meta i
 	config := meta.(*transport_tpg.Config)
 
 	//project
-	project, err := GetProjectFromDiff(diff, config)
-	if err != nil {
-		return fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", project, err)
+	if project := diff.Get("project"); project != nil {
+		project, err := GetProjectFromDiff(diff, config)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", project, err)
+		}
+		diff.SetNew("project", project)
 	}
-	diff.SetNew("project", project)
-
 	return nil
 }
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -19,6 +19,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-cty/cty"
 	fwDiags "github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/tpgtools/overrides/apikeys/beta/key.yaml
+++ b/tpgtools/overrides/apikeys/beta/key.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/apikeys/key.yaml
+++ b/tpgtools/overrides/apikeys/key.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/bigqueryreservation/assignment.yaml
+++ b/tpgtools/overrides/bigqueryreservation/assignment.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/bigqueryreservation/beta/assignment.yaml
+++ b/tpgtools/overrides/bigqueryreservation/beta/assignment.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/cloudbuild/beta/worker_pool.yaml
+++ b/tpgtools/overrides/cloudbuild/beta/worker_pool.yaml
@@ -4,3 +4,7 @@
     diffsuppressfunc: tpgresource.CompareResourceNames
 - type: EXCLUDE
   field: etag
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/cloudbuild/worker_pool.yaml
+++ b/tpgtools/overrides/cloudbuild/worker_pool.yaml
@@ -4,3 +4,7 @@
     diffsuppressfunc: tpgresource.CompareResourceNames
 - type: EXCLUDE
   field: etag
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/cloudbuildv2/beta/connection.yaml
+++ b/tpgtools/overrides/cloudbuildv2/beta/connection.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/cloudbuildv2/beta/repository.yaml
+++ b/tpgtools/overrides/cloudbuildv2/beta/repository.yaml
@@ -16,3 +16,7 @@
     required: false
     optional: true
     computed: true
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/cloudbuildv2/connection.yaml
+++ b/tpgtools/overrides/cloudbuildv2/connection.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/cloudbuildv2/repository.yaml
+++ b/tpgtools/overrides/cloudbuildv2/repository.yaml
@@ -16,3 +16,7 @@
     required: false
     optional: true
     computed: true
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/clouddeploy/beta/delivery_pipeline.yaml
+++ b/tpgtools/overrides/clouddeploy/beta/delivery_pipeline.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/clouddeploy/beta/target.yaml
+++ b/tpgtools/overrides/clouddeploy/beta/target.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/clouddeploy/delivery_pipeline.yaml
+++ b/tpgtools/overrides/clouddeploy/delivery_pipeline.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/clouddeploy/target.yaml
+++ b/tpgtools/overrides/clouddeploy/target.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/beta/firewall_policy.yaml
+++ b/tpgtools/overrides/compute/beta/firewall_policy.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/beta/firewall_policy_association.yaml
+++ b/tpgtools/overrides/compute/beta/firewall_policy_association.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/beta/firewall_policy_rule.yaml
+++ b/tpgtools/overrides/compute/beta/firewall_policy_rule.yaml
@@ -2,3 +2,7 @@
   field: target_resources
   details:
     diffsuppressfunc: tpgresource.CompareSelfLinkOrResourceName
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/beta/network_firewall_policy.yaml
+++ b/tpgtools/overrides/compute/beta/network_firewall_policy.yaml
@@ -15,3 +15,8 @@
   details:
     id: projects/{{project}}/regions/{{region}}/firewallPolicies/{{name}}
   location: region
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject
+    - tpgresource.DefaultProviderRegion

--- a/tpgtools/overrides/compute/beta/network_firewall_policy_association.yaml
+++ b/tpgtools/overrides/compute/beta/network_firewall_policy_association.yaml
@@ -31,3 +31,8 @@
     - "projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/associations/{{name}}"
     - "{{project}}/{{firewall_policy}}/{{name}}"
   location: global 
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject
+    - tpgresource.DefaultProviderRegion

--- a/tpgtools/overrides/compute/beta/network_firewall_policy_rule.yaml
+++ b/tpgtools/overrides/compute/beta/network_firewall_policy_rule.yaml
@@ -17,3 +17,8 @@
   details:
     id: projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/{{priority}}
   location: region
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject
+    - tpgresource.DefaultProviderRegion

--- a/tpgtools/overrides/compute/firewall_policy.yaml
+++ b/tpgtools/overrides/compute/firewall_policy.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/firewall_policy_association.yaml
+++ b/tpgtools/overrides/compute/firewall_policy_association.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/firewall_policy_rule.yaml
+++ b/tpgtools/overrides/compute/firewall_policy_rule.yaml
@@ -2,3 +2,7 @@
   field: target_resources
   details:
     diffsuppressfunc: tpgresource.CompareSelfLinkOrResourceName
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/compute/network_firewall_policy.yaml
+++ b/tpgtools/overrides/compute/network_firewall_policy.yaml
@@ -15,3 +15,8 @@
   details:
     id: projects/{{project}}/regions/{{region}}/firewallPolicies/{{name}}
   location: region
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject
+    - tpgresource.DefaultProviderRegion

--- a/tpgtools/overrides/compute/network_firewall_policy_association.yaml
+++ b/tpgtools/overrides/compute/network_firewall_policy_association.yaml
@@ -31,3 +31,8 @@
     - "projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/associations/{{name}}"
     - "{{project}}/{{firewall_policy}}/{{name}}"
   location: global 
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject
+    - tpgresource.DefaultProviderRegion

--- a/tpgtools/overrides/compute/network_firewall_policy_rule.yaml
+++ b/tpgtools/overrides/compute/network_firewall_policy_rule.yaml
@@ -17,3 +17,8 @@
   details:
     id: projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/{{priority}}
   location: region
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject
+    - tpgresource.DefaultProviderRegion

--- a/tpgtools/overrides/containeraws/beta/cluster.yaml
+++ b/tpgtools/overrides/containeraws/beta/cluster.yaml
@@ -1,2 +1,6 @@
 - type: EXCLUDE
   field: monitoring_config
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containeraws/beta/node_pool.yaml
+++ b/tpgtools/overrides/containeraws/beta/node_pool.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containeraws/cluster.yaml
+++ b/tpgtools/overrides/containeraws/cluster.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containeraws/node_pool.yaml
+++ b/tpgtools/overrides/containeraws/node_pool.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containerazure/azure_client.yaml
+++ b/tpgtools/overrides/containerazure/azure_client.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containerazure/beta/azure_client.yaml
+++ b/tpgtools/overrides/containerazure/beta/azure_client.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containerazure/beta/cluster.yaml
+++ b/tpgtools/overrides/containerazure/beta/cluster.yaml
@@ -1,2 +1,6 @@
 - type: EXCLUDE
   field: monitoring_config
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containerazure/beta/node_pool.yaml
+++ b/tpgtools/overrides/containerazure/beta/node_pool.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containerazure/cluster.yaml
+++ b/tpgtools/overrides/containerazure/cluster.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/containerazure/node_pool.yaml
+++ b/tpgtools/overrides/containerazure/node_pool.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataplex/asset.yaml
+++ b/tpgtools/overrides/dataplex/asset.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataplex/beta/asset.yaml
+++ b/tpgtools/overrides/dataplex/beta/asset.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataplex/beta/lake.yaml
+++ b/tpgtools/overrides/dataplex/beta/lake.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataplex/beta/zone.yaml
+++ b/tpgtools/overrides/dataplex/beta/zone.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataplex/lake.yaml
+++ b/tpgtools/overrides/dataplex/lake.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataplex/zone.yaml
+++ b/tpgtools/overrides/dataplex/zone.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataproc/beta/workflow_template.yaml
+++ b/tpgtools/overrides/dataproc/beta/workflow_template.yaml
@@ -9,3 +9,7 @@
   details:
     message: >-
       version is not useful as a configurable field, and will be removed in the future.
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/dataproc/workflow_template.yaml
+++ b/tpgtools/overrides/dataproc/workflow_template.yaml
@@ -9,3 +9,7 @@
   details:
     message: >-
       version is not useful as a configurable field, and will be removed in the future.
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/eventarc/beta/channel.yaml
+++ b/tpgtools/overrides/eventarc/beta/channel.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/eventarc/beta/google_channel_config.yaml
+++ b/tpgtools/overrides/eventarc/beta/google_channel_config.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/eventarc/beta/trigger.yaml
+++ b/tpgtools/overrides/eventarc/beta/trigger.yaml
@@ -11,4 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/eventarc/channel.yaml
+++ b/tpgtools/overrides/eventarc/channel.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/eventarc/google_channel_config.yaml
+++ b/tpgtools/overrides/eventarc/google_channel_config.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/eventarc/trigger.yaml
+++ b/tpgtools/overrides/eventarc/trigger.yaml
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/firebaserules/beta/release.yaml
+++ b/tpgtools/overrides/firebaserules/beta/release.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/firebaserules/beta/ruleset.yaml
+++ b/tpgtools/overrides/firebaserules/beta/ruleset.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/firebaserules/release.yaml
+++ b/tpgtools/overrides/firebaserules/release.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/firebaserules/ruleset.yaml
+++ b/tpgtools/overrides/firebaserules/ruleset.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -25,3 +25,7 @@
   details:
     message: >-
       Deprecated in favor of the `management` field
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/networkconnectivity/beta/hub.yaml
+++ b/tpgtools/overrides/networkconnectivity/beta/hub.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/networkconnectivity/beta/spoke.yaml
+++ b/tpgtools/overrides/networkconnectivity/beta/spoke.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/networkconnectivity/hub.yaml
+++ b/tpgtools/overrides/networkconnectivity/hub.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/networkconnectivity/spoke.yaml
+++ b/tpgtools/overrides/networkconnectivity/spoke.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/privateca/beta/certificate_template.yaml
+++ b/tpgtools/overrides/privateca/beta/certificate_template.yaml
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/privateca/certificate_template.yaml
+++ b/tpgtools/overrides/privateca/certificate_template.yaml
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/recaptchaenterprise/beta/key.yaml
+++ b/tpgtools/overrides/recaptchaenterprise/beta/key.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject

--- a/tpgtools/overrides/recaptchaenterprise/key.yaml
+++ b/tpgtools/overrides/recaptchaenterprise/key.yaml
@@ -1,0 +1,4 @@
+- type: CUSTOMIZE_DIFF
+  details:
+    functions: 
+    - tpgresource.DefaultProviderProject


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
