### PR TITLE
Add case sensitivity diff suppression for enums.

### DIFF
--- a/tpgtools/overrides/containeraws/beta/cluster.yaml
+++ b/tpgtools/overrides/containeraws/beta/cluster.yaml
@@ -1,2 +1,18 @@
 - type: EXCLUDE
   field: monitoring_config
+- type: DIFF_SUPPRESS_FUNC
+  field: control_plane.root_volume.volume_type
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: control_plane.main_volume.volume_type
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: logging_config.component_config.enable_components
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: control_plane.instance_placement.tenancy
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive

--- a/tpgtools/overrides/containeraws/beta/node_pool.yaml
+++ b/tpgtools/overrides/containeraws/beta/node_pool.yaml
@@ -1,0 +1,12 @@
+- type: DIFF_SUPPRESS_FUNC
+  field: config.root_volume.volume_type
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: config.taints.effect
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: config.instance_placement.tenancy
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive

--- a/tpgtools/overrides/containeraws/cluster.yaml
+++ b/tpgtools/overrides/containeraws/cluster.yaml
@@ -1,0 +1,8 @@
+- type: DIFF_SUPPRESS_FUNC
+  field: control_plane.root_volume.volume_type
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: control_plane.main_volume.volume_type
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive

--- a/tpgtools/overrides/containeraws/node_pool.yaml
+++ b/tpgtools/overrides/containeraws/node_pool.yaml
@@ -1,0 +1,8 @@
+- type: DIFF_SUPPRESS_FUNC
+  field: config.root_volume.volume_type
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive
+- type: DIFF_SUPPRESS_FUNC
+  field: config.taints.effect
+  details:
+    diffsuppressfunc: tpgresource.CompareCaseInsensitive

--- a/tpgtools/overrides/containeraws/samples/cluster/basic_enum.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/cluster/basic_enum.tf.tmpl
@@ -1,0 +1,84 @@
+data "google_container_aws_versions" "versions" {
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  description = "A sample aws cluster"
+  project     = "{{project}}"
+}
+

--- a/tpgtools/overrides/containeraws/samples/cluster/basic_enum.yaml
+++ b/tpgtools/overrides/containeraws/samples/cluster/basic_enum.yaml
@@ -1,0 +1,32 @@
+description: A basic example of a containeraws cluster with lowercase enums
+name: basic_enum_aws_cluster
+type: aws_cluster
+updates:
+- resource: ./basic_enum_update.tf.tmpl
+variables:
+- name: byo_multicloud_prefix
+  type: byo_multicloud_prefix
+- name: name
+  type: resource_name
+- name: project
+  type: project
+- name: project_number
+  type: project_number
+- name: aws_account_id
+  type: aws_account_id
+- name: aws_volume_encryption_key
+  type: aws_volume_encryption_key
+- name: aws_vpc
+  type: aws_vpc
+- name: aws_database_encryption_key
+  type: aws_database_encryption_key
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_subnet
+  type: aws_subnet
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_region
+  type: aws_region
+- name: test_service_account
+  type: test_service_account

--- a/tpgtools/overrides/containeraws/samples/cluster/basic_enum_update.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/cluster/basic_enum_update.tf.tmpl
@@ -1,0 +1,84 @@
+data "google_container_aws_versions" "versions" {
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-two = "value-two"
+  }
+
+  description = "An updated sample aws cluster"
+  project     = "{{project}}"
+}
+

--- a/tpgtools/overrides/containeraws/samples/cluster/beta_basic_enum.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/cluster/beta_basic_enum.tf.tmpl
@@ -1,0 +1,96 @@
+data "google_container_aws_versions" "versions" {
+  provider = google-beta
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  provider = google-beta
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+
+    instance_placement {
+      tenancy = "dedicated"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  description = "A sample aws cluster"
+  project     = "{{project}}"
+
+  logging_config {
+    component_config {
+      enable_components = ["system_components", "workloads"]
+    }
+  }
+
+}

--- a/tpgtools/overrides/containeraws/samples/cluster/beta_basic_enum.yaml
+++ b/tpgtools/overrides/containeraws/samples/cluster/beta_basic_enum.yaml
@@ -1,0 +1,34 @@
+description: A basic example of a containeraws cluster with lowercase enums (beta)
+name: beta_basic_enum_aws_cluster
+type: aws_cluster
+versions:
+- beta
+updates:
+- resource: ./beta_basic_enum_update.tf.tmpl
+variables:
+- name: byo_multicloud_prefix
+  type: byo_multicloud_prefix
+- name: name
+  type: resource_name
+- name: project
+  type: project
+- name: project_number
+  type: project_number
+- name: aws_account_id
+  type: aws_account_id
+- name: aws_volume_encryption_key
+  type: aws_volume_encryption_key
+- name: aws_vpc
+  type: aws_vpc
+- name: aws_database_encryption_key
+  type: aws_database_encryption_key
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_subnet
+  type: aws_subnet
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_region
+  type: aws_region
+- name: test_service_account
+  type: test_service_account

--- a/tpgtools/overrides/containeraws/samples/cluster/beta_basic_enum_update.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/cluster/beta_basic_enum_update.tf.tmpl
@@ -1,0 +1,97 @@
+data "google_container_aws_versions" "versions" {
+  provider = google-beta
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  provider = google-beta
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+       owner = "updated-{{test_service_account}}"
+    }
+
+    instance_placement {
+      tenancy = "dedicated"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-two = "value-two"
+  }
+
+  description = "An updated sample aws cluster"
+  project     = "{{project}}"
+
+  logging_config {
+    component_config {
+      enable_components = ["system_components", "workloads"]
+    }
+  }
+
+}
+

--- a/tpgtools/overrides/containeraws/samples/nodepool/basic_enum.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/nodepool/basic_enum.tf.tmpl
@@ -1,0 +1,151 @@
+data "google_container_aws_versions" "versions" {
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  description = "A sample aws cluster"
+  project     = "{{project}}"
+}
+
+
+resource "google_container_aws_node_pool" "primary" {
+  autoscaling {
+    max_node_count = 5
+    min_node_count = 1
+  }
+
+  cluster = google_container_aws_cluster.primary.name
+
+  config {
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-nodepool"
+    instance_type        = "t3.medium"
+
+    labels = {
+      label-one = "value-one"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      tag-one = "value-one"
+    }
+
+    taints {
+      effect = "prefer_no_schedule"
+      key    = "taint-key"
+      value  = "taint-value"
+    }
+  }
+
+  location = "us-west1"
+
+  max_pods_constraint {
+    max_pods_per_node = 110
+  }
+
+  name      = "{{node-pool-name}}"
+  subnet_id = "{{aws_subnet}}"
+  version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  project = "{{project}}"
+}
+

--- a/tpgtools/overrides/containeraws/samples/nodepool/basic_enum.yaml
+++ b/tpgtools/overrides/containeraws/samples/nodepool/basic_enum.yaml
@@ -1,0 +1,34 @@
+description: A basic example of a containeraws node pool with lowercase enums
+name: basic_enum_aws_cluster
+type: aws_cluster
+updates:
+- resource: ./basic_enum_update.tf.tmpl
+variables:
+- name: byo_multicloud_prefix
+  type: byo_multicloud_prefix
+- name: name
+  type: resource_name
+- name: node-pool-name
+  type: resource_name
+- name: project
+  type: project
+- name: project_number
+  type: project_number
+- name: aws_account_id
+  type: aws_account_id
+- name: aws_volume_encryption_key
+  type: aws_volume_encryption_key
+- name: aws_vpc
+  type: aws_vpc
+- name: aws_database_encryption_key
+  type: aws_database_encryption_key
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_subnet
+  type: aws_subnet
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_region
+  type: aws_region
+- name: test_service_account
+  type: test_service_account

--- a/tpgtools/overrides/containeraws/samples/nodepool/basic_enum_update.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/nodepool/basic_enum_update.tf.tmpl
@@ -1,0 +1,150 @@
+data "google_container_aws_versions" "versions" {
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  description = "A sample aws cluster"
+  project     = "{{project}}"
+}
+
+resource "google_container_aws_node_pool" "primary" {
+  autoscaling {
+    max_node_count = 5
+    min_node_count = 1
+  }
+
+  cluster = google_container_aws_cluster.primary.name
+
+  config {
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-nodepool"
+    instance_type        = "t3.large"
+
+    labels = {
+      label-one = "value-one"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      tag-one = "value-one"
+    }
+
+    taints {
+      effect = "prefer_no_schedule"
+      key    = "taint-key"
+      value  = "taint-value"
+    }
+  }
+
+  location = "us-west1"
+
+  max_pods_constraint {
+    max_pods_per_node = 110
+  }
+
+  name      = "{{node-pool-name}}"
+  subnet_id = "{{aws_subnet}}"
+  version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+
+  annotations = {
+    label-two = "value-two"
+  }
+
+  project = "{{project}}"
+}
+

--- a/tpgtools/overrides/containeraws/samples/nodepool/beta_basic_enum.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/nodepool/beta_basic_enum.tf.tmpl
@@ -1,0 +1,160 @@
+data "google_container_aws_versions" "versions" {
+  provider = google-beta
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  provider = google-beta
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  description = "A sample aws cluster"
+  project     = "{{project}}"
+}
+
+
+resource "google_container_aws_node_pool" "primary" {
+  provider = google-beta
+  autoscaling {
+    max_node_count = 5
+    min_node_count = 1
+  }
+
+  cluster = google_container_aws_cluster.primary.name
+
+  config {
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-nodepool"
+    instance_type        = "t3.medium"
+
+    labels = {
+      label-one = "value-one"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      tag-one = "value-one"
+    }
+
+    taints {
+      effect = "prefer_no_schedule"
+      key    = "taint-key"
+      value  = "taint-value"
+    }
+
+    instance_placement {
+      tenancy = "dedicated"
+    }
+
+    image_type = "ubuntu"
+  }
+
+  location = "us-west1"
+
+  max_pods_constraint {
+    max_pods_per_node = 110
+  }
+
+  name      = "{{node-pool-name}}"
+  subnet_id = "{{aws_subnet}}"
+  version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  project = "{{project}}"
+}
+

--- a/tpgtools/overrides/containeraws/samples/nodepool/beta_basic_enum.yaml
+++ b/tpgtools/overrides/containeraws/samples/nodepool/beta_basic_enum.yaml
@@ -1,0 +1,36 @@
+description: A basic example of a containeraws node pool with lowercase enums (beta)
+name: beta_basic_enum_aws_cluster
+type: aws_cluster
+versions:
+- beta
+updates:
+- resource: ./beta_basic_enum_update.tf.tmpl
+variables:
+- name: byo_multicloud_prefix
+  type: byo_multicloud_prefix
+- name: name
+  type: resource_name
+- name: node-pool-name
+  type: resource_name
+- name: project
+  type: project
+- name: project_number
+  type: project_number
+- name: aws_account_id
+  type: aws_account_id
+- name: aws_volume_encryption_key
+  type: aws_volume_encryption_key
+- name: aws_vpc
+  type: aws_vpc
+- name: aws_database_encryption_key
+  type: aws_database_encryption_key
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_subnet
+  type: aws_subnet
+- name: aws_security_group
+  type: aws_security_group
+- name: aws_region
+  type: aws_region
+- name: test_service_account
+  type: test_service_account

--- a/tpgtools/overrides/containeraws/samples/nodepool/beta_basic_enum_update.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/nodepool/beta_basic_enum_update.tf.tmpl
@@ -1,0 +1,159 @@
+data "google_container_aws_versions" "versions" {
+  provider = google-beta
+  project = "{{project}}"
+  location = "us-west1"
+}
+
+resource "google_container_aws_cluster" "primary" {
+  provider = google-beta
+  authorization {
+    admin_users {
+      username = "{{test_service_account}}"
+    }
+  }
+
+  aws_region = "{{aws_region}}"
+
+  control_plane {
+    aws_services_authentication {
+      role_arn          = "arn:aws:iam::{{aws_account_id}}:role/{{byo_multicloud_prefix}}-1p-dev-oneplatform"
+      role_session_name = "{{byo_multicloud_prefix}}-1p-dev-session"
+    }
+
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    database_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-controlplane"
+    subnet_ids           = ["{{aws_subnet}}"]
+    version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+    instance_type        = "t3.medium"
+
+    main_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "GP3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      owner = "{{test_service_account}}"
+    }
+  }
+
+  fleet {
+    project = "{{project_number}}"
+  }
+
+  location = "us-west1"
+  name     = "{{name}}"
+
+  networking {
+    pod_address_cidr_blocks     = ["10.2.0.0/16"]
+    service_address_cidr_blocks = ["10.1.0.0/16"]
+    vpc_id                      = "{{aws_vpc}}"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+
+  description = "A sample aws cluster"
+  project     = "{{project}}"
+}
+
+resource "google_container_aws_node_pool" "primary" {
+  provider = google-beta
+  autoscaling {
+    max_node_count = 5
+    min_node_count = 1
+  }
+
+  cluster = google_container_aws_cluster.primary.name
+
+  config {
+    config_encryption {
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_database_encryption_key}}"
+    }
+
+    iam_instance_profile = "{{byo_multicloud_prefix}}-1p-dev-nodepool"
+    instance_type        = "t3.large"
+
+    labels = {
+      label-one = "value-one"
+    }
+
+    root_volume {
+      iops        = 3000
+      kms_key_arn = "arn:aws:kms:{{aws_region}}:{{aws_account_id}}:key/{{aws_volume_encryption_key}}"
+      size_gib    = 10
+      volume_type = "gp3"
+    }
+
+    security_group_ids = ["{{aws_security_group}}"]
+
+    proxy_config {
+      secret_arn     = "arn:aws:secretsmanager:us-west-2:126285863215:secret:proxy_config20210824150329476300000001-ABCDEF"
+      secret_version = "12345678-ABCD-EFGH-IJKL-987654321098"
+    }
+
+    ssh_config {
+      ec2_key_pair = "{{byo_multicloud_prefix}}-1p-dev-ssh"
+    }
+
+    tags = {
+      tag-one = "value-one"
+    }
+
+    taints {
+      effect = "prefer_no_schedule"
+      key    = "taint-key"
+      value  = "taint-value"
+    }
+
+    instance_placement {
+      tenancy = "dedicated"
+    }
+
+    image_type = "ubuntu"
+  }
+
+  location = "us-west1"
+
+  max_pods_constraint {
+    max_pods_per_node = 110
+  }
+
+  name      = "{{node-pool-name}}"
+  subnet_id = "{{aws_subnet}}"
+  version   = "${data.google_container_aws_versions.versions.valid_versions[0]}"
+
+  annotations = {
+    label-two = "value-two"
+  }
+
+  project = "{{project}}"
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add case sensitivity diff suppression for enums in containeraws resources. The provider accepts upper or lower case enum values, but the server returns them upper case. This causes state mismatch with TF, which leads to clusters being destroyed and re-created.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
containeraws: added diff suppression for case changes of enum values in `google_container_aws_cluster` and `google_container_aws_node_pool`
```
