### PR TITLE
Bitbucket Trigger support for Manual, Pub/Sub and Webhook triggers

### DIFF
--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -71,6 +71,9 @@ examples:
     primary_resource_id: 'manual-ghe-trigger'
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudbuild_trigger_manual_bitbucket_server'
+    primary_resource_id: 'manual-bitbucket-trigger'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'cloudbuild_trigger_repo'
     primary_resource_id: 'repo-trigger'
     vars:
@@ -252,6 +255,11 @@ properties:
         description: |
           The full resource name of the github enterprise config.
           Format: projects/{project}/locations/{location}/githubEnterpriseConfigs/{id}. projects/{project}/githubEnterpriseConfigs/{id}.
+      - !ruby/object:Api::Type::String
+        name: 'bitbucketServerConfig'
+        description: |
+          The full resource name of the bitbucket server config.
+          Format: projects/{project}/locations/{location}/bitbucketServerConfigs/{id}.
   - !ruby/object:Api::Type::NestedObject
     name: 'repositoryEventConfig'
     description: |
@@ -378,6 +386,11 @@ properties:
         description: |
           The full resource name of the github enterprise config.
           Format: projects/{project}/locations/{location}/githubEnterpriseConfigs/{id}. projects/{project}/githubEnterpriseConfigs/{id}.
+      - !ruby/object:Api::Type::String
+        name: 'bitbucketServerConfig'
+        description: |
+          The full resource name of the bitbucket server config.
+          Format: projects/{project}/locations/{location}/bitbucketServerConfigs/{id}.
   - !ruby/object:Api::Type::Array
     name: 'ignoredFiles'
     item_type: Api::Type::String

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_manual_bitbucket_server.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_manual_bitbucket_server.tf.erb
@@ -1,0 +1,18 @@
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  name        = "terraform-manual-bbs-trigger"
+
+  source_to_build {
+    uri       = "https://bbs.com/scm/stag/test-repo.git"
+    ref       = "refs/heads/main"
+    repo_type = "BITBUCKET_SERVER"
+    bitbucket_server_config = "projects/myProject/locations/global/bitbucketServerConfigs/configID"
+  }
+
+  git_file_source {
+    path      = "cloudbuild.yaml"
+    uri       = "https://bbs.com/scm/stag/test-repo.git"
+    revision  = "refs/heads/main"
+    repo_type = "BITBUCKET_SERVER"
+    bitbucket_server_config = "projects/myProject/locations/global/bitbucketServerConfigs/configID"
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -303,6 +303,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     uri       = "https://bitbucket.org/myorg/myrepo"
     revision  = "refs/heads/develop"
     repo_type = "BITBUCKET_SERVER"
+    bitbucket_server_config = "projects/123456789/locations/us-central1/bitbucketServerConfigs/myBitbucketConfig"
   }
 }
 `, name)


### PR DESCRIPTION
Adds field bitbucket_server_config to Trigger.git_file_source and Trigger.source_to_build, supporting manual, pub/sub and webhook triggers.

Also fixes TestAccCloudBuildTrigger_basic_bitbucket test.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/15079



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: added `git_file_source.bitbucket_server_config` and `source_to_build.bitbucket_server_config` fields to `google_cloudbuild_trigger` resource
```
