### PR TITLE
Added Cloud Storage as a PubSub subscription

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -65,6 +65,13 @@ examples:
       subscription_name: 'example-subscription'
       dataset_id: 'example_dataset'
       table_id: 'example_table'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'pubsub_subscription_push_cloudstorage'
+    primary_resource_id: 'example'
+    vars:
+      topic_name: 'example-topic'
+      subscription_name: 'example-subscription'
+      bucket_name: 'example-bucket'
 docs: !ruby/object:Provider::Terraform::Docs
   note: |
     You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding
@@ -101,10 +108,11 @@ properties:
     name: 'bigqueryConfig'
     conflicts:
       - push_config
+      - cloud_storage_config
     description: |
       If delivery to BigQuery is used with this subscription, this field is used to configure it.
-      Either pushConfig or bigQueryConfig can be set, but not both.
-      If both are empty, then the subscriber will pull and ack messages using API methods.
+      Either pushConfig, bigQueryConfig or cloudStorageConfig can be set, but not combined.
+      If all three are empty, then the subscriber will pull and ack messages using API methods.
     properties:
       - !ruby/object:Api::Type::String
         name: 'table'
@@ -126,9 +134,63 @@ properties:
           When true and useTopicSchema is true, any fields that are a part of the topic schema that are not part of the BigQuery table schema are dropped when writing to BigQuery.
           Otherwise, the schemas must be kept in sync and any messages with extra fields are not written and remain in the subscription's backlog.
   - !ruby/object:Api::Type::NestedObject
+    name: 'cloudStorageConfig'
+    conflicts:
+      - push_config
+      - bigquery_config
+    description: |
+      If delivery to Cloud Storage is used with this subscription, this field is used to configure it.
+      Either pushConfig, bigQueryConfig or cloudStorageConfig can be set, but not combined.
+      If all three are empty, then the subscriber will pull and ack messages using API methods.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'bucket'
+        description: |
+          User-provided name for the Cloud Storage bucket. The bucket must be created by the user. The bucket name must be without any prefix like "gs://".
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'filenamePrefix'
+        description: |
+          User-provided prefix for Cloud Storage filename.
+      - !ruby/object:Api::Type::String
+        name: 'filenameSuffix'
+        description: |
+          User-provided suffix for Cloud Storage filename. Must not end in "/".
+      - !ruby/object:Api::Type::String
+        name: 'maxDuration'
+        description: |
+          The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. 
+          May not exceed the subscription's acknowledgement deadline.
+          A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+        default_value: '300s'
+      - !ruby/object:Api::Type::Integer
+        name: 'maxBytes'
+        description: |
+          The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. 
+          The maxBytes limit may be exceeded in cases where messages are larger than the limit.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          An output-only field that indicates whether or not the subscription can receive messages.
+        output: true
+        values:
+          - :ACTIVE
+          - :PERMISSION_DENIED
+          - :NOT_FOUND
+      - !ruby/object:Api::Type::NestedObject
+        name: 'avroConfig'
+        description: |
+          If set, message data will be written to Cloud Storage in Avro format.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'writeMetadata'
+            description: |
+              When true, write the subscription name, messageId, publishTime, attributes, and orderingKey as additional fields in the output.
+  - !ruby/object:Api::Type::NestedObject
     name: 'pushConfig'
     conflicts:
       - bigquery_config
+      - cloud_storage_config
     description: |
       If push delivery is used with this subscription, this field is used to
       configure it. An empty pushConfig signifies that the subscriber will

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -178,6 +178,16 @@ properties:
           - :PERMISSION_DENIED
           - :NOT_FOUND
       - !ruby/object:Api::Type::NestedObject
+        name: 'textConfig'
+        description: |
+          If set, message data will be written to Cloud Storage in text format.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'writeMetadata'
+            description: |
+              Message payloads will be written to files as raw text, seperated by a newline.
+            default_from_api: true
+      - !ruby/object:Api::Type::NestedObject
         name: 'avroConfig'
         description: |
           If set, message data will be written to Cloud Storage in Avro format.

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -166,14 +166,14 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'maxDuration'
         description: |
-          The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. 
+          The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes.
           May not exceed the subscription's acknowledgement deadline.
           A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
         default_value: '300s'
       - !ruby/object:Api::Type::Integer
         name: 'maxBytes'
         description: |
-          The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. 
+          The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB.
           The maxBytes limit may be exceeded in cases where messages are larger than the limit.
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(1000, 10737418240)'

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -72,6 +72,13 @@ examples:
       topic_name: 'example-topic'
       subscription_name: 'example-subscription'
       bucket_name: 'example-bucket'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'pubsub_subscription_push_cloudstorage_avro'
+    primary_resource_id: 'example'
+    vars:
+      topic_name: 'example-topic'
+      subscription_name: 'example-subscription'
+      bucket_name: 'example-bucket'
 docs: !ruby/object:Provider::Terraform::Docs
   note: |
     You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding
@@ -168,6 +175,8 @@ properties:
         description: |
           The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. 
           The maxBytes limit may be exceeded in cases where messages are larger than the limit.
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(1000, 10737418240)'
       - !ruby/object:Api::Type::Enum
         name: 'state'
         description: |

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -187,16 +187,6 @@ properties:
           - :PERMISSION_DENIED
           - :NOT_FOUND
       - !ruby/object:Api::Type::NestedObject
-        name: 'textConfig'
-        description: |
-          If set, message data will be written to Cloud Storage in text format.
-        properties:
-          - !ruby/object:Api::Type::Boolean
-            name: 'writeMetadata'
-            description: |
-              Message payloads will be written to files as raw text, seperated by a newline.
-            default_from_api: true
-      - !ruby/object:Api::Type::NestedObject
         name: 'avroConfig'
         description: |
           If set, message data will be written to Cloud Storage in Avro format.

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
@@ -1,0 +1,34 @@
+resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['bucket_name'] %>"
+  location = "us-central1"
+}
+
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['subscription_name'] %>"
+  topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.name
+
+  cloud_storage_config {
+    bucket = "<%= ctx[:vars]['bucket_name'] %>"
+  }
+
+  depends_on = [google_storage_bucket.<%= ctx[:primary_resource_id] %>]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_storage_bucket_iam_member" "viewer" {
+  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_storage_bucket_iam_member" "editor" {
+  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
@@ -23,29 +23,15 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
   }
   depends_on = [ 
     google_storage_bucket.<%= ctx[:primary_resource_id] %>,
-    google_storage_bucket_iam_member.reader,
-    google_storage_bucket_iam_member.viewer,
-    google_storage_bucket_iam_member.creator,
+    google_storage_bucket_iam_member.admin,
   ]
 }
 
 data "google_project" "project" {
 }
 
-resource "google_storage_bucket_iam_member" "reader" {
+resource "google_storage_bucket_iam_member" "admin" {
   bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-
-resource "google_storage_bucket_iam_member" "viewer" {
-  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-
-resource "google_storage_bucket_iam_member" "creator" {
-  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
-  role   = "roles/storage.objectCreator"
+  role   = "roles/storage.admin"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
@@ -1,6 +1,7 @@
 resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
   name  = "<%= ctx[:vars]['bucket_name'] %>"
-  location = "us-central1"
+  location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
@@ -18,24 +19,32 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
     filename_suffix = "-%{random_suffix}"
   
     max_bytes = 1000
+    max_duration = "300s"
   }
-
-  depends_on = [
-    google_storage_bucket_iam_member.viewer, 
-    google_storage_bucket_iam_member.editor
+  depends_on = [ 
+    google_storage_bucket.<%= ctx[:primary_resource_id] %>,
+    google_storage_bucket_iam_member.reader,
+    google_storage_bucket_iam_member.viewer,
+    google_storage_bucket_iam_member.creator,
   ]
 }
 
 data "google_project" "project" {
 }
 
-resource "google_storage_bucket_iam_member" "viewer" {
+resource "google_storage_bucket_iam_member" "reader" {
   bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
   role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
-resource "google_storage_bucket_iam_member" "editor" {
+resource "google_storage_bucket_iam_member" "viewer" {
+  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_storage_bucket_iam_member" "creator" {
   bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
   role   = "roles/storage.objectCreator"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
@@ -1,6 +1,7 @@
 resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
   name  = "<%= ctx[:vars]['bucket_name'] %>"
-  location = "us-central1"
+  location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
@@ -18,28 +19,36 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
     filename_suffix = "-%{random_suffix}"
   
     max_bytes = 1000
+    max_duration = "300s"
   
     avro_config {
       write_metadata = true
     }
   }
-
-  depends_on = [
-    google_storage_bucket_iam_member.viewer, 
-    google_storage_bucket_iam_member.editor
+  depends_on = [ 
+    google_storage_bucket.<%= ctx[:primary_resource_id] %>,
+    google_storage_bucket_iam_member.reader,
+    google_storage_bucket_iam_member.viewer,
+    google_storage_bucket_iam_member.creator,
   ]
 }
 
 data "google_project" "project" {
 }
 
-resource "google_storage_bucket_iam_member" "viewer" {
+resource "google_storage_bucket_iam_member" "reader" {
   bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
   role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
-resource "google_storage_bucket_iam_member" "editor" {
+resource "google_storage_bucket_iam_member" "viewer" {
+  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_storage_bucket_iam_member" "creator" {
   bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
   role   = "roles/storage.objectCreator"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
@@ -18,6 +18,10 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
     filename_suffix = "-%{random_suffix}"
   
     max_bytes = 1000
+  
+    avro_config {
+      write_metadata = true
+    }
   }
 
   depends_on = [

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
@@ -27,29 +27,15 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
   }
   depends_on = [ 
     google_storage_bucket.<%= ctx[:primary_resource_id] %>,
-    google_storage_bucket_iam_member.reader,
-    google_storage_bucket_iam_member.viewer,
-    google_storage_bucket_iam_member.creator,
+    google_storage_bucket_iam_member.admin,
   ]
 }
 
 data "google_project" "project" {
 }
 
-resource "google_storage_bucket_iam_member" "reader" {
+resource "google_storage_bucket_iam_member" "admin" {
   bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-
-resource "google_storage_bucket_iam_member" "viewer" {
-  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-
-resource "google_storage_bucket_iam_member" "creator" {
-  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
-  role   = "roles/storage.objectCreator"
+  role   = "roles/storage.admin"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: added `CloudStorageConfig` field to `google_pubsub_subscription` resource
```

Closes: https://github.com/hashicorp/terraform-provider-google/issues/15352
