### PR TITLE
Bugfix: Use API's default value for enableEndpointIndependentMapping

### DIFF
--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -371,7 +371,7 @@ properties:
   - !ruby/object:Api::Type::Boolean
     name: enableEndpointIndependentMapping
     description: |
-      Specifies if endpoint independent mapping is enabled. This is enabled by default. For more information
-      see the [official documentation](https://cloud.google.com/nat/docs/overview#specs-rfcs).
-    default_value: true
+      Enable endpoint independent mapping.
+      For more information see the [official documentation](https://cloud.google.com/nat/docs/overview#specs-rfcs).
+    default_from_api: true
     send_empty_value: true


### PR DESCRIPTION
Instead of using a hardcode default of `false` for `enableEndpointIndependentMapping`, use the default value from the API.

https://github.com/hashicorp/terraform-provider-google/issues/10547

<!-- Use API's default value for enableEndpointIndependentMapping -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: used APIs default value for field `enable_endpoint_independent_mapping` in resource `google_compute_router_nat`

```
