### PR TITLE
Add product backupdr with managementServer resource

### DIFF
--- a/mmv1/products/backupdr/ManagementServer.yaml
+++ b/mmv1/products/backupdr/ManagementServer.yaml
@@ -1,0 +1,102 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ManagementServer'
+base_url: projects/{{project}}/locations/{{location}}/managementServers
+create_url: projects/{{project}}/locations/{{location}}/managementServers/?management_server_id={{name}}
+self_link: projects/{{project}}/locations/{{location}}/managementServers/{{name}}
+create_verb: :POST
+immutable: true
+delete_url: projects/{{project}}/locations/{{location}}/managementServers/{{name}}
+description: A Backup and DR Management Server (Also referred as Management Console)
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/backup-disaster-recovery/docs'
+  api: 'https://cloud.google.com/backup-disaster-recovery/docs/deployment/deployment-plan'
+autogen_async: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'backup_dr_management_server'
+    primary_resource_id: 'ms-console'
+    vars:
+      network_name: 'vpc-network'
+    test_env_vars:
+      project: :PROJECT_NAME
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    required: true
+    url_param_only: true
+    description: |
+      Specify location for management server (management console)
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    required: true
+    url_param_only: true
+    description: |-
+      Specify the name of management server (management console)
+    custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+properties:
+  - !ruby/object:Api::Type::Enum
+    name: 'type'
+    values:
+      - :BACKUP_RESTORE
+      - :DR
+    default_value: :BACKUP_RESTORE
+    description: |
+      Specify the type of management server (management console)
+  - !ruby/object:Api::Type::Array
+    name: 'networks'
+    description: |
+      Specify network details.
+    required: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'network'
+          description: |
+            Specify network with format `projects/{{project_id}}/global/networks/{{network_id}}`
+          required: true
+          pattern: projects/{{project}}/global/networks/{{network}}
+        - !ruby/object:Api::Type::Enum
+          name: 'peeringMode'
+          description: |
+            Specify Network peeringMode
+          values:
+            - :PRIVATE_SERVICE_ACCESS
+            - :PEERING_MODE_UNSPECIFIED
+          default_value: :PRIVATE_SERVICE_ACCESS
+  ## outputs
+  - !ruby/object:Api::Type::String
+    name: 'oauth2ClientId'
+    description: |
+      The oauth2ClientId of management console.
+    output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'managementUri'
+    description: |-
+      The management console URI
+    output: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'webUi'
+        description: |-
+          The management console webUi.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'api'
+        description: |-
+          The management console api endpoint.
+        output: true

--- a/mmv1/products/backupdr/ManagementServer.yaml
+++ b/mmv1/products/backupdr/ManagementServer.yaml
@@ -25,6 +25,9 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Official Documentation': 'https://cloud.google.com/backup-disaster-recovery/docs'
   api: 'https://cloud.google.com/backup-disaster-recovery/docs/deployment/deployment-plan'
 autogen_async: true
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 40
+  delete_minutes: 40
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'backup_dr_management_server'

--- a/mmv1/products/backupdr/ManagementServer.yaml
+++ b/mmv1/products/backupdr/ManagementServer.yaml
@@ -34,6 +34,7 @@ examples:
     primary_resource_id: 'ms-console'
     vars:
       network_name: 'vpc-network'
+      ms_name: 'ms-console'
     test_env_vars:
       project: :PROJECT_NAME
 parameters:

--- a/mmv1/products/backupdr/product.yaml
+++ b/mmv1/products/backupdr/product.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: BackupDR
+display_name: Backup and DR
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://backupdr.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://backupdr.googleapis.com/v1/
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Backup and DR API
+    url: https://console.cloud.google.com/apis/library/backupdr.googleapis.com/
+async: !ruby/object:Api::OpAsync
+  actions: ['create', 'delete']
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+    resource_inside_response: true
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'

--- a/mmv1/templates/terraform/examples/backup_dr_management_server.tf.erb
+++ b/mmv1/templates/terraform/examples/backup_dr_management_server.tf.erb
@@ -18,7 +18,7 @@ resource "google_service_networking_connection" "default" {
 
 resource "google_backup_dr_management_server" "<%= ctx[:primary_resource_id] %>" {
   location = "us-central1"
-  name     = "<%= ctx[:primary_resource_id] %>"
+  name     = "<%= ctx[:vars]['ms_name'] %>"
   type     = "BACKUP_RESTORE" 
   networks {
     network      = google_compute_network.default.id

--- a/mmv1/templates/terraform/examples/backup_dr_management_server.tf.erb
+++ b/mmv1/templates/terraform/examples/backup_dr_management_server.tf.erb
@@ -1,0 +1,28 @@
+resource "google_compute_network" "default" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}
+
+resource "google_compute_global_address" "private_ip_address" {
+  name          = "<%= ctx[:vars]['network_name'] %>"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 20
+  network       = google_compute_network.default.id
+}
+
+resource "google_service_networking_connection" "default" {
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+}
+
+resource "google_backup_dr_management_server" "<%= ctx[:primary_resource_id] %>" {
+  location = "us-central1"
+  name     = "<%= ctx[:primary_resource_id] %>"
+  type     = "BACKUP_RESTORE" 
+  networks {
+    network      = google_compute_network.default.id
+    peering_mode = "PRIVATE_SERVICE_ACCESS"
+  }
+  depends_on = [ google_service_networking_connection.default ]
+}


### PR DESCRIPTION
This PR introduces a new gcp product backupdr and have resource to manage managementServer

This is the raised issue https://github.com/hashicorp/terraform-provider-google/issues/13319, though it's not directly connected, but part of provisioning the backupdr management console.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_backup_dr_management_server`
```
