### PR TITLE
TeamCity : Re-add templating of alternate cron days of week for feature branchs

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
@@ -92,7 +92,11 @@ class NightlyTriggerConfiguration(environment: String, branchRef: String, nightl
         // If the environment parameter is set to the value of MAJOR_RELEASE_TESTING, 
         // change the days of week to the day for v5.0.0 feature branch testing
         if (environment == MAJOR_RELEASE_TESTING) {
+<% if version == 'ga' -%>
             this.daysOfWeek = "4" // Thursday for GA
+<% elsif version == 'beta' -%>
+            this.daysOfWeek = "5" // Friday for Beta
+<% end -%>
         }
     }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Another fix for https://github.com/GoogleCloudPlatform/magic-modules/pull/8560

When checking the new TeamCity projects I'm making I realised that some of the templating performed to make `.teamcity/components/generated/project.kt` was lost during refactor



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
