### PR TITLE
Revert "Skip *_BetaBasicHandWritten tests that are consistently faili…

### DIFF
--- a/tpgtools/overrides/containeraws/samples/cluster/meta.yaml
+++ b/tpgtools/overrides/containeraws/samples/cluster/meta.yaml
@@ -2,6 +2,3 @@ ignore_read:
   - fleet.0.project
 doc_hide:
   - beta_basic.tf.tmpl
-test_hide:
-  # TODO: https://github.com/hashicorp/terraform-provider-google/issues/14392
-  - beta_basic.tf.tmpl

--- a/tpgtools/overrides/containeraws/samples/nodepool/meta.yaml
+++ b/tpgtools/overrides/containeraws/samples/nodepool/meta.yaml
@@ -2,7 +2,3 @@ ignore_read:
   - fleet.0.project
 doc_hide:
   - beta_basic.tf.tmpl
-test_hide:
-  # TODO: https://github.com/hashicorp/terraform-provider-google/issues/14085
-  # TODO: https://github.com/hashicorp/terraform-provider-google/issues/14392
-  - beta_basic.tf.tmpl

--- a/tpgtools/overrides/containerazure/samples/nodepool/meta.yaml
+++ b/tpgtools/overrides/containerazure/samples/nodepool/meta.yaml
@@ -1,5 +1,2 @@
 doc_hide:
   - beta_basic.tf.tmpl
-test_hide:
-  # TODO: https://github.com/hashicorp/terraform-provider-google/issues/14085
-  - beta_basic.tf.tmpl


### PR DESCRIPTION
Revert "Skip *_BetaBasicHandWritten tests that are consistently failing (#8476)"

This reverts commit 2a0393a3c9762599e729a5234f48d41d44585234.

The underlying issue (https://github.com/hashicorp/terraform-provider-google/issues/14085) has been fixed so we can revert this now.

Closes hashicorp/terraform-provider-google#14085