### PR TITLE
Clarify types of changes that should use release-note:none

### DIFF
--- a/docs/content/contribute/release-notes.md
+++ b/docs/content/contribute/release-notes.md
@@ -79,15 +79,6 @@ Replace `DATASOURCE_NAME` according to the pull request content. For example:
 ```
 ~~~
 {{< /tab >}}
-{{< tab "No user impact" >}}
-If there is no user impact, use an empty release note block of type `none`. This includes things like test fixes, website updates and
-CI changes. Example:
-
-~~~markdown
-```release-note:none
-```
-~~~
-{{< /tab >}}
 {{< tab "Other" >}}
 ### Choose a release note type
 For each release note block, choose an appropriate type from the following list:
@@ -97,6 +88,8 @@ For each release note block, choose an appropriate type from the following list:
 - `deprecation` : A field/resource is being marked as deprecated (not being removed)
 - `breaking-change` : Changes that require users to change their configuration
 - `note` : General type for other notes that might be relevant to users but don't fit into another category
+- `none` : Changes where there is no user impact, like test fixes, website updates and
+CI changes (release notes of this type should be empty)
 
 ### Guidelines
 

--- a/docs/content/contribute/release-notes.md
+++ b/docs/content/contribute/release-notes.md
@@ -89,7 +89,7 @@ For each release note block, choose an appropriate type from the following list:
 - `breaking-change` : Changes that require users to change their configuration
 - `note` : General type for other notes that might be relevant to users but don't fit into another category
 - `none` : Changes where there is no user impact, like test fixes, website updates and
-CI changes (release notes of this type should be empty)
+  CI changes. Release notes of this type should be empty.
 
 ### Guidelines
 

--- a/docs/content/contribute/release-notes.md
+++ b/docs/content/contribute/release-notes.md
@@ -80,7 +80,8 @@ Replace `DATASOURCE_NAME` according to the pull request content. For example:
 ~~~
 {{< /tab >}}
 {{< tab "No user impact" >}}
-If there is no user impact, use an empty release note block of type `none`. Example:
+If there is no user impact, use an empty release note block of type `none`. This includes things like test fixes, website updates and
+CI changes. Example:
 
 ~~~markdown
 ```release-note:none


### PR DESCRIPTION
This used to be more explicit in the older version of this documentation here: https://github.com/GoogleCloudPlatform/magic-modules/pull/8159/files, and I personally found it useful that things like test/docs changes were called out as not needing a release note.

If we actually do want these changes to have release notes, then we can of course change the guidance I added here, but either way it would be good to be explicit. Specifically, we regularly see people adding docs changes under the `NOTES` section or similar.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
