### PR TITLE
Added notes about ProtoV5ProviderBetaFactories and provider = google-beta to test writing docs

### DIFF
--- a/docs/content/develop/resource.md
+++ b/docs/content/develop/resource.md
@@ -196,6 +196,7 @@ For more information about types of resources and the generation process overall
    - Tests: [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests), and remove `_generated` from the filename
    - Sweepers: [`magic-modules/mmv1/third_party/terraform/utils`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/utils)
 4. Modify the Go code as needed.
+   - Replace all occurrences of `github.com/hashicorp/terraform-provider-google-beta/google-beta` with `github.com/hashicorp/terraform-provider-google/google`
    - Remove the `Example` suffix from all test function names.
    - Remove the comments at the top of the file.
    - If beta-only fields are being tested, do the following:
@@ -423,11 +424,12 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
    - Documentation: [`magic-modules/mmv1/third_party/terraform/website/docs/r`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/website/docs/r)
    - Tests: [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests)
 3. Modify the Go code as needed.
-   - Replace the comments at the top of the file with the following:
-     ```
-     <% autogen_exception -%>
-     ```
-   - If any of the added Go code (including any imports) is beta-only, change the file suffix to `.go.erb` and wrap the beta-only code in a version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`.
+   - Replace all occurrences of `github.com/hashicorp/terraform-provider-google-beta/google-beta` with `github.com/hashicorp/terraform-provider-google/google`
+   - Remove the comments at the top of the file.
+   - If any of the added Go code is beta-only:
+     - Change the file suffix to `.go.erb`
+     - Add `<% autogen_exception -%>` to the top of the file
+     - Wrap each beta-only code block (including any imports) in a separate version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`
 4. Register the binding, member, and policy resources in [`magic-modules/mmv1/third_party/terraform/utils/provider.go.erb`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/utils/provider.go.erb) under "START non-generated IAM resources"
    - Add a version guard for any beta-only resources.
 {{< /tab >}}

--- a/docs/content/develop/resource.md
+++ b/docs/content/develop/resource.md
@@ -197,11 +197,11 @@ For more information about types of resources and the generation process overall
    - Sweepers: [`magic-modules/mmv1/third_party/terraform/utils`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/utils)
 4. Modify the Go code as needed.
    - Remove the `Example` suffix from all test function names.
-   - Replace the comments at the top of the file with the following:
-     ```
-     <% autogen_exception -%>
-     ```
-   - If any of the added Go code (including any imports) is beta-only, change the file suffix to `.go.erb` and wrap the beta-only code in a version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`.
+   - Remove the comments at the top of the file.
+   - If beta-only fields are being tested, do the following:
+     - Change the file suffix to `.go.erb`
+     - Add `<% autogen_exception -%>` to the top of the file
+     - Wrap each beta-only test in a separate version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`
 5. Register the resource in [`magic-modules/mmv1/third_party/terraform/utils/provider.go.erb`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/utils/provider.go.erb) under "START handwritten resources"
    - Add a version guard for any beta-only resources.
 6. Optional: Complete other handwritten tasks that require the MMv1 configuration file.

--- a/docs/content/develop/test.md
+++ b/docs/content/develop/test.md
@@ -93,15 +93,15 @@ This section assumes you've used the [Add a resource]({{< ref "/develop/resource
 > **Note:** If not, you can create one now, or skip this guide and construct the test by hand. Writing tests by hand can sometimes be a better option if there is a similar test you can copy from.
 
 1. Add the test in MMv1. Repeat for all the create tests you will need.
-2. [Generate the providers]({{< ref "/get-started/generate-providers.md" >}}).
-3. From the provider, copy and paste the generated `*_generated_test.go` file into [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) as a new file call `*_test.go`.
+2. [Generate the beta provider]({{< ref "/get-started/generate-providers.md" >}}).
+3. From the beta provider, copy and paste the generated `*_generated_test.go` file into [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) as a new file call `*_test.go`.
 4. Modify the tests as needed.
    - Remove the comments at the top of the file.
    - Remove the `Example` suffix from all function names.
    - If beta-only fields are being tested, do the following:
-     - Change the file suffix to `.go.erb`.
-     - Add `<% autogen_exception -%>` to the top of the file.
-     - Wrap the beta-only tests in a version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`.
+     - Change the file suffix to `.go.erb`
+     - Add `<% autogen_exception -%>` to the top of the file
+     - Wrap each beta-only test in a separate version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -113,8 +113,8 @@ An update test is a test that creates the target resource and then makes updates
 
 {{< tabs "update" >}}
 {{< tab "MMv1" >}}
-1. [Generate the providers]({{< ref "/get-started/generate-providers.md" >}}).
-2. From the provider, copy and paste the generated `*_generated_test.go` file into [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) as a new file call `*_test.go`.
+1. [Generate the beta provider]({{< ref "/get-started/generate-providers.md" >}}).
+2. From the beta provider, copy and paste the generated `*_generated_test.go` file into [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) as a new file call `*_test.go`.
 3. Using an editor of your choice, delete the `*DestroyProducer` function, and all but one test. The remaining test should be the "full" test, or if there is no "full" test, the "basic" test. This will be the starting point for your new update test.
 4. Modify the `TestAcc*` *test function* to support updates.
    - Change the suffix of the test function to `_update`.
@@ -162,9 +162,11 @@ An update test is a test that creates the target resource and then makes updates
    - Modify the template function ending in `_update` so that updatable fields are changed or removed. This may require additions to the `context` map in the test function.
    - Remove the comments at the top of the file.
    - If beta-only fields are being tested, do the following:
-     - Change the file suffix to `.go.erb`.
-     - Add `<% autogen_exception -%>` to the top of the file.
-     - Wrap the beta-only tests in a version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`.
+     - Change the file suffix to `.go.erb`
+     - Add `<% autogen_exception -%>` to the top of the file
+     - Wrap each beta-only test in a separate version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`
+     - In each beta-only test, ensure that the TestCase sets `ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t)`
+     - In each beta-only test, ensure that all Terraform resources in all configs have `provider = google-beta` set
 {{< /tab >}}
 {{< tab "Handwritten" >}}
 1. Using an editor of your choice, open the existing `*_test.go` or `*_test.go.erb` file in [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) which contains your create tests.
@@ -209,9 +211,11 @@ An update test is a test that creates the target resource and then makes updates
    - Modify the new template function so that updatable fields are changed or removed. This may require additions to the `context` map in the test function.
    - Remove the comments at the top of the file.
    - If beta-only fields are being tested, do the following:
-     - Change the file suffix to `.go.erb`.
-     - Add `<% autogen_exception -%>` to the top of the file.
-     - Wrap the beta-only tests in a version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`.
+     - Change the file suffix to `.go.erb`
+     - Add `<% autogen_exception -%>` to the top of the file
+     - Wrap each beta-only test in a separate version guard: `<% unless version == 'ga' -%>...<% else -%>...<% end -%>`
+     - In each beta-only test, ensure that the TestCase sets `ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t)`
+     - In each beta-only test, ensure that all Terraform resources in all configs have `provider = google-beta` set
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/docs/content/develop/test.md
+++ b/docs/content/develop/test.md
@@ -96,6 +96,7 @@ This section assumes you've used the [Add a resource]({{< ref "/develop/resource
 2. [Generate the beta provider]({{< ref "/get-started/generate-providers.md" >}}).
 3. From the beta provider, copy and paste the generated `*_generated_test.go` file into [`magic-modules/mmv1/third_party/terraform/tests`](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) as a new file call `*_test.go`.
 4. Modify the tests as needed.
+   - Replace all occurrences of `github.com/hashicorp/terraform-provider-google-beta/google-beta` with `github.com/hashicorp/terraform-provider-google/google`
    - Remove the comments at the top of the file.
    - Remove the `Example` suffix from all function names.
    - If beta-only fields are being tested, do the following:
@@ -159,6 +160,7 @@ An update test is a test that creates the target resource and then makes updates
    }
    ```
 6. Modify the test as needed.
+   - Replace all occurrences of `github.com/hashicorp/terraform-provider-google-beta/google-beta` with `github.com/hashicorp/terraform-provider-google/google`
    - Modify the template function ending in `_update` so that updatable fields are changed or removed. This may require additions to the `context` map in the test function.
    - Remove the comments at the top of the file.
    - If beta-only fields are being tested, do the following:


### PR DESCRIPTION
yaqs/4716615711600934912. I've left off the new information for the create tests because those are recommended to generate from MMv1 (which will already handle this for users) but added it to the update tests because those are fully handwritten.

```release-note:none

```
