### PR TITLE
Fixed GOOGLE_USE_DEFAULT_CREDENTIALS=true casing

### DIFF
--- a/docs/content/develop/run-tests.md
+++ b/docs/content/develop/run-tests.md
@@ -21,13 +21,13 @@ aliases:
 
     ```bash
     gcloud auth application-default login
-    export GOOGLE_USE_DEFAULT_CREDENTIALS=TRUE
+    export GOOGLE_USE_DEFAULT_CREDENTIALS=true
     ```
 
 1. Set the following environment variables:
 
     ```bash
-    export GOOGLE_USE_DEFAULT_CREDENTIALS=TRUE
+    export GOOGLE_USE_DEFAULT_CREDENTIALS=true
     export GOOGLE_PROJECT=PROJECT_ID
     export GOOGLE_REGION=us-central1
     export GOOGLE_ZONE=us-central1-a


### PR DESCRIPTION
Compare to https://github.com/GoogleCloudPlatform/magic-modules/pull/8319. yaqs/8326074891077943296

```release-note:none 

```
