### PR TITLE
[GKE Hub]: Add Fleet Resource

### DIFF
--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -1,0 +1,97 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+!ruby/object:Api::Resource
+name: "Fleet"
+base_url: "projects/{{project}}/locations/global/fleets"
+create_url: "projects/{{project}}/locations/global/fleets"
+update_url: "projects/{{project}}/locations/global/fleets/default"
+self_link: "projects/{{project}}/locations/global/fleets/default"
+update_verb: :PATCH
+update_mask: true
+description: |
+  Fleet contains information about a group of clusters.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    "Registering a Cluster to a Fleet": "https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster#register_cluster"
+  api: "https://cloud.google.com/anthos/multicluster-management/reference/rest/v1/projects.locations.fleets"
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    kind: "gkehub#operation"
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+    resource_inside_response: true
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: "true"
+    allowed:
+      - "true"
+      - "false"
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error/errors"
+    message: "message"
+autogen_async: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "gkehub_fleet_basic"
+    skip_test: true
+    primary_resource_id: 'default'
+id_format: "projects/{{project}}/locations/global/fleets/default"
+import_format: ["projects/{{project}}/locations/global/fleets/default"]
+properties:
+  - !ruby/object:Api::Type::String
+    name: "displayName"
+    description: |
+      A user-assigned display name of the Fleet. When present, it must be between 4 to 30 characters.
+      Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point.
+  - !ruby/object:Api::Type::Time
+    name: "createTime"
+    description: |
+      The time the fleet was created, in RFC3339 text format.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: "updateTime"
+    description: |
+      The time the fleet was last updated, in RFC3339 text format.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: "deleteTime"
+    description: |
+      The time the fleet was deleted, in RFC3339 text format.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: "uid"
+    output: true
+    description: |
+      Google-generated UUID for this resource. This is unique across all
+      Fleet resources. If a Fleet resource is deleted and another
+      resource with the same name is created, it gets a different uid.
+  - !ruby/object:Api::Type::NestedObject
+    name: "state"
+    description: The state of the fleet resource.
+    output: true
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: "code"
+        description: Describes the state of a Fleet resource.
+        output: true
+        values:
+          - CODE_UNSPECIFIED
+          - CREATING
+          - READY
+          - DELETING
+          - UPDATING

--- a/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
@@ -1,0 +1,3 @@
+resource "google_gke_hub_fleet" "default" {
+  display_name = "my production fleet"
+}

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -1,0 +1,136 @@
+<% autogen_exception -%>
+package gkehub2_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestAccGKEHub2Fleet_gkehubFleetBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGKEHub2FleetDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time":   {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEHub2Fleet_basic(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_fleet.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGKEHub2Fleet_update(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_fleet.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGKEHub2Fleet_basic(context map[string]interface{}) string {
+	return gkeHubFleetProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_fleet" "default" {
+  project = google_project.project.project_id
+  display_name = "my production fleet"
+
+  depends_on = [time_sleep.wait_for_gkehub_enablement]
+}
+`, context)
+}
+
+func testAccGKEHub2Fleet_update(context map[string]interface{}) string {
+	return gkeHubFleetProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_fleet" "default" {
+  project = google_project.project.project_id
+  display_name = "my staging fleet"
+
+  depends_on = [time_sleep.wait_for_gkehub_enablement]
+}
+`, context)
+}
+
+func gkeHubFleetProjectSetupForGA(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  name            = "tf-test-gkehub%{random_suffix}"
+  project_id      = "tf-test-gkehub%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "gkehub" {
+  project = google_project.project.project_id
+  service = "gkehub.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "time_sleep" "wait_for_gkehub_enablement" {
+  create_duration = "150s"
+  depends_on = [google_project_service.gkehub]
+}
+`, context)
+}
+
+func testAccCheckGKEHub2FleetDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_gke_hub_fleet" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{GKEHub2BasePath}}projects/{{project}}/locations/global/fleets/default")
+			if err != nil {
+				return err
+			}
+
+			billingProject := ""
+
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
+
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("GKEHub2Fleet still exists at %s", url)
+			}
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Adds a new GKEHub resource "Fleet." This is a singleton resource such that a user may have exactly one named "default" inside each project. i.e. the resource name `project/{project_id}/location/{global}/fleets/default`.

b/296461330


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_gke_hub_fleet`
```
