### PR TITLE
Sync 5.0.0 with main Part 2

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -121,19 +121,12 @@ if [ "$REPO" == "terraform-google-conversion" ]; then
 
     pushd $LOCAL_PATH
 
-    if [ "$VERSION" == "ga" ]; then
-      if [ "$COMMAND" == "downstream" ]; then
-        go get -d github.com/hashicorp/terraform-provider-google@$BASE_BRANCH
-      else
-        go mod edit -replace github.com/hashicorp/terraform-provider-google=github.com/$SCRATCH_OWNER/terraform-provider-google@$BRANCH
-      fi
-    elif [ "$VERSION" == "beta" ]; then
-      if [ "$COMMAND" == "downstream" ]; then
-        go get -d github.com/hashicorp/terraform-provider-google-beta@$BASE_BRANCH
-      else
-        go mod edit -replace github.com/hashicorp/terraform-provider-google-beta=github.com/$SCRATCH_OWNER/terraform-provider-google-beta@$BRANCH
-      fi
+    if [ "$COMMAND" == "downstream" ]; then
+      go get -d github.com/hashicorp/terraform-provider-google-beta@$BASE_BRANCH
+    else
+      go mod edit -replace github.com/hashicorp/terraform-provider-google-beta=github.com/$SCRATCH_OWNER/terraform-provider-google-beta@$BRANCH
     fi
+
 
     go mod tidy
 

--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -129,7 +129,7 @@ steps:
       args:
           - 'head'
           - 'terraform-google-conversion'
-          - 'ga'
+          - 'beta'
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
@@ -141,7 +141,7 @@ steps:
       args:
           - 'base'
           - 'terraform-google-conversion'
-          - 'ga'
+          - 'beta'
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -113,7 +113,7 @@ steps:
       args:
           - 'downstream'
           - 'terraform-google-conversion'
-          - 'ga'
+          - 'beta'
           - $COMMIT_SHA
 
     - name: 'gcr.io/cloud-builders/git'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -80,7 +80,7 @@ teamcity-servicemap-generate:
 tgc:
 	cd mmv1;\
 		bundle;\
-		bundle exec compiler -e terraform -f validator -o $(OUTPUT_PATH) $(mmv1_compile);\
+		bundle exec compiler -e terraform -f validator -v beta -o $(OUTPUT_PATH) $(mmv1_compile);\
 
 test:
 	cd mmv1; \

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -472,6 +472,10 @@ module Provider
         %r{(?<!provider ")github.com/hashicorp/terraform-provider-google/google},
         'github.com/GoogleCloudPlatform/terraform-google-conversion/v2/tfplan2cai/converters/google/resources'
       )
+      data = data.gsub(
+        %r{(?<!provider ")github.com/hashicorp/terraform-provider-google-beta/google-beta},
+        'github.com/GoogleCloudPlatform/terraform-google-conversion/v2/tfplan2cai/converters/google/resources'
+      )
       # rubocop:enable Layout/LineLength
       File.write("#{output_folder}/#{target}", data)
     end

--- a/mmv1/third_party/validator/tests/data/example_compute_forwarding_rule.json
+++ b/mmv1/third_party/validator/tests/data/example_compute_forwarding_rule.json
@@ -11,7 +11,7 @@
       "data": {
         "IPProtocol": "TCP",
         "allowGlobalAccess": false,
-        "backendService": "https://compute.googleapis.com/compute/v1/projects/{{.Provider.project}}/regions/australia-southeast1/test-backend-service-id",
+        "backendService": "https://compute.googleapis.com/compute/beta/projects/{{.Provider.project}}/regions/australia-southeast1/test-backend-service-id",
         "loadBalancingScheme": "INTERNAL_MANAGED",
         "name": "test-forwarding-rule",
         "portRange": "80",

--- a/mmv1/third_party/validator/tests/source/iam_test.go.erb
+++ b/mmv1/third_party/validator/tests/source/iam_test.go.erb
@@ -15,7 +15,7 @@ import (
 	resources "github.com/GoogleCloudPlatform/terraform-google-conversion/v2/tfplan2cai/converters/google/resources"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v2/tfplan2cai/tfdata"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v2/tfplan2cai/tfplan"
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 )
 
 func TestIAMFetchFullResource(t *testing.T) {

--- a/mmv1/third_party/validator/tests/source/init_test.go
+++ b/mmv1/third_party/validator/tests/source/init_test.go
@@ -156,6 +156,12 @@ func normalizeAssets(t *testing.T, assets []caiasset.Asset, offline bool) []caia
 				asset.Resource.Data["name"] = re.ReplaceAllString(name, "/placeholder-foobar")
 			}
 		}
+		// skip comparing version, DiscoveryDocumentURI,
+		// since switching to beta generates version difference
+		if asset.Resource != nil {
+			asset.Resource.Version = ""
+			asset.Resource.DiscoveryDocumentURI = ""
+		}
 		ret[i] = asset
 	}
 	return ret


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is only to merge https://github.com/GoogleCloudPlatform/magic-modules/pull/7797 to the 5.0.0 branch and the `generate-diffs` check is expected to fail within this PR, I think.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
