### PR TITLE
Added docs type to resource.md

### DIFF
--- a/docs/content/develop/resource.md
+++ b/docs/content/develop/resource.md
@@ -80,7 +80,7 @@ For more information about types of resources and the generation process overall
 
    # Inserts styled markdown into the header of the resource's page in the
    # provider documentation.
-   # docs:
+   # docs: !ruby/object:Provider::Terraform::Docs
    #   warning: |
    #     MULTILINE_WARNING_MARKDOWN
    #   note: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Leaving this out causes:

```
/mm-tf-oics-beta-head/mmv1/google/yaml_validator.rb:107:in `check_type': Property 'docs' is 'Hash' instead of 'Provider::Terraform::Docs' (RuntimeError)
```

```release-note:none

```
