### PR TITLE
Modify labels fields for DCL resources

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_worker_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_worker_pool_test.go.erb
@@ -41,6 +41,7 @@ func TestAccCloudbuildWorkerPool_basic(t *testing.T) {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations"},
 				ResourceName:      "google_cloudbuild_worker_pool.pool",
 			},
 			{
@@ -78,6 +79,11 @@ resource "google_cloudbuild_worker_pool" "pool" {
 		disk_size_gb = 101
 		machine_type = "e2-standard-4"
 		no_external_ip = false
+	}
+
+	annotations = {
+		env                   = "foo"
+		default_expiration_ms = 3600000
 	}
 }
 `, context)

--- a/mmv1/third_party/terraform/tests/resource_dataproc_workflow_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_workflow_template_test.go.erb
@@ -37,6 +37,10 @@ func TestAccDataprocWorkflowTemplate_basic(t *testing.T) {
       {
         ImportState:             true,
         ImportStateVerify:       true,
+        // The "labels" field in the state are decided by the configuration.
+        // During importing, as the configuration is unavailableafter, the "labels" field in the state will be empty.
+        // So add the "labels" to the ImportStateVerifyIgnore list.
+        ImportStateVerifyIgnore: []string{"labels"},
         ResourceName:            "google_dataproc_workflow_template.template",
       },
     },
@@ -123,6 +127,11 @@ resource "google_dataproc_workflow_template" "template" {
     presto_job {
       query_file_uri = "someuri"
     }
+  }
+
+  labels = {
+    env     = "foo"
+    somekey = "somevalue"
   }
 }
 `, context)

--- a/tpgtools/overrides/dataplex/samples/asset/basic_asset.tf.tmpl
+++ b/tpgtools/overrides/dataplex/samples/asset/basic_asset.tf.tmpl
@@ -52,6 +52,12 @@ resource "google_dataplex_asset" "primary" {
     name = "projects/{{project}}/buckets/{{bucket}}"
     type = "STORAGE_BUCKET"
   }
+
+  labels = {
+    env     = "foo"
+    my-asset = "exists"
+  }
+
  
   project = "{{project}}"
   depends_on = [

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -890,13 +890,17 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 			resource.ReusedTypes = resource.RegisterReusedType(p)
 		}
 
-		props = append(props, p)
-
 		// Add the "effective_labels" property when the current property is top level "labels" or
 		// add the "effective_annotations" property when the current property is top level "annotations"
+
 		if p.IsResourceLabels() || p.IsResourceAnnotations() {
+			note := `**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+			Please refer to the field 'effective_labels' for all of the labels present on the resource.`
+			p.Description = fmt.Sprintf("%s\n\n%s", p.Description, note)
 			props = append(props, build_effective_labels_field(p, resource, parent))
 		}
+
+		props = append(props, p)
 	}
 
 	// handle conflict fields

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -931,7 +931,7 @@ func build_effective_field(p Property, resource *Resource, parent *Property) Pro
 		Description: description,
 		resource:    resource,
 		parent:      parent,
-		Optional:    true,
+		Optional:    false,
 		Computed:    true,
 		StateSetter: &stateSetter,
 	}

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -894,8 +894,8 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 		// add the "effective_annotations" property when the current property is top level "annotations"
 
 		if p.IsResourceLabels() || p.IsResourceAnnotations() {
-			note := `**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
-			Please refer to the field 'effective_labels' for all of the labels present on the resource.`
+			note := "**Note**: This field is non-authoritative, and will only manage the labels present in your configuration. " +
+				"Please refer to the field `effective_labels` for all of the labels present on the resource."
 			p.Description = fmt.Sprintf("%s\n\n%s", p.Description, note)
 			props = append(props, build_effective_labels_field(p, resource, parent))
 		}

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -895,7 +895,7 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 		// Add the "effective_labels" property when the current property is top level "labels" or
 		// add the "effective_annotations" property when the current property is top level "annotations"
 		if p.IsResourceLabels() || p.IsResourceAnnotations() {
-			props = append(props, build_effective_field(p, resource, parent))
+			props = append(props, build_effective_labels_field(p, resource, parent))
 		}
 	}
 
@@ -920,7 +920,7 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 	return props, nil
 }
 
-func build_effective_field(p Property, resource *Resource, parent *Property) Property {
+func build_effective_labels_field(p Property, resource *Resource, parent *Property) Property {
 	title := fmt.Sprintf("effective_%s", p.title)
 	description := fmt.Sprintf("All of %s (key/value pairs) present on the resource in GCP, including the %s configured through Terraform, other clients and services.", p.title, p.title)
 	stateSetter := fmt.Sprintf("d.Set(%q, res.%s)", title, p.PackageName)

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -516,13 +516,6 @@ func createResource(schema *openapi.Schema, info *openapi.Info, typeFetcher *Typ
 	}
 
 	props, err := createPropertiesFromSchema(schema, typeFetcher, overrides, &res, nil, location)
-
-	if res.TitleCaseFullName() == "DataplexLake" {
-		glog.Infof("[WARNING] Generating from resource %s %s", res.Name(), res.TitleCaseFullName())
-
-		glog.Infof("[WARNING] Generating from props %#v", props)
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -714,6 +714,42 @@ func flatten{{$.PathType}}{{$v.PackagePath}}(obj *{{$.Package}}.{{$v.ObjectType}
 }
 {{ end -}}
 
+{{ if $.HasLabels }}
+func flatten{{$.PathType}}Labels(v map[string]string, d *schema.ResourceData) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	if l, ok := d.Get("labels").(map[string]interface{}); ok {
+		for k, _ := range l {
+			transformed[k] = l[k]
+		}
+	}
+
+	log.Printf("[DEBUG] flattenDataplexLakeLabels %#v", transformed)
+	return transformed
+}
+{{ end }}
+
+{{ if $.HasAnnotations }}
+func flatten{{$.PathType}}Annotations(v map[string]string, d *schema.ResourceData) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	if l, ok := d.Get("annotations").(map[string]interface{}); ok {
+		for k, _ := range l {
+			transformed[k] = l[k]
+		}
+	}
+
+	log.Printf("[DEBUG] flattenDataplexLakeAnnotations %#v", transformed)
+	return transformed
+}
+{{ end }}
+
 {{ range $v := .EnumArrays -}}
 func flatten{{$.PathType}}{{$v.PackagePath}}Array(obj []{{$.Package}}.{{$v.ObjectType}}Enum) interface{} {
 	if obj == nil {

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -727,7 +727,6 @@ func flatten{{$.PathType}}Labels(v map[string]string, d *schema.ResourceData) in
 		}
 	}
 
-	log.Printf("[DEBUG] flattenDataplexLakeLabels %#v", transformed)
 	return transformed
 }
 {{ end }}
@@ -745,7 +744,6 @@ func flatten{{$.PathType}}Annotations(v map[string]string, d *schema.ResourceDat
 		}
 	}
 
-	log.Printf("[DEBUG] flattenDataplexLakeAnnotations %#v", transformed)
 	return transformed
 }
 {{ end }}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

1. Transform the top level "labels" and "annotations" fields for DCL resources. Currently all of labels fields for DCL resources are in the top level, so just handle this case now.
   * Add note to the description
   * Add new fields `effective_labels` and `effective_annotations`
   * Set the fields in the state based on the user's configuration
   *  Add the fields to the ImportStateVerifyIgnore list. As the configuration is unaccessible when importing, these fields will be empty after importing.
  
2. Add `labels` or `annotations` to acceptance tests for some DCL resources, which don't cover these filed in the tests. The tests for these fields already exist for most DCL resources having the labels fields.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
