### PR TITLE
Update .copywrite.hcl to ignore all test-fixtures regardless of package location

### DIFF
--- a/mmv1/third_party/terraform/.copywrite.hcl.erb
+++ b/mmv1/third_party/terraform/.copywrite.hcl.erb
@@ -17,9 +17,9 @@ project {
     "examples/**",
     "scripts/**",
 <% if version.nil? || version == 'ga' -%>
-    "google/test-fixtures/**",
+    "google/**/test-fixtures/**",
 <% else -%>
-    "google-<%= version -%>/test-fixtures/**",
+    "google-<%= version -%>/**/test-fixtures/**",
 <% end -%>
     "META.d/*.yml",
     ".golangci.yml",


### PR DESCRIPTION
Addresses https://github.com/hashicorp/terraform-provider-google-beta/pull/6059

Now test-fixtures are found in service packages the path to ignore them when adding copyright headers needs to be updated

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
