### PR TITLE
remove dispatch call for pre-build-validate

### DIFF
--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -64,15 +64,6 @@ steps:
           - --no-ff
           - head/$_HEAD_BRANCH
 
-    - name: 'gcr.io/graphite-docker-images/bash-plus'
-      id: pre-build-validate
-      entrypoint: '/workspace/.ci/scripts/bash-plus/pre-build-validator/validate.sh'
-      secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["merged"]
-      env:
-        - COMMIT_SHA=$COMMIT_SHA
-        - PR_NUMBER=$_PR_NUMBER
-
     - name: 'gcr.io/graphite-docker-images/build-environment'
       entrypoint: '/workspace/.ci/scripts/build-environment/downstream-builder/generate_downstream.sh'
       id: tpg-head

--- a/.ci/scripts/bash-plus/pre-build-validator/validate.sh
+++ b/.ci/scripts/bash-plus/pre-build-validator/validate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# remove after 9/2023
+
 set -e
 
 gh_repo=magic-modules


### PR DESCRIPTION
This operation was moved to an on_pull_request event in https://github.com/GoogleCloudPlatform/magic-modules/pull/8596/files#diff-af47aab3df4c9aeaad5d41f2680c393cc6432b6e434f0d9fe24f1c12db622b6b


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
