### PR TITLE
Rename bootstrapped networks

### DIFF
--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -43,7 +43,7 @@ examples:
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
     test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-basic")'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-basic")'
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
@@ -56,7 +56,7 @@ examples:
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
     test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-full")'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-full")'
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -38,7 +38,7 @@ examples:
       network_name: 'test-network'
       address_name: 'address'
     test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-instance-basic")'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-instance-basic-1")'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -38,7 +38,7 @@ examples:
       network_name: 'test-network'
       address_name: 'address'
     test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-instance-basic-1")'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-instance-basic")'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -30,9 +30,7 @@ timeouts: !ruby/object:Api::Timeouts
   delete_minutes: 20
 autogen_async: true
 examples:
-  # Temporary as CI has used up servicenetworking quota
   - !ruby/object:Provider::Terraform::Examples
-    skip_vcr: true
     name: 'memcache_instance_basic'
     primary_resource_id: 'instance'
     vars:
@@ -40,7 +38,7 @@ examples:
       network_name: 'test-network'
       address_name: 'address'
     test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-private")'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-instance-basic")'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -60,15 +60,13 @@ examples:
       network_name: 'acctest.BootstrapSharedTestNetwork(t, "redis-full-persis")'
   - !ruby/object:Provider::Terraform::Examples
     name: 'redis_instance_private_service'
-    # Temporary for servicenetworking problems
-    skip_vcr: true
     primary_resource_id: 'cache'
     vars:
       instance_name: 'private-cache'
       address_name: 'address'
       network_name: 'redis-test-network'
     test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "redis-private")'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "redis-private-service")'
   - !ruby/object:Provider::Terraform::Examples
     name: 'redis_instance_mrr'
     primary_resource_id: 'cache'

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -11,7 +11,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydb-update"),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-update"),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -172,7 +172,7 @@ func TestAccAlloydbBackup_usingCMEK(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydb-cmek"),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-cmek"),
 		"random_suffix": acctest.RandString(t, 10),
 		"key_name":      "tf-test-key-" + acctest.RandString(t, 10),
 	}

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -13,7 +13,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 
 	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)
-	network := acctest.BootstrapSharedTestNetwork(t, "memcach-instance-update")
+	network := acctest.BootstrapSharedTestNetwork(t, "memcache-instance-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -10,12 +10,10 @@ import (
 
 func TestAccMemcacheInstance_update(t *testing.T) {
 	t.Parallel()
-	// Temporary as CI has used up servicenetworking quota
-	acctest.SkipIfVcr(t)
 
 	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)
-	network := acctest.BootstrapSharedTestNetwork(t, "memcache-update")
+	network := acctest.BootstrapSharedTestNetwork(t, "memcach-instance-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -791,7 +791,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testi
 	addressName := "tf-test-" + acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated")
 	addressName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
-	networkName_update := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-ip-range-update")
+	networkName_update := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -173,13 +173,12 @@ func TestAccSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
 // possible, and we should attempt to find any other scenarios where the root user could otherwise
 // be left on the instance.
 func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *testing.T) {
-	// Service Networking
-	acctest.SkipIfVcr(t)
+
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-clone-2")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-clone-2")
 
 	// 1. Create an instance.
 	// 2. Add a root@'%' user.
@@ -737,7 +736,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -785,15 +784,14 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testing.T) {
-	// Service Networking
-	acctest.SkipIfVcr(t)
+
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-allocated-ip-range")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-ip-range")
 	addressName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
-	networkName_update := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-allocated-ip-range-update")
+	networkName_update := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-ip-range-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -823,13 +821,12 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testi
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t *testing.T) {
-	// Service Networking
-	acctest.SkipIfVcr(t)
+
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-replica")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-replica")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -856,13 +853,12 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t
 }
 
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(t *testing.T) {
-	// Service Networking
-	acctest.SkipIfVcr(t)
+
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-clone")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-clone")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -789,7 +789,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testi
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-ip-range")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated")
 	addressName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
 	networkName_update := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-ip-range-update")
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The following tests are currently failing due to a recent tenant resource clean up (b/293326201):
- TestAccAlloydbBackup_alloydbBackupBasicExample
- TestAccAlloydbBackup_alloydbBackupFullExample
- TestAccAlloydbBackup_update
- TestAccAlloydbBackup_usingCMEK
- TestAccMemcacheInstance_memcacheInstanceBasicExample
- TestAccMemcacheInstance_update
- TestAccRedisInstance_redisInstancePrivateServiceExample
- TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls
- TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange
- TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange
- TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica
- TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone

Failing error:
```
The request was invalid: error Invalid resource usage: 'The resource 'projects/xxxxxx' is already linked to another shared VPC host 'projects/xxxxxx'.'.
```

Renaming the corresponding networks to create new ones should fix the issue for now 

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
