### PR TITLE
feat: add the new resource: google_dataform_repository_release_config

### DIFF
--- a/mmv1/products/dataform/ReleaseConfig.yaml
+++ b/mmv1/products/dataform/ReleaseConfig.yaml
@@ -107,7 +107,7 @@ properties:
         name: 'tablePrefix'
         description: Optional. The prefix that should be prepended to all table names.
   - !ruby/object:Api::Type::Array
-    name: status
+    name: 'recentScheduledReleaseRecords'
     description:
       Records of the 10 most recent scheduled release attempts, 
       ordered in in descending order of releaseTime. 

--- a/mmv1/products/dataform/ReleaseConfig.yaml
+++ b/mmv1/products/dataform/ReleaseConfig.yaml
@@ -1,0 +1,145 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: RepositoryReleaseConfig
+base_url: projects/{{project}}/locations/{{region}}/repositories/{{repository}}/releaseConfigs
+create_url: projects/{{project}}/locations/{{region}}/repositories/{{repository}}/releaseConfigs?releaseConfigId={{name}}
+create_verb: :POST
+update_verb: :PATCH
+min_version: beta
+description: |-
+  A resource represents a Dataform release configuration
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/dataform/docs/release-configurations'
+  api: 'https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories.releaseConfigs'
+id_format: projects/{{project}}/locations/{{region}}/repositories/{{repository}}/releaseConfigs/{{name}}
+import_format:
+  ['projects/{{project}}/locations/{{region}}/repositories/{{repository}}/releaseConfigs/{{name}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataform_repository_release_config'
+    primary_resource_id: release
+    min_version: beta
+    vars:
+      release_name: 'my_release'
+      git_repository_name: 'my/repository'
+      dataform_repository_name: 'dataform_repository'
+      data: secret-data
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'region'
+    description: 'A reference to the region'
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'repository'
+    description: 'A reference to the Dataform repository'
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: The release's name.
+    immutable: true
+    required: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+  - !ruby/object:Api::Type::String
+    name: 'gitCommitish'
+    required: true
+    description:
+      Git commit/tag/branch name at which the repository should be compiled. 
+      Must exist in the remote repository.
+  - !ruby/object:Api::Type::String
+    name: 'cronSchedule'
+    description:
+      Optional. Optional schedule (in cron format) for automatic creation of compilation results.
+  - !ruby/object:Api::Type::String
+    name: 'timeZone'
+    description:
+      Optional. Specifies the time zone to be used when interpreting cronSchedule. 
+      Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). 
+      If left unspecified, the default is UTC.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'codeCompilationConfig'
+    description:
+      Optional. If set, fields of codeCompilationConfig override the default compilation 
+      settings that are specified in dataform.json.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'defaultDatabase'
+        description: Optional. The default database (Google Cloud project ID).
+      - !ruby/object:Api::Type::String
+        name: 'defaultSchema'
+        description: Optional. The default schema (BigQuery dataset ID).
+      - !ruby/object:Api::Type::String
+        name: 'defaultLocation'
+        description: |-
+          Optional. The default BigQuery location to use. Defaults to "US". 
+          See the BigQuery docs for a full list of locations: https://cloud.google.com/bigquery/docs/locations.
+      - !ruby/object:Api::Type::String
+        name: 'assertionSchema'
+        description: Optional. The default schema (BigQuery dataset ID) for assertions.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'vars'
+        description: |-
+          Optional. User-defined variables that are made available to project code during compilation.
+          An object containing a list of "key": value pairs. 
+          Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+      - !ruby/object:Api::Type::String
+        name: 'databaseSuffix'
+        description: Optional. The suffix that should be appended to all database (Google Cloud project ID) names.
+      - !ruby/object:Api::Type::String
+        name: 'schemaSuffix'
+        description: Optional. The suffix that should be appended to all schema (BigQuery dataset ID) names.
+      - !ruby/object:Api::Type::String
+        name: 'tablePrefix'
+        description: Optional. The prefix that should be prepended to all table names.
+  - !ruby/object:Api::Type::Array
+    name: status
+    description:
+      Records of the 10 most recent scheduled release attempts, 
+      ordered in in descending order of releaseTime. 
+      Updated whenever automatic creation of a compilation result is triggered by cronSchedule.
+    output: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'releaseTime'
+          output: true
+          description: The timestamp of this release attempt.
+        - !ruby/object:Api::Type::String
+          name: 'compilationResult'
+          output: true
+          description:
+            The name of the created compilation result, if one was successfully created. 
+            Must be in the format projects/*/locations/*/repositories/*/compilationResults/*.
+        - !ruby/object:Api::Type::NestedObject
+          name: 'errorStatus'
+          output: true
+          description:
+            The error status encountered upon this attempt to create the compilation 
+            result, if the attempt was unsuccessful.
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'code'
+              output: true
+              description: The status code, which should be an enum value of google.rpc.Code.
+            - !ruby/object:Api::Type::String
+              name: 'message'
+              output: true
+              description:
+                A developer-facing error message, which should be in English. 
+                Any user-facing error message should be localized and sent in 
+                the google.rpc.Status.details field, or localized by the client.

--- a/mmv1/products/dataform/ReleaseConfig.yaml
+++ b/mmv1/products/dataform/ReleaseConfig.yaml
@@ -59,7 +59,7 @@ properties:
     name: 'gitCommitish'
     required: true
     description:
-      Git commit/tag/branch name at which the repository should be compiled. 
+      Git commit/tag/branch name at which the repository should be compiled.
       Must exist in the remote repository.
   - !ruby/object:Api::Type::String
     name: 'cronSchedule'
@@ -68,13 +68,13 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'timeZone'
     description:
-      Optional. Specifies the time zone to be used when interpreting cronSchedule. 
-      Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). 
+      Optional. Specifies the time zone to be used when interpreting cronSchedule.
+      Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
       If left unspecified, the default is UTC.
   - !ruby/object:Api::Type::NestedObject
     name: 'codeCompilationConfig'
     description:
-      Optional. If set, fields of codeCompilationConfig override the default compilation 
+      Optional. If set, fields of codeCompilationConfig override the default compilation
       settings that are specified in dataform.json.
     properties:
       - !ruby/object:Api::Type::String
@@ -86,7 +86,7 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'defaultLocation'
         description: |-
-          Optional. The default BigQuery location to use. Defaults to "US". 
+          Optional. The default BigQuery location to use. Defaults to "US".
           See the BigQuery docs for a full list of locations: https://cloud.google.com/bigquery/docs/locations.
       - !ruby/object:Api::Type::String
         name: 'assertionSchema'
@@ -95,7 +95,7 @@ properties:
         name: 'vars'
         description: |-
           Optional. User-defined variables that are made available to project code during compilation.
-          An object containing a list of "key": value pairs. 
+          An object containing a list of "key": value pairs.
           Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
       - !ruby/object:Api::Type::String
         name: 'databaseSuffix'
@@ -109,8 +109,8 @@ properties:
   - !ruby/object:Api::Type::Array
     name: 'recentScheduledReleaseRecords'
     description:
-      Records of the 10 most recent scheduled release attempts, 
-      ordered in in descending order of releaseTime. 
+      Records of the 10 most recent scheduled release attempts,
+      ordered in in descending order of releaseTime.
       Updated whenever automatic creation of a compilation result is triggered by cronSchedule.
     output: true
     item_type: !ruby/object:Api::Type::NestedObject
@@ -123,13 +123,13 @@ properties:
           name: 'compilationResult'
           output: true
           description:
-            The name of the created compilation result, if one was successfully created. 
+            The name of the created compilation result, if one was successfully created.
             Must be in the format projects/*/locations/*/repositories/*/compilationResults/*.
         - !ruby/object:Api::Type::NestedObject
           name: 'errorStatus'
           output: true
           description:
-            The error status encountered upon this attempt to create the compilation 
+            The error status encountered upon this attempt to create the compilation
             result, if the attempt was unsuccessful.
           properties:
             - !ruby/object:Api::Type::Integer
@@ -140,6 +140,6 @@ properties:
               name: 'message'
               output: true
               description:
-                A developer-facing error message, which should be in English. 
-                Any user-facing error message should be localized and sent in 
+                A developer-facing error message, which should be in English.
+                Any user-facing error message should be localized and sent in
                 the google.rpc.Status.details field, or localized by the client.

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
@@ -1,0 +1,64 @@
+resource "google_sourcerepo_repository" "git_repository" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['git_repository_name'] %>"
+}
+
+resource "google_secret_manager_secret" "secret" {
+  provider  = google-beta
+  secret_id = "secret"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  provider = google-beta
+  secret   = google_secret_manager_secret.secret.id
+
+  secret_data = "<%= ctx[:vars]['data'] %>"
+}
+
+resource "google_dataform_repository" "repository" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['dataform_repository_name'] %>"
+  region   = "us-central1"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
+}
+
+resource "google_dataform_repository_release_config" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  project    = google_dataform_repository.repository.project
+  region     = google_dataform_repository.repository.region
+  repository = google_dataform_repository.repository.name
+
+  name          = "<%= ctx[:vars]['release_name'] %>"
+  git_commitish = "main"
+  cron_schedule = "0 7 * * *"
+  time_zone     = "America/New_York"
+
+  code_compilation_config {
+    default_database = "gcp-example-project"
+    default_schema   = "example-dataset"
+    default_location = "us-central1"
+    assertion_schema = "example-assertion-dataset"
+    database_suffix  = ""
+    schema_suffix    = ""
+    table_prefix     = ""
+    vars = {
+      var1 = "value"
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fix https://github.com/hashicorp/terraform-provider-google/issues/15308

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_dataform_repository_release_config (beta)
```
