### PR TITLE
Promoted SslPolicy on regional target HTTPS proxy resource

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -128,7 +128,6 @@ properties:
     name: 'sslPolicy'
     resource: 'RegionSslPolicy'
     imports: 'selfLink'
-    min_version: beta
     description: |
       A reference to the Region SslPolicy resource that will be associated with
       the TargetHttpsProxy resource. If not set, the TargetHttpsProxy

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
@@ -35,16 +35,14 @@ func TestAccComputeRegionTargetHttpsProxy_update(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-      <% unless version == 'ga' -%>
 			{
-				Config: testAccComputeRegionTargetHttpsProxy_basicBeta(resourceSuffix),
+				Config: testAccComputeRegionTargetHttpsProxy_basic3(resourceSuffix),
 			},
 			{
 				ResourceName:      "google_compute_region_target_https_proxy.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-      <% end -%>
 		},
 	})
 }
@@ -246,8 +244,7 @@ resource "google_compute_region_ssl_certificate" "foobar2" {
 `, id, id, id, id, id, id, id, id, id)
 }
 
-<% unless version == 'ga' -%>
-func testAccComputeRegionTargetHttpsProxy_basicBeta(id string) string {
+func testAccComputeRegionTargetHttpsProxy_basic3(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_target_https_proxy" "foobar" {
   description      = "Resource created for Terraform acceptance testing"
@@ -352,4 +349,3 @@ resource "google_compute_region_ssl_certificate" "foobar2" {
 }
 `, id, id, id, id, id, id, id, id, id, id)
 }
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted the `ssl_policy` field on the `google_compute_region_target_https_proxy` resource to GA.
```

Closes: https://github.com/hashicorp/terraform-provider-google/issues/15486
