### PR TITLE
TeamCity: Usability improvements : tag builds to distinguish nightly builds vs ad hoc builds, add project descriptions

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
@@ -35,6 +35,7 @@ class packageDetails(packageName: String, displayName: String, providerName: Str
 
             steps {
                 SetGitCommitBuildId()
+                TagBuildToIndicatePurpose()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTests()

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -68,7 +68,7 @@ fun BuildSteps.TagBuildToIndicatePurpose() {
 
             if [[ "${'$'}TRIGGERED_BY_USERNAME" = "n/a" ]] ; then
                 echo "Build was triggered as part of automated testing. We know this because the `triggeredBy.username` value was `n/a`, value: ${'$'}{TRIGGERED_BY_USERNAME}"
-                TAG="nightly-${'$'}(date +%F)" # e.g. nightly-2023-08-17
+                TAG="nightly-test"
                 echo "##teamcity[addBuildTag '${'$'}{TAG}']"
             else
                 echo "Build wasn't triggered as part of automated testing. We know this because the `triggeredBy.username` value was not `n/a`, value: ${'$'}{TRIGGERED_BY_USERNAME}"

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -69,7 +69,7 @@ fun BuildSteps.TagBuildToIndicatePurpose() {
 
             if [[ "${'$'}TRIGGERED_BY_USERNAME" = "n/a" ]] && [[ ${'$'}TRIGGERED_BY == *"Schedule Trigger"* ]]; then
                 echo "Build was triggered as part of automated testing controlled by a Schedule Trigger"
-                TAG="nightly-${'$'}(date +'%Y-%m-%d')" # e.g. nightly-2023-08-17
+                TAG="nightly-${'$'}(date +%F)" # e.g. nightly-2023-08-17
                 echo "##teamcity[addBuildTag '${'$'}{TAG}']"
             else
                 echo "Build wasn't triggered as part of automated testing; it was triggered manually by user ${'$'}{TRIGGERED_BY_USERNAME}."

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -64,15 +64,14 @@ fun BuildSteps.TagBuildToIndicatePurpose() {
         name = "Set build tag to indicate if build is run automatically or manually triggered"
         scriptContent = """
             #!/bin/bash
-            TRIGGERED_BY=%teamcity.build.triggeredBy%
             TRIGGERED_BY_USERNAME=%teamcity.build.triggeredBy.username%
 
-            if [[ "${'$'}TRIGGERED_BY_USERNAME" = "n/a" ]] && [[ ${'$'}TRIGGERED_BY == *"Schedule Trigger"* ]]; then
-                echo "Build was triggered as part of automated testing controlled by a Schedule Trigger"
+            if [[ "${'$'}TRIGGERED_BY_USERNAME" = "n/a" ]] ; then
+                echo "Build was triggered as part of automated testing. We know this because the `triggeredBy.username` value was `n/a`, value: ${'$'}{TRIGGERED_BY_USERNAME}"
                 TAG="nightly-${'$'}(date +%F)" # e.g. nightly-2023-08-17
                 echo "##teamcity[addBuildTag '${'$'}{TAG}']"
             else
-                echo "Build wasn't triggered as part of automated testing; it was triggered manually by user ${'$'}{TRIGGERED_BY_USERNAME}."
+                echo "Build wasn't triggered as part of automated testing. We know this because the `triggeredBy.username` value was not `n/a`, value: ${'$'}{TRIGGERED_BY_USERNAME}"
                 TAG="one-off-build"
                 echo "##teamcity[addBuildTag '${'$'}{TAG}']"
             fi

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -59,6 +59,30 @@ fun BuildSteps.SetGitCommitBuildId() {
     })
 }
 
+fun BuildSteps.TagBuildToIndicatePurpose() {
+    step(ScriptBuildStep {
+        name = "Set build tag to indicate if build is run automatically or manually triggered"
+        scriptContent = """
+            #!/bin/bash
+            TRIGGERED_BY=%teamcity.build.triggeredBy%
+            TRIGGERED_BY_USERNAME=%teamcity.build.triggeredBy.username%
+
+            if [[ "${'$'}TRIGGERED_BY_USERNAME" = "n/a" ]] && [[ ${'$'}TRIGGERED_BY == *"Schedule Trigger"* ]]; then
+                echo "Build was triggered as part of automated testing controlled by a Schedule Trigger"
+                TAG="nightly-${'$'}(date +'%Y-%m-%d')" # e.g. nightly-2023-08-17
+                echo "##teamcity[addBuildTag '${'$'}{TAG}']"
+            else
+                echo "Build wasn't triggered as part of automated testing; it was triggered manually by user ${'$'}{TRIGGERED_BY_USERNAME}."
+                TAG="one-off-build"
+                echo "##teamcity[addBuildTag '${'$'}{TAG}']"
+            fi
+        """.trimIndent()
+        // ${'$'} is required to allow creating a script in TeamCity that contains
+        // parts like ${GIT_HASH_SHORT} without having Kotlin syntax issues. For more info see:
+        // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
+    })
+}
+
 fun BuildSteps.DownloadTerraformBinary() {
     // https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_linux_amd64.zip
     var terraformUrl = "https://releases.hashicorp.com/terraform/%env.TERRAFORM_CORE_VERSION%/terraform_%env.TERRAFORM_CORE_VERSION%_linux_amd64.zip"

--- a/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
@@ -13,7 +13,7 @@ const val providerName = "google<%= "-" + version unless version == 'ga' -%>"
 // Google<%= version.capitalize unless version == 'ga' -%> returns an instance of Project,
 // which has multiple build configurations defined within it.
 // See https://teamcity.jetbrains.com/app/dsl-documentation/root/project/index.html
-fun Google<%= version.capitalize unless version == 'ga' -%>(environment: String, manualVcsRoot: AbsoluteId, branchRef: String, configuration: ClientConfiguration) : Project {
+fun Google<%= version.capitalize unless version == 'ga' -%>(environment: String, projDescription: String, manualVcsRoot: AbsoluteId, branchRef: String, configuration: ClientConfiguration) : Project {
 
     // Create build configs for each package defined in packages.kt and services.kt files
     val allPackages = packages + services
@@ -29,8 +29,9 @@ fun Google<%= version.capitalize unless version == 'ga' -%>(environment: String,
         postSweeperConfig.addTrigger(triggerConfig)
     }
 
-    
     return Project{
+
+        description = projDescription
 
         // Register build configs in the project
         buildType(preSweeperConfig)

--- a/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
@@ -37,6 +37,7 @@ class sweeperDetails() {
 
             steps {
                 SetGitCommitBuildId()
+                TagBuildToIndicatePurpose()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunSweepers(sweeperName)

--- a/mmv1/third_party/terraform/.teamcity/generated/settings.kts.erb
+++ b/mmv1/third_party/terraform/.teamcity/generated/settings.kts.erb
@@ -42,9 +42,10 @@ var manualVcsRoot = DslContext.settingsRootId
 // Values of these context parameters change configuration code behaviour.
 var environment = DslContext.getParameter("environment", "default")
 var branchRef = DslContext.getParameter("branch", "refs/heads/main")
+var projDescription = DslContext.getParameter("description", "")
 
 var clientConfig = ClientConfiguration(custId, org, org2, billingAccount, billingAccount2, masterBillingAccount, credentials, project, orgDomain, projectNumber, region, serviceAccount, zone, firestoreProject, identityUser)
 
 // This is the entry point of the code in .teamcity/
 // See https://teamcity.jetbrains.com/app/dsl-documentation/root/project.html
-project(Google<%= version.capitalize unless version == 'ga' -%>(environment, manualVcsRoot, branchRef, clientConfig))
+project(Google<%= version.capitalize unless version == 'ga' -%>(environment, projDescription, manualVcsRoot, branchRef, clientConfig))

--- a/mmv1/third_party/terraform/.teamcity/tests/generated/configuration.erb
+++ b/mmv1/third_party/terraform/.teamcity/tests/generated/configuration.erb
@@ -17,7 +17,7 @@ import useTeamCityGoTest
 class ConfigurationTests {
     @Test
     fun buildShouldFailOnError() {
-        val project = Google<%= version.capitalize unless version == 'ga' -%>("default", testVcsRootId(), "refs/heads/main", testConfiguration())
+        val project = Google<%= version.capitalize unless version == 'ga' -%>("default", "description", testVcsRootId(), "refs/heads/main", testConfiguration())
         project.buildTypes.forEach { bt ->
             assertTrue("Build '${bt.id}' should fail on errors!", bt.failureConditions.errorMessage)
         }
@@ -25,7 +25,7 @@ class ConfigurationTests {
 
     @Test
     fun buildShouldHaveGoTestFeature() {
-        val project = Google<%= version.capitalize unless version == 'ga' -%>("default",  testVcsRootId(), "refs/heads/main",testConfiguration())
+        val project = Google<%= version.capitalize unless version == 'ga' -%>("default", "description", testVcsRootId(), "refs/heads/main", testConfiguration())
         project.buildTypes.forEach{ bt ->
             var exists = false
             bt.features.items.forEach { f ->
@@ -44,7 +44,7 @@ class ConfigurationTests {
     // Once I have the ability to run tests I'll address this - writing new tests for the new config
     // @Test
     // fun buildShouldHaveTrigger() {
-    //     val project = Google("default",  testVcsRootId(), "refs/heads/main", testConfiguration())
+    //     val project = Google("default", "description", testVcsRootId(), "refs/heads/main", testConfiguration())
     //     var exists = false
     //     project.buildTypes.forEach{ bt ->
     //         bt.triggers.items.forEach { t ->

--- a/mmv1/third_party/terraform/.teamcity/tests/generated/vcs_roots.erb
+++ b/mmv1/third_party/terraform/.teamcity/tests/generated/vcs_roots.erb
@@ -16,7 +16,7 @@ import org.junit.Test
 class VcsTests {
     @Test
     fun buildsHaveCleanCheckOut() {
-        val project = Google<%= version.capitalize unless version == 'ga' -%>("default",  testVcsRootId(), "refs/heads/main", testConfiguration())
+        val project = Google<%= version.capitalize unless version == 'ga' -%>("default", "description", testVcsRootId(), "refs/heads/main", testConfiguration())
         project.buildTypes.forEach { bt ->
             assertTrue("Build '${bt.id}' doesn't use clean checkout", bt.vcs.cleanCheckout)
         }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



This PR is to address two areas where users of the new project might be confused:
- Understanding what the new projects are used for
- Understanding which builds are relevant to a release cut, when the timing of builds isn't strongly related to being a nightly test anymore.


To address these problems I'm going to add descriptions to projects in TeamCity, and also add a step to build configurations so they automatically tag themselves based on how they're triggered.

Builds triggered by the cron schedule at night will be labelled ~~`nightly-YYYY-MM-DD`~~ `nightly-test`, ~~with the date in the tag~~. All other builds are tagged with `one-off-build`. Builds know if they're triggered by cron or not based on whether there's details about a user who triggered a given build (directly or indirectly, via dependencies)


[Here's a test project where I set this up](https://hashicorp.teamcity.com/project/TerraformProviders_Google_SarahTestTaggingBuilds?mode=builds) - if you trigger a build it'll be tagged appropriately. Note: this project has none of the ENVs set up, so all the builds will fail their tests but they'll be able to do the tagging fine.

<img width="75%" alt="Screenshot 2023-08-24 at 11 50 51" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/076bbdfd-344b-4198-a342-703cc0d55c1c">


----

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
