### PR TITLE
Replace static, unsweepable name in `TestAccCloudBuildTrigger_pubsub_config`

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -463,7 +463,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
 func testAccCloudBuildTrigger_pubsub_config(name string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "build-trigger" {
-  name = "topic-name"
+  name = "%s"
 }
 
 resource "google_cloudbuild_trigger" "build_trigger" {
@@ -485,13 +485,13 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     google_pubsub_topic.build-trigger
   ]
 }
-`, name)
+`, name, name)
 }
 
 func testAccCloudBuildTrigger_pubsub_config_update(name string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "build-trigger" {
-  name = "topic-name"
+  name = "%s"
 }
 
 resource "google_cloudbuild_trigger" "build_trigger" {
@@ -513,7 +513,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     google_pubsub_topic.build-trigger
   ]
 }
-`, name)
+`, name, name)
 }
 
 func testAccCloudBuildTrigger_webhook_config(name string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addresses this test failure I saw in the nightly tests:

```
TestAccCloudBuildTrigger_pubsub_config


Stacktrace
Copy to clipboard
------- Stdout: -------
=== RUN   TestAccCloudBuildTrigger_pubsub_config
=== PAUSE TestAccCloudBuildTrigger_pubsub_config
=== CONT  TestAccCloudBuildTrigger_pubsub_config
    vcr_utils.go:152: Step 1/4 error: Error running apply: exit status 1
        Error: Error creating Topic: googleapi: Error 409: Resource already exists in the project (resource=topic-name).
          with google_pubsub_topic.build-trigger,
          on terraform_plugin_test.tf line 2, in resource "google_pubsub_topic" "build-trigger":
           2: resource "google_pubsub_topic" "build-trigger" {
--- FAIL: TestAccCloudBuildTrigger_pubsub_config (6.37s)
FAIL

```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
