### PR TITLE
Switch rake test to be run in our build-environment 

### DIFF
--- a/.ci/gcb-run-rake-tests.yml
+++ b/.ci/gcb-run-rake-tests.yml
@@ -1,6 +1,6 @@
 ---
 steps:
-- name: 'gcr.io/$PROJECT_ID/downstream-builder'
+- name: 'gcr.io/graphite-docker-images/build-environment'
   id: run-rake-tests
   entrypoint: bundle
   dir: mmv1


### PR DESCRIPTION
Furthers [allow us to make CI changes easily](https://docs.google.com/document/d/19Q6-ePKDQX9NriNOPq73kv-O1rE_aDMSv5rR1Z3Bt3I/edit). I'm pointing rake test directly at the build environment in place of `downstream-builder`.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
