### PR TITLE
Add support for setting `sendPreviousResourceOnDelete` for FHIR store notification configs.

### DIFF
--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -309,3 +309,11 @@ properties:
             full FHIR resource. When a resource change is too large or during heavy traffic, only the resource name will be
             sent. Clients should always check the "payloadType" label from a Pub/Sub message to determine whether
             it needs to fetch the full resource as a separate operation.
+        - !ruby/object:Api::Type::Boolean
+          name: sendPreviousResourceOnDelete
+          description: |
+            Whether to send full FHIR resource to this Pub/Sub topic for deleting FHIR resource. Note that setting this to 
+            true does not guarantee that all previous resources will be sent in the format of full FHIR resource. When a 
+            resource change is too large or during heavy traffic, only the resource name will be sent. Clients should always 
+            check the "payloadType" label from a Pub/Sub message to determine whether it needs to fetch the full previous 
+            resource as a separate operation.

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -312,8 +312,8 @@ properties:
         - !ruby/object:Api::Type::Boolean
           name: sendPreviousResourceOnDelete
           description: |
-            Whether to send full FHIR resource to this Pub/Sub topic for deleting FHIR resource. Note that setting this to 
-            true does not guarantee that all previous resources will be sent in the format of full FHIR resource. When a 
-            resource change is too large or during heavy traffic, only the resource name will be sent. Clients should always 
-            check the "payloadType" label from a Pub/Sub message to determine whether it needs to fetch the full previous 
+            Whether to send full FHIR resource to this Pub/Sub topic for deleting FHIR resource. Note that setting this to
+            true does not guarantee that all previous resources will be sent in the format of full FHIR resource. When a
+            resource change is too large or during heavy traffic, only the resource name will be sent. Clients should always
+            check the "payloadType" label from a Pub/Sub message to determine whether it needs to fetch the full previous
             resource as a separate operation.

--- a/mmv1/templates/terraform/examples/healthcare_fhir_store_notification_configs.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_fhir_store_notification_configs.tf.erb
@@ -14,8 +14,9 @@ resource "google_healthcare_fhir_store" "default" {
   }
 
   notification_configs {
-    pubsub_topic       = "${google_pubsub_topic.topic.id}"
-    send_full_resource = true
+    pubsub_topic                     = "${google_pubsub_topic.topic.id}"
+    send_full_resource               = true
+    send_previous_resource_on_delete = true
   }
 }
 

--- a/mmv1/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -152,6 +153,14 @@ resource "google_healthcare_fhir_store" "default" {
     pubsub_topic = google_pubsub_topic.topic.id
   }
 
+<% unless version == "ga" -%>
+  notification_configs {
+	pubsub_topic                     = google_pubsub_topic.topic.id
+	send_full_resource               = true
+	send_previous_resource_on_delete = true
+  }
+
+<% end -%>
   labels = {
     label1 = "labelvalue1"
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15349.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added `send_previous_resource_on_delete` field to `notification_configs` of `google_healthcare_fhir_store`
```
