### PR TITLE
Updated 5.0.0 upgrade guide about the change in enableEndpointIndependentMapping's default value

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -131,3 +131,13 @@ These two unsupported fields were introduced incorrectly. They are now removed.
 ### `liveness_probe.tcp_socket` is now removed
 
 This unsupported field was introduced incorrectly. It is now removed.
+
+## Resource: `google_compute_router_nat`
+
+### `enable_endpoint_independent_mapping` now defaults to API's default value which is `FALSE`
+
+Previously, the default value of `enable_endpoint_independent_mapping` was `TRUE`. Now,
+it will use the default value from the API which is `FALSE`. If you want to
+enable endpoint independent mapping, then explicity set the value of
+`enable_endpoint_independent_mapping` field to `TRUE`.
+


### PR DESCRIPTION
…

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
In 5.0.0 feature branch, enableEndpointIndependentMapping's default value got changed from true to API's default value which is false.  This change is to update the 5.0.0 upgrade guide.

https://github.com/hashicorp/terraform-provider-google/issues/15477

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none


```
