### PR TITLE
Promote DenyPolicy to GA

### DIFF
--- a/mmv1/products/iam2/DenyPolicy.yaml
+++ b/mmv1/products/iam2/DenyPolicy.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Resource
 name: 'DenyPolicy'
-min_version: beta
 base_url: policies/{{parent}}/denypolicies
 create_url: policies/{{parent}}/denypolicies?policyId={{name}}
 description: |
@@ -21,7 +20,7 @@ description: |
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Permissions supported in deny policies': 'https://cloud.google.com/iam/docs/deny-permissions-support'
-  api: 'https://cloud.google.com/iam/docs/reference/rest/v2beta/policies'
+  api: 'https://cloud.google.com/iam/docs/reference/rest/v2/policies'
 autogen_async: true
 import_format: ['{{parent}}/{{name}}']
 id_format: '{{parent}}/{{name}}'
@@ -36,7 +35,6 @@ examples:
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
-    min_version: beta
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'

--- a/mmv1/templates/terraform/examples/iam_deny_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_deny_policy_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "<%= ctx[:vars]["project_name"] %>"
   name            = "<%= ctx[:vars]["project_name"] %>"
   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
@@ -7,7 +6,6 @@ resource "google_project" "project" {
 }
 
 resource "google_iam_deny_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   parent   = urlencode("cloudresourcemanager.googleapis.com/projects/${google_project.project.project_id}")
   name     = "<%= ctx[:vars]["policy_name"] %>"
   display_name = "A deny rule"
@@ -37,7 +35,6 @@ resource "google_iam_deny_policy" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_service_account" "test-account" {
-  provider = google-beta
   account_id   = "<%= ctx[:vars]['account_id'] %>"
   display_name = "Test Service Account"
   project      = google_project.project.project_id

--- a/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb
@@ -95,7 +95,6 @@ func TestAccIAM2DenyPolicy_iamDenyPolicyFolderParent(t *testing.T) {
 func testAccIAM2DenyPolicy_iamDenyPolicyUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
@@ -103,7 +102,6 @@ resource "google_project" "project" {
 }
 
 resource "google_iam_deny_policy" "example" {
-  provider = google-beta
   parent   = urlencode("cloudresourcemanager.googleapis.com/projects/${google_project.project.project_id}")
   name     = "tf-test-my-deny-policy%{random_suffix}"
   display_name = "A deny rule"
@@ -133,7 +131,6 @@ resource "google_iam_deny_policy" "example" {
 }
 
 resource "google_service_account" "test-account" {
-  provider = google-beta
   account_id   = "tf-test-deny-account%{random_suffix}"
   display_name = "Test Service Account"
   project      = google_project.project.project_id
@@ -144,7 +141,6 @@ resource "google_service_account" "test-account" {
 func testAccIAM2DenyPolicy_iamDenyPolicyUpdate2(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
@@ -152,7 +148,6 @@ resource "google_project" "project" {
 }
 
 resource "google_iam_deny_policy" "example" {
-  provider = google-beta
   parent   = urlencode("cloudresourcemanager.googleapis.com/projects/${google_project.project.project_id}")
   name     = "tf-test-my-deny-policy%{random_suffix}"
   display_name = "A deny rule"
@@ -172,7 +167,6 @@ resource "google_iam_deny_policy" "example" {
 }
 
 resource "google_service_account" "test-account" {
-  provider = google-beta
   account_id   = "tf-test-deny-account%{random_suffix}"
   display_name = "Test Service Account"
   project      = google_project.project.project_id
@@ -183,7 +177,6 @@ resource "google_service_account" "test-account" {
 func testAccIAM2DenyPolicy_iamDenyPolicyFolder(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_iam_deny_policy" "example" {
-  provider = google-beta
   parent   = urlencode("cloudresourcemanager.googleapis.com/${google_folder.folder.id}")
   name     = "tf-test-my-deny-policy%{random_suffix}"
   display_name = "A deny rule"
@@ -201,7 +194,6 @@ resource "google_iam_deny_policy" "example" {
 }
 
 resource "google_folder" "folder" {
-  provider = google-beta
   display_name = "tf-test-%{random_suffix}"
   parent       = "organizations/%{org_id}"
 }
@@ -211,7 +203,6 @@ resource "google_folder" "folder" {
 func testAccIAM2DenyPolicy_iamDenyPolicyFolderUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_iam_deny_policy" "example" {
-  provider = google-beta
   parent   = urlencode("cloudresourcemanager.googleapis.com/${google_folder.folder.id}")
   name     = "tf-test-my-deny-policy%{random_suffix}"
   display_name = "A deny rule"
@@ -225,7 +216,6 @@ resource "google_iam_deny_policy" "example" {
 }
 
 resource "google_folder" "folder" {
-  provider = google-beta
   display_name = "tf-test-%{random_suffix}"
   parent       = "organizations/%{org_id}"
 }

--- a/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb
@@ -1,8 +1,6 @@
 <% autogen_exception -%>
 package iam2_test
 
-<% unless version == 'ga' -%>
-
 import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -23,7 +21,7 @@ func TestAccIAM2DenyPolicy_iamDenyPolicyUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckIAM2DenyPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -67,7 +65,7 @@ func TestAccIAM2DenyPolicy_iamDenyPolicyFolderParent(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckIAM2DenyPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -221,5 +219,3 @@ resource "google_folder" "folder" {
 }
 `, context)
 }
-
-<% end -%>


### PR DESCRIPTION
* Remove `min_version: beta` from the resource configuration [DenyPolicy.yaml](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/iam2/DenyPolicy.yaml).
* Remove  `provider = google-beta` from the example that is used for documentation [iam_deny_policy_basic.tf.erb](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/examples/iam_deny_policy_basic.tf.erb).
* Remove `provider = google-beta` from the the handwritten tests [resource_iam_deny_policy_test.go.erb](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb).

Related documentation: [Magic Modules Promote from beta to GA](https://googlecloudplatform.github.io/magic-modules/develop/promote-to-ga/)

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

```release-note:new-resource
`google_iam_deny_policy` (ga only)
```
