### PR TITLE
Update subnetwork descriptions and tests to use REGIONAL_MANAGED_PROXY instead of deprecated INTERNAL_HTTPS_LOAD_BALANCER

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -165,7 +165,7 @@ properties:
     name: 'purpose'
     immutable: true
     description: |
-      The purpose of the resource. This field can be either `PRIVATE_RFC_1918`, `REGIONAL_MANAGED_PROXY`, `GLOBAL_MANAGED_PROXY`, `PRIVATE_SERVICE_CONNECT`, or `INTERNAL_HTTPS_LOAD_BALANCER`.
+      The purpose of the resource. This field can be either `PRIVATE_RFC_1918`, `REGIONAL_MANAGED_PROXY`, `GLOBAL_MANAGED_PROXY`, or `PRIVATE_SERVICE_CONNECT`.
       A subnet with purpose set to `REGIONAL_MANAGED_PROXY` is a user-created subnetwork that is reserved for regional Envoy-based load balancers.
       A subnetwork in a given region with purpose set to `GLOBAL_MANAGED_PROXY` is a proxy-only subnet and is shared between all the cross-regional Envoy-based load balancers.
       A subnetwork with purpose set to `PRIVATE_SERVICE_CONNECT` reserves the subnet for hosting a Private Service Connect published service.

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -166,7 +166,7 @@ properties:
     immutable: true
     description: |
       The purpose of the resource. This field can be either `PRIVATE_RFC_1918`, `REGIONAL_MANAGED_PROXY`, `GLOBAL_MANAGED_PROXY`, `PRIVATE_SERVICE_CONNECT`, or `INTERNAL_HTTPS_LOAD_BALANCER`.
-      A subnet with purpose set to REGIONAL_MANAGED_PROXY is a user-created subnetwork that is reserved for regional Envoy-based load balancers.
+      A subnet with purpose set to `REGIONAL_MANAGED_PROXY` is a user-created subnetwork that is reserved for regional Envoy-based load balancers.
       A subnetwork in a given region with purpose set to `GLOBAL_MANAGED_PROXY` is a proxy-only subnet and is shared between all the cross-regional Envoy-based load balancers.
       A subnetwork with purpose set to `PRIVATE_SERVICE_CONNECT` reserves the subnet for hosting a Private Service Connect published service.
       Note that `REGIONAL_MANAGED_PROXY` is the preferred setting for all regional Envoy load balancers.

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -169,7 +169,7 @@ properties:
       A subnet with purpose set to REGIONAL_MANAGED_PROXY is a user-created subnetwork that is reserved for regional Envoy-based load balancers.
       A subnetwork in a given region with purpose set to `GLOBAL_MANAGED_PROXY` is a proxy-only subnet and is shared between all the cross-regional Envoy-based load balancers.
       A subnetwork with purpose set to `PRIVATE_SERVICE_CONNECT` reserves the subnet for hosting a Private Service Connect published service.
-      A subnet with purpose set to INTERNAL_HTTPS_LOAD_BALANCER is a proxy-only subnet that can be used only by regional internal HTTP(S) load balancers. Note that REGIONAL_MANAGED_PROXY is the preferred setting for all regional Envoy load balancers.
+      Note that `REGIONAL_MANAGED_PROXY` is the preferred setting for all regional Envoy load balancers.
       If unspecified, the purpose defaults to `PRIVATE_RFC_1918`.
       The enableFlowLogs field isn't supported with the purpose field set to `INTERNAL_HTTPS_LOAD_BALANCER` or `REGIONAL_MANAGED_PROXY` or `GLOBAL_MANAGED_PROXY`.
     default_from_api: true

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -165,11 +165,11 @@ properties:
     name: 'purpose'
     immutable: true
     description: |
-      The purpose of the resource. This field can be either `PRIVATE_RFC_1918`, `INTERNAL_HTTPS_LOAD_BALANCER`, `REGIONAL_MANAGED_PROXY`, `GLOBAL_MANAGED_PROXY` or `PRIVATE_SERVICE_CONNECT`.
-      A subnetwork with purpose set to `INTERNAL_HTTPS_LOAD_BALANCER` is a user-created subnetwork that is reserved for Internal HTTP(S) Load Balancing.
-      A subnetwork in a given region with purpose set to `REGIONAL_MANAGED_PROXY` is a proxy-only subnet and is shared between all the regional Envoy-based load balancers.
+      The purpose of the resource. This field can be either `PRIVATE_RFC_1918`, `REGIONAL_MANAGED_PROXY`, `GLOBAL_MANAGED_PROXY`, `PRIVATE_SERVICE_CONNECT`, or `INTERNAL_HTTPS_LOAD_BALANCER`.
+      A subnet with purpose set to REGIONAL_MANAGED_PROXY is a user-created subnetwork that is reserved for regional Envoy-based load balancers.
       A subnetwork in a given region with purpose set to `GLOBAL_MANAGED_PROXY` is a proxy-only subnet and is shared between all the cross-regional Envoy-based load balancers.
       A subnetwork with purpose set to `PRIVATE_SERVICE_CONNECT` reserves the subnet for hosting a Private Service Connect published service.
+      A subnet with purpose set to INTERNAL_HTTPS_LOAD_BALANCER is a proxy-only subnet that can be used only by regional internal HTTP(S) load balancers. Note that REGIONAL_MANAGED_PROXY is the preferred setting for all regional Envoy load balancers.
       If unspecified, the purpose defaults to `PRIVATE_RFC_1918`.
       The enableFlowLogs field isn't supported with the purpose field set to `INTERNAL_HTTPS_LOAD_BALANCER` or `REGIONAL_MANAGED_PROXY` or `GLOBAL_MANAGED_PROXY`.
     default_from_api: true
@@ -184,11 +184,11 @@ properties:
       - :BACKUP
     description: |
       The role of subnetwork.
+      Currently, this field is only used when purpose = `REGIONAL_MANAGED_PROXY`.
       The value can be set to `ACTIVE` or `BACKUP`.
-      An `ACTIVE` subnetwork is one that is currently being used.
-      A `BACKUP` subnetwork is one that is ready to be promoted to `ACTIVE` or is currently draining.
-
-      Subnetwork role must be specified when purpose is set to `INTERNAL_HTTPS_LOAD_BALANCER` or `REGIONAL_MANAGED_PROXY`.
+      An `ACTIVE` subnetwork is one that is currently being used for Envoy-based load balancers in a region.
+      A `BACKUP` subnetwork is one that is ready to be promoted to ACTIVE or is currently draining.
+      This field can be updated with a patch request.
   - !ruby/object:Api::Type::Array
     name: 'secondaryIpRange'
     api_name: secondaryIpRanges

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -187,7 +187,7 @@ properties:
       Currently, this field is only used when `purpose` is `REGIONAL_MANAGED_PROXY`.
       The value can be set to `ACTIVE` or `BACKUP`.
       An `ACTIVE` subnetwork is one that is currently being used for Envoy-based load balancers in a region.
-      A `BACKUP` subnetwork is one that is ready to be promoted to ACTIVE or is currently draining.
+      A `BACKUP` subnetwork is one that is ready to be promoted to `ACTIVE` or is currently draining.
       This field can be updated with a patch request.
   - !ruby/object:Api::Type::Array
     name: 'secondaryIpRange'

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -184,7 +184,7 @@ properties:
       - :BACKUP
     description: |
       The role of subnetwork.
-      Currently, this field is only used when purpose = `REGIONAL_MANAGED_PROXY`.
+      Currently, this field is only used when `purpose` is `REGIONAL_MANAGED_PROXY`.
       The value can be set to `ACTIVE` or `BACKUP`.
       An `ACTIVE` subnetwork is one that is currently being used for Envoy-based load balancers in a region.
       A `BACKUP` subnetwork is one that is ready to be promoted to ACTIVE or is currently draining.

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -171,7 +171,6 @@ properties:
       A subnetwork with purpose set to `PRIVATE_SERVICE_CONNECT` reserves the subnet for hosting a Private Service Connect published service.
       Note that `REGIONAL_MANAGED_PROXY` is the preferred setting for all regional Envoy load balancers.
       If unspecified, the purpose defaults to `PRIVATE_RFC_1918`.
-      The enableFlowLogs field isn't supported with the purpose field set to `INTERNAL_HTTPS_LOAD_BALANCER` or `REGIONAL_MANAGED_PROXY` or `GLOBAL_MANAGED_PROXY`.
     default_from_api: true
   - !ruby/object:Api::Type::Enum
     name: 'role'
@@ -265,9 +264,10 @@ properties:
     fingerprint_name: 'fingerprint'
     update_id: 'logConfig'
     description: |
-      Denotes the logging options for the subnetwork flow logs. If logging is enabled
-      logs will be exported to Stackdriver. This field cannot be set if the `purpose` of this
-      subnetwork is `INTERNAL_HTTPS_LOAD_BALANCER` or `REGIONAL_MANAGED_PROXY` or `GLOBAL_MANAGED_PROXY`
+      This field denotes the VPC flow logging options for this subnetwork. If
+      logging is enabled, logs are exported to Cloud Logging. Flow logging
+      isn't supported if the subnet `purpose` field is set to subnetwork is
+      `REGIONAL_MANAGED_PROXY` or `GLOBAL_MANAGED_PROXY`.
     send_empty_value: true
     custom_expand: 'templates/terraform/custom_expand/subnetwork_log_config.go.erb'
     custom_flatten: 'templates/terraform/custom_flatten/subnetwork_log_config.go.erb'

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -188,7 +188,6 @@ properties:
       The value can be set to `ACTIVE` or `BACKUP`.
       An `ACTIVE` subnetwork is one that is currently being used for Envoy-based load balancers in a region.
       A `BACKUP` subnetwork is one that is ready to be promoted to `ACTIVE` or is currently draining.
-      This field can be updated with a patch request.
   - !ruby/object:Api::Type::Array
     name: 'secondaryIpRange'
     api_name: secondaryIpRanges

--- a/mmv1/templates/terraform/examples/forwarding_rule_http_lb.tf.erb
+++ b/mmv1/templates/terraform/examples/forwarding_rule_http_lb.tf.erb
@@ -184,6 +184,6 @@ resource "google_compute_subnetwork" "proxy" {
   ip_cidr_range = "10.129.0.0/26"
   region        = "us-central1"
   network       = google_compute_network.default.id
-  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  purpose       = "REGIONAL_MANAGED_PROXY"
   role          = "ACTIVE"
 }

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -13,7 +13,7 @@ resource "google_compute_subnetwork" "proxy_subnet" {
   name          = "<%= ctx[:vars]['l7_ilb_proxy_subnet'] %>"
   ip_cidr_range = "10.0.0.0/24"
   region        = "europe-west1"
-  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  purpose       = "REGIONAL_MANAGED_PROXY"
   role          = "ACTIVE"
   network       = google_compute_network.default.id
 }

--- a/mmv1/templates/terraform/examples/internal_http_lb_with_mig_backend.tf.erb
+++ b/mmv1/templates/terraform/examples/internal_http_lb_with_mig_backend.tf.erb
@@ -14,7 +14,7 @@ resource "google_compute_subnetwork" "proxy_subnet" {
   provider      = google-beta
   ip_cidr_range = "10.0.0.0/24"
   region        = "europe-west1"
-  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  purpose       = "REGIONAL_MANAGED_PROXY"
   role          = "ACTIVE"
   network       = google_compute_network.ilb_network.id
 }

--- a/mmv1/templates/terraform/examples/subnetwork_internal_l7lb.tf.erb
+++ b/mmv1/templates/terraform/examples/subnetwork_internal_l7lb.tf.erb
@@ -4,7 +4,7 @@ resource "google_compute_subnetwork" "network-for-l7lb" {
   name          = "<%= ctx[:vars]['subnetwork_name'] %>"
   ip_cidr_range = "10.0.0.0/22"
   region        = "us-central1"
-  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  purpose       = "REGIONAL_MANAGED_PROXY"
   role          = "ACTIVE"
   network       = google_compute_network.custom-test.id
 }


### PR DESCRIPTION


<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Update subnetwork descriptions and tests to use REGIONAL_MANAGED_PROXY instead of deprecated INTERNAL_HTTPS_LOAD_BALANCER



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
