### PR TITLE
add scaling_config to google_dataproc_metastore_service resource in google

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -184,6 +184,33 @@ properties:
       - :DEVELOPER
       - :ENTERPRISE
     default_from_api: true
+    conflicts:
+      - scalingConfig
+
+  - !ruby/object:Api::Type::NestedObject
+    name: 'scalingConfig'
+    description: |
+      Represents the scaling configuration of a metastore service.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'instanceSize'
+        description: |
+          Metastore instance sizes.
+        required: false
+        conflicts:
+          - tier
+        values:
+          - :INSTANCE_SIZE_UNSPECIFIED
+          - :EXTRA_SMALL
+          - :SMALL
+          - :MEDIUM
+          - :LARGE
+          - :EXTRA_LARGE
+      - !ruby/object:Api::Type::Integer
+        name: 'scalingFactor'
+        description: |
+          Scaling factor, in increments of 0.1 for values less than 1.0, and increments of 1.0 for values greater than 1.0.
+        required: false
   - !ruby/object:Api::Type::NestedObject
     name: 'maintenanceWindow'
     description: |

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -115,6 +115,11 @@ examples:
     primary_resource_id: 'telemetry'
     vars:
       metastore_service_name: 'telemetry'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_dpms2'
+    primary_resource_id: 'dpms2'
+    vars:
+      metastore_service_name: 'dpms2'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'serviceId'

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -205,7 +205,6 @@ properties:
         conflicts:
           - tier
         values:
-          - :INSTANCE_SIZE_UNSPECIFIED
           - :EXTRA_SMALL
           - :SMALL
           - :MEDIUM

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -120,6 +120,17 @@ examples:
     primary_resource_id: 'dpms2'
     vars:
       metastore_service_name: 'dpms2'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_dpms2_scaling_factor'
+    primary_resource_id: 'dpms2_scaling_factor'
+    vars:
+      metastore_service_name: 'dpms2sf'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_dpms2_scaling_factor_lt1'
+    skip_docs: true
+    primary_resource_id: 'dpms2_scaling_factor_lt1'
+    vars:
+      metastore_service_name: 'dpms2sflt1'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'serviceId'
@@ -210,7 +221,7 @@ properties:
           - :MEDIUM
           - :LARGE
           - :EXTRA_LARGE
-      - !ruby/object:Api::Type::Integer
+      - !ruby/object:Api::Type::Double
         name: 'scalingFactor'
         description: |
           Scaling factor, in increments of 0.1 for values less than 1.0, and increments of 1.0 for values greater than 1.0.

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -213,6 +213,9 @@ properties:
         description: |
           Metastore instance sizes.
         required: false
+        exactly_one_of:
+          - scaling_config.0.instance_size
+          - scaling_config.0.scaling_factor
         conflicts:
           - tier
         values:

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2.tf.erb
@@ -1,6 +1,5 @@
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
-  provider   = google-beta
   location   = "us-central1"
 
   # DPMS 2 requires SPANNER database type, and does not require
@@ -9,10 +8,6 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
 
   hive_metastore_config {
     version           = "3.1.2"
-    endpoint_protocol = "GRPC"
-    config_overrides = {
-      endpoint_protocol              = "GRPC"
-    }
   }
 
   scaling_config {

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2.tf.erb
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  provider   = google-beta
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+    endpoint_protocol = "GRPC"
+    config_overrides = {
+      endpoint_protocol              = "GRPC"
+    }
+  }
+
+  scaling_config {
+    instance_size = "EXTRA_SMALL"
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor.tf.erb
@@ -1,6 +1,5 @@
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
-  provider   = google-beta
   location   = "us-central1"
 
   # DPMS 2 requires SPANNER database type, and does not require
@@ -9,10 +8,6 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
 
   hive_metastore_config {
     version           = "3.1.2"
-    endpoint_protocol = "GRPC"
-    config_overrides = {
-      endpoint_protocol              = "GRPC"
-    }
   }
 
   scaling_config {

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor.tf.erb
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  provider   = google-beta
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+    endpoint_protocol = "GRPC"
+    config_overrides = {
+      endpoint_protocol              = "GRPC"
+    }
+  }
+
+  scaling_config {
+    scaling_factor = "2"
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor_lt1.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor_lt1.tf.erb
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  provider   = google-beta
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+    endpoint_protocol = "GRPC"
+    config_overrides = {
+      endpoint_protocol              = "GRPC"
+    }
+  }
+
+  scaling_config {
+    scaling_factor = "1.1"
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor_lt1.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_dpms2_scaling_factor_lt1.tf.erb
@@ -1,6 +1,5 @@
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
-  provider   = google-beta
   location   = "us-central1"
 
   # DPMS 2 requires SPANNER database type, and does not require
@@ -9,13 +8,9 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
 
   hive_metastore_config {
     version           = "3.1.2"
-    endpoint_protocol = "GRPC"
-    config_overrides = {
-      endpoint_protocol              = "GRPC"
-    }
   }
 
   scaling_config {
-    scaling_factor = "1.1"
+    scaling_factor = "0.1"
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds the `scaling_config` field to the `google_dataproc_metastore_service` beta resource. This PR fixes [15342](https://github.com/hashicorp/terraform-provider-google/issues/15342)

The `scaling_config` field enables the user to create a [DPMS2](https://cloud.google.com/dataproc-metastore/docs/core-concepts#versioning-2) service using Terraform.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataproc_metastore: added `scaling_config` field to `google_dataproc_metastore_service` resource
```