### PR TITLE
Add new fields in VMware and BareMetal cluster resources

### DIFF
--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -748,6 +748,19 @@ properties:
                   description: |
                     The name of the user, e.g. `my-gcp-id@gmail.com`.
   - !ruby/object:Api::Type::NestedObject
+    name: 'binaryAuthorization'
+    description: Binary Authorization related configurations.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'evaluationMode'
+        description: |
+          Mode of operation for binauthz policy evaluation. If unspecified, 
+          defaults to DISABLED.
+        values:
+          - EVALUATION_MODE_UNSPECIFIED
+          - DISABLED
+          - PROJECT_SINGLETON_POLICY_ENFORCE
+  - !ruby/object:Api::Type::NestedObject
     name: 'upgradePolicy'
     description: The cluster upgrade policy.
     properties:

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -747,6 +747,17 @@ properties:
                   required: true
                   description: |
                     The name of the user, e.g. `my-gcp-id@gmail.com`.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'upgradePolicy'
+    description: The cluster upgrade policy.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'policy'
+        description: Specifies which upgrade policy to use.
+        values:
+          - NODE_POOL_POLICY_UNSPECIFIED
+          - SERIAL
+          - CONCURRENT
   - !ruby/object:Api::Type::String
     name: "uid"
     description: |

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -754,7 +754,7 @@ properties:
       - !ruby/object:Api::Type::Enum
         name: 'evaluationMode'
         description: |
-          Mode of operation for binauthz policy evaluation. If unspecified, 
+          Mode of operation for binauthz policy evaluation. If unspecified,
           defaults to DISABLED.
         values:
           - DISABLED

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -757,7 +757,6 @@ properties:
           Mode of operation for binauthz policy evaluation. If unspecified, 
           defaults to DISABLED.
         values:
-          - EVALUATION_MODE_UNSPECIFIED
           - DISABLED
           - PROJECT_SINGLETON_POLICY_ENFORCE
   - !ruby/object:Api::Type::NestedObject
@@ -768,7 +767,6 @@ properties:
         name: 'policy'
         description: Specifies which upgrade policy to use.
         values:
-          - NODE_POOL_POLICY_UNSPECIFIED
           - SERIAL
           - CONCURRENT
   - !ruby/object:Api::Type::String

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -538,6 +538,14 @@ properties:
   - !ruby/object:Api::Type::Boolean
     name: 'enableControlPlaneV2'
     description: Enable control plane V2. Default to false.
+  - !ruby/object:Api::Type::NestedObject
+    name: upgradePolicy
+    description: Specifies upgrade policy for the cluster.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: controlPlaneOnly
+        description: |
+          Controls whether the upgrade applies to the control plane only.
   - !ruby/object:Api::Type::String
     name: 'uid'
     description: |

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -546,9 +546,6 @@ properties:
         name: 'controlPlaneOnly'
         description: |
           Controls whether the upgrade applies to the control plane only.
-  - !ruby/object:Api::Type::Boolean
-    name: 'disableBundledIngress'
-    description: Disable bundled ingress.
   - !ruby/object:Api::Type::String
     name: 'uid'
     description: |

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -539,13 +539,16 @@ properties:
     name: 'enableControlPlaneV2'
     description: Enable control plane V2. Default to false.
   - !ruby/object:Api::Type::NestedObject
-    name: upgradePolicy
+    name: 'upgradePolicy'
     description: Specifies upgrade policy for the cluster.
     properties:
       - !ruby/object:Api::Type::Boolean
-        name: controlPlaneOnly
+        name: 'controlPlaneOnly'
         description: |
           Controls whether the upgrade applies to the control plane only.
+  - !ruby/object:Api::Type::Boolean
+    name: 'disableBundledIngress'
+    description: Disable bundled ingress.
   - !ruby/object:Api::Type::String
     name: 'uid'
     description: |

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_manuallb.tf.erb
@@ -54,6 +54,9 @@ resource "google_gkeonprem_bare_metal_cluster" "<%= ctx[:primary_resource_id] %>
       }
     }
   }
+  binary_authorization {
+    evaluation_mode = "DISABLED"
+  }
   upgrade_policy {
     policy = "SERIAL"
   }

--- a/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_bare_metal_cluster_manuallb.tf.erb
@@ -54,4 +54,7 @@ resource "google_gkeonprem_bare_metal_cluster" "<%= ctx[:primary_resource_id] %>
       }
     }
   }
+  upgrade_policy {
+    policy = "SERIAL"
+  }
 }

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
@@ -65,6 +65,9 @@ resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
   }
   vm_tracking_enabled = true
   enable_control_plane_v2 = true
+  upgrade_policy {
+    control_plane_only = true
+  }
   authorization {
     admin_users {
       username = "testuser@gmail.com"

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
@@ -68,7 +68,6 @@ resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
   upgrade_policy {
     control_plane_only = true
   }
-  disable_bundled_ingress = true
   authorization {
     admin_users {
       username = "testuser@gmail.com"

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
@@ -68,6 +68,7 @@ resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
   upgrade_policy {
     control_plane_only = true
   }
+  disable_bundled_ingress = true
   authorization {
     admin_users {
       username = "testuser@gmail.com"

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go.erb
@@ -324,6 +324,12 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLbStart(contex
         }
       }
     }
+    binary_authorization {
+      evaluation_mode = "DISABLED"
+    }
+    upgrade_policy {
+      policy = "SERIAL"
+    }
   }
 `, context)
 }
@@ -386,6 +392,12 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLb(context map
           username = "admin-updated@hashicorptest.com"
         }
       }
+    }
+    binary_authorization {
+      evaluation_mode = "DISABLED"
+    }
+    upgrade_policy {
+      policy = "SERIAL"
     }
   }
 `, context)

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go.erb
@@ -11,7 +11,9 @@ import (
 func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBasic(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix":   acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -41,7 +43,9 @@ func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBasic(t *testing.T) 
 func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLb(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix":   acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -71,7 +75,9 @@ func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLb(t *testing.
 func TestAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBgpLb(t *testing.T) {
   t.Parallel()
 
-  context := map[string]interface{}{}
+  context := map[string]interface{}{
+    "random_suffix":   acctest.RandString(t, 10),
+  }
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -103,7 +109,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateMetalLbStart(context
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster-metallb" {
     provider = google-beta
-    name = "cluster-metallb"
+    name = "cluster-metallb%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -179,7 +185,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateMetalLb(context map[
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster-metallb" {
     provider = google-beta
-    name = "cluster-metallb"
+    name = "cluster-metallb%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -253,7 +259,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLbStart(contex
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster-manuallb" {
     provider = google-beta
-    name = "cluster-manuallb"
+    name = "cluster-manuallb%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -327,7 +333,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLb(context map
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster-manuallb" {
     provider = google-beta
-    name = "cluster-manuallb"
+    name = "cluster-manuallb%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -390,7 +396,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBgpLbStart(context m
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster-bgplb" {
     provider = google-beta
-    name = "cluster-bgplb"
+    name = "cluster-bgplb%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"
@@ -475,7 +481,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBgpLb(context map[st
 
   resource "google_gkeonprem_bare_metal_cluster" "cluster-bgplb" {
     provider = google-beta
-    name = "cluster-bgplb"
+    name = "cluster-bgplb%{random_suffix}"
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     bare_metal_version = "1.12.3"

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go.erb
@@ -394,10 +394,10 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateManualLb(context map
       }
     }
     binary_authorization {
-      evaluation_mode = "DISABLED"
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
     }
     upgrade_policy {
-      policy = "SERIAL"
+      policy = "CONCURRENT"
     }
   }
 `, context)

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.erb
@@ -367,6 +367,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLbStart(context map[
     }
     vm_tracking_enabled = true
     enable_control_plane_v2 = true
+    upgrade_policy {
+      control_plane_only = true
+    }
     authorization {
       admin_users {
         username = "testuser@gmail.com"
@@ -449,6 +452,9 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(context map[strin
     }
     vm_tracking_enabled = false
     enable_control_plane_v2 = false
+    upgrade_policy {
+      control_plane_only = true
+    }
     authorization {
       admin_users {
         username = "testuser-updated@gmail.com"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkeonprem: added `upgrade_policy` field in `google_gkeonprem_vmware_cluster` resource (beta)
```

```release-note:enhancement
gkeonprem: added `upgrade_policy` and `binary_authorization` fields in `google_gkeonprem_bare_metal_cluster` resource (beta)
```
