### PR TITLE
Artifact Registry: Implement cleanup policies

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -82,6 +82,12 @@ examples:
     vars:
       repository_id: 'my-repository'
       description: 'example remote docker repository'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'artifact_registry_repository_cleanup'
+    primary_resource_id: 'my-repo'
+    vars:
+      repository_id: 'my-repository'
+      description: 'example docker repository with cleanup policies'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/location_from_region.go.erb
 properties:
@@ -220,6 +226,94 @@ properties:
               name: 'priority'
               description: |-
                 Entries with a greater priority value take precedence in the pull order.
+  - !ruby/object:Api::Type::Map
+    name: 'cleanupPolicies'
+    min_version: beta
+    description: |-
+      Cleanup policies for this repository. Cleanup policies indicate when
+      certain package versions can be automatically deleted.
+      Map keys are policy IDs supplied by users during policy creation. They must
+      unique within a repository and be under 128 characters in length.
+    key_name: id
+    key_description: |-
+      The policy ID. Must be unique within a repository.
+    value_type: !ruby/object:Api::Type::NestedObject
+      min_version: beta
+      properties:
+        - !ruby/object:Api::Type::Enum
+          name: action
+          min_version: beta
+          description: |-
+            Policy action.
+          values:
+            - :DELETE
+            - :KEEP
+        - !ruby/object:Api::Type::NestedObject
+          name: condition
+          min_version: beta
+          description: |-
+            Policy condition for matching versions.
+          # TODO (jrsb): exactly_one_of: condition, mostRecentVersions
+          properties:
+            - !ruby/object:Api::Type::Enum
+              name: tagState
+              min_version: beta
+              description: |-
+                Match versions by tag status.
+              values:
+                - :TAGGED
+                - :UNTAGGED
+                - :ANY
+              default_value: :ANY
+            - !ruby/object:Api::Type::Array
+              name: tagPrefixes
+              min_version: beta
+              description: |-
+                Match versions by tag prefix. Applied on any prefix match.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: versionNamePrefixes
+              min_version: beta
+              description: |-
+                Match versions by version name prefix. Applied on any prefix match.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: packageNamePrefixes
+              min_version: beta
+              description: |-
+                Match versions by package prefix. Applied on any prefix match.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::String
+              name: olderThan
+              min_version: beta
+              description: |-
+                Match versions older than a duration.
+              diff_suppress_func: 'tpgresource.DurationDiffSuppress'
+            - !ruby/object:Api::Type::String
+              name: newerThan
+              min_version: beta
+              description: |-
+                Match versions newer than a duration.
+              diff_suppress_func: 'tpgresource.DurationDiffSuppress'
+        - !ruby/object:Api::Type::NestedObject
+          name: mostRecentVersions
+          min_version: beta
+          description: |-
+            Policy condition for retaining a minimum number of versions. May only be
+            specified with a Keep action.
+          # TODO (jrsb): exactly_one_of: condition, mostRecentVersions
+          properties:
+            - !ruby/object:Api::Type::Array
+              name: packageNamePrefixes
+              min_version: beta
+              description: |-
+                Match versions by package prefix. Applied on any prefix match.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Integer
+              name: keepCount
+              min_version: beta
+              description: |-
+                Minimum number of versions to keep.
   - !ruby/object:Api::Type::NestedObject
     name: 'remoteRepositoryConfig'
     conflicts:
@@ -317,3 +411,9 @@ properties:
             values:
               - :PYPI
             default_value: :PYPI
+  - !ruby/object:Api::Type::Boolean
+    name: 'cleanupPolicyDryRun'
+    min_version: beta
+    description: |-
+      If true, the cleanup pipeline is prevented from deleting versions in this
+      repository.

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_cleanup.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_cleanup.tf.erb
@@ -1,0 +1,33 @@
+resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>" {
+  location      = "us-central1"
+  repository_id = "<%= ctx[:vars]['repository_id'] %>"
+  description   = "<%= ctx[:vars]['description'] %>"
+  format        = "DOCKER"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    id     = "delete-prerelease"
+    action = "DELETE"
+    condition {
+      tag_state    = "TAGGED"
+      tag_prefixes = ["alpha", "v0"]
+      older_than   = "2592000s"
+    }
+  }
+  cleanup_policies {
+    id     = "keep-tagged-release"
+    action = "KEEP"
+    condition {
+      tag_state             = "TAGGED"
+      tag_prefixes          = ["release"]
+      package_name_prefixes = ["webapp", "mobile"]
+    }
+  }
+  cleanup_policies {
+    id     = "keep-minimum-versions"
+    action = "KEEP"
+    most_recent_versions {
+      package_name_prefixes = ["webapp", "mobile", "sandbox"]
+      keep_count            = 5
+    }
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Implements Cleanup Policies for Artifact Registry in beta provider.
Fixes hashicorp/terraform-provider-google#13824
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
artifactregistry: added `cleanup_policies` and `cleanup_policy_dry_run` fields to `Repository` resource
```
