### PR TITLE
feat(bigquery): add option to use Non-incremental materialized views

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -837,6 +837,13 @@ func ResourceBigQueryTable() *schema.Resource {
 							Description: `Specifies maximum frequency at which this materialized view will be refreshed. The default is 1800000`,
 						},
 
+						"allow_non_incremental_definition": {
+							Type:        schema.TypeBool,
+							Default:     false,
+							Optional:    true,
+							Description: `Allow non incremental materialized view definition. The default value is false.`,
+						},
+
 						// Query: [Required] A query whose result is persisted
 						"query": {
 							Type:        schema.TypeString,
@@ -1982,6 +1989,11 @@ func expandMaterializedView(configured interface{}) *bigquery.MaterializedViewDe
 		mvd.ForceSendFields = append(mvd.ForceSendFields, "RefreshIntervalMs")
 	}
 
+	if v, ok := raw["allow_non_incremental_definition"]; ok {
+		mvd.AllowNonIncrementalDefinition = v.(bool)
+		mvd.ForceSendFields = append(mvd.ForceSendFields, "AllowNonIncrementalDefinition")
+	}
+
 	return mvd
 }
 
@@ -1989,6 +2001,7 @@ func flattenMaterializedView(mvd *bigquery.MaterializedViewDefinition) []map[str
 	result := map[string]interface{}{"query": mvd.Query}
 	result["enable_refresh"] = mvd.EnableRefresh
 	result["refresh_interval_ms"] = mvd.RefreshIntervalMs
+	result["allow_non_incremental_definition"] = mvd.AllowNonIncrementalDefinition
 
 	return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -841,6 +841,7 @@ func ResourceBigQueryTable() *schema.Resource {
 							Type:        schema.TypeBool,
 							Default:     false,
 							Optional:    true,
+							ForceNew:    true,
 							Description: `Allow non incremental materialized view definition. The default value is false.`,
 						},
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -487,6 +487,39 @@ func TestAccBigQueryTable_MaterializedView_DailyTimePartioning_Update(t *testing
 	})
 }
 
+func TestAccBigQueryTable_MaterializedView_NonIncremental_basic(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	materialized_viewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	query := fmt.Sprintf("SELECT count(some_string) as count, some_int, ts FROM `%s.%s` WHERE DATE(ts) = '2019-01-01' GROUP BY some_int, ts", datasetID, tableID)
+	maxStaleness := "0-0 0 10:0:0"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableWithMatViewNonIncremental_basic(datasetID, tableID, materialized_viewID, query, maxStaleness),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
+			},
+			{
+				ResourceName:            "google_bigquery_table.mv_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccBigQueryExternalDataTable_parquet(t *testing.T) {
 	t.Parallel()
 
@@ -1836,6 +1869,86 @@ resource "google_bigquery_table" "mv_test" {
   ]
 }
 `, datasetID, tableID, mViewID, enable_refresh, refresh_interval, query)
+}
+
+func testAccBigQueryTableWithMatViewNonIncremental_basic(datasetID, tableID, mViewID, query, maxStaleness string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+  deletion_protection = false
+  table_id   = "%s"
+  dataset_id = google_bigquery_dataset.test.dataset_id
+
+  time_partitioning {
+    type                     = "DAY"
+    field                    = "ts"
+    require_partition_filter = true
+  }
+  clustering = ["some_int", "some_string"]
+  schema     = <<EOH
+[
+  {
+    "name": "ts",
+    "type": "TIMESTAMP"
+  },
+  {
+    "name": "some_string",
+    "type": "STRING"
+  },
+  {
+    "name": "some_int",
+    "type": "INTEGER"
+  },
+  {
+    "name": "city",
+    "type": "RECORD",
+    "fields": [
+  {
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "name": "coord",
+    "type": "RECORD",
+    "fields": [
+    {
+    "name": "lon",
+    "type": "FLOAT"
+    }
+    ]
+  }
+    ]
+  }
+]
+EOH
+
+}
+
+resource "google_bigquery_table" "mv_test" {
+  deletion_protection = false
+  table_id   = "%s"
+  dataset_id = google_bigquery_dataset.test.dataset_id
+
+  time_partitioning {
+    type    = "DAY"
+    field   = "ts"
+  }
+
+  materialized_view {
+    query          = "%s"
+    allow_non_incremental_definition = true
+  }
+
+  depends_on = [
+    google_bigquery_table.test,
+  ]
+
+  max_staleness = "%s"
+}
+`, datasetID, tableID, mViewID, query, maxStaleness)
 }
 
 func testAccBigQueryTableUpdated(datasetID, tableID string) string {

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -355,6 +355,9 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 * `refresh_interval_ms` - (Optional) The maximum frequency at which this materialized view will be refreshed.
     The default value is 1800000
 
+* `allow_non_incremental_definition` - (Optional) Allow non incremental materialized view definition.
+    The default value is false.
+
 <a name="nested_encryption_configuration"></a>The `encryption_configuration` block supports the following arguments:
 
 * `kms_key_name` - (Required) The self link or full name of a key which should be used to


### PR DESCRIPTION
feat(bigquery): add option to use Non-incremental materialized views

This adds an option  `use allow_non_incremental_definition` to create a non-incremental materialized view in bigquery, and a basic test for this.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `allow_non_incremental_definition` to `google_bigquery_table` resource
```
