### PR TITLE
Workstations : workstation_config > add enable_nested_virtualization

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -193,6 +193,7 @@ properties:
       - 'host.gceInstance.poolSize'
       - 'host.gceInstance.tags'
       - 'host.gceInstance.disablePublicIpAddresses'
+      - 'host.gceInstance.enableNestedVirtualization'
       - 'host.gceInstance.shieldedInstanceConfig.enableSecureBoot'
       - 'host.gceInstance.shieldedInstanceConfig.enableVtpm'
       - 'host.gceInstance.shieldedInstanceConfig.enableIntegrityMonitoring'
@@ -235,6 +236,12 @@ properties:
             name: 'disablePublicIpAddresses'
             description: |
               Whether instances have no public IP address.
+          - !ruby/object:Api::Type::Boolean
+            name: 'enableNestedVirtualization'
+            description: |
+              Whether to enable nested virtualization on the Compute Engine VMs backing the Workstations.
+
+              See https://cloud.google.com/workstations/docs/reference/rest/v1beta/projects.locations.workstationClusters.workstationConfigs#GceInstance.FIELDS.enable_nested_virtualization
           - !ruby/object:Api::Type::NestedObject
             name: 'shieldedInstanceConfig'
             description: |

--- a/mmv1/templates/terraform/examples/workstation_config_container.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_container.tf.erb
@@ -33,12 +33,13 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
   workstation_config_id  = "<%= ctx[:vars]['workstation_config_name'] %>"
   workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
   location   		         = "us-central1"
-  
+
   host {
     gce_instance {
-      machine_type                = "e2-standard-4"
-      boot_disk_size_gb           = 35
-      disable_public_ip_addresses = true
+      machine_type                 = "n1-standard-4"
+      boot_disk_size_gb            = 35
+      disable_public_ip_addresses  = true
+      enable_nested_virtualization = true
     }
   }
 

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -111,7 +111,7 @@ func TestAccWorkstationsWorkstationConfig_displayName(t *testing.T) {
 }
 
 func testAccWorkstationsWorkstationConfig_displayName(context map[string]interface{}, update string) string {
-	context["display_name"] = context["display_name"].(string) + update	
+	context["display_name"] = context["display_name"].(string) + update
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
   provider                = google-beta
@@ -253,6 +253,15 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"etag"},
 			},
+      {
+				Config: testAccWorkstationsWorkstationConfig_workstationConfigBasicExample(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
 		},
 	})
 }
@@ -293,14 +302,19 @@ resource "google_workstations_workstation_config" "default" {
 
   host {
     gce_instance {
-      machine_type                = "e2-standard-4"
-      boot_disk_size_gb           = 35
-      disable_public_ip_addresses = true
+      machine_type                 = "n1-standard-4"
+      boot_disk_size_gb            = 35
+      disable_public_ip_addresses  = true
+      enable_nested_virtualization = true
     }
   }
 
   labels = {
 	foo = "bar"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }
 `, context)


### PR DESCRIPTION
Adds support for enable_nested_virtualization to workstation_config. Fixes [#15351](https://github.com/hashicorp/terraform-provider-google/issues/15351).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added `enable_nested_virtualization` field to `google_workstations_workstation_config` resource
```