### PR TITLE
Fix Inconsistent logic when getting zone/region/location

### DIFF
--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -80,9 +80,8 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	}
 	// Region from zone in resource config
 	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
-		regionSelfLink := tpgresource.GetRegionFromZone(ld.ResourceZone.ValueString())
-		region := tpgresource.GetResourceNameFromSelfLink(regionSelfLink) // Region could be a self link
-		return types.StringValue(region), nil
+		region := tpgresource.GetResourceNameFromSelfLink(ld.ResourceZone.ValueString()) // Region could be a self link
+		return tpgresource.GetRegionFromZone(region), nil
 	}
 	// Region from provider config
 	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
@@ -91,9 +90,8 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	}
 	// Region from zone in provider config
 	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
-		regionSelfLink := tpgresource.GetRegionFromZone(ld.ProviderZone.ValueString())
-		region := tpgresource.GetResourceNameFromSelfLink(regionSelfLink) // Region could be a self link
-		return types.StringValue(region), nil
+		region := tpgresource.GetResourceNameFromSelfLink(ld.ProviderZone.ValueString()) // Region could be a self link
+		return tpgresource.GetRegionFromZone(region), nil
 	}
 
 	var err error

--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -48,6 +48,12 @@ func (ld *LocationDescription) GetLocation() (types.String, error) {
 		return types.StringValue(location), nil
 	}
 
+	// Location from region in provider config
+	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
+		location := tpgresource.GetResourceNameFromSelfLink(ld.ProviderRegion.ValueString()) // Zone could be a self link
+		return types.StringValue(location), nil
+	}
+
 	// Location from zone in provider config
 	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
 		location := tpgresource.GetResourceNameFromSelfLink(ld.ProviderZone.ValueString()) // Zone could be a self link

--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -81,7 +81,7 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	// Region from zone in resource config
 	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
 		region := tpgresource.GetResourceNameFromSelfLink(ld.ResourceZone.ValueString()) // Region could be a self link
-		return tpgresource.GetRegionFromZone(region), nil
+		return types.StringValue(tpgresource.GetRegionFromZone(region)), nil
 	}
 	// Region from provider config
 	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
@@ -91,7 +91,7 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	// Region from zone in provider config
 	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
 		region := tpgresource.GetResourceNameFromSelfLink(ld.ProviderZone.ValueString()) // Region could be a self link
-		return tpgresource.GetRegionFromZone(region), nil
+		return types.StringValue(tpgresource.GetRegionFromZone(region)), nil
 	}
 
 	var err error

--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -74,7 +74,8 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	}
 	// Region from zone in resource config
 	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
-		region := tpgresource.GetRegionFromZone(ld.ResourceZone.ValueString())
+		regionSelfLink := tpgresource.GetRegionFromZone(ld.ResourceZone.ValueString())
+		region := tpgresource.GetResourceNameFromSelfLink(regionSelfLink) // Region could be a self link
 		return types.StringValue(region), nil
 	}
 	// Region from provider config

--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -50,7 +50,7 @@ func (ld *LocationDescription) GetLocation() (types.String, error) {
 
 	// Location from region in provider config
 	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
-		location := tpgresource.GetResourceNameFromSelfLink(ld.ProviderRegion.ValueString()) // Zone could be a self link
+		location := tpgresource.GetResourceNameFromSelfLink(ld.ProviderRegion.ValueString()) // Region could be a self link
 		return types.StringValue(location), nil
 	}
 
@@ -86,11 +86,13 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	}
 	// Region from provider config
 	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
-		return ld.ProviderRegion, nil
+		region := tpgresource.GetResourceNameFromSelfLink(ld.ProviderRegion.ValueString()) // Region could be a self link
+		return types.StringValue(region), nil
 	}
 	// Region from zone in provider config
 	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
-		region := tpgresource.GetRegionFromZone(ld.ProviderZone.ValueString())
+		regionSelfLink := tpgresource.GetRegionFromZone(ld.ProviderZone.ValueString())
+		region := tpgresource.GetResourceNameFromSelfLink(regionSelfLink) // Region could be a self link
 		return types.StringValue(region), nil
 	}
 
@@ -113,7 +115,9 @@ func (ld *LocationDescription) GetZone() (types.String, error) {
 		return types.StringValue(zone), nil
 	}
 	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
-		return ld.ProviderZone, nil
+		// Zone could be a self link
+		zone := tpgresource.GetResourceNameFromSelfLink(ld.ProviderZone.ValueString())
+		return types.StringValue(zone), nil
 	}
 
 	var err error

--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -32,12 +32,14 @@ type LocationDescription struct {
 func (ld *LocationDescription) GetLocation() (types.String, error) {
 	// Location from resource config
 	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() && !ld.ResourceLocation.Equal(types.StringValue("")) {
-		return ld.ResourceLocation, nil
+		location := tpgresource.GetResourceNameFromSelfLink(ld.ResourceLocation.ValueString()) // Location could be a self link
+		return types.StringValue(location), nil
 	}
 
 	// Location from region in resource config
 	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() && !ld.ResourceRegion.Equal(types.StringValue("")) {
-		return ld.ResourceRegion, nil
+		region := tpgresource.GetResourceNameFromSelfLink(ld.ResourceRegion.ValueString()) // Region could be a self link
+		return types.StringValue(region), nil
 	}
 
 	// Location from zone in resource config
@@ -48,7 +50,8 @@ func (ld *LocationDescription) GetLocation() (types.String, error) {
 
 	// Location from zone in provider config
 	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
-		return ld.ProviderZone, nil
+		location := tpgresource.GetResourceNameFromSelfLink(ld.ProviderZone.ValueString()) // Zone could be a self link
+		return types.StringValue(location), nil
 	}
 
 	var err error

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -126,7 +126,7 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("provider-zone"), // is truncated
 		},
-		"does not shorten region values when derived from a zone self link set in the resource config": {
+		"shortens region values when derived from a zone self link set in the resource config": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
 			},
@@ -228,7 +228,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("resource-location"),
 		},
-		"does not shorten the location value when it is set as a self link in the resource config": {
+		"shortens the location value when it is set as a self link in the resource config": {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/locations/resource-location"),
 			},
@@ -241,7 +241,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("resource-region"),
 		},
-		"does not shorten the region value when it is set as a self link in the resource config": {
+		"shortens the region value when it is set as a self link in the resource config": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/resource-region"),
 			},
@@ -272,7 +272,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
-		"does not shorten the zone value when it is set as a self link in the provider config": {
+		"shortens the zone value when it is set as a self link in the provider config": {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a"),
 			},

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -232,7 +232,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/locations/resource-location"),
 			},
-			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/locations/resource-location"),
+			ExpectedLocation: types.StringValue("resource-location"),
 		},
 		"returns the region value set in the resource config when location is not in the schema": {
 			ld: LocationDescription{
@@ -245,7 +245,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/resource-region"),
 			},
-			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/resource-region"),
+			ExpectedLocation: types.StringValue("resource-region"),
 		},
 		"returns the zone value set in the resource config when neither location nor region in the schema": {
 			ld: LocationDescription{
@@ -270,7 +270,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a"),
 			},
-			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a"),
+			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
 		// Handling of empty strings
 		"returns the region value set in the resource config when location is an empty string": {

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -130,7 +130,7 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
 			},
-			ExpectedRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1"), // Value isn't shortened from URI to name
+			ExpectedRegion: types.StringValue("us-central1"), // Value isn't shortened from URI to name
 		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -130,7 +130,7 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
 			},
-			ExpectedRegion: types.StringValue("us-central1"), // Value isn't shortened from URI to name
+			ExpectedRegion: types.StringValue("us-central1"),
 		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -303,13 +303,6 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
-		// // Error states - TODO: What is the purpose of this error catch???
-		// "does not use the region value set in the provider config": {
-		// 	ld: LocationDescription{
-		// 		ProviderRegion: types.StringValue("provider-region"),
-		// 	},
-		// 	ExpectedError: true,
-		// },
 		"returns an error when none of location/region/zone are set on the resource, and neither region or zone is set on the provider": {
 			ExpectedError: true,
 		},

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -259,10 +259,16 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("resource-zone-a"),
 		},
+		"returns the region value from the provider config when none of location/region/zone are set in the resource config": {
+			ld: LocationDescription{
+				ProviderRegion: types.StringValue("provider-region"), // Preferred to use region value over zone value if both are set
+				ProviderZone:   types.StringValue("provider-zone-a"),
+			},
+			ExpectedLocation: types.StringValue("provider-region"),
+		},
 		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
 			ld: LocationDescription{
-				ProviderRegion: types.StringValue("provider-region"), // unused
-				ProviderZone:   types.StringValue("provider-zone-a"),
+				ProviderZone: types.StringValue("provider-zone-a"),
 			},
 			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
@@ -297,13 +303,13 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("provider-zone-a"),
 		},
-		// Error states
-		"does not use the region value set in the provider config": {
-			ld: LocationDescription{
-				ProviderRegion: types.StringValue("provider-region"),
-			},
-			ExpectedError: true,
-		},
+		// // Error states - TODO: What is the purpose of this error catch???
+		// "does not use the region value set in the provider config": {
+		// 	ld: LocationDescription{
+		// 		ProviderRegion: types.StringValue("provider-region"),
+		// 	},
+		// 	ExpectedError: true,
+		// },
 		"returns an error when none of location/region/zone are set on the resource, and neither region or zone is set on the provider": {
 			ExpectedError: true,
 		},

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -266,7 +266,7 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			},
 			ExpectedLocation: types.StringValue("provider-region"),
 		},
-		"returns the zone value from the provider config when none of location/region/zone are set in the resource config": {
+		"returns the zone value from the provider config when none of location/region/zone are set in the resource config and region is not set in the provider config": {
 			ld: LocationDescription{
 				ProviderZone: types.StringValue("provider-zone-a"),
 			},

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -132,6 +132,18 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 			},
 			ExpectedRegion: types.StringValue("us-central1"),
 		},
+		"shortens region values set as self links in the provider config": {
+			ld: LocationDescription{
+				ProviderRegion: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1"),
+			},
+			ExpectedRegion: types.StringValue("us-central1"),
+		},
+		"shortens region values when derived from a zone self link set in the provider config": {
+			ld: LocationDescription{
+				ProviderZone: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a"),
+			},
+			ExpectedRegion: types.StringValue("us-central1"),
+		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ld: LocationDescription{
 				ProviderRegion: types.StringValue("provider-region"),

--- a/mmv1/third_party/terraform/tpgresource/field_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/field_helpers.go
@@ -387,8 +387,8 @@ func GetRegionFromSchema(regionSchemaField, zoneSchemaField string, d TerraformR
 		return GetResourceNameFromSelfLink(v.(string)), nil
 	}
 	if v, ok := d.GetOk(zoneSchemaField); ok && zoneSchemaField != "" {
-		zone := GetResourceNameFromSelfLink(v.(string)), nil
-		return GetRegionFromZone(zone)
+		zone := GetResourceNameFromSelfLink(v.(string))
+		return GetRegionFromZone(zone), nil
 	}
 	if config.Region != "" {
 		return config.Region, nil

--- a/mmv1/third_party/terraform/tpgresource/field_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/field_helpers.go
@@ -387,7 +387,8 @@ func GetRegionFromSchema(regionSchemaField, zoneSchemaField string, d TerraformR
 		return GetResourceNameFromSelfLink(v.(string)), nil
 	}
 	if v, ok := d.GetOk(zoneSchemaField); ok && zoneSchemaField != "" {
-		return GetRegionFromZone(v.(string)), nil
+		zoneSelfLink := GetRegionFromZone(v.(string))
+		return GetResourceNameFromSelfLink(zoneSelfLink), nil
 	}
 	if config.Region != "" {
 		return config.Region, nil

--- a/mmv1/third_party/terraform/tpgresource/field_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/field_helpers.go
@@ -387,8 +387,8 @@ func GetRegionFromSchema(regionSchemaField, zoneSchemaField string, d TerraformR
 		return GetResourceNameFromSelfLink(v.(string)), nil
 	}
 	if v, ok := d.GetOk(zoneSchemaField); ok && zoneSchemaField != "" {
-		zoneSelfLink := GetRegionFromZone(v.(string))
-		return GetResourceNameFromSelfLink(zoneSelfLink), nil
+		zone := GetResourceNameFromSelfLink(v.(string)), nil
+		return GetRegionFromZone(zone)
 	}
 	if config.Region != "" {
 		return config.Region, nil

--- a/mmv1/third_party/terraform/tpgresource/regional_utils.go
+++ b/mmv1/third_party/terraform/tpgresource/regional_utils.go
@@ -29,9 +29,9 @@ func GetLocation(d TerraformResourceData, config *transport_tpg.Config) (string,
 			return GetResourceNameFromSelfLink(v.(string)), nil
 		} else {
 			if config.Region != "" {
-				return config.Region, nil
+				return GetResourceNameFromSelfLink(config.Region), nil
 			} else if config.Zone != "" {
-				return config.Zone, nil
+				return GetResourceNameFromSelfLink(config.Zone), nil
 			} else {
 				return "", fmt.Errorf("Unable to determine location: region/zone not configured in resource/provider config")
 			}

--- a/mmv1/third_party/terraform/tpgresource/regional_utils.go
+++ b/mmv1/third_party/terraform/tpgresource/regional_utils.go
@@ -20,9 +20,9 @@ func IsZone(location string) bool {
 // - zone argument set in the provider config
 func GetLocation(d TerraformResourceData, config *transport_tpg.Config) (string, error) {
 	if v, ok := d.GetOk("location"); ok {
-		return v.(string), nil
+		return GetResourceNameFromSelfLink(v.(string)), nil
 	} else if v, isRegionalCluster := d.GetOk("region"); isRegionalCluster {
-		return v.(string), nil
+		return GetResourceNameFromSelfLink(v.(string)), nil
 	} else {
 		// If region is not explicitly set, use "zone" (or fall back to the provider-level zone).
 		// For now, to avoid confusion, we require region to be set in the config to create a regional

--- a/mmv1/third_party/terraform/tpgresource/utils_test.go
+++ b/mmv1/third_party/terraform/tpgresource/utils_test.go
@@ -310,13 +310,18 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "provider-zone-a",
 		},
-		// Error states
-		"returns an error when only a region value is set in the the provider config and none of location/region/zone are set in the resource config": {
+		"returns the region value when only a region value is set in the the provider config and none of location/region/zone are set in the resource config": {
+			ResourceConfig: map[string]interface{}{
+				"location": "",
+				"region":   "",
+				"zone":     "",
+			},
 			ProviderConfig: map[string]string{
 				"region": "provider-region",
 			},
-			ExpectError: true,
+			ExpectedLocation: "provider-region",
 		},
+		// Error states
 		"returns an error when none of location/region/zone are set on the resource, and neither region or zone is set on the provider": {
 			ExpectError: true,
 		},

--- a/mmv1/third_party/terraform/tpgresource/utils_test.go
+++ b/mmv1/third_party/terraform/tpgresource/utils_test.go
@@ -499,7 +499,7 @@ func TestGetRegion(t *testing.T) {
 			ResourceConfig: map[string]interface{}{
 				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a",
 			},
-			ExpectedRegion: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1", // Value is not shortenedfrom URI to name
+			ExpectedRegion: "us-central1", // Value is not shortenedfrom URI to name
 		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ProviderConfig: map[string]string{

--- a/mmv1/third_party/terraform/tpgresource/utils_test.go
+++ b/mmv1/third_party/terraform/tpgresource/utils_test.go
@@ -236,11 +236,11 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "resource-location",
 		},
-		"does not shorten the location value when it is set as a self link in the resource config": {
+		"shortens the location value when it is set as a self link in the resource config": {
 			ResourceConfig: map[string]interface{}{
 				"location": "https://www.googleapis.com/compute/v1/projects/my-project/locations/resource-location",
 			},
-			ExpectedLocation: "https://www.googleapis.com/compute/v1/projects/my-project/locations/resource-location", // No shortening takes place
+			ExpectedLocation: "resource-location",
 		},
 		"returns the region value set in the resource config when location is not in the schema": {
 			ResourceConfig: map[string]interface{}{
@@ -249,11 +249,11 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "resource-region",
 		},
-		"does not shorten the region value when it is set as a self link in the resource config": {
+		"shortens the region value when it is set as a self link in the resource config": {
 			ResourceConfig: map[string]interface{}{
 				"region": "https://www.googleapis.com/compute/v1/projects/my-project/region/resource-region",
 			},
-			ExpectedLocation: "https://www.googleapis.com/compute/v1/projects/my-project/region/resource-region", // No shortening takes place
+			ExpectedLocation: "resource-region",
 		},
 		"returns the zone value set in the resource config when neither location nor region in the schema": {
 			ResourceConfig: map[string]interface{}{
@@ -495,11 +495,11 @@ func TestGetRegion(t *testing.T) {
 			},
 			ExpectedRegion: "resource-zone", // is truncated
 		},
-		"does not shorten region values when derived from a zone self link set in the resource config": {
+		"shortens region values when derived from a zone self link set in the resource config": {
 			ResourceConfig: map[string]interface{}{
 				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a",
 			},
-			ExpectedRegion: "us-central1", // Value is not shortenedfrom URI to name
+			ExpectedRegion: "us-central1",
 		},
 		"returns the value of the region field in provider config when region/zone is unset in resource config": {
 			ProviderConfig: map[string]string{

--- a/mmv1/third_party/terraform/tpgresource/utils_test.go
+++ b/mmv1/third_party/terraform/tpgresource/utils_test.go
@@ -275,13 +275,23 @@ func TestGetLocation(t *testing.T) {
 			},
 			ExpectedLocation: "provider-zone-a",
 		},
-		"does not shorten the zone value when it is set as a self link in the provider config": {
-			// This behaviour makes sense because provider config values don't originate from APIs
-			// Users should always configure the provider with the short names of regions/zones
+		"returns the region value from the provider config when none of location/region/zone are set in the resource config": {
+			ProviderConfig: map[string]string{
+				"region": "provider-region",
+			},
+			ExpectedLocation: "provider-region",
+		},
+		"shortens the region value when it is set as a self link in the provider config": {
+			ProviderConfig: map[string]string{
+				"region": "https://www.googleapis.com/compute/v1/projects/my-project/region/provider-region",
+			},
+			ExpectedLocation: "provider-region",
+		},
+		"shortens the zone value when it is set as a self link in the provider config": {
 			ProviderConfig: map[string]string{
 				"zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a",
 			},
-			ExpectedLocation: "https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a",
+			ExpectedLocation: "provider-zone-a",
 		},
 		// Handling of empty strings
 		"returns the region value set in the resource config when location is an empty string": {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14503

Addressed the following inconsistencies to both the plugin-framework and SDK tests: 
`framework_location.go` and `utils_test.go`

`getLocation`

- Preferentially uses the default region value over the default zone value. Before, the default region value was ignored.
- Now can handle self links when using `location` and `region` in a resource block to get a location values
- Can handle self links being the value of default region or zone set on the provider

`getRegion`
- When determining a region value from a zone, it can handle self links now. This is now possible for zone values set on the resource and when using the default zone value.
- Can handle default region values that are self links


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
