### PR TITLE
Add ignore read on reservedIpRange field Filestore Instance 

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -216,7 +216,6 @@ properties:
           # When using connectMode=PRIVATE_SERVICE_ACCESS, the returned value
           # won't match the sent value as the returned value is an IP range
           # from the provided named range.
-          ignore_read: true
           custom_flatten: templates/terraform/custom_flatten/filestore_instance_networks_reserved_ip_range.go.erb
         - !ruby/object:Api::Type::Array
           name: 'ipAddresses'

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -213,6 +213,10 @@ properties:
             A /29 CIDR block that identifies the range of IP
             addresses reserved for this instance.
           default_from_api: true
+          # When using connectMode=PRIVATE_SERVICE_ACCESS, the returned value
+          # won't match the sent value as the returned value is an IP range
+          # from the provided named range.
+          ignore_read: true
         - !ruby/object:Api::Type::Array
           name: 'ipAddresses'
           description: |

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -217,6 +217,7 @@ properties:
           # won't match the sent value as the returned value is an IP range
           # from the provided named range.
           ignore_read: true
+          custom_flatten: templates/terraform/custom_flatten/filestore_instance_networks_reserved_ip_range.go.erb
         - !ruby/object:Api::Type::Array
           name: 'ipAddresses'
           description: |

--- a/mmv1/templates/terraform/custom_flatten/filestore_instance_networks_reserved_ip_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/filestore_instance_networks_reserved_ip_range.go.erb
@@ -1,0 +1,17 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2018 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("networks.0.reserved_ip_range")
+}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -134,7 +134,7 @@ func TestAccFilestoreInstance_reservedIpRange_update(t *testing.T) {
 				ResourceName:            "google_filestore_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone", "location", "reserved_ip_range"},
+				ImportStateVerifyIgnore: []string{"zone", "location", "networks.0.reserved_ip_range"},
 			},
 			{
 				Config: testAccFilestoreInstance_reservedIpRange_update2(name),
@@ -143,7 +143,7 @@ func TestAccFilestoreInstance_reservedIpRange_update(t *testing.T) {
 				ResourceName:            "google_filestore_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone", "location", "reserved_ip_range"},
+				ImportStateVerifyIgnore: []string{"zone", "location", "networks.0.reserved_ip_range"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -134,7 +134,7 @@ func TestAccFilestoreInstance_reservedIpRange_update(t *testing.T) {
 				ResourceName:            "google_filestore_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone", "location"},
+				ImportStateVerifyIgnore: []string{"zone", "location", "reserved_ip_range"},
 			},
 			{
 				Config: testAccFilestoreInstance_reservedIpRange_update2(name),
@@ -143,7 +143,7 @@ func TestAccFilestoreInstance_reservedIpRange_update(t *testing.T) {
 				ResourceName:            "google_filestore_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone", "location"},
+				ImportStateVerifyIgnore: []string{"zone", "location", "reserved_ip_range"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
When using connectMode=PRIVATE_SERVICE_ACCESS, the returned value won't match the sent value as the returned value is an IP range from the provided named range.

It should be safe to ignore read on this field as it is immutable after instance creation.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12877
b/257089398


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
filestore: fixed a bug causing premadiff on `reserved_ip_range` field in `google_filestore_instance`
```
