### PR TITLE
Add additional_pod_ranges_config field

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2448,37 +2448,37 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			return errwrap.Wrapf("Error while waiting to enable private endpoint: {{err}}", err)
 		}
+	}
 
-		if names := d.Get("additional_pod_ranges_config.0.pod_range_names").([]interface{}); len(names) > 0 {
-			name := containerClusterFullName(project, location, clusterName)
-			additionalPodRangesConfig := &container.AdditionalPodRangesConfig{
-				PodRangeNames: tpgresource.ConvertStringArr(names),
-			}
-	
-			req := &container.UpdateClusterRequest{
-				Update: &container.ClusterUpdate{
-					AdditionalPodRangesConfig: additionalPodRangesConfig,
-				},
-			}
-	
-			err = transport_tpg.Retry(transport_tpg.RetryOptions{
-				RetryFunc: func() error {
-					clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
-					if config.UserProjectOverride {
-						clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-					}
-					op, err = clusterUpdateCall.Do()
-					return err
-				},
-			})
-			if err != nil {
-				return errwrap.Wrapf("Error updating AdditionalPodRangesConfig: {{err}}", err)
-			}
-	
-			err = ContainerOperationWait(config, op, project, location, "updating AdditionalPodRangesConfig", userAgent, d.Timeout(schema.TimeoutCreate))
-			if err != nil {
-				return errwrap.Wrapf("Error while waiting to update AdditionalPodRangesConfig: {{err}}", err)
-			}
+	if names := d.Get("additional_pod_ranges_config.0.pod_range_names").([]interface{}); len(names) > 0 {
+		name := containerClusterFullName(project, location, clusterName)
+		additionalPodRangesConfig := &container.AdditionalPodRangesConfig{
+			PodRangeNames: tpgresource.ConvertStringArr(names),
+		}
+
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				AdditionalPodRangesConfig: additionalPodRangesConfig,
+			},
+		}
+
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: func() error {
+				clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+				if config.UserProjectOverride {
+					clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
+				}
+				op, err = clusterUpdateCall.Do()
+				return err
+			},
+		})
+		if err != nil {
+			return errwrap.Wrapf("Error updating AdditionalPodRangesConfig: {{err}}", err)
+		}
+
+		err = ContainerOperationWait(config, op, project, location, "updating AdditionalPodRangesConfig", userAgent, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return errwrap.Wrapf("Error while waiting to update AdditionalPodRangesConfig: {{err}}", err)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1580,6 +1580,23 @@ func ResourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			"additional_pod_ranges_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: `AdditionalPodRangesConfig is the configuration for additional pod secondary ranges supporting the ClusterUpdate message.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"pod_range_names": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `Name for pod secondary ipv4 range which has the actual range defined ahead.`,
+						},
+					},
+				},
+			},
+
 			"networking_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -2431,6 +2448,38 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			return errwrap.Wrapf("Error while waiting to enable private endpoint: {{err}}", err)
 		}
+
+		if names := d.Get("additional_pod_ranges_config.0.pod_range_names").([]interface{}); len(names) > 0 {
+			name := containerClusterFullName(project, location, clusterName)
+			additionalPodRangesConfig := &container.AdditionalPodRangesConfig{
+				PodRangeNames: tpgresource.ConvertStringArr(names),
+			}
+	
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
+					AdditionalPodRangesConfig: additionalPodRangesConfig,
+				},
+			}
+	
+			err = transport_tpg.Retry(transport_tpg.RetryOptions{
+				RetryFunc: func() error {
+					clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+					if config.UserProjectOverride {
+						clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
+					}
+					op, err = clusterUpdateCall.Do()
+					return err
+				},
+			})
+			if err != nil {
+				return errwrap.Wrapf("Error updating AdditionalPodRangesConfig: {{err}}", err)
+			}
+	
+			err = ContainerOperationWait(config, op, project, location, "updating AdditionalPodRangesConfig", userAgent, d.Timeout(schema.TimeoutCreate))
+			if err != nil {
+				return errwrap.Wrapf("Error while waiting to update AdditionalPodRangesConfig: {{err}}", err)
+			}
+		}
 	}
 
 	if err := resourceContainerClusterRead(d, meta); err != nil {
@@ -2605,6 +2654,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
                 return fmt.Errorf("Error setting allow_net_admin: %s", err)
             }
         }
+	}
+	if err := d.Set("additional_pod_ranges_config", flattenAdditionalPodRangesConfig(cluster.IpAllocationPolicy)); err != nil {
+		return fmt.Errorf("Error setting additional_pod_ranges_config: %s", err)
 	}
 	if cluster.ShieldedNodes != nil {
 		if err := d.Set("enable_shielded_nodes", cluster.ShieldedNodes.Enabled); err != nil {
@@ -3353,6 +3405,55 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		log.Printf("[INFO] Network policy for GKE cluster %s has been updated", d.Id())
 
+	}
+
+	if d.HasChange("additional_pod_ranges_config") {
+		o, n := d.GetChange("additional_pod_ranges_config.0.pod_range_names")
+		old_names := tpgresource.GolangSetFromStringSlice(tpgresource.ConvertStringArr(o.([]interface{})))
+		new_names := tpgresource.GolangSetFromStringSlice(tpgresource.ConvertStringArr(n.([]interface{})))
+
+		// Filter out unchanged names. old_names will contain names to be removed, new_names will contain names to add.
+		for name := range old_names {
+			if _, ok := new_names[name]; ok {
+				delete(old_names, name)
+				delete(new_names, name)
+			}
+		}
+
+		var additional_config *container.AdditionalPodRangesConfig
+		var removed_config *container.AdditionalPodRangesConfig
+		if len(new_names) > 0 {
+			var names []string
+			for name := range new_names {
+				names = append(names, name)
+			}
+			additional_config = &container.AdditionalPodRangesConfig{
+				PodRangeNames: names,
+			}
+		}
+		if len(old_names) > 0 {
+			var names []string
+			for name := range old_names {
+				names = append(names, name)
+			}
+			removed_config = &container.AdditionalPodRangesConfig{
+				PodRangeNames: names,
+			}
+		}
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				AdditionalPodRangesConfig:        additional_config,
+				RemovedAdditionalPodRangesConfig: removed_config,
+			},
+		}
+
+		updateF := updateFunc(req, "updating AdditionalPodRangesConfig")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's AdditionalPodRangesConfig has been updated", d.Id())
 	}
 
 	if n, ok := d.GetOk("node_pool.#"); ok {
@@ -4645,6 +4746,25 @@ func flattenSecurityPostureConfig(spc *container.SecurityPostureConfig) []map[st
 
 	result["mode"] = spc.Mode
 	result["vulnerability_mode"] = spc.VulnerabilityMode
+
+	return []map[string]interface{}{result}
+}
+
+func flattenAdditionalPodRangesConfig(ipAllocationPolicy *container.IPAllocationPolicy) []map[string]interface{} {
+	if ipAllocationPolicy == nil {
+		return nil
+	}
+	result := make(map[string]interface{})
+
+	if aprc := ipAllocationPolicy.AdditionalPodRangesConfig; aprc != nil {
+		if len(aprc.PodRangeNames) > 0 {
+			result["pod_range_names"] = aprc.PodRangeNames
+		} else {
+			return nil
+		}
+	} else {
+		return nil
+	}
 
 	return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1588,7 +1588,8 @@ func ResourceContainerCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pod_range_names": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
+							MinItems:    1,
 							Required:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: `Name for pod secondary ipv4 range which has the actual range defined ahead.`,
@@ -2450,10 +2451,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if names := d.Get("additional_pod_ranges_config.0.pod_range_names").([]interface{}); len(names) > 0 {
+	if names, ok := d.GetOk("additional_pod_ranges_config.0.pod_range_names"); ok {
 		name := containerClusterFullName(project, location, clusterName)
 		additionalPodRangesConfig := &container.AdditionalPodRangesConfig{
-			PodRangeNames: tpgresource.ConvertStringArr(names),
+			PodRangeNames: tpgresource.ConvertStringSet(names.(*schema.Set)),
 		}
 
 		req := &container.UpdateClusterRequest{
@@ -2655,8 +2656,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
             }
         }
 	}
-	if err := d.Set("additional_pod_ranges_config", flattenAdditionalPodRangesConfig(cluster.IpAllocationPolicy)); err != nil {
-		return fmt.Errorf("Error setting additional_pod_ranges_config: %s", err)
+	if aprc := flattenAdditionalPodRangesConfig(cluster.IpAllocationPolicy); aprc != nil {
+		if err := d.Set("additional_pod_ranges_config", aprc); err != nil {
+			return fmt.Errorf("Error setting additional_pod_ranges_config: %s", err)
+		}
 	}
 	if cluster.ShieldedNodes != nil {
 		if err := d.Set("enable_shielded_nodes", cluster.ShieldedNodes.Enabled); err != nil {
@@ -3409,32 +3412,28 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("additional_pod_ranges_config") {
 		o, n := d.GetChange("additional_pod_ranges_config.0.pod_range_names")
-		old_names := tpgresource.GolangSetFromStringSlice(tpgresource.ConvertStringArr(o.([]interface{})))
-		new_names := tpgresource.GolangSetFromStringSlice(tpgresource.ConvertStringArr(n.([]interface{})))
-
-		// Filter out unchanged names. old_names will contain names to be removed, new_names will contain names to add.
-		for name := range old_names {
-			if _, ok := new_names[name]; ok {
-				delete(old_names, name)
-				delete(new_names, name)
-			}
-		}
+		old_names := o.(*schema.Set)
+		new_names := n.(*schema.Set)
+		
+		// Filter unchanged names.
+		removed_names := old_names.Difference(new_names)
+		added_names := new_names.Difference(old_names)
 
 		var additional_config *container.AdditionalPodRangesConfig
 		var removed_config *container.AdditionalPodRangesConfig
-		if len(new_names) > 0 {
+		if added_names.Len() > 0 {
 			var names []string
-			for name := range new_names {
-				names = append(names, name)
+			for _, name := range added_names.List() {
+				names = append(names, name.(string))
 			}
 			additional_config = &container.AdditionalPodRangesConfig{
 				PodRangeNames: names,
 			}
 		}
-		if len(old_names) > 0 {
+		if removed_names.Len() > 0 {
 			var names []string
-			for name := range old_names {
-				names = append(names, name)
+			for _, name := range removed_names.List() {
+				names = append(names, name.(string))
 			}
 			removed_config = &container.AdditionalPodRangesConfig{
 				PodRangeNames: names,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1576,23 +1576,22 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-					},
-				},
-			},
-
-			"additional_pod_ranges_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: `AdditionalPodRangesConfig is the configuration for additional pod secondary ranges supporting the ClusterUpdate message.`,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"pod_range_names": {
-							Type:        schema.TypeSet,
-							MinItems:    1,
-							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: `Name for pod secondary ipv4 range which has the actual range defined ahead.`,
+						"additional_pod_ranges_config": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: `AdditionalPodRangesConfig is the configuration for additional pod secondary ranges supporting the ClusterUpdate message.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"pod_range_names": {
+										Type:        schema.TypeSet,
+										MinItems:    1,
+										Required:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `Name for pod secondary ipv4 range which has the actual range defined ahead.`,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -2451,7 +2450,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if names, ok := d.GetOk("additional_pod_ranges_config.0.pod_range_names"); ok {
+	if names, ok := d.GetOk("ip_allocation_policy.0.additional_pod_ranges_config.0.pod_range_names"); ok {
 		name := containerClusterFullName(project, location, clusterName)
 		additionalPodRangesConfig := &container.AdditionalPodRangesConfig{
 			PodRangeNames: tpgresource.ConvertStringSet(names.(*schema.Set)),
@@ -2655,11 +2654,6 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
                 return fmt.Errorf("Error setting allow_net_admin: %s", err)
             }
         }
-	}
-	if aprc := flattenAdditionalPodRangesConfig(cluster.IpAllocationPolicy); aprc != nil {
-		if err := d.Set("additional_pod_ranges_config", aprc); err != nil {
-			return fmt.Errorf("Error setting additional_pod_ranges_config: %s", err)
-		}
 	}
 	if cluster.ShieldedNodes != nil {
 		if err := d.Set("enable_shielded_nodes", cluster.ShieldedNodes.Enabled); err != nil {
@@ -3410,8 +3404,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	}
 
-	if d.HasChange("additional_pod_ranges_config") {
-		o, n := d.GetChange("additional_pod_ranges_config.0.pod_range_names")
+	if d.HasChange("ip_allocation_policy.0.additional_pod_ranges_config") {
+		o, n := d.GetChange("ip_allocation_policy.0.additional_pod_ranges_config.0.pod_range_names")
 		old_names := o.(*schema.Set)
 		new_names := n.(*schema.Set)
 		
@@ -5669,6 +5663,7 @@ func flattenIPAllocationPolicy(c *container.Cluster, d *schema.ResourceData, con
 			"services_secondary_range_name": p.ServicesSecondaryRangeName,
 			"stack_type":                    p.StackType,
 			"pod_cidr_overprovision_config": flattenPodCidrOverprovisionConfig(p.PodCidrOverprovisionConfig),
+			"additional_pod_ranges_config":  flattenAdditionalPodRangesConfig(c.IpAllocationPolicy),
 		},
 	}, nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3934,7 +3934,7 @@ func TestAccContainerCluster_additional_pod_ranges_config_on_create(t *testing.T
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, true),
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, 1),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -3955,7 +3955,7 @@ func TestAccContainerCluster_additional_pod_ranges_config_on_update(t *testing.T
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, false),
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, 0),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -3963,7 +3963,31 @@ func TestAccContainerCluster_additional_pod_ranges_config_on_update(t *testing.T
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, true),
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, 2),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, 0),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, 1),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, 0),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -8112,11 +8136,21 @@ resource "google_container_cluster" "cluster" {
 }`, policyName, cluster, np)
 }
 
-func testAccContainerCluster_additional_pod_ranges_config(name string, addName bool) string {
+func testAccContainerCluster_additional_pod_ranges_config(name string, nameCount int) string {
 	var podRangeNamesStr string
-	if addName {
-		podRangeNamesStr = "\"gke-autopilot-pods-add\""
+	names := []string{"\"gke-autopilot-pods-add\",", "\"gke-autopilot-pods-add-2\""}
+	for i := 0; i < nameCount; i++ {
+		podRangeNamesStr += names[i]
 	}
+	var aprc string
+	if len(podRangeNamesStr) > 0 {
+		aprc = fmt.Sprintf(`
+			additional_pod_ranges_config {
+				pod_range_names = [%s]
+			}
+		`, podRangeNamesStr)
+	}
+	
 	return fmt.Sprintf(`
 	resource "google_compute_network" "main" {
 		name                    = "%s"
@@ -8142,6 +8176,10 @@ func testAccContainerCluster_additional_pod_ranges_config(name string, addName b
 			range_name    = "gke-autopilot-pods-add"
 			ip_cidr_range = "10.100.0.0/16"
 		}
+		secondary_ip_range {
+			range_name    = "gke-autopilot-pods-add-2"
+			ip_cidr_range = "100.0.0.0/16"
+		}
 	}
 	resource "google_container_cluster" "primary" {
 		name     = "%s"
@@ -8162,14 +8200,19 @@ func testAccContainerCluster_additional_pod_ranges_config(name string, addName b
 			master_ipv4_cidr_block  = "172.16.0.0/28"
 		}
 
+		# supresses permadiff
+		dns_config {
+			cluster_dns = "CLOUD_DNS"
+			cluster_dns_domain = "cluster.local"
+			cluster_dns_scope = "CLUSTER_SCOPE"
+		}
+
 		ip_allocation_policy {
 			cluster_secondary_range_name  = "gke-autopilot-pods"
 			services_secondary_range_name = "gke-autopilot-services"
 		}
 
-		additional_pod_ranges_config {
-			pod_range_names = [%s]
-		}
+		%s
 	}
-	`, name, name, name, podRangeNamesStr)
+	`, name, name, name, aprc)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3924,6 +3924,56 @@ func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_additional_pod_ranges_config_on_create(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, true),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_additional_pod_ranges_config_on_update(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, false),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerCluster_additional_pod_ranges_config(clusterName, true),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccContainerCluster_masterAuthorizedNetworksDisabled(t *testing.T, resource_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resource_name]
@@ -8060,4 +8110,66 @@ resource "google_container_cluster" "cluster" {
     }
   }
 }`, policyName, cluster, np)
+}
+
+func testAccContainerCluster_additional_pod_ranges_config(name string, addName bool) string {
+	var podRangeNamesStr string
+	if addName {
+		podRangeNamesStr = "\"gke-autopilot-pods-add\""
+	}
+	return fmt.Sprintf(`
+	resource "google_compute_network" "main" {
+		name                    = "%s"
+		auto_create_subnetworks = false
+	}
+	resource "google_compute_subnetwork" "main" {
+		ip_cidr_range = "10.10.0.0/16"
+		name          = "%s"
+		network       = google_compute_network.main.self_link
+		region        = "us-central1"
+
+		secondary_ip_range {
+			range_name    = "gke-autopilot-services"
+			ip_cidr_range = "10.11.0.0/20"
+		}
+
+		secondary_ip_range {
+			range_name    = "gke-autopilot-pods"
+			ip_cidr_range = "10.12.0.0/16"
+		}
+
+		secondary_ip_range {
+			range_name    = "gke-autopilot-pods-add"
+			ip_cidr_range = "10.100.0.0/16"
+		}
+	}
+	resource "google_container_cluster" "primary" {
+		name     = "%s"
+		location = "us-central1"
+
+		enable_autopilot = true
+
+		release_channel {
+			channel = "REGULAR"
+		}
+
+		network    = google_compute_network.main.name
+		subnetwork = google_compute_subnetwork.main.name
+
+		private_cluster_config {
+			enable_private_endpoint = false
+			enable_private_nodes    = true
+			master_ipv4_cidr_block  = "172.16.0.0/28"
+		}
+
+		ip_allocation_policy {
+			cluster_secondary_range_name  = "gke-autopilot-pods"
+			services_secondary_range_name = "gke-autopilot-services"
+		}
+
+		additional_pod_ranges_config {
+			pod_range_names = [%s]
+		}
+	}
+	`, name, name, name, podRangeNamesStr)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -8210,9 +8210,8 @@ func testAccContainerCluster_additional_pod_ranges_config(name string, nameCount
 		ip_allocation_policy {
 			cluster_secondary_range_name  = "gke-autopilot-pods"
 			services_secondary_range_name = "gke-autopilot-services"
+			%s
 		}
-
-		%s
 	}
 	`, name, name, name, aprc)
 }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -728,7 +728,7 @@ the cluster level. Used for Autopilot clusters and Standard clusters with which 
 secondary Pod IP address assignment to node pools isn't needed. Structure is [documented below](#nested_additional_pod_ranges_config).
 
 
-<a name="additional_pod_ranges_config"></a>The `additional_pod_ranges_config` block supports:
+<a name="nested_additional_pod_ranges_config"></a>The `additional_pod_ranges_config` block supports:
 
 * `pod_range_names` - (Required) The names of the Pod ranges to add to the cluster.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -198,12 +198,6 @@ below](#nested_ip_allocation_policy).
 Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
 and requires the `ip_allocation_policy` block to be defined. By default, when this field is unspecified and no `ip_allocation_policy` blocks are set, GKE will create a `ROUTES`-based cluster.
 
-* `additional_pod_ranges_config` - (Optional) The configuration for additional pod secondary ranges at
-the cluster level. Used for Autopilot clusters and Standard clusters with which control of the 
-secondary Pod IP address assignment to node pools isn't needed.
-
-* `pod_range_names` - (Required) The names of the Pod ranges to add to the cluster.
-
 * `logging_config` - (Optional) Logging configuration for the cluster.
     Structure is [documented below](#nested_logging_config).
 
@@ -728,6 +722,16 @@ pick a specific range to use.
 * `stack_type` - (Optional) The IP Stack Type of the cluster.
 Default value is `IPV4`.
 Possible values are `IPV4` and `IPV4_IPV6`.
+
+* `additional_pod_ranges_config` - (Optional) The configuration for additional pod secondary ranges at
+the cluster level. Used for Autopilot clusters and Standard clusters with which control of the 
+secondary Pod IP address assignment to node pools isn't needed. Structure is [documented below](#nested_additional_pod_ranges_config).
+
+
+<a name="additional_pod_ranges_config"></a>The `additional_pod_ranges_config` block supports:
+
+* `pod_range_names` - (Required) The names of the Pod ranges to add to the cluster.
+
 
 <a name="nested_master_auth"></a>The `master_auth` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -198,6 +198,12 @@ below](#nested_ip_allocation_policy).
 Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
 and requires the `ip_allocation_policy` block to be defined. By default, when this field is unspecified and no `ip_allocation_policy` blocks are set, GKE will create a `ROUTES`-based cluster.
 
+* `additional_pod_ranges_config` - (Optional) The configuration for additional pod secondary ranges at
+the cluster level. Used for Autopilot clusters and Standard clusters with which control of the 
+secondary Pod IP address assignment to node pools isn't needed.
+
+* `pod_range_names` - (Required) The names of the Pod ranges to add to the cluster.
+
 * `logging_config` - (Optional) Logging configuration for the cluster.
     Structure is [documented below](#nested_logging_config).
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `additional_pod_ranges_config` field to `google_container_cluster` resource
```
