### PR TITLE
Added support for defaultSearchHandlingStrict in FHIR Store resource

### DIFF
--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -286,8 +286,8 @@ properties:
   - !ruby/object:Api::Type::Boolean
     name: defaultSearchHandlingStrict
     description: |
-      If true, overrides the default search behavior for this FHIR store to handling=strict which returns an error for unrecognized search parameters. 
-      If false, uses the FHIR specification default handling=lenient which ignores unrecognized search parameters. 
+      If true, overrides the default search behavior for this FHIR store to handling=strict which returns an error for unrecognized search parameters.
+      If false, uses the FHIR specification default handling=lenient which ignores unrecognized search parameters.
       The handling can always be changed from the default on an individual API call by setting the HTTP header Prefer: handling=strict or Prefer: handling=lenient.
   - !ruby/object:Api::Type::Array
     name: notificationConfigs

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -283,7 +283,12 @@ properties:
                       name: expirationMs
                       description: |
                         Number of milliseconds for which to keep the storage for a partition.
-
+  - !ruby/object:Api::Type::Boolean
+    name: defaultSearchHandlingStrict
+    description: |
+      If true, overrides the default search behavior for this FHIR store to handling=strict which returns an error for unrecognized search parameters. 
+      If false, uses the FHIR specification default handling=lenient which ignores unrecognized search parameters. 
+      The handling can always be changed from the default on an individual API call by setting the HTTP header Prefer: handling=strict or Prefer: handling=lenient.
   - !ruby/object:Api::Type::Array
     name: notificationConfigs
     description: |-

--- a/mmv1/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
@@ -4,10 +4,11 @@ resource "google_healthcare_fhir_store" "default" {
   version = "R4"
   complex_data_type_reference_parsing = "DISABLED"
 
-  enable_update_create          = false
-  disable_referential_integrity = false
-  disable_resource_versioning   = false
-  enable_history_import         = false
+  enable_update_create           = false
+  disable_referential_integrity  = false
+  disable_resource_versioning    = false
+  enable_history_import          = false
+  default_search_handling_strict = false
 
   notification_config {
     pubsub_topic = google_pubsub_topic.topic.id


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added `defaultSearchHandlingStrict` field to `google_healthcare_fhir_store` resource
```

Closes: https://github.com/hashicorp/terraform-provider-google/issues/15316
