### PR TITLE
TeamCity: Address edge case of `google-beta` package containing a hyphen

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
@@ -70,7 +70,7 @@ class packageDetails(packageName: String, displayName: String, providerName: Str
         // Replacing chars can be necessary, due to limitations on IDs
         // "ID should start with a latin letter and contain only latin letters, digits and underscores (at most 225 characters)." 
         var pv = this.providerName.replace("-", "").toUpperCase()
-        var pkg = this.packageName.toUpperCase()
+        var pkg = this.packageName.replace("-", "").toUpperCase()
 
         return "%s_PACKAGE_%s".format(pv, pkg)
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Quick fix hot on the heels of https://github.com/GoogleCloudPlatform/magic-modules/pull/8560

I forgot that the Beta provider would have a package with a hyphen in the name, and we need to protect against it.

```diff
    fun uniqueID() : String {
        // Replacing chars can be necessary, due to limitations on IDs
        // "ID should start with a latin letter and contain only latin letters, digits and underscores (at most 225 characters)." 
        var pv = this.providerName.replace("-", "").toUpperCase()
-        var pkg = this.packageName.toUpperCase()
+        var pkg = this.packageName.replace("-", "").toUpperCase()

        return "%s_PACKAGE_%s".format(pv, pkg)
    }
```


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
