### PR TITLE
Add some output only fields to Cloud Run V2 resources

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -146,6 +146,36 @@ properties:
       All system annotations in v1 now have a corresponding field in v2 Job.
 
       This field follows Kubernetes annotations' namespacing, limits, and rules.
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |-
+      The creation time.
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |-
+      The last-modified time.
+  - !ruby/object:Api::Type::Time
+    name: 'deleteTime'
+    output: true
+    description: |-
+      The deletion time.
+  - !ruby/object:Api::Type::Time
+    name: 'expireTime'
+    output: true
+    description: |-
+      For a deleted resource, the time after which it will be permamently deleted.
+  - !ruby/object:Api::Type::String
+    name: 'creator'
+    output: true
+    description: |-
+      Email address of the authenticated creator.
+  - !ruby/object:Api::Type::String
+    name: 'lastModifier'
+    output: true
+    description: |-
+      Email address of the last authenticated modifier.
   - !ruby/object:Api::Type::String
     name: 'client'
     description: |

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -161,6 +161,36 @@ properties:
       All system annotations in v1 now have a corresponding field in v2 Service.
 
       This field follows Kubernetes annotations' namespacing, limits, and rules.
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |-
+      The creation time.
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |-
+      The last-modified time.
+  - !ruby/object:Api::Type::Time
+    name: 'deleteTime'
+    output: true
+    description: |-
+      The deletion time.
+  - !ruby/object:Api::Type::Time
+    name: 'expireTime'
+    output: true
+    description: |-
+      For a deleted resource, the time after which it will be permamently deleted.
+  - !ruby/object:Api::Type::String
+    name: 'creator'
+    output: true
+    description: |-
+      Email address of the authenticated creator.
+  - !ruby/object:Api::Type::String
+    name: 'lastModifier'
+    output: true
+    description: |-
+      Email address of the last authenticated modifier.
   - !ruby/object:Api::Type::String
     name: 'client'
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: Added the following output only fields to `google_cloud_run_v2_job` resource: `createTime`, `updateTime`, `deleteTime`, `expireTime`, `creator` and `lastModifier`.
```

```release-note:enhancement
cloudrunv2: Added the following output only fields to `google_cloud_run_v2_service` resource: `createTime`, `updateTime`, `deleteTime`, `expireTime`, `creator` and `lastModifier`.
```
