### PR TITLE
Potential fix for downstream waiter for feature branches

### DIFF
--- a/.ci/containers/downstream-waiter/wait_for_commit.sh
+++ b/.ci/containers/downstream-waiter/wait_for_commit.sh
@@ -24,13 +24,21 @@ if git merge-base --is-ancestor $SHA origin/$SYNC_BRANCH; then
 fi
 
 while true; do
-    commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"
-    if [ "$commits" == "$SHA" ]; then
-        break
-    else
-        echo "git log says waiting on: $commits"
-        echo "command says waiting on $SHA"
-        git fetch origin $SYNC_BRANCH
+    if [ "$BASE_BRANCH" != "main" ]; then
+        SYNC_HEAD="$(git rev-parse --short origin/$SYNC_BRANCH)"
+        BASE_PARENT="$(git rev-parse --short origin/$BASE_BRANCH~)"
+        if [ "$SYNC_HEAD" == "$BASE_PARENT" ]; then
+            break;
+        fi
+    else 
+        commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"
+        if [ "$commits" == "$SHA" ]; then
+            break
+        else
+            echo "git log says waiting on: $commits"
+            echo "command says waiting on $SHA"
+            git fetch origin $SYNC_BRANCH
+        fi
     fi
     sleep 5
 done

--- a/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
+++ b/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
@@ -24,13 +24,21 @@ if git merge-base --is-ancestor $SHA origin/$SYNC_BRANCH; then
 fi
 
 while true; do
-    commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"
-    if [ "$commits" == "$SHA" ]; then
-        break
-    else
-        echo "git log says waiting on: $commits"
-        echo "command says waiting on $SHA"
-        git fetch origin $SYNC_BRANCH
+    if [ "$BASE_BRANCH" != "main" ]; then
+        SYNC_HEAD="$(git rev-parse --short origin/$SYNC_BRANCH)"
+        BASE_PARENT="$(git rev-parse --short origin/$BASE_BRANCH~)"
+        if [ "$SYNC_HEAD" == "$BASE_PARENT" ]; then
+            break;
+        fi
+    else 
+        commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"
+        if [ "$commits" == "$SHA" ]; then
+            break
+        else
+            echo "git log says waiting on: $commits"
+            echo "command says waiting on $SHA"
+            git fetch origin $SYNC_BRANCH
+        fi
     fi
     sleep 5
 done


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
