### PR TITLE
Make mysql_profile.password mutable to avoid recreation of the connection profile.

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -178,7 +178,6 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'password'
         required: true
-        immutable: true
         description: |
           Password for the MySQL connection.
         sensitive: true

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -16,6 +16,9 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
+	random_pass_1 := acctest.RandString(t, 10)
+	random_pass_2 := acctest.RandString(t, 10)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -45,6 +48,29 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 			{
 				// Disable prevent_destroy
 				Config: testAccDatastreamConnectionProfile_update2(context, false),
+			},
+			{
+				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_1),
+			},
+			{
+				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
+			},
+			{
+			    // run once more to update the password. it should update it in-place
+				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_2),
+			},
+			{
+				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
+			},
+			{
+				// Disable prevent_destroy
+				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, false, random_pass_2),
 			},
 		},
 	})
@@ -138,6 +164,85 @@ resource "google_datastream_connection_profile" "default" {
 		username = google_sql_user.user.name
 		password = google_sql_user.user.password
 		database = google_sql_database.db.name
+	}
+	%{lifecycle_block}
+}
+`, context)
+}
+
+
+func testAccDatastreamConnectionProfile_mySQLUpdate(context map[string]interface{}, preventDestroy bool, password string) string {
+	context["lifecycle_block"] = ""
+	if preventDestroy {
+		context["lifecycle_block"] = `
+		lifecycle {
+			prevent_destroy = true
+		}`
+	}
+
+	context["password"] = password
+
+	return acctest.Nprintf(`
+resource "google_sql_database_instance" "mysql_instance" {
+    name             = "tf-test-mysql-database-instance%{random_suffix}"
+    database_version = "MYSQL_8_0"
+    region           = "us-central1"
+    settings {
+      tier = "db-f1-micro"
+        backup_configuration {
+            enabled            = true
+            binary_log_enabled = true
+        }
+
+      ip_configuration {
+
+        // Datastream IPs will vary by region.
+        authorized_networks {
+            value = "34.71.242.81"
+        }
+
+        authorized_networks {
+            value = "34.72.28.29"
+        }
+
+        authorized_networks {
+            value = "34.67.6.157"
+        }
+
+        authorized_networks {
+            value = "34.67.234.134"
+        }
+
+        authorized_networks {
+            value = "34.72.239.218"
+        }
+      }
+    }
+
+    deletion_protection  = "false"
+}
+
+resource "google_sql_database" "mysql_db" {
+    instance = google_sql_database_instance.mysql_instance.name
+    name     = "db"
+}
+
+resource "google_sql_user" "mysql_user" {
+    name = "user"
+    instance = google_sql_database_instance.mysql_instance.name
+    host     = "%"
+    password = "%{password}"
+}
+
+resource "google_datastream_connection_profile" "mysql_con_profile" {
+    display_name          = "Source connection profile"
+	location              = "us-central1"
+	connection_profile_id = "tf-test-mysql-profile%{random_suffix}"
+
+    mysql_profile {
+		hostname = google_sql_database_instance.mysql_instance.public_ip_address
+		username = google_sql_user.mysql_user.name
+		password = google_sql_user.mysql_user.password
 	}
 	%{lifecycle_block}
 }

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -59,7 +59,7 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
 			},
 			{
-			    // run once more to update the password. it should update it in-place
+				// run once more to update the password. it should update it in-place
 				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_2),
 			},
 			{
@@ -169,7 +169,6 @@ resource "google_datastream_connection_profile" "default" {
 }
 `, context)
 }
-
 
 func testAccDatastreamConnectionProfile_mySQLUpdate(context map[string]interface{}, preventDestroy bool, password string) string {
 	context["lifecycle_block"] = ""


### PR DESCRIPTION
The recreation of connection profile fails the streams permanently. They have to be recreated from the scratch.

It's the solution to https://github.com/hashicorp/terraform-provider-google/issues/15489

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
datastream: made `password` mutable in `google_datastream_connection_profile` resource.
```
