### PR TITLE
TeamCity: Add ability to save test log artifacts to all build configurations

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
@@ -58,7 +58,7 @@ class packageDetails(packageName: String, displayName: String, providerName: Str
                 WorkingDirectory(path)
             }
 
-            artifactRules = "%teamcity.build.checkoutDir%/debug*.log"
+            artifactRules = "%teamcity.build.checkoutDir%/debug*.txt"
 
             failureConditions {
                 errorMessage = true

--- a/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
@@ -57,6 +57,8 @@ class packageDetails(packageName: String, displayName: String, providerName: Str
                 WorkingDirectory(path)
             }
 
+            artifactRules = "%teamcity.build.checkoutDir%/debug*.log"
+
             failureConditions {
                 errorMessage = true
                 executionTimeoutMin = buildTimeout

--- a/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/build_config_package.kt
@@ -50,6 +50,7 @@ class packageDetails(packageName: String, displayName: String, providerName: Str
                 // TODO(SarahFrench) Split TerraformAcceptanceTestParameters function into 2: one that's used for all tests/sweeper commands, and one that's specific to sweepers
                 // We shouldn't be adding sweeper-specific parameters to non-sweeper builds
                 TerraformAcceptanceTestParameters(parallelism, testPrefix, testTimeout, sweeperRegions, sweeperRun)
+                TerraformLoggingParameters()
                 TerraformAcceptanceTestsFlag()
                 TerraformCoreBinaryTesting()
                 TerraformShouldPanicForSchemaErrors()

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -145,7 +145,7 @@ fun ParametrizedWithType.TerraformLoggingParameters() {
 
     // Set where logs are sent
     text("PROVIDER_NAME", providerName)
-    text("env.TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.log")
+    text("env.TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.txt")
 }
 
 fun ParametrizedWithType.ReadOnlySettings() {

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -137,7 +137,7 @@ fun ParametrizedWithType.TerraformAcceptanceTestParameters(parallelism : Int, pr
     text("SWEEP_RUN", sweepRun)
 }
 
-fun ParametrizedWithType.TerraformLoggingParameters(parallelism : Int, prefix : String, timeout: String, sweeperRegions: String, sweepRun: String) {
+fun ParametrizedWithType.TerraformLoggingParameters() {
     // Set logging levels to match old projects
     text("TF_LOG", "DEBUG")
     text("TF_LOG_CORE", "WARN")

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -141,7 +141,7 @@ fun ParametrizedWithType.TerraformLoggingParameters() {
     // Set logging levels to match old projects
     text("TF_LOG", "DEBUG")
     text("TF_LOG_CORE", "WARN")
-    text("TF_LOG_SDK_FRAMEWORK ", "INFO")
+    text("TF_LOG_SDK_FRAMEWORK", "INFO")
 
     // Set where logs are sent
     text("TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.log")

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -137,6 +137,16 @@ fun ParametrizedWithType.TerraformAcceptanceTestParameters(parallelism : Int, pr
     text("SWEEP_RUN", sweepRun)
 }
 
+fun ParametrizedWithType.TerraformLoggingParameters(parallelism : Int, prefix : String, timeout: String, sweeperRegions: String, sweepRun: String) {
+    // Set logging levels to match old projects
+    text("TF_LOG", "DEBUG")
+    text("TF_LOG_CORE", "WARN")
+    text("TF_LOG_SDK_FRAMEWORK ", "INFO")
+
+    // Set where logs are sent
+    text("TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.log")
+}
+
 fun ParametrizedWithType.ReadOnlySettings() {
     hiddenVariable("teamcity.ui.settings.readOnly", "true", "Requires build configurations be edited via Kotlin")
 }

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -139,13 +139,13 @@ fun ParametrizedWithType.TerraformAcceptanceTestParameters(parallelism : Int, pr
 
 fun ParametrizedWithType.TerraformLoggingParameters() {
     // Set logging levels to match old projects
-    text("TF_LOG", "DEBUG")
-    text("TF_LOG_CORE", "WARN")
-    text("TF_LOG_SDK_FRAMEWORK", "INFO")
+    text("env.TF_LOG", "DEBUG")
+    text("env.TF_LOG_CORE", "WARN")
+    text("env.TF_LOG_SDK_FRAMEWORK", "INFO")
 
     // Set where logs are sent
     text("PROVIDER_NAME", providerName)
-    text("TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.log")
+    text("env.TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.log")
 }
 
 fun ParametrizedWithType.ReadOnlySettings() {

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -144,6 +144,7 @@ fun ParametrizedWithType.TerraformLoggingParameters() {
     text("TF_LOG_SDK_FRAMEWORK", "INFO")
 
     // Set where logs are sent
+    text("PROVIDER_NAME", providerName)
     text("TF_LOG_PATH_MASK", "%system.teamcity.build.checkoutDir%/debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%s.log")
 }
 

--- a/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
@@ -50,6 +50,7 @@ class sweeperDetails() {
             params {
                 ConfigureGoogleSpecificTestParameters(environmentVariables)
                 TerraformAcceptanceTestParameters(parallelism, testPrefix, testTimeout, sweeperRegions, sweeperRun)
+                TerraformLoggingParameters()
                 TerraformAcceptanceTestsFlag()
                 TerraformCoreBinaryTesting()
                 TerraformShouldPanicForSchemaErrors()

--- a/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
@@ -57,6 +57,8 @@ class sweeperDetails() {
                 WorkingDirectory(path)
             }
 
+            artifactRules = "%teamcity.build.checkoutDir%/debug*.log"
+
             failureConditions {
                 errorMessage = true
                 executionTimeoutMin = buildTimeout

--- a/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/sweepers.kt
@@ -58,7 +58,7 @@ class sweeperDetails() {
                 WorkingDirectory(path)
             }
 
-            artifactRules = "%teamcity.build.checkoutDir%/debug*.log"
+            artifactRules = "%teamcity.build.checkoutDir%/debug*.txt"
 
             failureConditions {
                 errorMessage = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds the ability to make log artefacts (see here for [example in old projects](https://ci-oss.hashicorp.engineering/buildConfiguration/GoogleCloud_ProviderGoogleCloudGoogleProject/425950?buildTab=artifacts)) to the new TC projects.

Here's a place I manually tested the code changes in this PR and got log artifacts created per test : https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_SarahManualTestingProject_GOOGLE_PACKAGE_BILLING/17306?buildTab=artifacts

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
