### PR TITLE
Changed the type of automatic field and added support for customer_managed_encryption in automatic field

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -26,6 +26,8 @@ references: !ruby/object:Api::Resource::ReferenceLinks
   api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets'
 description: |
   A Secret is a logical secret whose value and versions can be accessed.
+schema_version: 1
+state_upgraders: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'secret_config_basic'
@@ -38,7 +40,17 @@ examples:
     primary_resource_id: 'secret-with-annotations'
     vars:
       secret_id: 'secret'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'secret_with_automatic_cmek'
+    primary_resource_id: 'secret-with-automatic-cmek'
+    vars:
+      secret_id: 'secret'
+      kms_key_name: 'kms-key'
+    test_vars_overrides:
+      kms_key_name: 'acctest.BootstrapKMSKey(t).CryptoKey.Name'
 import_format: ['projects/{{project}}/secrets/{{secret_id}}']
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_update: templates/terraform/pre_update/secret_manager_secret.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: secretId
@@ -99,7 +111,7 @@ properties:
       The replication policy of the secret data attached to the Secret. It cannot be changed
       after the Secret has been created.
     properties:
-      - !ruby/object:Api::Type::Boolean
+      - !ruby/object:Api::Type::NestedObject
         name: automatic
         immutable: true
         exactly_one_of:
@@ -107,8 +119,21 @@ properties:
           - replication.0.user_managed
         description: |
           The Secret will automatically be replicated without any restrictions.
-        custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
-        custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
+        allow_empty_object: true
+        send_empty_value: true
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: customerManagedEncryption
+            description: |
+              The customer-managed encryption configuration of the Secret.
+              If no configuration is provided, Google-managed default
+              encryption is used.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: kmsKeyName
+                required: true
+                description: |
+                  The resource name of the Cloud KMS CryptoKey used to encrypt secret payloads.
       - !ruby/object:Api::Type::NestedObject
         name: userManaged
         immutable: true

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
@@ -4,7 +4,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
@@ -4,7 +4,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
@@ -44,7 +44,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
@@ -48,7 +48,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
@@ -33,7 +33,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.erb
@@ -51,7 +51,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/secret_version_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_version_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/secret_with_annotations.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_annotations.tf.erb
@@ -14,6 +14,6 @@ resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
   }
 
   replication {
-    automatic = true
+    automatic {}
   }
 }

--- a/mmv1/templates/terraform/examples/secret_with_automatic_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_automatic_cmek.tf.erb
@@ -1,0 +1,21 @@
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding" {
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+
+  replication {
+    automatic {
+      customer_managed_encryption {
+        kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+      }
+    }
+  }
+
+  depends_on = [ google_kms_crypto_key_iam_member.kms-secret-binding ]
+}

--- a/mmv1/templates/terraform/pre_update/secret_manager_secret.go.erb
+++ b/mmv1/templates/terraform/pre_update/secret_manager_secret.go.erb
@@ -1,0 +1,32 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+replicationProp, err := expandSecretManagerSecretReplication(d.Get("replication"), d, config)
+if err != nil {
+    return err
+} else if v, ok := d.GetOkExists("replication"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, replicationProp)) {
+    obj["replication"] = replicationProp
+}
+
+if d.HasChange("replication") {
+    updateMask = append(updateMask, "replication")
+}
+
+// Refreshing updateMask after adding extra schema entries
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}
+
+log.Printf("[DEBUG] Update URL %q: %v", d.Id(), url)

--- a/mmv1/templates/terraform/state_migrations/secret_manager_secret.go.erb
+++ b/mmv1/templates/terraform/state_migrations/secret_manager_secret.go.erb
@@ -1,0 +1,49 @@
+func resourceSecretManagerSecretResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"replication": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Description: `The replication policy of the secret data attached to the Secret. It cannot be changed
+after the Secret has been created.`,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"automatic": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							ForceNew:     true,
+							Description:  `The Secret will automatically be replicated without any restrictions.`,
+							ExactlyOneOf: []string{"replication.0.automatic", "replication.0.user_managed"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ResourceSecretManagerSecretUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+	replicationOld := rawState["replication"]
+	// To handle the case where replication is not present in the state file.
+	// As the replication field is required, replication must be present in the
+	// rawState but kept this check just in case such scenario occurs.
+	if replicationOld == nil || len(replicationOld.([]interface{})) == 0 {
+		log.Print("[DEBUG] Error while migrating the state because replication is nil in the state file")
+		return rawState, fmt.Errorf("cannot migrate state as replication is nil in state file")
+	}
+
+	replicationInternalMap := replicationOld.([]interface{})[0].(map[string]interface{})
+
+	replicationNew := make([]interface{}, 1)
+
+	interMap := make(map[string]interface{})
+	interMap["automatic"] = []interface{}{}
+	interMap["user_managed"] = replicationInternalMap["user_managed"]
+	replicationNew[0] = interMap
+
+	rawState["replication"] = replicationNew
+
+	return rawState, nil
+}

--- a/mmv1/third_party/terraform/tests/data_source_secret_manager_secret_version_access_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_secret_manager_secret_version_access_test.go
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -112,7 +112,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/third_party/terraform/tests/data_source_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_secret_manager_secret_version_test.go
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -112,7 +112,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloud_run_service_test.go.erb
@@ -184,14 +184,14 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret1" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
 resource "google_secret_manager_secret" "secret2" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -308,14 +308,14 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret1" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
 resource "google_secret_manager_secret" "secret2" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataform_repository_test.go.erb
@@ -56,7 +56,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/mmv1/third_party/terraform/tests/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_secret_manager_secret_test.go.erb
@@ -2,10 +2,13 @@
 package google
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -107,6 +110,64 @@ func TestAccSecretManagerSecret_annotationsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	key1 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "global", "tf-secret-manager-automatic-key1")
+	key2 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "global", "tf-secret-manager-automatic-key2")
+	context := map[string]interface{}{
+		"pid":            envvar.GetTestProjectFromEnv(),
+		"random_suffix":  suffix,
+		"kms_key_name_1": key1.CryptoKey.Name,
+		"kms_key_name_2": key2.CryptoKey.Name,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretMangerSecret_automaticCmekBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+			{
+				Config: testAccSecretMangerSecret_automaticCmekUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+			{
+				Config: testAccSecretMangerSecret_automaticCmekUpdate2(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+			{
+				Config: testAccSecretMangerSecret_automaticCmekBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+		},
+	})
+}
+
 func testAccSecretManagerSecret_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_secret_manager_secret" "secret-basic" {
@@ -189,7 +250,7 @@ resource "google_secret_manager_secret" "secret-with-annotations" {
   }
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 `, context)
@@ -212,8 +273,194 @@ resource "google_secret_manager_secret" "secret-with-annotations" {
   }
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 `, context)
+}
+
+func testAccSecretMangerSecret_automaticCmekBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic {}
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretMangerSecret_automaticCmekUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic {
+      customer_managed_encryption {
+        kms_key_name = "%{kms_key_name_1}"
+      }
+    }
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretMangerSecret_automaticCmekUpdate2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic {
+      customer_managed_encryption {
+        kms_key_name = "%{kms_key_name_2}"
+      }
+    }
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testSecretManagerSecretReplicationWithAutomaticV0() map[string]any {
+	return map[string]any{
+		"replication": []interface{}{
+			map[string]interface{}{
+				"automatic":    true,
+				"user_managed": []interface{}{},
+			},
+		},
+	}
+}
+
+func testSecretManagerSecretReplicationWithAutomaticV1() map[string]any {
+	return map[string]any{
+		"replication": []interface{}{
+			map[string]interface{}{
+				"automatic":    []interface{}{},
+				"user_managed": []interface{}{},
+			},
+		},
+	}
+}
+
+func TestSecretManagerSecretReplicationWithAutomaticStateUpgradeV0(t *testing.T) {
+	expected := testSecretManagerSecretReplicationWithAutomaticV1()
+	actual, err := secretmanager.ResourceSecretManagerSecretUpgradeV0(context.Background(), testSecretManagerSecretReplicationWithAutomaticV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}
+
+func testSecretManagerSecretReplicationWithoutAutomaticV0() map[string]any {
+	return map[string]any{
+		"replication": []interface{}{
+			map[string]interface{}{
+				"automatic":    false,
+				"user_managed": []interface{}{
+					map[string]interface{}{
+						"location": "us-central1",
+					},
+					map[string]interface{}{
+						"location": "us-east1",
+					},
+				},
+			},
+		},
+	}
+}
+
+func testSecretManagerSecretReplicationWithoutAutomaticV1() map[string]any {
+	return map[string]any{
+		"replication": []interface{}{
+			map[string]interface{}{
+				"automatic":    []interface{}{},
+				"user_managed": []interface{}{
+					map[string]interface{}{
+						"location": "us-central1",
+					},
+					map[string]interface{}{
+						"location": "us-east1",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSecretManagerSecretReplicationWithoutAutomaticStateUpgradeV0(t *testing.T) {
+	expected := testSecretManagerSecretReplicationWithoutAutomaticV1()
+	actual, err := secretmanager.ResourceSecretManagerSecretUpgradeV0(context.Background(), testSecretManagerSecretReplicationWithoutAutomaticV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
 }

--- a/mmv1/third_party/terraform/tests/resource_secret_manager_secret_version_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_secret_manager_secret_version_test.go.erb
@@ -61,7 +61,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -84,7 +84,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "private-key-secret" {
   secret_id = "ghe-pk-secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "github-token-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "private-key-secret" {
   secret_id = "ghe-pk-secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "github-token-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic {}
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Changed the type of the `automatic` field from TypeBool to TypeList and added support for the `replication.automatic.customer_managed_encryption` field in the `google_secret_manager_secret` resource.

fixes https://github.com/hashicorp/terraform-provider-google/issues/10679
fixes https://github.com/hashicorp/terraform-provider-google/issues/9272
fixes https://github.com/hashicorp/terraform-provider-google/issues/14282

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
secretmanager: changed the type of `automatic` field from TypeBool to TypeList
```
```release-note:enhancement
secretmanager: added `replication.automatic.customer_managed_encryption` field to `google_secret_manager_secret` resource
```