### PR TITLE
Change provider import path for tools

### DIFF
--- a/tools/diff-processor/diff/comparison.go
+++ b/tools/diff-processor/diff/comparison.go
@@ -1,8 +1,8 @@
 package diff
 
 import (
-	newProvider "google/provider/new/google"
-	oldProvider "google/provider/old/google"
+	newProvider "google/provider/new/google/provider"
+	oldProvider "google/provider/old/google/provider"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/magic-modules/.ci/diff-processor/rules"

--- a/tools/missing-test-detector/changed.go
+++ b/tools/missing-test-detector/changed.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	newProvider "google/provider/new/google-beta"
-	oldProvider "google/provider/old/google-beta"
+	newProvider "google/provider/new/google-beta/provider"
+	oldProvider "google/provider/old/google-beta/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/tools/missing-test-detector/changed_test.go
+++ b/tools/missing-test-detector/changed_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	newProvider "google/provider/new/google-beta"
-	oldProvider "google/provider/old/google-beta"
+	newProvider "google/provider/new/google-beta/provider"
+	oldProvider "google/provider/old/google-beta/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Change the provider import path, as the the function `ResourceMap` has been migrated to the provider package from  the google package.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
