### PR TITLE
Changed OICS to use default cloud shell image

### DIFF
--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -262,7 +262,7 @@ module Provider
         hash = {
           cloudshell_git_repo: 'https://github.com/terraform-google-modules/docs-examples.git',
           cloudshell_working_dir: @name,
-          cloudshell_image: 'gcr.io/graphite-cloud-shell-images/terraform:latest',
+          cloudshell_image: 'gcr.io/cloudshell-images/cloudshell:latest',
           open_in_editor: 'main.tf',
           cloudshell_print: './motd',
           cloudshell_tutorial: './tutorial.md'


### PR DESCRIPTION
Seems like OICS links like on https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/datastream_connection_profile already use the version of Terraform from the default cloud shell image rather than the version we thought we were providing to users. We should standardize on the default image.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
