### PR TITLE
Don't run VCR tests if there is a build failure

### DIFF
--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -97,8 +97,11 @@ export GOOGLE_TEST_DIRECTORY=$(go list ./... | grep -v github.com/hashicorp/terr
 echo "checking terraform version"
 terraform version
 
-go build ./...
-add_comment "build status: $?"
+go build $GOOGLE_TEST_DIRECTORY
+if [ $? != 0 ]; then
+  echo "Skipping tests: Build failure detected"
+  exit 1
+fi
 TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $GOOGLE_TEST_DIRECTORY -parallel $ACCTEST_PARALLELISM -v -run=TestAcc -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" > replaying_test.log
 
 test_exit_code=$?

--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -97,7 +97,8 @@ export GOOGLE_TEST_DIRECTORY=$(go list ./... | grep -v github.com/hashicorp/terr
 echo "checking terraform version"
 terraform version
 
-
+go build ./...
+add_comment "build status: $?"
 TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $GOOGLE_TEST_DIRECTORY -parallel $ACCTEST_PARALLELISM -v -run=TestAcc -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" > replaying_test.log
 
 test_exit_code=$?

--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -52,8 +52,6 @@ function update_status {
     -d "$post_body"
 }
 
-update_status "pending"
-
 # for backwards-compatibility
 if [ -z "$BASE_BRANCH" ]; then
   BASE_BRANCH=main
@@ -102,6 +100,9 @@ if [ $? != 0 ]; then
   echo "Skipping tests: Build failure detected"
   exit 1
 fi
+
+update_status "pending"
+
 TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $GOOGLE_TEST_DIRECTORY -parallel $ACCTEST_PARALLELISM -v -run=TestAcc -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" > replaying_test.log
 
 test_exit_code=$?


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/14657


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
