### PR TITLE
Certificate manager update description for scope property certificate resource

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -108,7 +108,9 @@ properties:
 
       EDGE_CACHE: Certificates with scope EDGE_CACHE are special-purposed certificates,
       served from non-core Google data centers.
-      Currently allowed only for managed certificates.
+
+      ALL_REGIONS: Certificates with ALL_REGIONS scope are served from all GCP regions (You can only use ALL_REGIONS with global certs).
+      see https://cloud.google.com/compute/docs/regions-zones
     default_value: DEFAULT
     diff_suppress_func: 'certManagerDefaultScopeDiffSuppress'
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -58,8 +58,9 @@ examples:
     primary_resource_id: 'default'
     vars:
       cert_name: 'issuance-config-cert'
-      ca_name: 'my-ca'
-      pool_name: 'my-ca-pool'
+      ca_name: 'ca-authority'
+      pool_name: 'ca-pool'
+      issuance_config_name: 'issuance-config'
   - !ruby/object:Provider::Terraform::Examples
     name: 'certificate_manager_self_managed_certificate'
     primary_resource_id: 'default'

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -49,8 +49,9 @@ examples:
     name: 'certificate_manager_certificate_issuance_config'
     primary_resource_id: 'default'
     vars:
-      ca_name: 'my-ca'
-      pool_name: 'my-ca-pool'
+      ca_name: 'ca-authority'
+      pool_name: 'ca-pool'
+      issuance_config_name: 'issuance-config'
 
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/templates/terraform/examples/certificate_manager_certificate_issuance_config.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_certificate_issuance_config.tf.erb
@@ -1,5 +1,5 @@
 resource "google_certificate_manager_certificate_issuance_config" "<%= ctx[:primary_resource_id] %>" {
-  name    = "issuanceconfigtestterraform"
+  name    = "<%= ctx[:vars]["issuance_config_name"] %>"
   description = "sample description for the certificate issuanceConfigs"
   certificate_authority_config {
     certificate_authority_service_config {

--- a/mmv1/templates/terraform/examples/certificate_manager_google_managed_certificate_issuance_config.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_google_managed_certificate_issuance_config.tf.erb
@@ -14,7 +14,7 @@ resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id]
 
 # creating certificate_issuance_config to use it in the managed certificate
 resource "google_certificate_manager_certificate_issuance_config" "issuanceconfig" {
-  name    = "issuanceconfigtestterraform"
+  name    = "<%= ctx[:vars]["issuance_config_name"] %>"
   description = "sample description for the certificate issuanceConfigs"
   certificate_authority_config {
     certificate_authority_service_config {

--- a/mmv1/templates/terraform/examples/certificate_manager_self_managed_certificate.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_self_managed_certificate.tf.erb
@@ -1,7 +1,7 @@
 resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]['cert_name'] %>"
   description = "Global cert"
-  scope       = "EDGE_CACHE"
+  scope       = "ALL_REGIONS"
   self_managed {
     pem_certificate = file("test-fixtures/certificatemanager/cert.pem")
     pem_private_key = file("test-fixtures/certificatemanager/private-key.pem")


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
- Updated the description of the `scope` field in `certificate` resource to reflect that a new value, ALL_REGIONS, is now supported.
- Modified an example to use `scope=ALL_REGIONS`.
- Some of the resources names in the tests weren't identified using variables. That caused "resource already exists" error whenever I ran all acceptance tests for CCM at once(`make testacc TEST=./google TESTARGS='-run=TestAccCertificateManagerCertificate'`). Adding them to variables will make TF add a random suffix to the names when It creates the resources and hence avoid concurrency issues.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
certificatemanager: updated the description of the `scope` field in `certificate` resource to show that ALL_REGIONS is supported 
```
