### PR TITLE
Add disk.provisioned_iops to compute_instance_template

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -1338,6 +1338,7 @@ type diskCharacteristics struct {
 	diskSizeGb  string
 	autoDelete  bool
 	sourceImage string
+	provisionedIops string
 }
 
 func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
@@ -1366,6 +1367,13 @@ func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
 	if v := m["source_image"]; v != nil {
 		dc.sourceImage = v.(string)
 	}
+
+	if v := m["provisioned_iops"]; v != nil {
+		// Terraform and GCP return ints as different types (int vs int64), so just
+		// use strings to compare for simplicity.
+		dc.provisionedIops = fmt.Sprintf("%v", v)
+	}
+
 	return dc
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -169,6 +169,14 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Description: `A set of key/value label pairs to assign to disks,`,
 						},
 
+						"provisioned_iops": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
+						},
+
 						"source_image": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1102,7 +1110,7 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 		}
 		if v, ok := d.GetOk(prefix + ".source"); ok {
 			disk.Source = v.(string)
-			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "source_image", "source_snapshot", "labels"}
+			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "provisioned_iops", "source_image", "source_snapshot", "labels"}
 			for _, conflict := range conflicts {
 				if _, ok := d.GetOk(prefix + "." + conflict); ok {
 					return nil, fmt.Errorf("Cannot use `source` with any of the fields in %s", conflicts)
@@ -1121,6 +1129,9 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 			disk.InitializeParams.DiskType = "pd-standard"
 			if v, ok := d.GetOk(prefix + ".disk_type"); ok {
 				disk.InitializeParams.DiskType = v.(string)
+			}
+			if v, ok := d.GetOk(prefix + ".provisioned_iops"); ok {
+				disk.InitializeParams.ProvisionedIops = int64(v.(int))
 			}
 
 			disk.InitializeParams.Labels = tpgresource.ExpandStringMap(d, prefix+".labels")
@@ -1378,6 +1389,7 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 			diskMap["source_image"] = ""
 		}
 		diskMap["disk_type"] = disk.InitializeParams.DiskType
+		diskMap["provisioned_iops"] = disk.InitializeParams.ProvisionedIops
 		diskMap["disk_name"] = disk.InitializeParams.DiskName
 		diskMap["labels"] = disk.InitializeParams.Labels
 		// The API does not return a disk size value for scratch disks. They are largely only one size,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -336,6 +336,26 @@ func TestAccComputeInstanceTemplate_regionDisks(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_diskIops(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_diskIops(acctest.RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -2225,6 +2245,35 @@ resource "google_compute_instance_template" "foobar" {
   }
 }
 `, suffix, suffix)
+}
+
+func testAccComputeInstanceTemplate_diskIops(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete      = true
+    disk_size_gb     = 100
+    boot             = true
+    provisioned_iops = 10000
+    labels = {
+      foo = "bar"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, suffix)
 }
 
 func testAccComputeInstanceTemplate_subnet_auto(network, suffix string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -149,6 +149,14 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 							Description: `A set of key/value label pairs to assign to disks,`,
 						},
 
+						"provisioned_iops": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
+						},
+
 						"source_image": {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -280,6 +280,26 @@ func TestAccComputeRegionInstanceTemplate_regionDisks(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionInstanceTemplate_diskIops(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_diskIops(acctest.RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeRegionInstanceTemplate_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -2076,6 +2096,33 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 }
 `, suffix, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_diskIops(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete      = true
+    disk_size_gb     = 100
+    boot             = true
+    provisioned_iops = 10000
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, suffix)
 }
 
 func testAccComputeRegionInstanceTemplate_subnet_auto(network, suffix string) string {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14858

This allows `provisioned_iops` to be set on a disk directly within a `compute_instance_template`, instead of needing to specify it on a separate disk resource.

Since they reuse the same functions, I also updated `compute_region_instance_template` to include this field, which seems like an appropriate change anyway.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `disk.provisioned_iops` to `google_compute_instance_template`
```

```release-note:enhancement
compute: added `disk.provisioned_iops` to `google_compute_region_instance_template`
```
