### PR TITLE
Fix issues with unpopulated gc_rules and handling of Xd duration

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper.go
+++ b/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper.go
@@ -1,0 +1,221 @@
+package bigtable
+
+import (
+	"errors"
+	"time"
+)
+
+var unitMap = map[string]uint64{
+	"ns": uint64(time.Nanosecond),
+	"us": uint64(time.Microsecond),
+	"µs": uint64(time.Microsecond), // U+00B5 = micro symbol
+	"μs": uint64(time.Microsecond), // U+03BC = Greek letter mu
+	"ms": uint64(time.Millisecond),
+	"s":  uint64(time.Second),
+	"m":  uint64(time.Minute),
+	"h":  uint64(time.Hour),
+	"d":  uint64(time.Hour) * 24,
+	"w":  uint64(time.Hour) * 24 * 7,
+}
+
+// ParseDuration parses a duration string.
+// A duration string is a possibly signed sequence of
+// decimal numbers, each with optional fraction and a unit suffix,
+// such as "300ms", "-1.5h" or "2h45m".
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+func ParseDuration(s string) (time.Duration, error) {
+	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
+	orig := s
+	var d uint64
+	neg := false
+
+	// Consume [-+]?
+	if s != "" {
+		c := s[0]
+		if c == '-' || c == '+' {
+			neg = c == '-'
+			s = s[1:]
+		}
+	}
+	// Special case: if all that is left is "0", this is zero.
+	if s == "0" {
+		return 0, nil
+	}
+	if s == "" {
+		return 0, errors.New("time: invalid duration " + quote(orig))
+	}
+	for s != "" {
+		var (
+			v, f  uint64      // integers before, after decimal point
+			scale float64 = 1 // value = v + f/scale
+		)
+
+		var err error
+
+		// The next character must be [0-9.]
+		if !(s[0] == '.' || '0' <= s[0] && s[0] <= '9') {
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+		// Consume [0-9]*
+		pl := len(s)
+		v, s, err = leadingInt(s)
+		if err != nil {
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+		pre := pl != len(s) // whether we consumed anything before a period
+
+		// Consume (\.[0-9]*)?
+		post := false
+		if s != "" && s[0] == '.' {
+			s = s[1:]
+			pl := len(s)
+			f, scale, s = leadingFraction(s)
+			post = pl != len(s)
+		}
+		if !pre && !post {
+			// no digits (e.g. ".s" or "-.s")
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+
+		// Consume unit.
+		i := 0
+		for ; i < len(s); i++ {
+			c := s[i]
+			if c == '.' || '0' <= c && c <= '9' {
+				break
+			}
+		}
+		if i == 0 {
+			return 0, errors.New("time: missing unit in duration " + quote(orig))
+		}
+		u := s[:i]
+		s = s[i:]
+		unit, ok := unitMap[u]
+		if !ok {
+			return 0, errors.New("time: unknown unit " + quote(u) + " in duration " + quote(orig))
+		}
+		if v > 1<<63/unit {
+			// overflow
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+		v *= unit
+		if f > 0 {
+			// float64 is needed to be nanosecond accurate for fractions of hours.
+			// v >= 0 && (f*unit/scale) <= 3.6e+12 (ns/h, h is the largest unit)
+			v += uint64(float64(f) * (float64(unit) / scale))
+			if v > 1<<63 {
+				// overflow
+				return 0, errors.New("time: invalid duration " + quote(orig))
+			}
+		}
+		d += v
+		if d > 1<<63 {
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+	}
+	if neg {
+		return -time.Duration(d), nil
+	}
+	if d > 1<<63-1 {
+		return 0, errors.New("time: invalid duration " + quote(orig))
+	}
+	return time.Duration(d), nil
+}
+
+var errLeadingInt = errors.New("time: bad [0-9]*") // never printed
+
+// leadingInt consumes the leading [0-9]* from s.
+func leadingInt[bytes []byte | string](s bytes) (x uint64, rem bytes, err error) {
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if x > 1<<63/10 {
+			// overflow
+			return 0, rem, errLeadingInt
+		}
+		x = x*10 + uint64(c) - '0'
+		if x > 1<<63 {
+			// overflow
+			return 0, rem, errLeadingInt
+		}
+	}
+	return x, s[i:], nil
+}
+
+// leadingFraction consumes the leading [0-9]* from s.
+// It is used only for fractions, so does not return an error on overflow,
+// it just stops accumulating precision.
+func leadingFraction(s string) (x uint64, scale float64, rem string) {
+	i := 0
+	scale = 1
+	overflow := false
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if overflow {
+			continue
+		}
+		if x > (1<<63-1)/10 {
+			// It's possible for overflow to give a positive number, so take care.
+			overflow = true
+			continue
+		}
+		y := x*10 + uint64(c) - '0'
+		if y > 1<<63 {
+			overflow = true
+			continue
+		}
+		x = y
+		scale *= 10
+	}
+	return x, scale, s[i:]
+}
+
+// These are borrowed from unicode/utf8 and strconv and replicate behavior in
+// that package, since we can't take a dependency on either.
+const (
+	lowerhex  = "0123456789abcdef"
+	runeSelf  = 0x80
+	runeError = '\uFFFD'
+)
+
+func quote(s string) string {
+	buf := make([]byte, 1, len(s)+2) // slice will be at least len(s) + quotes
+	buf[0] = '"'
+	for i, c := range s {
+		if c >= runeSelf || c < ' ' {
+			// This means you are asking us to parse a time.Duration or
+			// time.Location with unprintable or non-ASCII characters in it.
+			// We don't expect to hit this case very often. We could try to
+			// reproduce strconv.Quote's behavior with full fidelity but
+			// given how rarely we expect to hit these edge cases, speed and
+			// conciseness are better.
+			var width int
+			if c == runeError {
+				width = 1
+				if i+2 < len(s) && s[i:i+3] == string(runeError) {
+					width = 3
+				}
+			} else {
+				width = len(string(c))
+			}
+			for j := 0; j < width; j++ {
+				buf = append(buf, `\x`...)
+				buf = append(buf, lowerhex[s[i+j]>>4])
+				buf = append(buf, lowerhex[s[i+j]&0xF])
+			}
+		} else {
+			if c == '"' || c == '\\' {
+				buf = append(buf, '\\')
+			}
+			buf = append(buf, string(c)...)
+		}
+	}
+	buf = append(buf, '"')
+	return string(buf)
+}

--- a/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/services/bigtable"
 )
 
 var parseDurationTests = []struct {
 	in   string
-	want Duration
+	want time.Duration
 }{
 	// simple
 	{"0", 0},
@@ -72,9 +74,9 @@ var parseDurationTests = []struct {
 
 func TestParseDuration(t *testing.T) {
 	for _, tc := range parseDurationTests {
-		d, err := ParseDuration(tc.in)
+		d, err := bigtable.ParseDuration(tc.in)
 		if err != nil || d != tc.want {
-			t.Errorf("ParseDuration(%q) = %v, %v, want %v, nil", tc.in, d, err, tc.want)
+			t.Errorf("bigtable.ParseDuration(%q) = %v, %v, want %v, nil", tc.in, d, err, tc.want)
 		}
 	}
 }
@@ -110,25 +112,25 @@ var parseDurationErrorTests = []struct {
 
 func TestParseDurationErrors(t *testing.T) {
 	for _, tc := range parseDurationErrorTests {
-		_, err := ParseDuration(tc.in)
+		_, err := bigtable.ParseDuration(tc.in)
 		if err == nil {
-			t.Errorf("ParseDuration(%q) = _, nil, want _, non-nil", tc.in)
+			t.Errorf("bigtable.ParseDuration(%q) = _, nil, want _, non-nil", tc.in)
 		} else if !strings.Contains(err.Error(), tc.expect) {
-			t.Errorf("ParseDuration(%q) = _, %q, error does not contain %q", tc.in, err, tc.expect)
+			t.Errorf("bigtable.ParseDuration(%q) = _, %q, error does not contain %q", tc.in, err, tc.expect)
 		}
 	}
 }
 
 func TestParseDurationRoundTrip(t *testing.T) {
 	// https://golang.org/issue/48629
-	max0 := Duration(math.MaxInt64)
-	max1, err := ParseDuration(max0.String())
+	max0 := time.Duration(math.MaxInt64)
+	max1, err := bigtable.ParseDuration(max0.String())
 	if err != nil || max0 != max1 {
 		t.Errorf("round-trip failed: %d => %q => %d, %v", max0, max0.String(), max1, err)
 	}
 
-	min0 := Duration(math.MinInt64)
-	min1, err := ParseDuration(min0.String())
+	min0 := time.Duration(math.MinInt64)
+	min1, err := bigtable.ParseDuration(min0.String())
 	if err != nil || min0 != min1 {
 		t.Errorf("round-trip failed: %d => %q => %d, %v", min0, min0.String(), min1, err)
 	}
@@ -136,9 +138,9 @@ func TestParseDurationRoundTrip(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		// Resolutions finer than milliseconds will result in
 		// imprecise round-trips.
-		d0 := Duration(rand.Int31()) * time.Millisecond
+		d0 := time.Duration(rand.Int31()) * time.Millisecond
 		s := d0.String()
-		d1, err := ParseDuration(s)
+		d1, err := bigtable.ParseDuration(s)
 		if err != nil || d0 != d1 {
 			t.Errorf("round-trip failed: %d => %q => %d, %v", d0, s, d1, err)
 		}
@@ -147,7 +149,7 @@ func TestParseDurationRoundTrip(t *testing.T) {
 
 func BenchmarkParseDuration(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ParseDuration("9007199254.740993ms")
-		ParseDuration("9007199254740993ns")
+		bigtable.ParseDuration("9007199254.740993ms")
+		bigtable.ParseDuration("9007199254740993ns")
 	}
 }

--- a/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
@@ -43,6 +43,7 @@ var parseDurationTests = []struct {
 	{"14s", 14 * time.Second},
 	{"15m", 15 * time.Minute},
 	{"16h", 16 * time.Hour},
+	{"5d", 5 * 24 * time.Hour},
 	// composite durations
 	{"3h30m", 3*time.Hour + 30*time.Minute},
 	{"10.5s4m", 4*time.Minute + 10*time.Second + 500*time.Millisecond},
@@ -94,7 +95,6 @@ var parseDurationErrorTests = []struct {
 	{"-.", `"-."`},
 	{".s", `".s"`},
 	{"+.s", `"+.s"`},
-	{"1d", `"1d"`},
 	{"\x85\x85", `"\x85\x85"`},
 	{"\xffff", `"\xffff"`},
 	{"hello \xffff world", `"hello \xffff world"`},

--- a/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
@@ -1,4 +1,4 @@
-package time_test
+package bigtable_test
 
 import (
 	"math"

--- a/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/duration_parsing_helper_test.go
@@ -1,0 +1,153 @@
+package time_test
+
+import (
+	"math"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+)
+
+var parseDurationTests = []struct {
+	in   string
+	want Duration
+}{
+	// simple
+	{"0", 0},
+	{"5s", 5 * time.Second},
+	{"30s", 30 * time.Second},
+	{"1478s", 1478 * time.Second},
+	// sign
+	{"-5s", -5 * time.Second},
+	{"+5s", 5 * time.Second},
+	{"-0", 0},
+	{"+0", 0},
+	// decimal
+	{"5.0s", 5 * time.Second},
+	{"5.6s", 5*time.Second + 600*time.Millisecond},
+	{"5.s", 5 * time.Second},
+	{".5s", 500 * time.Millisecond},
+	{"1.0s", 1 * time.Second},
+	{"1.00s", 1 * time.Second},
+	{"1.004s", 1*time.Second + 4*time.Millisecond},
+	{"1.0040s", 1*time.Second + 4*time.Millisecond},
+	{"100.00100s", 100*time.Second + 1*time.Millisecond},
+	// different units
+	{"10ns", 10 * time.Nanosecond},
+	{"11us", 11 * time.Microsecond},
+	{"12µs", 12 * time.Microsecond}, // U+00B5
+	{"12μs", 12 * time.Microsecond}, // U+03BC
+	{"13ms", 13 * time.Millisecond},
+	{"14s", 14 * time.Second},
+	{"15m", 15 * time.Minute},
+	{"16h", 16 * time.Hour},
+	// composite durations
+	{"3h30m", 3*time.Hour + 30*time.Minute},
+	{"10.5s4m", 4*time.Minute + 10*time.Second + 500*time.Millisecond},
+	{"-2m3.4s", -(2*time.Minute + 3*time.Second + 400*time.Millisecond)},
+	{"1h2m3s4ms5us6ns", 1*time.Hour + 2*time.Minute + 3*time.Second + 4*time.Millisecond + 5*time.Microsecond + 6*time.Nanosecond},
+	{"39h9m14.425s", 39*time.Hour + 9*time.Minute + 14*time.Second + 425*time.Millisecond},
+	// large value
+	{"52763797000ns", 52763797000 * time.Nanosecond},
+	// more than 9 digits after decimal point, see https://golang.org/issue/6617
+	{"0.3333333333333333333h", 20 * time.Minute},
+	// 9007199254740993 = 1<<53+1 cannot be stored precisely in a float64
+	{"9007199254740993ns", (1<<53 + 1) * time.Nanosecond},
+	// largest duration that can be represented by int64 in nanoseconds
+	{"9223372036854775807ns", (1<<63 - 1) * time.Nanosecond},
+	{"9223372036854775.807us", (1<<63 - 1) * time.Nanosecond},
+	{"9223372036s854ms775us807ns", (1<<63 - 1) * time.Nanosecond},
+	{"-9223372036854775808ns", -1 << 63 * time.Nanosecond},
+	{"-9223372036854775.808us", -1 << 63 * time.Nanosecond},
+	{"-9223372036s854ms775us808ns", -1 << 63 * time.Nanosecond},
+	// largest negative value
+	{"-9223372036854775808ns", -1 << 63 * time.Nanosecond},
+	// largest negative round trip value, see https://golang.org/issue/48629
+	{"-2562047h47m16.854775808s", -1 << 63 * time.Nanosecond},
+	// huge string; issue 15011.
+	{"0.100000000000000000000h", 6 * time.Minute},
+	// This value tests the first overflow check in leadingFraction.
+	{"0.830103483285477580700h", 49*time.Minute + 48*time.Second + 372539827*time.Nanosecond},
+}
+
+func TestParseDuration(t *testing.T) {
+	for _, tc := range parseDurationTests {
+		d, err := ParseDuration(tc.in)
+		if err != nil || d != tc.want {
+			t.Errorf("ParseDuration(%q) = %v, %v, want %v, nil", tc.in, d, err, tc.want)
+		}
+	}
+}
+
+var parseDurationErrorTests = []struct {
+	in     string
+	expect string
+}{
+	// invalid
+	{"", `""`},
+	{"3", `"3"`},
+	{"-", `"-"`},
+	{"s", `"s"`},
+	{".", `"."`},
+	{"-.", `"-."`},
+	{".s", `".s"`},
+	{"+.s", `"+.s"`},
+	{"1d", `"1d"`},
+	{"\x85\x85", `"\x85\x85"`},
+	{"\xffff", `"\xffff"`},
+	{"hello \xffff world", `"hello \xffff world"`},
+	{"\uFFFD", `"\xef\xbf\xbd"`},                                             // utf8.RuneError
+	{"\uFFFD hello \uFFFD world", `"\xef\xbf\xbd hello \xef\xbf\xbd world"`}, // utf8.RuneError
+	// overflow
+	{"9223372036854775810ns", `"9223372036854775810ns"`},
+	{"9223372036854775808ns", `"9223372036854775808ns"`},
+	{"-9223372036854775809ns", `"-9223372036854775809ns"`},
+	{"9223372036854776us", `"9223372036854776us"`},
+	{"3000000h", `"3000000h"`},
+	{"9223372036854775.808us", `"9223372036854775.808us"`},
+	{"9223372036854ms775us808ns", `"9223372036854ms775us808ns"`},
+}
+
+func TestParseDurationErrors(t *testing.T) {
+	for _, tc := range parseDurationErrorTests {
+		_, err := ParseDuration(tc.in)
+		if err == nil {
+			t.Errorf("ParseDuration(%q) = _, nil, want _, non-nil", tc.in)
+		} else if !strings.Contains(err.Error(), tc.expect) {
+			t.Errorf("ParseDuration(%q) = _, %q, error does not contain %q", tc.in, err, tc.expect)
+		}
+	}
+}
+
+func TestParseDurationRoundTrip(t *testing.T) {
+	// https://golang.org/issue/48629
+	max0 := Duration(math.MaxInt64)
+	max1, err := ParseDuration(max0.String())
+	if err != nil || max0 != max1 {
+		t.Errorf("round-trip failed: %d => %q => %d, %v", max0, max0.String(), max1, err)
+	}
+
+	min0 := Duration(math.MinInt64)
+	min1, err := ParseDuration(min0.String())
+	if err != nil || min0 != min1 {
+		t.Errorf("round-trip failed: %d => %q => %d, %v", min0, min0.String(), min1, err)
+	}
+
+	for i := 0; i < 100; i++ {
+		// Resolutions finer than milliseconds will result in
+		// imprecise round-trips.
+		d0 := Duration(rand.Int31()) * time.Millisecond
+		s := d0.String()
+		d1, err := ParseDuration(s)
+		if err != nil || d0 != d1 {
+			t.Errorf("round-trip failed: %d => %q => %d, %v", d0, s, d1, err)
+		}
+	}
+}
+
+func BenchmarkParseDuration(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ParseDuration("9007199254.740993ms")
+		ParseDuration("9007199254740993ns")
+	}
+}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
@@ -590,10 +590,6 @@ func validateNestedPolicy(p map[string]interface{}, isTopLevel bool) error {
 		return fmt.Errorf("`rules` need at least 2 GC rule when mode is specified")
 	}
 
-	if isTopLevel && !modeOk && !rulesOk {
-		return nil
-	}
-
 	if isTopLevel && !rulesOk {
 		return fmt.Errorf("invalid nested policy, need `rules`")
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
@@ -57,7 +57,7 @@ func resourceBigtableGCPolicyCustomizeDiffFunc(diff tpgresource.TerraformResourc
 
 	return nil
 }
-func handleGCRulesDiffs(oldRules, newRules interface{}) bool {
+func gcRulesDiffSuppress(oldRules, newRules interface{}) bool {
 	var oldPolicyRaw map[string]interface{}
 	if err := json.Unmarshal([]byte(oldRules.(string)), &oldPolicyRaw); err != nil {
 		return false
@@ -139,7 +139,7 @@ func ResourceBigtableGCPolicy() *schema.Resource {
 					return json
 				},
 				DiffSuppressFunc: func(k, old, new string, _ *schema.ResourceData) bool {
-					return handleGCRulesDiffs(old, new)
+					return gcRulesDiffSuppress(old, new)
 				},
 			},
 			"mode": {

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -37,7 +38,7 @@ func resourceBigtableGCPolicyCustomizeDiffFunc(diff tpgresource.TerraformResourc
 	if oldDuration == "" && newDuration != "" {
 		// flatten the old days and the new duration to duration... if they are
 		// equal then do nothing.
-		do, err := time.ParseDuration(newDuration.(string))
+		do, err := ParseDuration(newDuration.(string))
 		if err != nil {
 			return err
 		}
@@ -55,6 +56,36 @@ func resourceBigtableGCPolicyCustomizeDiffFunc(diff tpgresource.TerraformResourc
 	}
 
 	return nil
+}
+func handleGCRulesDiffs(oldRules, newRules interface{}) bool {
+	var oldPolicyRaw map[string]interface{}
+	if err := json.Unmarshal([]byte(oldRules.(string)), &oldPolicyRaw); err != nil {
+		return false
+	}
+	oldPolicy, err := getGCPolicyFromJSON(oldPolicyRaw /*isTopLevel=*/, true)
+	if err != nil {
+		return false
+	}
+	var newPolicyRaw map[string]interface{}
+	if err := json.Unmarshal([]byte(newRules.(string)), &newPolicyRaw); err != nil {
+		return false
+	}
+	newPolicy, err := getGCPolicyFromJSON(newPolicyRaw /*isTopLevel=*/, true)
+	if err != nil {
+		return false
+	}
+	oldPolicyString, err := GcPolicyToGCRuleString(oldPolicy /*isTopLevel=*/, true)
+	if err != nil {
+		return false
+	}
+	newPolicyString, err := GcPolicyToGCRuleString(newPolicy /*isTopLevel=*/, true)
+	if err != nil {
+		return false
+	}
+	if reflect.DeepEqual(oldPolicyString, newPolicyString) {
+		return true
+	}
+	return false
 }
 
 func resourceBigtableGCPolicyCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
@@ -106,6 +137,9 @@ func ResourceBigtableGCPolicy() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
+				},
+				DiffSuppressFunc: func(k, old, new string, _ *schema.ResourceData) bool {
+					return handleGCRulesDiffs(old, new)
 				},
 			},
 			"mode": {
@@ -302,7 +336,7 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 		// Only set `gc_rules`` when the legacy fields are not set. We are not planning to support legacy fields.
 		maxAge := d.Get("max_age")
 		maxVersion := d.Get("max_version")
-		if d.Get("mode") == "" && len(maxAge.([]interface{})) == 0 && len(maxVersion.([]interface{})) == 0 {
+		if len(maxAge.([]interface{})) == 0 && len(maxVersion.([]interface{})) == 0 {
 			gcRuleString, err := GcPolicyToGCRuleString(fi.FullGCPolicy, true)
 			if err != nil {
 				return err
@@ -504,7 +538,7 @@ func getGCPolicyFromJSON(inputPolicy map[string]interface{}, isTopLevel bool) (b
 
 		if childPolicy["max_age"] != nil {
 			maxAge := childPolicy["max_age"].(string)
-			duration, err := time.ParseDuration(maxAge)
+			duration, err := ParseDuration(maxAge)
 			if err != nil {
 				return nil, fmt.Errorf("invalid duration string: %v", maxAge)
 			}
@@ -556,6 +590,10 @@ func validateNestedPolicy(p map[string]interface{}, isTopLevel bool) error {
 		return fmt.Errorf("`rules` need at least 2 GC rule when mode is specified")
 	}
 
+	if isTopLevel && !modeOk && !rulesOk {
+		return nil
+	}
+
 	if isTopLevel && !rulesOk {
 		return fmt.Errorf("invalid nested policy, need `rules`")
 	}
@@ -586,7 +624,7 @@ func validateNestedPolicy(p map[string]interface{}, isTopLevel bool) error {
 func getMaxAgeDuration(values map[string]interface{}) (time.Duration, error) {
 	d := values["duration"].(string)
 	if d != "" {
-		return time.ParseDuration(d)
+		return ParseDuration(d)
 	}
 
 	days := values["days"].(int)

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_internal_test.go
@@ -180,6 +180,20 @@ var testUnitBigtableGCPolicyCustomizeDiffTestcases = []testUnitBigtableGCPolicyC
 		cleared:     true,
 	},
 	{
+		testName:    "DaysToDurationEqUsingDayDuration",
+		arraySize:   1,
+		oldDays:     3,
+		newDuration: "3d",
+		cleared:     true,
+	},
+	{
+		testName:    "DaysToDurationEqUsingCompoundWeekDayDuration",
+		arraySize:   1,
+		oldDays:     8,
+		newDuration: "1w1d",
+		cleared:     true,
+	},
+	{
 		testName:    "DaysToDurationNotEq",
 		arraySize:   1,
 		oldDays:     3,

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_internal_test.go
@@ -173,7 +173,7 @@ func TestGCRulesDiffSuppress(t *testing.T) {
 		"s->h-diff": {
 			Old:                "3601s",
 			New:                "1h",
-			ExpectDiffSuppress: true,
+			ExpectDiffSuppress: false,
 		},
 	}
 

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_internal_test.go
@@ -178,7 +178,7 @@ func TestGCRulesDiffSuppress(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		if gcRulesDiffSuppress(fmt.Sprintf(format, tc.Old), fmt.Sprintf(format, tc.New), nil) != tc.ExpectDiffSuppress {
+		if gcRulesDiffSuppress(fmt.Sprintf(format, tc.Old), fmt.Sprintf(format, tc.New)) != tc.ExpectDiffSuppress {
 			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
 		}
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
@@ -174,7 +174,7 @@ func TestAccBigtableGCPolicy_gcRulesPolicy(t *testing.T) {
 	familyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	gcRulesOriginal := "{\"mode\":\"intersection\",\"rules\":[{\"max_age\":\"10h\"},{\"max_version\":2}]}"
-	gcRulesUpdate := "{\"mode\":\"intersection\",\"rules\":[{\"max_age\":\"16h\"},{\"max_version\":1}]}"
+	gcRulesUpdate := "{\"mode\":\"intersection\",\"rules\":[{\"max_age\":\"40h\"},{\"max_version\":1}]}"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -253,14 +253,14 @@ var testUnitGcPolicyToGCRuleStringTestCases = []testUnitGcPolicyToGCRuleString{
 		errorExpected: false,
 	},
 	{
-		name:          "MaxVersionPolicyNotTopeLevel",
+		name:          "MaxVersionPolicyNotTopLevel",
 		policy:        bigtable.MaxVersionsPolicy(1),
 		topLevel:      false,
 		want:          `{"max_version":1}`,
 		errorExpected: false,
 	},
 	{
-		name:          "MaxAgePolicyNotTopeLevel",
+		name:          "MaxAgePolicyNotTopLevel",
 		policy:        bigtable.MaxAgePolicy(time.Hour),
 		topLevel:      false,
 		want:          `{"max_age":"1h"}`,
@@ -793,7 +793,7 @@ func testAccBigtableGCPolicy_gcRulesUpdate(instanceName, tableName, family strin
 		table         = google_bigtable_table.table.name
 		column_family = "%s"
 
-		gc_rules = "{\"mode\":\"intersection\", \"rules\":[{\"max_age\":\"16h\"},{\"max_version\":1}]}"
+		gc_rules = "{\"mode\":\"intersection\", \"rules\":[{\"max_age\":\"1d16h\"},{\"max_version\":1}]}"
 	}
 `, instanceName, instanceName, tableName, family, family)
 }

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
@@ -362,7 +362,7 @@ func TestGCRulesDiffSuppress(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		if gcRulesDiffSuppress(fmt.Sprintf(format, tc.Old), fmt.Sprintf(format, tc.New), nil) != tc.ExpectDiffSuppress {
+		if bigtable.gcRulesDiffSuppress(fmt.Sprintf(format, tc.Old), fmt.Sprintf(format, tc.New), nil) != tc.ExpectDiffSuppress {
 			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
 		}
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
@@ -327,47 +327,6 @@ func testAccCheckBigtableGCPolicyDestroyProducer(t *testing.T) func(s *terraform
 	}
 }
 
-func TestGCRulesDiffSuppress(t *testing.T) {
-	format := "{\"rules\": [{\"max_age\":\"%s\"}]}"
-	cases := map[string]struct {
-		Old, New           string
-		ExpectDiffSuppress bool
-	}{
-		"compound": {
-			Old:                "1d1h",
-			New:                "25h",
-			ExpectDiffSuppress: true,
-		},
-		"s->h": {
-			Old:                "3600s",
-			New:                "1h",
-			ExpectDiffSuppress: true,
-		},
-		"s->m": {
-			Old:                "3600s",
-			New:                "60m",
-			ExpectDiffSuppress: true,
-		},
-		"compound-diff": {
-			Old:                "1d1h",
-			New:                "26h",
-			ExpectDiffSuppress: false,
-		},
-
-		"s->h-diff": {
-			Old:                "3601s",
-			New:                "1h",
-			ExpectDiffSuppress: true,
-		},
-	}
-
-	for tn, tc := range cases {
-		if bigtable.gcRulesDiffSuppress(fmt.Sprintf(format, tc.Old), fmt.Sprintf(format, tc.New), nil) != tc.ExpectDiffSuppress {
-			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
-		}
-	}
-}
-
 func testAccBigtableGCPolicyExists(t *testing.T, n string, compareGcRules bool) resource.TestCheckFunc {
 	var ctx = context.Background()
 	return func(s *terraform.State) error {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed permadiff in `google_bigtable_gc_policy.gc_rules` when `mode` is specified
```

```release-note:bug
bigtable: fixed permadiff in `google_bigtable_gc_policy.gc_rules` when `max_age` is specified using increments larger than hours
```

fixes https://github.com/hashicorp/terraform-provider-google/issues/14149