### PR TITLE
feat: add resource for dataform repository workflow config

### DIFF
--- a/mmv1/products/dataform/WorkflowConfig.yaml
+++ b/mmv1/products/dataform/WorkflowConfig.yaml
@@ -1,0 +1,148 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: RepositoryWorkflowConfig
+base_url: projects/{{project}}/locations/{{region}}/repositories/{{repository}}/workflowConfigs
+create_url: projects/{{project}}/locations/{{region}}/repositories/{{repository}}/workflowConfigs?workflowConfigId={{name}}
+create_verb: :POST
+update_verb: :PATCH
+min_version: beta
+description: |-
+  A resource represents a Dataform workflow configuration
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/dataform/docs/workflow-configurations'
+  api: 'https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories.workflowConfigs'
+id_format: projects/{{project}}/locations/{{region}}/repositories/{{repository}}/workflowConfigs/{{name}}
+import_format:
+  ['projects/{{project}}/locations/{{region}}/repositories/{{repository}}/workflowConfigs/{{name}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataform_repository_workflow_config'
+    primary_resource_id: workflow
+    min_version: beta
+    vars:
+      workflow_name: 'my_workflow'
+      release_name: 'my_release'
+      git_repository_name: 'my/repository'
+      dataform_repository_name: 'dataform_repository'
+      data: secret-data
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'region'
+    description: 'A reference to the region'
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'repository'
+    description: 'A reference to the Dataform repository'
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: The workflow's name.
+    immutable: true
+    required: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+  - !ruby/object:Api::Type::String
+    name: 'releaseConfig'
+    required: true
+    description:
+      The name of the release config whose releaseCompilationResult should be executed. 
+      Must be in the format projects/*/locations/*/repositories/*/releaseConfigs/*.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'invocationConfig'
+    description:
+      Optional. If left unset, a default InvocationConfig will be used.
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'includedTargets'
+        description: Optional. The set of action identifiers to include.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'database'
+              description: The action's database (Google Cloud project ID).
+            - !ruby/object:Api::Type::String
+              name: 'schema'
+              description:
+                The action's schema (BigQuery dataset ID), within database.
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description:
+                The action's name, within database and schema.
+      - !ruby/object:Api::Type::Array
+        name: 'includedTags'
+        description: Optional. The set of tags to include.
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::Boolean
+        name: 'transitiveDependenciesIncluded'
+        description: Optional. When set to true, transitive dependencies of included actions will be executed.
+      - !ruby/object:Api::Type::Boolean
+        name: 'transitiveDependentsIncluded'
+        description: Optional. When set to true, transitive dependents of included actions will be executed.
+      - !ruby/object:Api::Type::Boolean
+        name: 'fullyRefreshIncrementalTablesEnabled'
+        description: Optional. When set to true, any incremental tables will be fully refreshed.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccount'
+        description: Optional. The service account to run workflow invocations under.
+  - !ruby/object:Api::Type::String
+    name: 'cronSchedule'
+    description:
+      Optional. Optional schedule (in cron format) for automatic creation of compilation results.
+  - !ruby/object:Api::Type::String
+    name: 'timeZone'
+    description:
+      Optional. Specifies the time zone to be used when interpreting cronSchedule.
+      Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+      If left unspecified, the default is UTC.
+  - !ruby/object:Api::Type::Array
+    name: 'recentScheduledExecutionRecords'
+    description:
+      Records of the 10 most recent scheduled execution attempts, 
+      ordered in in descending order of executionTime.
+      Updated whenever automatic creation of a workflow invocation is triggered by cronSchedule.
+    output: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'executionTime'
+          output: true
+          description: The timestamp of this workflow attempt.
+        - !ruby/object:Api::Type::String
+          name: 'workflowInvocation'
+          output: true
+          description:
+            The name of the created workflow invocation, if one was successfully created. 
+            In the format projects/*/locations/*/repositories/*/workflowInvocations/*.
+        - !ruby/object:Api::Type::NestedObject
+          name: 'errorStatus'
+          output: true
+          description:
+            The error status encountered upon this attempt to create the workflow invocation, 
+            if the attempt was unsuccessful.
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'code'
+              output: true
+              description: The status code, which should be an enum value of google.rpc.Code.
+            - !ruby/object:Api::Type::String
+              name: 'message'
+              output: true
+              description:
+                A developer-facing error message, which should be in English.
+                Any user-facing error message should be localized and sent in
+                the google.rpc.Status.details field, or localized by the client.

--- a/mmv1/products/dataform/WorkflowConfig.yaml
+++ b/mmv1/products/dataform/WorkflowConfig.yaml
@@ -60,7 +60,7 @@ properties:
     name: 'releaseConfig'
     required: true
     description:
-      The name of the release config whose releaseCompilationResult should be executed. 
+      The name of the release config whose releaseCompilationResult should be executed.
       Must be in the format projects/*/locations/*/repositories/*/releaseConfigs/*.
   - !ruby/object:Api::Type::NestedObject
     name: 'invocationConfig'
@@ -112,7 +112,7 @@ properties:
   - !ruby/object:Api::Type::Array
     name: 'recentScheduledExecutionRecords'
     description:
-      Records of the 10 most recent scheduled execution attempts, 
+      Records of the 10 most recent scheduled execution attempts,
       ordered in in descending order of executionTime.
       Updated whenever automatic creation of a workflow invocation is triggered by cronSchedule.
     output: true
@@ -126,13 +126,13 @@ properties:
           name: 'workflowInvocation'
           output: true
           description:
-            The name of the created workflow invocation, if one was successfully created. 
+            The name of the created workflow invocation, if one was successfully created.
             In the format projects/*/locations/*/repositories/*/workflowInvocations/*.
         - !ruby/object:Api::Type::NestedObject
           name: 'errorStatus'
           output: true
           description:
-            The error status encountered upon this attempt to create the workflow invocation, 
+            The error status encountered upon this attempt to create the workflow invocation,
             if the attempt was unsuccessful.
           properties:
             - !ruby/object:Api::Type::Integer

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -64,6 +64,7 @@ resource "google_dataform_repository_release_config" "release_config" {
 }
 
 resource "google_service_account" "dataform_sa" {
+  provider     = google-beta
   account_id   = "dataform-workflow-sa"
   display_name = "Dataform Service Account"
 }

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -1,0 +1,94 @@
+resource "google_sourcerepo_repository" "git_repository" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['git_repository_name'] %>"
+}
+
+resource "google_secret_manager_secret" "secret" {
+  provider  = google-beta
+  secret_id = "secret"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  provider = google-beta
+  secret   = google_secret_manager_secret.secret.id
+
+  secret_data = "<%= ctx[:vars]['data'] %>"
+}
+
+resource "google_dataform_repository" "repository" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['dataform_repository_name'] %>"
+  region   = "us-central1"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
+}
+
+resource "google_dataform_repository_release_config" "release_config" {
+  provider = google-beta
+
+  project    = google_dataform_repository.repository.project
+  region     = google_dataform_repository.repository.region
+  repository = google_dataform_repository.repository.name
+
+  name          = "<%= ctx[:vars]['release_name'] %>"
+  git_commitish = "main"
+  cron_schedule = "0 7 * * *"
+  time_zone     = "America/New_York"
+
+  code_compilation_config {
+    default_database = "gcp-example-project"
+    default_schema   = "example-dataset"
+    default_location = "us-central1"
+    assertion_schema = "example-assertion-dataset"
+    database_suffix  = ""
+    schema_suffix    = ""
+    table_prefix     = ""
+    vars = {
+      var1 = "value"
+    }
+  }
+}
+
+resource "google_dataform_repository_workflow_config" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  project        = google_dataform_repository.repository.project
+  region         = google_dataform_repository.repository.region
+  repository     = google_dataform_repository.repository.name
+  name           = "<%= ctx[:vars]['workflow_name'] %>"
+  release_config = google_dataform_repository_release_config.release_config.id
+
+  invocation_config {
+    included_targets {
+      database = "gcp-example-project"
+      schema   = "example-dataset"
+      name     = "target_1"
+    }
+    included_targets {
+      database = "gcp-example-project"
+      schema   = "example-dataset"
+      name     = "target_2"
+    }
+    included_tags                            = ["tag_1"]
+    transitive_dependencies_included         = true
+    transitive_dependents_included           = true
+    fully_refresh_incremental_tables_enabled = false
+  }
+
+  cron_schedule = "0 7 * * *"
+  time_zone     = "America/New_York"
+}

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -63,6 +63,11 @@ resource "google_dataform_repository_release_config" "release_config" {
   }
 }
 
+resource "google_service_account" "dataform_sa" {
+  account_id   = "dataform-workflow-sa"
+  display_name = "Dataform Service Account"
+}
+
 resource "google_dataform_repository_workflow_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
 
@@ -87,8 +92,9 @@ resource "google_dataform_repository_workflow_config" "<%= ctx[:primary_resource
     transitive_dependencies_included         = true
     transitive_dependents_included           = true
     fully_refresh_incremental_tables_enabled = false
+    service_account                          = google_service_account.dataform_sa.email
   }
 
-  cron_schedule = "0 7 * * *"
-  time_zone     = "America/New_York"
+  cron_schedule   = "0 7 * * *"
+  time_zone       = "America/New_York"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds a terraform resource for Dataform Repository Workflow Config

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15488


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
dataform_repository_workflow_config (beta)
```
