### PR TITLE
TeamCity : Skip `google_project` sweeper in Beta projects

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
@@ -63,7 +63,7 @@ fun Google<%= version.capitalize unless version == 'ga' -%>(environment: String,
             param("BRANCH_NAME", branchRef)
 <% unless version == 'ga' -%>
             // Skip the sweeper for project resources in the Beta tests only
-            param("SKIP_PROJECT_SWEEPER", 1)
+            param("env.SKIP_PROJECT_SWEEPER", 1)
 <% end -%>
             // Not used, but making `environment` a param makes the value visible to non-admins in TeamCity
             param("ENVIRONMENT", environment)

--- a/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
@@ -59,8 +59,12 @@ fun Google<%= version.capitalize unless version == 'ga' -%>(environment: String,
         // Adding this allows custom builds to use alternative branches. E.g. testing release branches in the downstreams
 
         params {
+            // Controls the VCS root, and allows custom builds to point at different branches
             param("BRANCH_NAME", branchRef)
-            
+<% unless version == 'ga' -%>
+            // Skip the sweeper for project resources in the Beta tests only
+            param("SKIP_PROJECT_SWEEPER", 1)
+<% end -%>
             // Not used, but making `environment` a param makes the value visible to non-admins in TeamCity
             param("ENVIRONMENT", environment)
         }

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go
@@ -21,6 +21,7 @@ func init() {
 	// already be in-progress.
 	// Example: SKIP_PROJECT_SWEEPER=1 go test ./google -v -sweep=us-central1 -sweep-run=
 	if os.Getenv("SKIP_PROJECT_SWEEPER") != "" {
+		log.Printf("[INFO][SWEEPER_LOG] Skipping sweeper for GoogleProject because `SKIP_PROJECT_SWEEPER` is set")
 		return
 	}
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go
@@ -21,7 +21,7 @@ func init() {
 	// already be in-progress.
 	// Example: SKIP_PROJECT_SWEEPER=1 go test ./google -v -sweep=us-central1 -sweep-run=
 	if os.Getenv("SKIP_PROJECT_SWEEPER") != "" {
-		log.Printf("[INFO][SWEEPER_LOG] Skipping sweeper for GoogleProject because `SKIP_PROJECT_SWEEPER` is set")
+		// No logging here - see https://github.com/GoogleCloudPlatform/magic-modules/pull/7439
 		return
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR allows TeamCity projects made from the TPGB repo to include setting the `SKIP_PROJECT_SWEEPER` ENV, while projects for testing the GA provider do not have it set. Any builds within the project will inherit the value set on the project.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
