### PR TITLE
B0

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -33,13 +33,6 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		ForceNew:    true,
 		Description: `The ID of the project to create the sink in. If omitted, the project associated with the provider is used.`,
 	}
-	schm.Schema["unique_writer_identity"] = &schema.Schema{
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		ForceNew:    true,
-		Description: `Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
-	}
 	return schm
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -126,7 +126,8 @@ The following arguments are supported:
     - `storage.googleapis.com/[GCS_BUCKET]`
     - `bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET]`
     - `pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]`
-    - `logging.googleapis.com/projects/[PROJECT_ID]]/locations/global/buckets/[BUCKET_ID]`
+    - `logging.googleapis.com/projects/[PROJECT_ID]/locations/global/buckets/[BUCKET_ID]`
+    - `logging.googleapis.com/projects/[PROJECT_ID]`
 
     The writer associated with the sink must have access to write to the above resource.
 


### PR DESCRIPTION
<!-- Disable ForceNew for project sink unique_writer_identity field, so that sink can be updated in place. fixes https://github.com/hashicorp/terraform-provider-google/issues/15266-->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Disable ForceNew for project sink unique_writer_identity field, so that sink can be updated in place. fixes https://github.com/hashicorp/terraform-provider-google/issues/15266
```
