### PR TITLE
Add the latest changes in Datascan API

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -557,6 +557,19 @@ properties:
                   name: 'threshold'
                   description: |
                     The minimum ratio of passing_rows / total_rows required to pass this rule, with a range of [0.0, 1.0]. 0 indicates default value (i.e. 1.0).
+                - !ruby/object:Api::Type::String
+                  name: 'name'
+                  description: |
+                    A mutable name for the rule.
+                    The name must contain only letters (a-z, A-Z), numbers (0-9), or hyphens (-).
+                    The maximum length is 63 characters.
+                    Must start with a letter.
+                    Must end with a number or a letter.
+                - !ruby/object:Api::Type::String
+                  name: 'description'
+                  description: |
+                    Description of the rule.
+                    The maximum length is 1,024 characters.
                 - !ruby/object:Api::Type::NestedObject
                   name: 'rangeExpectation'
                   output: true

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -254,6 +254,22 @@ properties:
         name: 'rowFilter'
         description: |
           A filter applied to all rows in a single DataScan job. The filter needs to be a valid SQL expression for a WHERE clause in BigQuery standard SQL syntax. Example: col1 >= 0 AND col2 < 10
+      - !ruby/object:Api::Type::NestedObject
+        name: 'postScanActions'
+        description: |
+          Actions to take upon job completion.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'bigQueryExport'
+            description: |
+              If set, results will be exported to the provided BigQuery table.
+            properties:
+              - !ruby/object:Api::Type::String
+              name: 'resultsTable'
+              description: |
+                The BigQuery table to export DataQualityScan results to.
+                Format:
+                projects/{project}/datasets/{dataset}/tables/{table}
       - !ruby/object:Api::Type::Array
         name: 'rules'
         min_size: 1
@@ -278,6 +294,19 @@ properties:
               name: 'threshold'
               description: |
                 The minimum ratio of passing_rows / total_rows required to pass this rule, with a range of [0.0, 1.0]. 0 indicates default value (i.e. 1.0).
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                A mutable name for the rule.
+                The name must contain only letters (a-z, A-Z), numbers (0-9), or hyphens (-).
+                The maximum length is 63 characters.
+                Must start with a letter.
+                Must end with a number or a letter.
+            - !ruby/object:Api::Type::String
+              name: 'description'
+              description: |
+                Description of the rule.
+                The maximum length is 1,024 characters.
             - !ruby/object:Api::Type::NestedObject
               name: 'rangeExpectation'
               description: |
@@ -413,6 +442,48 @@ properties:
         name: 'rowFilter'
         description: |
           A filter applied to all rows in a single DataScan job. The filter needs to be a valid SQL expression for a WHERE clause in BigQuery standard SQL syntax. Example: col1 >= 0 AND col2 < 10
+      - !ruby/object:Api::Type::NestedObject
+        name: 'postScanActions'
+        description: |
+          Actions to take upon job completion.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'bigQueryExport'
+            description: |
+              If set, results will be exported to the provided BigQuery table.
+            properties:
+              - !ruby/object:Api::Type::String
+              name: 'resultsTable'
+              description: |
+                The BigQuery table to export DataProfileScan results to.
+                Format:
+                projects/{project}/datasets/{dataset}/tables/{table}
+      - !ruby/object:Api::Type::NestedObject
+        name: 'includeFields'
+        description: |
+          The fields to include in data profile.
+          If not specified, all fields at the time of profile scan job execution are included, except for ones listed in `exclude_fields`.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'fieldNames'
+            description: |
+              Expected input is a list of fully qualified names of fields as in the schema.
+              Only top-level field names for nested fields are supported.
+              For instance, if 'x' is of nested field type, listing 'x' is supported but 'x.y.z' is not supported. Here 'y' and 'y.z' are nested fields of 'x'.
+            item_type: !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'excludeFields'
+        description: |
+          The fields to exclude from data profile.
+          If specified, the fields will be excluded from data profile, regardless of `include_fields` value.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'fieldNames'
+            description: |
+              Expected input is a list of fully qualified names of fields as in the schema.
+              Only top-level field names for nested fields are supported.
+              For instance, if 'x' is of nested field type, listing 'x' is supported but 'x.y.z' is not supported. Here 'y' and 'y.z' are nested fields of 'x'.
+            item_type: !ruby/object:Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'dataQualityResult'
     output: true
@@ -424,6 +495,29 @@ properties:
         output: true
         description: |
           Overall data quality result -- true if all rules passed.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'postScanActionsResult'
+        decription: |
+           The result of post scan actions.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'bigQueryExportResult'
+            description: |
+              The result of BigQuery export post scan action.
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'state'
+                decription: |
+                  Execution state for the BigQuery exporting.
+                values:
+                  - STATE_UNSPECIFIED
+                  - SUCCEEDED
+                  - FAILED
+                  - SKIPPED
+              - !ruby/object:Api::Type::String
+                name: 'message'
+                description: |
+                  Additional information about the BigQuery exporting.
       - !ruby/object:Api::Type::Array
         name: 'dimensions'
         description: |
@@ -794,3 +888,26 @@ properties:
               - !ruby/object:Api::Type::String
                 name: 'end'
                 description: Value that marks the end of the range.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'postScanActionsResult'
+        decription: |
+           The result of post scan actions.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'bigQueryExportResult'
+            description: |
+              The result of BigQuery export post scan action.
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'state'
+                decription: |
+                  Execution state for the BigQuery exporting.
+                values:
+                  - STATE_UNSPECIFIED
+                  - SUCCEEDED
+                  - FAILED
+                  - SKIPPED
+              - !ruby/object:Api::Type::String
+                name: 'message'
+                description: |
+                  Additional information about the BigQuery exporting.

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -265,11 +265,10 @@ properties:
               If set, results will be exported to the provided BigQuery table.
             properties:
               - !ruby/object:Api::Type::String
-              name: 'resultsTable'
-              description: |
-                The BigQuery table to export DataQualityScan results to.
-                Format:
-                projects/{project}/datasets/{dataset}/tables/{table}
+                name: 'resultsTable'
+                description: |
+                  The BigQuery table to export DataQualityScan results to.
+                  Format:projects/{project}/datasets/{dataset}/tables/{table}
       - !ruby/object:Api::Type::Array
         name: 'rules'
         min_size: 1
@@ -453,11 +452,10 @@ properties:
               If set, results will be exported to the provided BigQuery table.
             properties:
               - !ruby/object:Api::Type::String
-              name: 'resultsTable'
-              description: |
-                The BigQuery table to export DataProfileScan results to.
-                Format:
-                projects/{project}/datasets/{dataset}/tables/{table}
+                name: 'resultsTable'
+                description: |
+                  The BigQuery table to export DataProfileScan results to.
+                  Format:projects/{project}/datasets/{dataset}/tables/{table}
       - !ruby/object:Api::Type::NestedObject
         name: 'includeFields'
         description: |

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -262,7 +262,7 @@ properties:
           Actions to take upon job completion.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: 'bigQueryExport'
+            name: 'bigqueryExport'
             description: |
               If set, results will be exported to the provided BigQuery table.
             properties:
@@ -451,7 +451,7 @@ properties:
           Actions to take upon job completion.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: 'bigQueryExport'
+            name: 'bigqueryExport'
             description: |
               If set, results will be exported to the provided BigQuery table.
             properties:

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -250,6 +250,8 @@ properties:
         name: 'samplingPercent'
         description: |
           The percentage of the records to be selected from the dataset for DataScan.
+          Value can range between 0.0 and 100.0 with up to 3 significant decimal digits.
+          Sampling is not applied if `sampling_percent` is not specified, 0 or 100.
       - !ruby/object:Api::Type::String
         name: 'rowFilter'
         description: |
@@ -268,7 +270,7 @@ properties:
                 name: 'resultsTable'
                 description: |
                   The BigQuery table to export DataQualityScan results to.
-                  Format:projects/{project}/datasets/{dataset}/tables/{table}
+                  Format://bigquery.googleapis.com/projects/PROJECT_ID/datasets/DATASET_ID/tables/TABLE_ID
       - !ruby/object:Api::Type::Array
         name: 'rules'
         min_size: 1
@@ -364,7 +366,7 @@ properties:
               allow_empty_object: true
               send_empty_value: true
               description: |
-                ColumnAggregate rule which evaluates whether the column has duplicates.
+                Row-level rule which evaluates whether each column value is unique.
               properties: []
             - !ruby/object:Api::Type::NestedObject
               name: 'statisticRangeExpectation'
@@ -437,6 +439,8 @@ properties:
         name: 'samplingPercent'
         description: |
           The percentage of the records to be selected from the dataset for DataScan.
+          Value can range between 0.0 and 100.0 with up to 3 significant decimal digits.
+          Sampling is not applied if `sampling_percent` is not specified, 0 or 100.
       - !ruby/object:Api::Type::String
         name: 'rowFilter'
         description: |
@@ -455,7 +459,7 @@ properties:
                 name: 'resultsTable'
                 description: |
                   The BigQuery table to export DataProfileScan results to.
-                  Format:projects/{project}/datasets/{dataset}/tables/{table}
+                  Format://bigquery.googleapis.com/projects/PROJECT_ID/datasets/DATASET_ID/tables/TABLE_ID
       - !ruby/object:Api::Type::NestedObject
         name: 'includeFields'
         description: |
@@ -468,7 +472,7 @@ properties:
               Expected input is a list of fully qualified names of fields as in the schema.
               Only top-level field names for nested fields are supported.
               For instance, if 'x' is of nested field type, listing 'x' is supported but 'x.y.z' is not supported. Here 'y' and 'y.z' are nested fields of 'x'.
-            item_type: !ruby/object:Api::Type::String
+            item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'excludeFields'
         description: |
@@ -481,7 +485,7 @@ properties:
               Expected input is a list of fully qualified names of fields as in the schema.
               Only top-level field names for nested fields are supported.
               For instance, if 'x' is of nested field type, listing 'x' is supported but 'x.y.z' is not supported. Here 'y' and 'y.z' are nested fields of 'x'.
-            item_type: !ruby/object:Api::Type::String
+            item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'dataQualityResult'
     output: true
@@ -493,29 +497,6 @@ properties:
         output: true
         description: |
           Overall data quality result -- true if all rules passed.
-      - !ruby/object:Api::Type::NestedObject
-        name: 'postScanActionsResult'
-        decription: |
-           The result of post scan actions.
-        properties:
-          - !ruby/object:Api::Type::NestedObject
-            name: 'bigQueryExportResult'
-            description: |
-              The result of BigQuery export post scan action.
-            properties:
-              - !ruby/object:Api::Type::Enum
-                name: 'state'
-                decription: |
-                  Execution state for the BigQuery exporting.
-                values:
-                  - STATE_UNSPECIFIED
-                  - SUCCEEDED
-                  - FAILED
-                  - SKIPPED
-              - !ruby/object:Api::Type::String
-                name: 'message'
-                description: |
-                  Additional information about the BigQuery exporting.
       - !ruby/object:Api::Type::Array
         name: 'dimensions'
         description: |
@@ -555,19 +536,6 @@ properties:
                   name: 'threshold'
                   description: |
                     The minimum ratio of passing_rows / total_rows required to pass this rule, with a range of [0.0, 1.0]. 0 indicates default value (i.e. 1.0).
-                - !ruby/object:Api::Type::String
-                  name: 'name'
-                  description: |
-                    A mutable name for the rule.
-                    The name must contain only letters (a-z, A-Z), numbers (0-9), or hyphens (-).
-                    The maximum length is 63 characters.
-                    Must start with a letter.
-                    Must end with a number or a letter.
-                - !ruby/object:Api::Type::String
-                  name: 'description'
-                  description: |
-                    Description of the rule.
-                    The maximum length is 1,024 characters.
                 - !ruby/object:Api::Type::NestedObject
                   name: 'rangeExpectation'
                   output: true
@@ -899,26 +867,3 @@ properties:
               - !ruby/object:Api::Type::String
                 name: 'end'
                 description: Value that marks the end of the range.
-      - !ruby/object:Api::Type::NestedObject
-        name: 'postScanActionsResult'
-        decription: |
-           The result of post scan actions.
-        properties:
-          - !ruby/object:Api::Type::NestedObject
-            name: 'bigQueryExportResult'
-            description: |
-              The result of BigQuery export post scan action.
-            properties:
-              - !ruby/object:Api::Type::Enum
-                name: 'state'
-                decription: |
-                  Execution state for the BigQuery exporting.
-                values:
-                  - STATE_UNSPECIFIED
-                  - SUCCEEDED
-                  - FAILED
-                  - SKIPPED
-              - !ruby/object:Api::Type::String
-                name: 'message'
-                description: |
-                  Additional information about the BigQuery exporting.

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -23,7 +23,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {
     post_scan_actions {
       bigquery_export {
-        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/google_bigquery_dataset.source.dataset_id/tables/profile_export"
+        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex_dataset_%{random_suffix}/tables/profile_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -14,7 +14,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
 
   data_profile_spec {  
     post_scan_actions {
-      bigquery_export {
+      big_query_export {
         results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/profile_export"
       }
     }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -1,6 +1,6 @@
 resource "google_bigquery_dataset" "source" {
   count = 1
-  dataset_id                  = "dataplex-dataset-%{random_suffix}"
+  dataset_id                  = "dataplex_dataset_%{random_suffix}"
   friendly_name               = "test"
   description                 = "This is a test description"
   location                    = "US"
@@ -23,7 +23,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {
     post_scan_actions {
       bigquery_export {
-        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex-dataset-%{random_suffix}/tables/profile_export"
+        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex_dataset_%{random_suffix}/tables/profile_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -13,6 +13,11 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   }
 
   data_profile_spec {  
+    post_scan_actions {
+      bigquery_export {
+        results_table: "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/profile_export"
+      }
+    }
   }
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -14,7 +14,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
 
   data_profile_spec {  
     post_scan_actions {
-      big_query_export {
+      bigquery_export {
         results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/profile_export"
       }
     }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -23,7 +23,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {
     post_scan_actions {
       bigquery_export {
-        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex_dataset_%{random_suffix}/tables/profile_export"
+        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/google_bigquery_dataset.source.dataset_id/tables/profile_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -12,13 +12,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 
-  data_profile_spec {  
-    post_scan_actions {
-      bigquery_export {
-        results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/profile_export"
-      }
-    }
-  }
+  data_profile_spec {}
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"
 }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -23,7 +23,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {
     post_scan_actions {
       bigquery_export {
-        results_table: "//bigquery.googleapis.com/projects/"<%= ctx[:test_env_vars]['project_name'] %>"/datasets/dataplex-dataset-%{random_suffix}/tables/profile_export"
+        results_table: "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex-dataset-%{random_suffix}/tables/profile_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -15,7 +15,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {  
     post_scan_actions {
       bigquery_export {
-        results_table: "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/profile_export"
+        results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/profile_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -23,7 +23,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {
     post_scan_actions {
       bigquery_export {
-        results_table: "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex-dataset-%{random_suffix}/tables/profile_export"
+        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex-dataset-%{random_suffix}/tables/profile_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -1,3 +1,11 @@
+resource "google_bigquery_dataset" "source" {
+  count = 1
+  dataset_id                  = "dataplex-dataset-%{random_suffix}"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
 resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   location     = "us-central1"
   data_scan_id = "tf-test-datascan%{random_suffix}"
@@ -12,7 +20,13 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 
-  data_profile_spec {}
+  data_profile_spec {
+    post_scan_actions {
+      bigquery_export {
+        results_table: "//bigquery.googleapis.com/projects/"<%= ctx[:test_env_vars]['project_name'] %>"/datasets/dataplex-dataset-%{random_suffix}/tables/profile_export"
+      }
+    }
+  }
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"
 }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -1,11 +1,3 @@
-resource "google_bigquery_dataset" "source" {
-  count = 1
-  dataset_id                  = "dataplex_dataset_%{random_suffix}"
-  friendly_name               = "test"
-  description                 = "This is a test description"
-  location                    = "US"
-}
-
 resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   location     = "us-central1"
   data_scan_id = "tf-test-datascan%{random_suffix}"
@@ -20,18 +12,9 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
     }
   }
 
-  data_profile_spec {
-    post_scan_actions {
-      bigquery_export {
-        results_table = "//bigquery.googleapis.com/projects/<%= ctx[:test_env_vars]['project_name'] %>/datasets/dataplex_dataset_%{random_suffix}/tables/profile_export"
-      }
-    }
-  }
+data_profile_spec {}
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"
-  depends_on = [
-    google_bigquery_dataset.source
-  ]
 }
 
 

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_profile.tf.erb
@@ -29,6 +29,9 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   }
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"
+  depends_on = [
+    google_bigquery_dataset.source
+  ]
 }
 
 

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
@@ -22,7 +22,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
       }
     }
     post_scan_actions {
-      big_query_export {
+      bigquery_export {
         results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/quality_export"
       }
     }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
@@ -21,11 +21,6 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
         sql_expression = "COUNT(*) > 0"
       }
     }
-    post_scan_actions {
-      bigquery_export {
-        results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/quality_export"
-      }
-    }
   }
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
@@ -23,7 +23,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
     }
     post_scan_actions {
       bigquery_export {
-        results_table: "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/quality_export"
+        results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/quality_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
@@ -15,8 +15,15 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_quality_spec {
     rules {
       dimension = "VALIDITY"
+      name = "rule1"
+      description = "rule 1 for validity dimension"
       table_condition_expectation {
         sql_expression = "COUNT(*) > 0"
+      }
+    }
+    post_scan_actions {
+      bigquery_export {
+        results_table: "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/quality_export"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_basic_quality.tf.erb
@@ -22,7 +22,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
       }
     }
     post_scan_actions {
-      bigquery_export {
+      big_query_export {
         results_table = "//bigquery.googleapis.com/projects/bigquery-public-data/datasets/samples/tables/quality_export"
       }
     }

--- a/mmv1/templates/terraform/examples/dataplex_datascan_full_profile.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_full_profile.tf.erb
@@ -22,6 +22,12 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
   data_profile_spec {
     sampling_percent = 80
     row_filter = "word_count > 10"
+    include_fields {
+      field_names = ["word_count"]
+    }
+    exclude_fields {
+      field_names = ["property_type"]
+    }
   }
 
   project = "<%= ctx[:test_env_vars]['project_name'] %>"


### PR DESCRIPTION
Updating Datascan terraform support with the latest changes and additions in Datascan API.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_dataplex_datascan`
```
