### PR TITLE
Add custom apiKeyId to Firebase apps

### DIFF
--- a/mmv1/products/firebase/AndroidApp.yaml
+++ b/mmv1/products/firebase/AndroidApp.yaml
@@ -63,12 +63,28 @@ examples:
     primary_resource_id: 'basic'
     vars:
       display_name: 'Display Name Basic'
+      package_name: 'android.package.app'
     test_env_vars:
-      org_id: :ORG_ID
       project_id: :PROJECT_NAME
     test_vars_overrides:
       package_name: '"android.package.app" + acctest.RandString(t, 4)'
       display_name: '"tf-test Display Name Basic"'
+    ignore_read_extra:
+      - project
+      - deletion_policy
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firebase_android_app_custom_api_key'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      display_name: 'Display Name'
+      api_key_name: 'api-key'
+      package_name: 'android.package.app'
+    test_env_vars:
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      package_name: '"android.package.app" + acctest.RandString(t, 4)'
+      display_name: '"tf-test Display Name"'
     ignore_read_extra:
       - project
       - deletion_policy
@@ -116,6 +132,13 @@ properties:
     description: |
       The SHA256 certificate hashes for the AndroidApp.
     item_type: Api::Type::String
+  - !ruby/object:Api::Type::String
+    name: apiKeyId
+    default_from_api: true
+    description: |
+      The globally unique, Google-assigned identifier (UID) for the Firebase API key associated with the AndroidApp.
+      If apiKeyId is not set during creation, then Firebase automatically associates an apiKeyId with the AndroidApp.
+      This auto-associated key may be an existing valid key or, if no valid key exists, a new one will be provisioned.
   - !ruby/object:Api::Type::Fingerprint
     name: etag
     description: |

--- a/mmv1/products/firebase/AppleApp.yaml
+++ b/mmv1/products/firebase/AppleApp.yaml
@@ -78,6 +78,7 @@ examples:
       bundle_id: 'apple.app.12345'
       app_store_id: '12345'
       team_id: '9987654321'  # Has to be a 10-digit number.
+      api_key_name: 'api-key'
     test_env_vars:
       org_id: :ORG_ID
       project_id: :PROJECT_NAME
@@ -131,3 +132,10 @@ properties:
     name: teamId
     description: |
       The Apple Developer Team ID associated with the App in the App Store.
+  - !ruby/object:Api::Type::String
+    name: apiKeyId
+    default_from_api: true
+    description: |
+      The globally unique, Google-assigned identifier (UID) for the Firebase API key associated with the AppleApp.
+      If apiKeyId is not set during creation, then Firebase automatically associates an apiKeyId with the AppleApp.
+      This auto-associated key may be an existing valid key or, if no valid key exists, a new one will be provisioned.

--- a/mmv1/products/firebase/WebApp.yaml
+++ b/mmv1/products/firebase/WebApp.yaml
@@ -73,6 +73,18 @@ examples:
     ignore_read_extra:
       - project
       - deletion_policy
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firebase_web_app_custom_api_key'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      display_name: 'Display Name'
+      api_key_name: "api-key"
+    test_env_vars:
+      project_id: :PROJECT_NAME
+    ignore_read_extra:
+      - project
+      - deletion_policy
 virtual_fields:
   # TODO: make this an enum in a future major version. If using this field as a reference, look at PerInstanceConfig's minimal_action field for enum configuration.
   - !ruby/object:Api::Type::String
@@ -108,3 +120,10 @@ properties:
     description: |
       The URLs where the `WebApp` is hosted.
     item_type: Api::Type::String
+  - !ruby/object:Api::Type::String
+    name: apiKeyId
+    default_from_api: true
+    description: |
+      The globally unique, Google-assigned identifier (UID) for the Firebase API key associated with the WebApp.
+      If apiKeyId is not set during creation, then Firebase automatically associates an apiKeyId with the WebApp.
+      This auto-associated key may be an existing valid key or, if no valid key exists, a new one will be provisioned.

--- a/mmv1/templates/terraform/examples/firebase_android_app_custom_api_key.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_android_app_custom_api_key.tf.erb
@@ -1,0 +1,26 @@
+resource "google_firebase_android_app" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  display_name = "<%= ctx[:vars]['display_name'] %>"
+  package_name = "<%= ctx[:vars]['package_name'] %>"
+  sha1_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21c"]
+  sha256_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21ca1b2c3d4e5f6123456789abc"]
+  api_key_id = google_apikeys_key.android.uid
+}
+
+resource "google_apikeys_key" "android" {
+  provider = google-beta
+
+  name         = "<%= ctx[:vars]['api_key_name'] %>"
+  display_name = "<%= ctx[:vars]['display_name'] %>"
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  
+  restrictions {
+    android_key_restrictions {
+      allowed_applications {
+        package_name     = "<%= ctx[:vars]['package_name'] %>"
+        sha1_fingerprint = "2145bdf698b8715039bd0e83f2069bed435ac21c"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/firebase_apple_app_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_apple_app_full.tf.erb
@@ -5,4 +5,19 @@ resource "google_firebase_apple_app" "full" {
   bundle_id = "<%= ctx[:vars]['bundle_id'] %>"
   app_store_id = "<%= ctx[:vars]['app_store_id'] %>"
   team_id = "<%= ctx[:vars]['team_id'] %>"
+  api_key_id = google_apikeys_key.apple.uid
+}
+
+resource "google_apikeys_key" "apple" {
+  provider = google-beta
+
+  name         = "<%= ctx[:vars]['api_key_name'] %>"
+  display_name = "<%= ctx[:vars]['display_name'] %>"
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  
+  restrictions {
+    ios_key_restrictions {
+      allowed_bundle_ids = ["<%= ctx[:vars]['bundle_id'] %>"]
+    }
+  }
 }

--- a/mmv1/templates/terraform/examples/firebase_web_app_custom_api_key.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_web_app_custom_api_key.tf.erb
@@ -1,0 +1,20 @@
+resource "google_firebase_web_app" "<%= ctx[:primary_resource_id] %>" {
+	provider = google-beta
+	project = "<%= ctx[:test_env_vars]['project_id'] %>"
+	display_name = "<%= ctx[:vars]['display_name'] %>"
+	api_key_id = google_apikeys_key.web.uid
+	deletion_policy = "DELETE"
+}
+
+resource "google_apikeys_key" "web" {
+	provider = google-beta
+	project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+	name         = "<%= ctx[:vars]['api_key_name'] %>"
+	display_name = "<%= ctx[:vars]['display_name'] %>"
+
+	restrictions {
+	    browser_key_restrictions {
+	        allowed_referrers = ["*"]
+	    }
+	}
+}

--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_update_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_android_app_update_test.go.erb
@@ -23,25 +23,62 @@ func TestAccFirebaseAndroidApp_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirebaseAndroidApp(context, ""),
+				Config: testAccFirebaseAndroidApp(context, "", "key1"),
 			},
 			{
-				Config: testAccFirebaseAndroidApp(context, "2"),
+				Config: testAccFirebaseAndroidApp(context, "2", "key2"),
 			},
 		},
 	})
 }
 
-func testAccFirebaseAndroidApp(context map[string]interface{}, update string) string {
+func testAccFirebaseAndroidApp(context map[string]interface{}, update string, apiKeyLabel string) string {
 	context["display_name"] = context["display_name"].(string) + update
+	context["api_key_label"] = apiKeyLabel
 	return acctest.Nprintf(`
 resource "google_firebase_android_app" "update" {
-        provider = google-beta
-        project = "%{project_id}"
-        package_name = "%{package_name}"
-        display_name = "%{display_name} %{random_suffix}"
-        sha1_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21c"]
-        sha256_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21ca1b2c3d4e5f6123456789abc"]
+	provider = google-beta
+	project  = "%{project_id}"
+
+	package_name  = "%{package_name}"
+	display_name  = "%{display_name} %{random_suffix}"
+	sha1_hashes   = ["2145bdf698b8715039bd0e83f2069bed435ac21c"]
+	sha256_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21ca1b2c3d4e5f6123456789abc"]
+	api_key_id    = google_apikeys_key.%{api_key_label}.uid
+}
+
+resource "google_apikeys_key" "key1" {
+	provider = google-beta
+	project  = "%{project_id}"
+
+	name         = "tf-test-api-key1%{random_suffix}"
+	display_name = "Test api key 1"
+  
+	restrictions {
+		android_key_restrictions {
+			allowed_applications {
+				package_name     = "%{package_name}"
+				sha1_fingerprint = "2145bdf698b8715039bd0e83f2069bed435ac21c"
+			}
+		}
+    }
+}
+
+resource "google_apikeys_key" "key2" {
+	provider = google-beta
+	project = "%{project_id}"
+
+	name         = "tf-test-api-key2%{random_suffix}"
+	display_name = "Test api key 2"
+  
+	restrictions {
+		android_key_restrictions {
+			allowed_applications {
+				package_name     = "%{package_name}"
+				sha1_fingerprint = "2145bdf698b8715039bd0e83f2069bed435ac21c"
+			}
+		}
+    }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_apple_app_update_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_apple_app_update_test.go.erb
@@ -23,27 +23,58 @@ func TestAccFirebaseAppleApp_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirebaseAppleApp(context, 12345, "1"),
+				Config: testAccFirebaseAppleApp(context, 12345, "1", "key1"),
 			},
 			{
-				Config: testAccFirebaseAppleApp(context, 67890, "2"),
+				Config: testAccFirebaseAppleApp(context, 67890, "2", "key2"),
 			},
 		},
 	})
 }
 
-func testAccFirebaseAppleApp(context map[string]interface{}, appStoreId int, delta string) string {
+func testAccFirebaseAppleApp(context map[string]interface{}, appStoreId int, delta string, apiKeyLabel string) string {
         context["display_name"] = context["display_name"].(string) + delta
         context["app_store_id"] = appStoreId
         context["team_id"] = "123456789" + delta
+        context["api_key_label"] = apiKeyLabel
 	return acctest.Nprintf(`
 resource "google_firebase_apple_app" "update" {
-        provider = google-beta
-        project = "%{project_id}"
-        bundle_id = "%{bundle_id}"
-        display_name = "%{display_name} %{random_suffix}"
-        app_store_id = "%{app_store_id}"
-        team_id = "%{team_id}"
+  provider = google-beta
+  project  = "%{project_id}"
+
+  bundle_id    = "%{bundle_id}"
+  display_name = "%{display_name} %{random_suffix}"
+  app_store_id = "%{app_store_id}"
+  team_id      = "%{team_id}"
+  api_key_id   = google_apikeys_key.%{api_key_label}.uid
+}
+
+resource "google_apikeys_key" "key1" {
+  provider = google-beta
+  project  = "%{project_id}"
+
+  name         = "tf-test-api-key1%{random_suffix}"
+  display_name = "Test api key 1"
+  
+  restrictions {
+    ios_key_restrictions {
+      allowed_bundle_ids = ["%{bundle_id}"]
+    }
+  }
+}
+
+resource "google_apikeys_key" "key2" {
+  provider = google-beta
+  project  = "%{project_id}"
+
+  name         = "tf-test-api-key2%{random_suffix}"
+  display_name = "Test api key 2"
+  
+  restrictions {
+    ios_key_restrictions {
+      allowed_bundle_ids = ["%{bundle_id}"]
+    }
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_web_app_test.go.erb
@@ -37,7 +37,7 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
 					},
 				},
-				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, ""),
+				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "", "key1"),
 			},
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -46,7 +46,7 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
 					},
 				},
-				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2"),
+				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2", "key2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "api_key"),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "auth_domain"),
@@ -55,11 +55,11 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, ""),
+				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "", "key1"),
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2"),
+				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2", "key2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "api_key"),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "auth_domain"),
@@ -70,8 +70,9 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 	})
 }
 
-func testAccFirebaseWebApp_firebaseWebAppFull(context map[string]interface{}, update string) string {
+func testAccFirebaseWebApp_firebaseWebAppFull(context map[string]interface{}, update string, apiKeyLabel string) string {
 	context["display_name"] = context["display_name"].(string) + update
+	context["api_key_label"] = apiKeyLabel
 	return acctest.Nprintf(`
 resource "google_project" "default" {
 	provider = google-beta
@@ -89,10 +90,37 @@ resource "google_firebase_project" "default" {
 	project  = google_project.default.project_id
 }
 
+resource "google_apikeys_key" "key1" {
+	provider     = google-beta
+	name         = "tf-test-api-key1%{random_suffix}"
+	display_name = "Test api key 1"
+	project      = google_project.default.project_id
+
+	restrictions {
+		browser_key_restrictions {
+			allowed_referrers = ["*"]
+		}
+	}
+}
+
+resource "google_apikeys_key" "key2" {
+	provider     = google-beta
+	name         = "tf-test-api-key2%{random_suffix}"
+	display_name = "Test api key 2"
+	project      = google_project.default.project_id
+
+	restrictions {
+		browser_key_restrictions {
+			allowed_referrers = ["*"]
+		}
+	}
+}
+
 resource "google_firebase_web_app" "default" {
 	provider = google-beta
 	project = google_project.default.project_id
 	display_name = "%{display_name} %{random_suffix}"
+	api_key_id = google_apikeys_key.%{api_key_label}.uid
 
 	depends_on = [google_firebase_project.default]
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/15485

This allows users to associate their own API key with an Android/Apple/Web app registered in their Firebase project.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firebase: added `api_key_id` field to `google_firebase_web_app`, `google_firebase_android_app`, and `google_firebase_apple_app`.
```
