### PR TITLE
Fully supporting Dialogflow CX Page and Flow objects

### DIFF
--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -116,19 +116,6 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object:Api::Type::Enum
-                    name: 'responseType'
-                    description: |
-                      Represents different response types.
-                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                    values:
-                      - :RESPONSE_TYPE_UNSPECIFIED
-                      - :ENTRY_PROMPT
-                      - :PARAMETER_PROMPT
-                      - :HANDLER_PROMPT
                   - !ruby/object:Api::Type::String
                     name: 'channel'
                     description: |
@@ -337,19 +324,6 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object:Api::Type::Enum
-                    name: 'responseType'
-                    description: |
-                      Represents different response types.
-                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                    values:
-                      - :RESPONSE_TYPE_UNSPECIFIED
-                      - :ENTRY_PROMPT
-                      - :PARAMETER_PROMPT
-                      - :HANDLER_PROMPT
                   - !ruby/object:Api::Type::String
                     name: 'channel'
                     description: |

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -116,6 +116,23 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
+                  - !ruby/object:Api::Type::Enum
+                    name: 'responseType'
+                    description: |
+                      Represents different response types.
+                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                    values:
+                      - :RESPONSE_TYPE_UNSPECIFIED
+                      - :ENTRY_PROMPT
+                      - :PARAMETER_PROMPT
+                      - :HANDLER_PROMPT
+                  - !ruby/object:Api::Type::String
+                    name: 'channel'
+                    description: |
+                      The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
                   - !ruby/object:Api::Type::NestedObject
                     name: 'text'
                     description: |
@@ -131,6 +148,103 @@ properties:
                         output: true
                         description: |
                           Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                  - !ruby/object:Api::Type::String
+                    name: 'payload'
+                    description: |
+                      A custom, platform-specific payload.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'conversationSuccess'
+                    description: |
+                      Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                      Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                      * In a webhook response when you determine that you handled the customer issue.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'outputAudioText'
+                    description: |
+                      A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                    properties:
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      - !ruby/object:Api::Type::String
+                        name: 'text'
+                        description: |
+                          The raw text to be synthesized.
+                      - !ruby/object:Api::Type::String
+                        name: 'ssml'
+                        description: |
+                          The SSML text to be synthesized. For more information, see SSML.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'liveAgentHandoff'
+                    description: |
+                      Indicates that the conversation should be handed off to a live agent.
+                      Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                      * In a webhook response when you determine that the customer issue can only be handled by a human.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'playAudio'
+                    description: |
+                      Specifies an audio clip to be played by the client as part of the response.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'audioUri'
+                        required: true
+                        description: |
+                          URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'telephonyTransferCall'
+                    description: |
+                      Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'phoneNumber'
+                        required: true
+                        description: |
+                          Transfer the call to a phone number in E.164 format.
             - !ruby/object:Api::Type::String
               name: 'webhook'
               description: |
@@ -143,6 +257,45 @@ properties:
               name: 'tag'
               description: |
                 The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+            - !ruby/object:Api::Type::Array
+              name: 'setParameterActions'
+              description: |
+                Set parameter values before executing the webhook.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'parameter'
+                    description: |
+                      Display name of the parameter.
+                  - !ruby/object:Api::Type::String
+                    name: 'value'
+                    description: |
+                      The new JSON-encoded value of the parameter. A null value clears the parameter.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::Array
+              name: 'conditionalCases'
+              description: |
+                Conditional cases for this fulfillment.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  # This object has a recursive schema so we use a string instead of a NestedObject
+                  - !ruby/object:Api::Type::Array
+                    name: 'cases'
+                    description: |
+                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                    item_type: Api::Type::String
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |
@@ -183,6 +336,23 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
+                  - !ruby/object:Api::Type::Enum
+                    name: 'responseType'
+                    description: |
+                      Represents different response types.
+                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                    values:
+                      - :RESPONSE_TYPE_UNSPECIFIED
+                      - :ENTRY_PROMPT
+                      - :PARAMETER_PROMPT
+                      - :HANDLER_PROMPT
+                  - !ruby/object:Api::Type::String
+                    name: 'channel'
+                    description: |
+                      The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
                   - !ruby/object:Api::Type::NestedObject
                     name: 'text'
                     description: |
@@ -198,6 +368,103 @@ properties:
                         output: true
                         description: |
                           Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                  - !ruby/object:Api::Type::String
+                    name: 'payload'
+                    description: |
+                      A custom, platform-specific payload.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'conversationSuccess'
+                    description: |
+                      Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                      Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                      * In a webhook response when you determine that you handled the customer issue.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'outputAudioText'
+                    description: |
+                      A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                    properties:
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      - !ruby/object:Api::Type::String
+                        name: 'text'
+                        description: |
+                          The raw text to be synthesized.
+                      - !ruby/object:Api::Type::String
+                        name: 'ssml'
+                        description: |
+                          The SSML text to be synthesized. For more information, see SSML.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'liveAgentHandoff'
+                    description: |
+                      Indicates that the conversation should be handed off to a live agent.
+                      Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                      * In a webhook response when you determine that the customer issue can only be handled by a human.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'playAudio'
+                    description: |
+                      Specifies an audio clip to be played by the client as part of the response.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'audioUri'
+                        required: true
+                        description: |
+                          URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'telephonyTransferCall'
+                    description: |
+                      Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'phoneNumber'
+                        required: true
+                        description: |
+                          Transfer the call to a phone number in E.164 format.
             - !ruby/object:Api::Type::String
               name: 'webhook'
               description: |
@@ -210,6 +477,45 @@ properties:
               name: 'tag'
               description: |
                 The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+            - !ruby/object:Api::Type::Array
+              name: 'setParameterActions'
+              description: |
+                Set parameter values before executing the webhook.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'parameter'
+                    description: |
+                      Display name of the parameter.
+                  - !ruby/object:Api::Type::String
+                    name: 'value'
+                    description: |
+                      The new JSON-encoded value of the parameter. A null value clears the parameter.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::Array
+              name: 'conditionalCases'
+              description: |
+                Conditional cases for this fulfillment.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  # This object has a recursive schema so we use a string instead of a NestedObject
+                  - !ruby/object:Api::Type::Array
+                    name: 'cases'
+                    description: |
+                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                    item_type: Api::Type::String
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -285,17 +285,18 @@ properties:
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   # This object has a recursive schema so we use a string instead of a NestedObject
-                  - !ruby/object:Api::Type::Array
+                  - !ruby/object:Api::Type::String
                     name: 'cases'
                     description: |
-                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                       See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-                    item_type: Api::Type::String
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                       return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |
@@ -505,17 +506,18 @@ properties:
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   # This object has a recursive schema so we use a string instead of a NestedObject
-                  - !ruby/object:Api::Type::Array
+                  - !ruby/object:Api::Type::String
                     name: 'cases'
                     description: |
-                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                       See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-                    item_type: Api::Type::String
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                       return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -271,7 +271,7 @@ properties:
                     name: 'value'
                     description: |
                       The new JSON-encoded value of the parameter. A null value clears the parameter.
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
@@ -491,7 +491,7 @@ properties:
                     name: 'value'
                     description: |
                       The new JSON-encoded value of the parameter. A null value clears the parameter.
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -91,19 +91,6 @@ properties:
           The list of rich message responses to present to the user.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
-            - !ruby/object:Api::Type::Enum
-              name: 'responseType'
-              description: |
-                Represents different response types.
-                * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-              values:
-                - :RESPONSE_TYPE_UNSPECIFIED
-                - :ENTRY_PROMPT
-                - :PARAMETER_PROMPT
-                - :HANDLER_PROMPT
             - !ruby/object:Api::Type::String
               name: 'channel'
               description: |
@@ -317,19 +304,6 @@ properties:
                         The list of rich message responses to present to the user.
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
-                          - !ruby/object:Api::Type::Enum
-                            name: 'responseType'
-                            description: |
-                              Represents different response types.
-                              * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                              * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                              * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                              * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                            values:
-                              - :RESPONSE_TYPE_UNSPECIFIED
-                              - :ENTRY_PROMPT
-                              - :PARAMETER_PROMPT
-                              - :HANDLER_PROMPT
                           - !ruby/object:Api::Type::String
                             name: 'channel'
                             description: |
@@ -534,19 +508,6 @@ properties:
                               The list of rich message responses to present to the user.
                             item_type: !ruby/object:Api::Type::NestedObject
                               properties:
-                                - !ruby/object:Api::Type::Enum
-                                  name: 'responseType'
-                                  description: |
-                                    Represents different response types.
-                                    * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                                    * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                                    * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                                    * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                                  values:
-                                    - :RESPONSE_TYPE_UNSPECIFIED
-                                    - :ENTRY_PROMPT
-                                    - :PARAMETER_PROMPT
-                                    - :HANDLER_PROMPT
                                 - !ruby/object:Api::Type::String
                                   name: 'channel'
                                   description: |
@@ -789,19 +750,6 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object:Api::Type::Enum
-                    name: 'responseType'
-                    description: |
-                      Represents different response types.
-                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                    values:
-                      - :RESPONSE_TYPE_UNSPECIFIED
-                      - :ENTRY_PROMPT
-                      - :PARAMETER_PROMPT
-                      - :HANDLER_PROMPT
                   - !ruby/object:Api::Type::String
                     name: 'channel'
                     description: |
@@ -1006,19 +954,6 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object:Api::Type::Enum
-                    name: 'responseType'
-                    description: |
-                      Represents different response types.
-                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
-                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                    values:
-                      - :RESPONSE_TYPE_UNSPECIFIED
-                      - :ENTRY_PROMPT
-                      - :PARAMETER_PROMPT
-                      - :HANDLER_PROMPT
                   - !ruby/object:Api::Type::String
                     name: 'channel'
                     description: |

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -91,6 +91,23 @@ properties:
           The list of rich message responses to present to the user.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
+            - !ruby/object:Api::Type::Enum
+              name: 'responseType'
+              description: |
+                Represents different response types.
+                * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+              values:
+                - :RESPONSE_TYPE_UNSPECIFIED
+                - :ENTRY_PROMPT
+                - :PARAMETER_PROMPT
+                - :HANDLER_PROMPT
+            - !ruby/object:Api::Type::String
+              name: 'channel'
+              description: |
+                The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
             - !ruby/object:Api::Type::NestedObject
               name: 'text'
               description: |
@@ -106,6 +123,103 @@ properties:
                   output: true
                   description: |
                     Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+            # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+            - !ruby/object:Api::Type::String
+              name: 'payload'
+              description: |
+                A custom, platform-specific payload.
+              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+              state_func:
+                'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                return s }'
+              validation: !ruby/object:Provider::Terraform::Validation
+                function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::NestedObject
+              name: 'conversationSuccess'
+              description: |
+                Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                You may set this, for example:
+                * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                * In a webhook response when you determine that you handled the customer issue.
+              properties:
+                # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                - !ruby/object:Api::Type::String
+                  name: 'metadata'
+                  description: |
+                    Custom metadata. Dialogflow doesn't impose any structure on this.
+                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                  state_func:
+                    'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                    return s }'
+                  validation: !ruby/object:Provider::Terraform::Validation
+                    function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::NestedObject
+              name: 'outputAudioText'
+              description: |
+                A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+              properties:
+                - !ruby/object:Api::Type::Boolean
+                  name: 'allowPlaybackInterruption'
+                  output: true
+                  description: |
+                    Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                - !ruby/object:Api::Type::String
+                  name: 'text'
+                  description: |
+                    The raw text to be synthesized.
+                - !ruby/object:Api::Type::String
+                  name: 'ssml'
+                  description: |
+                    The SSML text to be synthesized. For more information, see SSML.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'liveAgentHandoff'
+              description: |
+                Indicates that the conversation should be handed off to a live agent.
+                Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                You may set this, for example:
+                * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                * In a webhook response when you determine that the customer issue can only be handled by a human.
+              properties:
+                # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                - !ruby/object:Api::Type::String
+                  name: 'metadata'
+                  description: |
+                    Custom metadata. Dialogflow doesn't impose any structure on this.
+                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                  state_func:
+                    'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                    return s }'
+                  validation: !ruby/object:Provider::Terraform::Validation
+                    function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::NestedObject
+              name: 'playAudio'
+              description: |
+                Specifies an audio clip to be played by the client as part of the response.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'audioUri'
+                  required: true
+                  description: |
+                    URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                - !ruby/object:Api::Type::Boolean
+                  name: 'allowPlaybackInterruption'
+                  output: true
+                  description: |
+                    Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'telephonyTransferCall'
+              description: |
+                Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'phoneNumber'
+                  required: true
+                  description: |
+                    Transfer the call to a phone number in E.164 format.
       - !ruby/object:Api::Type::String
         name: 'webhook'
         description: |
@@ -118,6 +232,45 @@ properties:
         name: 'tag'
         description: |
           The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+      - !ruby/object:Api::Type::Array
+        name: 'setParameterActions'
+        description: |
+          Set parameter values before executing the webhook.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'parameter'
+              description: |
+                Display name of the parameter.
+            - !ruby/object:Api::Type::String
+              name: 'value'
+              description: |
+                The new JSON-encoded value of the parameter. A null value clears the parameter.
+              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+              state_func:
+                'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                return s }'
+              validation: !ruby/object:Provider::Terraform::Validation
+                function: 'validation.StringIsJSON'
+      - !ruby/object:Api::Type::Array
+        name: 'conditionalCases'
+        description: |
+          Conditional cases for this fulfillment.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            # This object has a recursive schema so we use a string instead of a NestedObject
+            - !ruby/object:Api::Type::Array
+              name: 'cases'
+              description: |
+                A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+              item_type: Api::Type::String
+              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+              state_func:
+                'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                return s }'
   - !ruby/object:Api::Type::NestedObject
     name: 'form'
     description: |
@@ -163,6 +316,23 @@ properties:
                         The list of rich message responses to present to the user.
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
+                          - !ruby/object:Api::Type::Enum
+                            name: 'responseType'
+                            description: |
+                              Represents different response types.
+                              * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                              * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                              * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                              * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                            values:
+                              - :RESPONSE_TYPE_UNSPECIFIED
+                              - :ENTRY_PROMPT
+                              - :PARAMETER_PROMPT
+                              - :HANDLER_PROMPT
+                          - !ruby/object:Api::Type::String
+                            name: 'channel'
+                            description: |
+                              The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
                           - !ruby/object:Api::Type::NestedObject
                             name: 'text'
                             description: |
@@ -178,6 +348,103 @@ properties:
                                 output: true
                                 description: |
                                   Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                          # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                          - !ruby/object:Api::Type::String
+                            name: 'payload'
+                            description: |
+                              A custom, platform-specific payload.
+                            custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                            custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                            state_func:
+                              'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                              return s }'
+                            validation: !ruby/object:Provider::Terraform::Validation
+                              function: 'validation.StringIsJSON'
+                          - !ruby/object:Api::Type::NestedObject
+                            name: 'conversationSuccess'
+                            description: |
+                              Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                              Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                              You may set this, for example:
+                              * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                              * In a webhook response when you determine that you handled the customer issue.
+                            properties:
+                              # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                              - !ruby/object:Api::Type::String
+                                name: 'metadata'
+                                description: |
+                                  Custom metadata. Dialogflow doesn't impose any structure on this.
+                                custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                state_func:
+                                  'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                  return s }'
+                                validation: !ruby/object:Provider::Terraform::Validation
+                                  function: 'validation.StringIsJSON'
+                          - !ruby/object:Api::Type::NestedObject
+                            name: 'outputAudioText'
+                            description: |
+                              A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                            properties:
+                              - !ruby/object:Api::Type::Boolean
+                                name: 'allowPlaybackInterruption'
+                                output: true
+                                description: |
+                                  Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                              - !ruby/object:Api::Type::String
+                                name: 'text'
+                                description: |
+                                  The raw text to be synthesized.
+                              - !ruby/object:Api::Type::String
+                                name: 'ssml'
+                                description: |
+                                  The SSML text to be synthesized. For more information, see SSML.
+                          - !ruby/object:Api::Type::NestedObject
+                            name: 'liveAgentHandoff'
+                            description: |
+                              Indicates that the conversation should be handed off to a live agent.
+                              Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                              You may set this, for example:
+                              * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                              * In a webhook response when you determine that the customer issue can only be handled by a human.
+                            properties:
+                              # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                              - !ruby/object:Api::Type::String
+                                name: 'metadata'
+                                description: |
+                                  Custom metadata. Dialogflow doesn't impose any structure on this.
+                                custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                state_func:
+                                  'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                  return s }'
+                                validation: !ruby/object:Provider::Terraform::Validation
+                                  function: 'validation.StringIsJSON'
+                          - !ruby/object:Api::Type::NestedObject
+                            name: 'playAudio'
+                            description: |
+                              Specifies an audio clip to be played by the client as part of the response.
+                            properties:
+                              - !ruby/object:Api::Type::String
+                                name: 'audioUri'
+                                required: true
+                                description: |
+                                  URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                              - !ruby/object:Api::Type::Boolean
+                                name: 'allowPlaybackInterruption'
+                                output: true
+                                description: |
+                                  Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                          - !ruby/object:Api::Type::NestedObject
+                            name: 'telephonyTransferCall'
+                            description: |
+                              Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                            properties:
+                              - !ruby/object:Api::Type::String
+                                name: 'phoneNumber'
+                                required: true
+                                description: |
+                                  Transfer the call to a phone number in E.164 format.
                     - !ruby/object:Api::Type::String
                       name: 'webhook'
                       description: |
@@ -190,6 +457,283 @@ properties:
                       name: 'tag'
                       description: |
                         The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+                    - !ruby/object:Api::Type::Array
+                      name: 'setParameterActions'
+                      description: |
+                        Set parameter values before executing the webhook.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                          - !ruby/object:Api::Type::String
+                            name: 'parameter'
+                            description: |
+                              Display name of the parameter.
+                          - !ruby/object:Api::Type::String
+                            name: 'value'
+                            description: |
+                              The new JSON-encoded value of the parameter. A null value clears the parameter.
+                            custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                            custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                            state_func:
+                              'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                              return s }'
+                            validation: !ruby/object:Provider::Terraform::Validation
+                              function: 'validation.StringIsJSON'
+                    - !ruby/object:Api::Type::Array
+                      name: 'conditionalCases'
+                      description: |
+                        Conditional cases for this fulfillment.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                          # This object has a recursive schema so we use a string instead of a NestedObject
+                          - !ruby/object:Api::Type::Array
+                            name: 'cases'
+                            description: |
+                              A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                              See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                            item_type: Api::Type::String
+                            custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                            custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                            state_func:
+                              'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                              return s }'
+                - !ruby/object:Api::Type::Array
+                  name: 'repromptEventHandlers'
+                  description: |
+                    The handlers for parameter-level events, used to provide reprompt for the parameter or transition to a different page/flow. The supported events are:
+                    * sys.no-match-<N>, where N can be from 1 to 6
+                    * sys.no-match-default
+                    * sys.no-input-<N>, where N can be from 1 to 6
+                    * sys.no-input-default
+                    * sys.invalid-parameter
+                    [initialPromptFulfillment][initialPromptFulfillment] provides the first prompt for the parameter.
+                    If the user's response does not fill the parameter, a no-match/no-input event will be triggered, and the fulfillment associated with the sys.no-match-1/sys.no-input-1 handler (if defined) will be called to provide a prompt. The sys.no-match-2/sys.no-input-2 handler (if defined) will respond to the next no-match/no-input event, and so on.
+                    A sys.no-match-default or sys.no-input-default handler will be used to handle all following no-match/no-input events after all numbered no-match/no-input handlers for the parameter are consumed.
+                    A sys.invalid-parameter handler can be defined to handle the case where the parameter values have been invalidated by webhook. For example, if the user's response fill the parameter, however the parameter was invalidated by webhook, the fulfillment associated with the sys.invalid-parameter handler (if defined) will be called to provide a prompt.
+                    If the event handler for the corresponding event can't be found on the parameter, initialPromptFulfillment will be re-prompted.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'name'
+                        output: true
+                        description: |
+                          The unique identifier of this event handler.
+                      - !ruby/object:Api::Type::String
+                        name: 'event'
+                        description: |
+                          The name of the event to handle.
+                      - !ruby/object:Api::Type::NestedObject
+                        name: 'triggerFulfillment'
+                        description: |
+                          The fulfillment to call when the event occurs. Handling webhook errors with a fulfillment enabled with webhook could cause infinite loop. It is invalid to specify such fulfillment for a handler handling webhooks.
+                        properties:
+                          - !ruby/object:Api::Type::Array
+                            name: 'messages'
+                            description: |
+                              The list of rich message responses to present to the user.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                                - !ruby/object:Api::Type::Enum
+                                  name: 'responseType'
+                                  description: |
+                                    Represents different response types.
+                                    * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                                    * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                                    * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                                    * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                                  values:
+                                    - :RESPONSE_TYPE_UNSPECIFIED
+                                    - :ENTRY_PROMPT
+                                    - :PARAMETER_PROMPT
+                                    - :HANDLER_PROMPT
+                                - !ruby/object:Api::Type::String
+                                  name: 'channel'
+                                  description: |
+                                    The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'text'
+                                  description: |
+                                    The text response message.
+                                  properties:
+                                    - !ruby/object:Api::Type::Array
+                                      name: 'text'
+                                      description: |
+                                        A collection of text responses.
+                                      item_type: Api::Type::String
+                                    - !ruby/object:Api::Type::Boolean
+                                      name: 'allowPlaybackInterruption'
+                                      output: true
+                                      description: |
+                                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                                # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                                - !ruby/object:Api::Type::String
+                                  name: 'payload'
+                                  description: |
+                                    A custom, platform-specific payload.
+                                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                  state_func:
+                                    'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                    return s }'
+                                  validation: !ruby/object:Provider::Terraform::Validation
+                                    function: 'validation.StringIsJSON'
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'conversationSuccess'
+                                  description: |
+                                    Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                                    Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                                    You may set this, for example:
+                                    * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                                    * In a webhook response when you determine that you handled the customer issue.
+                                  properties:
+                                    # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'metadata'
+                                      description: |
+                                        Custom metadata. Dialogflow doesn't impose any structure on this.
+                                      custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                      custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                      state_func:
+                                        'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                        return s }'
+                                      validation: !ruby/object:Provider::Terraform::Validation
+                                        function: 'validation.StringIsJSON'
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'outputAudioText'
+                                  description: |
+                                    A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                                  properties:
+                                    - !ruby/object:Api::Type::Boolean
+                                      name: 'allowPlaybackInterruption'
+                                      output: true
+                                      description: |
+                                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'text'
+                                      description: |
+                                        The raw text to be synthesized.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'ssml'
+                                      description: |
+                                        The SSML text to be synthesized. For more information, see SSML.
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'liveAgentHandoff'
+                                  description: |
+                                    Indicates that the conversation should be handed off to a live agent.
+                                    Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                                    You may set this, for example:
+                                    * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                                    * In a webhook response when you determine that the customer issue can only be handled by a human.
+                                  properties:
+                                    # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'metadata'
+                                      description: |
+                                        Custom metadata. Dialogflow doesn't impose any structure on this.
+                                      custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                      custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                      state_func:
+                                        'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                        return s }'
+                                      validation: !ruby/object:Provider::Terraform::Validation
+                                        function: 'validation.StringIsJSON'
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'playAudio'
+                                  description: |
+                                    Specifies an audio clip to be played by the client as part of the response.
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'audioUri'
+                                      required: true
+                                      description: |
+                                        URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                                    - !ruby/object:Api::Type::Boolean
+                                      name: 'allowPlaybackInterruption'
+                                      output: true
+                                      description: |
+                                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'telephonyTransferCall'
+                                  description: |
+                                    Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'phoneNumber'
+                                      required: true
+                                      description: |
+                                        Transfer the call to a phone number in E.164 format.
+                          - !ruby/object:Api::Type::String
+                            name: 'webhook'
+                            description: |
+                              The webhook to call. Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/webhooks/<Webhook ID>.
+                          - !ruby/object:Api::Type::Boolean
+                            name: 'returnPartialResponses'
+                            description: |
+                              Whether Dialogflow should return currently queued fulfillment response messages in streaming APIs. If a webhook is specified, it happens before Dialogflow invokes webhook. Warning: 1) This flag only affects streaming API. Responses are still queued and returned once in non-streaming API. 2) The flag can be enabled in any fulfillment but only the first 3 partial responses will be returned. You may only want to apply it to fulfillments that have slow webhooks.
+                          - !ruby/object:Api::Type::String
+                            name: 'tag'
+                            description: |
+                              The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+                          - !ruby/object:Api::Type::Array
+                            name: 'setParameterActions'
+                            description: |
+                              Set parameter values before executing the webhook.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'parameter'
+                                  description: |
+                                    Display name of the parameter.
+                                - !ruby/object:Api::Type::String
+                                  name: 'value'
+                                  description: |
+                                    The new JSON-encoded value of the parameter. A null value clears the parameter.
+                                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                  state_func:
+                                    'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                    return s }'
+                                  validation: !ruby/object:Provider::Terraform::Validation
+                                    function: 'validation.StringIsJSON'
+                          - !ruby/object:Api::Type::Array
+                            name: 'conditionalCases'
+                            description: |
+                              Conditional cases for this fulfillment.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                                # This object has a recursive schema so we use a string instead of a NestedObject
+                                - !ruby/object:Api::Type::Array
+                                  name: 'cases'
+                                  description: |
+                                    A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                                    See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                                  item_type: Api::Type::String
+                                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                                  state_func:
+                                    'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                                    return s }'
+                      - !ruby/object:Api::Type::String
+                        name: 'targetPage'
+                        description: |
+                          The target page to transition to.
+                          Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>/pages/<Page ID>.
+                      - !ruby/object:Api::Type::String
+                        name: 'targetFlow'
+                        description: |
+                          The target flow to transition to.
+                          Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>.
+            # This can be an arbitrary value, so we use a string instead of a NestedObject.
+            - !ruby/object:Api::Type::String
+              name: 'defaultValue'
+              description: |
+                The default value of an optional parameter. If the parameter is required, the default value will be ignored.
+              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+              state_func:
+                'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                return s }'
+              validation: !ruby/object:Provider::Terraform::Validation
+                function: 'validation.StringIsJSON'
             - !ruby/object:Api::Type::Boolean
               name: 'redact'
               description: |
@@ -234,7 +778,7 @@ properties:
         - !ruby/object:Api::Type::NestedObject
           name: 'triggerFulfillment'
           description: |
-            The fulfillment to call when the event occurs. Handling webhook errors with a fulfillment enabled with webhook could cause infinite loop. It is invalid to specify such fulfillment for a handler handling webhooks.
+            The fulfillment to call when the condition is satisfied. At least one of triggerFulfillment and target must be specified. When both are defined, triggerFulfillment is executed first.
           properties:
             - !ruby/object:Api::Type::Array
               name: 'messages'
@@ -242,6 +786,23 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
+                  - !ruby/object:Api::Type::Enum
+                    name: 'responseType'
+                    description: |
+                      Represents different response types.
+                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                    values:
+                      - :RESPONSE_TYPE_UNSPECIFIED
+                      - :ENTRY_PROMPT
+                      - :PARAMETER_PROMPT
+                      - :HANDLER_PROMPT
+                  - !ruby/object:Api::Type::String
+                    name: 'channel'
+                    description: |
+                      The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
                   - !ruby/object:Api::Type::NestedObject
                     name: 'text'
                     description: |
@@ -257,6 +818,103 @@ properties:
                         output: true
                         description: |
                           Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                  - !ruby/object:Api::Type::String
+                    name: 'payload'
+                    description: |
+                      A custom, platform-specific payload.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'conversationSuccess'
+                    description: |
+                      Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                      Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                      * In a webhook response when you determine that you handled the customer issue.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'outputAudioText'
+                    description: |
+                      A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                    properties:
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      - !ruby/object:Api::Type::String
+                        name: 'text'
+                        description: |
+                          The raw text to be synthesized.
+                      - !ruby/object:Api::Type::String
+                        name: 'ssml'
+                        description: |
+                          The SSML text to be synthesized. For more information, see SSML.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'liveAgentHandoff'
+                    description: |
+                      Indicates that the conversation should be handed off to a live agent.
+                      Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                      * In a webhook response when you determine that the customer issue can only be handled by a human.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'playAudio'
+                    description: |
+                      Specifies an audio clip to be played by the client as part of the response.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'audioUri'
+                        required: true
+                        description: |
+                          URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'telephonyTransferCall'
+                    description: |
+                      Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'phoneNumber'
+                        required: true
+                        description: |
+                          Transfer the call to a phone number in E.164 format.
             - !ruby/object:Api::Type::String
               name: 'webhook'
               description: |
@@ -269,6 +927,45 @@ properties:
               name: 'tag'
               description: |
                 The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+            - !ruby/object:Api::Type::Array
+              name: 'setParameterActions'
+              description: |
+                Set parameter values before executing the webhook.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'parameter'
+                    description: |
+                      Display name of the parameter.
+                  - !ruby/object:Api::Type::String
+                    name: 'value'
+                    description: |
+                      The new JSON-encoded value of the parameter. A null value clears the parameter.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::Array
+              name: 'conditionalCases'
+              description: |
+                Conditional cases for this fulfillment.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  # This object has a recursive schema so we use a string instead of a NestedObject
+                  - !ruby/object:Api::Type::Array
+                    name: 'cases'
+                    description: |
+                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                    item_type: Api::Type::String
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |
@@ -305,6 +1002,23 @@ properties:
                 The list of rich message responses to present to the user.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
+                  - !ruby/object:Api::Type::Enum
+                    name: 'responseType'
+                    description: |
+                      Represents different response types.
+                      * RESPONSE_TYPE_UNSPECIFIED: Not specified.
+                      * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                      * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                      * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                    values:
+                      - :RESPONSE_TYPE_UNSPECIFIED
+                      - :ENTRY_PROMPT
+                      - :PARAMETER_PROMPT
+                      - :HANDLER_PROMPT
+                  - !ruby/object:Api::Type::String
+                    name: 'channel'
+                    description: |
+                      The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
                   - !ruby/object:Api::Type::NestedObject
                     name: 'text'
                     description: |
@@ -320,6 +1034,103 @@ properties:
                         output: true
                         description: |
                           Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                  - !ruby/object:Api::Type::String
+                    name: 'payload'
+                    description: |
+                      A custom, platform-specific payload.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'conversationSuccess'
+                    description: |
+                      Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                      Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                      * In a webhook response when you determine that you handled the customer issue.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'outputAudioText'
+                    description: |
+                      A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                    properties:
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      - !ruby/object:Api::Type::String
+                        name: 'text'
+                        description: |
+                          The raw text to be synthesized.
+                      - !ruby/object:Api::Type::String
+                        name: 'ssml'
+                        description: |
+                          The SSML text to be synthesized. For more information, see SSML.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'liveAgentHandoff'
+                    description: |
+                      Indicates that the conversation should be handed off to a live agent.
+                      Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                      You may set this, for example:
+                      * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                      * In a webhook response when you determine that the customer issue can only be handled by a human.
+                    properties:
+                      # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                      - !ruby/object:Api::Type::String
+                        name: 'metadata'
+                        description: |
+                          Custom metadata. Dialogflow doesn't impose any structure on this.
+                        custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                        state_func:
+                          'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                          return s }'
+                        validation: !ruby/object:Provider::Terraform::Validation
+                          function: 'validation.StringIsJSON'
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'playAudio'
+                    description: |
+                      Specifies an audio clip to be played by the client as part of the response.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'audioUri'
+                        required: true
+                        description: |
+                          URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'allowPlaybackInterruption'
+                        output: true
+                        description: |
+                          Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'telephonyTransferCall'
+                    description: |
+                      Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'phoneNumber'
+                        required: true
+                        description: |
+                          Transfer the call to a phone number in E.164 format.
             - !ruby/object:Api::Type::String
               name: 'webhook'
               description: |
@@ -332,6 +1143,45 @@ properties:
               name: 'tag'
               description: |
                 The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+            - !ruby/object:Api::Type::Array
+              name: 'setParameterActions'
+              description: |
+                Set parameter values before executing the webhook.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'parameter'
+                    description: |
+                      Display name of the parameter.
+                  - !ruby/object:Api::Type::String
+                    name: 'value'
+                    description: |
+                      The new JSON-encoded value of the parameter. A null value clears the parameter.
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
+            - !ruby/object:Api::Type::Array
+              name: 'conditionalCases'
+              description: |
+                Conditional cases for this fulfillment.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  # This object has a recursive schema so we use a string instead of a NestedObject
+                  - !ruby/object:Api::Type::Array
+                    name: 'cases'
+                    description: |
+                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                    item_type: Api::Type::String
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+                    state_func:
+                      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+                      return s }'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -246,7 +246,7 @@ properties:
               name: 'value'
               description: |
                 The new JSON-encoded value of the parameter. A null value clears the parameter.
-              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_expand: 'templates/terraform/custom_expand/json_value.erb'
               custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
               state_func:
                 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
@@ -471,7 +471,7 @@ properties:
                             name: 'value'
                             description: |
                               The new JSON-encoded value of the parameter. A null value clears the parameter.
-                            custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                            custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                             custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                             state_func:
                               'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
@@ -687,7 +687,7 @@ properties:
                                   name: 'value'
                                   description: |
                                     The new JSON-encoded value of the parameter. A null value clears the parameter.
-                                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                  custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                                   custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                                   state_func:
                                     'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
@@ -727,7 +727,7 @@ properties:
               name: 'defaultValue'
               description: |
                 The default value of an optional parameter. If the parameter is required, the default value will be ignored.
-              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_expand: 'templates/terraform/custom_expand/json_value.erb'
               custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
               state_func:
                 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
@@ -941,7 +941,7 @@ properties:
                     name: 'value'
                     description: |
                       The new JSON-encoded value of the parameter. A null value clears the parameter.
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
@@ -1157,7 +1157,7 @@ properties:
                     name: 'value'
                     description: |
                       The new JSON-encoded value of the parameter. A null value clears the parameter.
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -260,17 +260,18 @@ properties:
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             # This object has a recursive schema so we use a string instead of a NestedObject
-            - !ruby/object:Api::Type::Array
+            - !ruby/object:Api::Type::String
               name: 'cases'
               description: |
-                A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                 See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-              item_type: Api::Type::String
-              custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+              custom_expand: 'templates/terraform/custom_expand/json_value.erb'
               custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
               state_func:
                 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                 return s }'
+              validation: !ruby/object:Provider::Terraform::Validation
+                function: 'validation.StringIsJSON'
   - !ruby/object:Api::Type::NestedObject
     name: 'form'
     description: |
@@ -485,17 +486,18 @@ properties:
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
                           # This object has a recursive schema so we use a string instead of a NestedObject
-                          - !ruby/object:Api::Type::Array
+                          - !ruby/object:Api::Type::String
                             name: 'cases'
                             description: |
-                              A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                              A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                               See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-                            item_type: Api::Type::String
-                            custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                            custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                             custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                             state_func:
                               'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                               return s }'
+                            validation: !ruby/object:Provider::Terraform::Validation
+                              function: 'validation.StringIsJSON'
                 - !ruby/object:Api::Type::Array
                   name: 'repromptEventHandlers'
                   description: |
@@ -701,17 +703,18 @@ properties:
                             item_type: !ruby/object:Api::Type::NestedObject
                               properties:
                                 # This object has a recursive schema so we use a string instead of a NestedObject
-                                - !ruby/object:Api::Type::Array
+                                - !ruby/object:Api::Type::String
                                   name: 'cases'
                                   description: |
-                                    A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                                    A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                                     See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-                                  item_type: Api::Type::String
-                                  custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                                  custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                                   custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                                   state_func:
                                     'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                                     return s }'
+                                  validation: !ruby/object:Provider::Terraform::Validation
+                                    function: 'validation.StringIsJSON'
                       - !ruby/object:Api::Type::String
                         name: 'targetPage'
                         description: |
@@ -955,17 +958,18 @@ properties:
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   # This object has a recursive schema so we use a string instead of a NestedObject
-                  - !ruby/object:Api::Type::Array
+                  - !ruby/object:Api::Type::String
                     name: 'cases'
                     description: |
-                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                       See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-                    item_type: Api::Type::String
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                       return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |
@@ -1171,17 +1175,18 @@ properties:
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   # This object has a recursive schema so we use a string instead of a NestedObject
-                  - !ruby/object:Api::Type::Array
+                  - !ruby/object:Api::Type::String
                     name: 'cases'
                     description: |
-                      A list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                      A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
                       See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
-                    item_type: Api::Type::String
-                    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+                    custom_expand: 'templates/terraform/custom_expand/json_value.erb'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
                     state_func:
                       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
                       return s }'
+                    validation: !ruby/object:Provider::Terraform::Validation
+                      function: 'validation.StringIsJSON'
         - !ruby/object:Api::Type::String
           name: 'targetPage'
           description: |

--- a/mmv1/templates/terraform/custom_expand/json_value.erb
+++ b/mmv1/templates/terraform/custom_expand/json_value.erb
@@ -1,0 +1,25 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	b := []byte(v.(string))
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var j interface{}
+	if err := json.Unmarshal(b, &j); err != nil {
+		return nil, err
+	}
+	return j, nil
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_basic.tf.erb
@@ -1,62 +1,62 @@
 resource "google_dialogflow_cx_agent" "agent" {
-	display_name               = "<%= ctx[:vars]["agent_name"] %>"
-	location                   = "global"
-	default_language_code      = "en"
-	supported_language_codes   = ["fr", "de", "es"]
-	time_zone                  = "America/New_York"
-	description                = "Example description."
-	avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
-	enable_stackdriver_logging = true
-	enable_spell_correction    = true
-	speech_to_text_settings {
-		enable_speech_adaptation = true
-	}
+  display_name               = "<%= ctx[:vars]["agent_name"] %>"
+  location                   = "global"
+  default_language_code      = "en"
+  supported_language_codes   = ["fr", "de", "es"]
+  time_zone                  = "America/New_York"
+  description                = "Example description."
+  avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+  enable_stackdriver_logging = true
+  enable_spell_correction    = true
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
 }
 
 
 resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
-	parent       = google_dialogflow_cx_agent.agent.id
-	display_name = "MyFlow"
-	description  = "Test Flow"
+  parent       = google_dialogflow_cx_agent.agent.id
+  display_name = "MyFlow"
+  description  = "Test Flow"
 
-	nlu_settings {
-		classification_threshold = 0.3
-		model_type               = "MODEL_TYPE_STANDARD"
-	}
+  nlu_settings {
+    classification_threshold = 0.3
+    model_type               = "MODEL_TYPE_STANDARD"
+  }
 
-	event_handlers {
-		event = "custom-event"
-		trigger_fulfillment {
-			return_partial_responses = false
-			messages {
-				text {
-					text = ["I didn't get that. Can you say it again?"]
-				}
-			}
-		}
-	}
+  event_handlers {
+    event = "custom-event"
+    trigger_fulfillment {
+      return_partial_responses = false
+      messages {
+        text {
+          text = ["I didn't get that. Can you say it again?"]
+        }
+      }
+    }
+  }
 
-	event_handlers {
-		event = "sys.no-match-default"
-		trigger_fulfillment {
-			return_partial_responses = false
-			messages {
-				text {
-					text = ["Sorry, could you say that again?"]
-				}
-			}
-		}
-	}
+  event_handlers {
+    event = "sys.no-match-default"
+    trigger_fulfillment {
+      return_partial_responses = false
+      messages {
+        text {
+          text = ["Sorry, could you say that again?"]
+        }
+      }
+    }
+  }
 
-	event_handlers {
-		event = "sys.no-input-default"
-		trigger_fulfillment {
-			return_partial_responses = false
-			messages {
-				text {
-					text = ["One more time?"]
-				}
-			}
-		}
-	}
+  event_handlers {
+    event = "sys.no-input-default"
+    trigger_fulfillment {
+      return_partial_responses = false
+      messages {
+        text {
+          text = ["One more time?"]
+        }
+      }
+    }
+  }
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_basic.tf.erb
@@ -1,0 +1,62 @@
+resource "google_dialogflow_cx_agent" "agent" {
+	display_name               = "<%= ctx[:vars]["agent_name"] %>"
+	location                   = "global"
+	default_language_code      = "en"
+	supported_language_codes   = ["fr", "de", "es"]
+	time_zone                  = "America/New_York"
+	description                = "Example description."
+	avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+	enable_stackdriver_logging = true
+	enable_spell_correction    = true
+	speech_to_text_settings {
+		enable_speech_adaptation = true
+	}
+}
+
+
+resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
+	parent       = google_dialogflow_cx_agent.agent.id
+	display_name = "MyFlow"
+	description  = "Test Flow"
+
+	nlu_settings {
+		classification_threshold = 0.3
+		model_type               = "MODEL_TYPE_STANDARD"
+	}
+
+	event_handlers {
+		event = "custom-event"
+		trigger_fulfillment {
+			return_partial_responses = false
+			messages {
+				text {
+					text = ["I didn't get that. Can you say it again?"]
+				}
+			}
+		}
+	}
+
+	event_handlers {
+		event = "sys.no-match-default"
+		trigger_fulfillment {
+			return_partial_responses = false
+			messages {
+				text {
+					text = ["Sorry, could you say that again?"]
+				}
+			}
+		}
+	}
+
+	event_handlers {
+		event = "sys.no-input-default"
+		trigger_fulfillment {
+			return_partial_responses = false
+			messages {
+				text {
+					text = ["One more time?"]
+				}
+			}
+		}
+	}
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -41,7 +41,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
     trigger_fulfillment {
       return_partial_responses = false
       messages {
-        response_type = "RESPONSE_TYPE_UNSPECIFIED"
         text {
           text = ["Sorry, could you say that again?"]
         }
@@ -54,7 +53,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
     trigger_fulfillment {
       return_partial_responses = false
       messages {
-        response_type = "ENTRY_PROMPT"
         text {
           text = ["One more time?"]
         }
@@ -169,7 +167,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
       return_partial_responses = true
       messages {
         channel = "some-channel"
-        response_type = "RESPONSE_TYPE_UNSPECIFIED"
         text {
           text = ["Some text"]
         }

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -114,8 +114,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
         }
       }
 
-      tag = "some-tag"
-
       set_parameter_actions {
         parameter = "some-param"
         value     = "123.45"
@@ -217,8 +215,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
           phone_number = "1-234-567-8901"
         }
       }
-
-      tag = "some-tag"
 
       set_parameter_actions {
         parameter = "some-param"

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -171,6 +171,7 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
       return_partial_responses = true
       messages {
         channel = "some-channel"
+        response_type = "RESPONSE_TYPE_UNSPECIFIED"
         text {
           text = ["Some text"]
         }

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -130,12 +130,12 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
       }
 
       conditional_cases {
-        cases = [
-          jsonencode({
+        cases = jsonencode([
+          {
             condition = "$sys.func.RAND() < 0.5",
             caseContent = [
               {
-                message = { text = ["First case"] }
+                message = { text = { text = ["First case"] } }
               },
               {
                 additionalCases = {
@@ -144,7 +144,7 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
                       condition = "$sys.func.RAND() < 0.2"
                       caseContent = [
                         {
-                          message = { text = ["Nested case"] }
+                          message = { text = { text = ["Nested case"] } }
                         }
                       ]
                     }
@@ -152,16 +152,16 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
                 }
               }
             ]
-          }),
-          jsonencode({
+          },
+          {
             condition = "",
             caseContent = [
               {
-                message = { text = ["Final case"] }
+                message = { text = { text = ["Final case"] } }
               }
             ]
-          }),
-        ]
+          },
+        ])
       }
     }
   }
@@ -234,12 +234,12 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
       }
 
       conditional_cases {
-        cases = [
-          jsonencode({
+        cases = jsonencode([
+          {
             condition = "$sys.func.RAND() < 0.5",
             caseContent = [
               {
-                message = { text = ["First case"] }
+                message = { text = { text = ["First case"] } }
               },
               {
                 additionalCases = {
@@ -248,7 +248,7 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
                       condition = "$sys.func.RAND() < 0.2"
                       caseContent = [
                         {
-                          message = { text = ["Nested case"] }
+                          message = { text = { text = ["Nested case"] } }
                         }
                       ]
                     }
@@ -256,16 +256,16 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
                 }
               }
             ]
-          }),
-          jsonencode({
+          },
+          {
             condition = "",
             caseContent = [
               {
-                message = { text = ["Final case"] }
+                message = { text = { text = ["Final case"] } }
               }
             ]
-          }),
-        ]
+          },
+        ])
       }
     }
     target_flow = google_dialogflow_cx_agent.agent.start_flow

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -1,16 +1,16 @@
 resource "google_dialogflow_cx_agent" "agent" {
-  display_name = "<%= ctx[:vars]["agent_name"] %>"
-  location = "global"
-  default_language_code = "en"
-  supported_language_codes = ["fr","de","es"]
-  time_zone = "America/New_York"
-  description = "Example description."
-  avatar_uri = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+  display_name               = "<%= ctx[:vars]["agent_name"] %>"
+  location                   = "global"
+  default_language_code      = "en"
+  supported_language_codes   = ["fr", "de", "es"]
+  time_zone                  = "America/New_York"
+  description                = "Example description."
+  avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
   enable_stackdriver_logging = true
   enable_spell_correction    = true
-	speech_to_text_settings {
-		enable_speech_adaptation = true
-	}
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
 }
 
 
@@ -20,43 +20,149 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
   description  = "Test Flow"
 
   nlu_settings {
-		classification_threshold = 0.3 
-		model_type               = "MODEL_TYPE_STANDARD"
-	}
+    classification_threshold = 0.3
+    model_type               = "MODEL_TYPE_STANDARD"
+  }
 
   event_handlers {
-		   event                    = "custom-event"
-		   trigger_fulfillment {
-			    return_partial_responses = false
-				messages {
-					text {
-						text  = ["I didn't get that. Can you say it again?"]
-					}
-				}
-		    }
-		}
+    event = "custom-event"
+    trigger_fulfillment {
+      return_partial_responses = false
+      messages {
+        text {
+          text = ["I didn't get that. Can you say it again?"]
+        }
+      }
+    }
+  }
 
-		event_handlers {
-			event                    = "sys.no-match-default"
-			trigger_fulfillment {
-				 return_partial_responses = false
-				 messages {
-					 text {
-						 text  = ["Sorry, could you say that again?"]
-					 }
-				 }
-			 }
-		 }
+  event_handlers {
+    event = "sys.no-match-default"
+    trigger_fulfillment {
+      return_partial_responses = false
+      messages {
+        response_type = "RESPONSE_TYPE_UNSPECIFIED"
+        text {
+          text = ["Sorry, could you say that again?"]
+        }
+      }
+    }
+  }
 
-		 event_handlers {
-			event                    = "sys.no-input-default"
-			trigger_fulfillment {
-				 return_partial_responses = false
-				 messages {
-					 text {
-						 text  = ["One more time?"]
-					 }
-				 }
-			 }
-		 }
+  event_handlers {
+    event = "sys.no-input-default"
+    trigger_fulfillment {
+      return_partial_responses = false
+      messages {
+        response_type = "ENTRY_PROMPT"
+        text {
+          text = ["One more time?"]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "another-event"
+    trigger_fulfillment {
+      return_partial_responses = true
+      messages {
+        channel = "some-channel"
+        text {
+          text = ["Some text"]
+        }
+      }
+      messages {
+        payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8901"
+        }
+      }
+
+      tag = "some-tag"
+
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      set_parameter_actions {
+        parameter = "another-param"
+        value     = jsonencode("abc")
+      }
+      set_parameter_actions {
+        parameter = "other-param"
+        value     = jsonencode(["foo"])
+      }
+
+      conditional_cases {
+        cases = [
+          jsonencode({
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = ["First case"] }
+              },
+              {
+                additionalCases = {
+                  cases = [
+                    {
+                      condition = "$sys.func.RAND() < 0.2"
+                      caseContent = [
+                        {
+                          message = { text = ["Nested case"] }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }),
+          jsonencode({
+            condition = "",
+            caseContent = [
+              {
+                message = { text = ["Final case"] }
+              }
+            ]
+          }),
+        ]
+      }
+    }
+  }
 } 

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -165,4 +165,108 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
       }
     }
   }
+
+  transition_routes {
+    trigger_fulfillment {
+      return_partial_responses = true
+      messages {
+        channel = "some-channel"
+        text {
+          text = ["Some text"]
+        }
+      }
+      messages {
+        payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8901"
+        }
+      }
+
+      tag = "some-tag"
+
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      set_parameter_actions {
+        parameter = "another-param"
+        value     = jsonencode("abc")
+      }
+      set_parameter_actions {
+        parameter = "other-param"
+        value     = jsonencode(["foo"])
+      }
+
+      conditional_cases {
+        cases = [
+          jsonencode({
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = ["First case"] }
+              },
+              {
+                additionalCases = {
+                  cases = [
+                    {
+                      condition = "$sys.func.RAND() < 0.2"
+                      caseContent = [
+                        {
+                          message = { text = ["Nested case"] }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }),
+          jsonencode({
+            condition = "",
+            caseContent = [
+              {
+                message = { text = ["Final case"] }
+              }
+            ]
+          }),
+        ]
+      }
+    }
+    target_flow = google_dialogflow_cx_agent.agent.start_flow
+  }
 } 

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -154,7 +154,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
             ]
           },
           {
-            condition = "",
             caseContent = [
               {
                 message = { text = { text = ["Final case"] } }
@@ -259,7 +258,6 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
             ]
           },
           {
-            condition = "",
             caseContent = [
               {
                 message = { text = { text = ["Final case"] } }

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.erb
@@ -167,6 +167,7 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
   }
 
   transition_routes {
+    condition = "true"
     trigger_fulfillment {
       return_partial_responses = true
       messages {

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_basic.tf.erb
@@ -1,63 +1,63 @@
 resource "google_dialogflow_cx_agent" "agent" {
-	display_name               = "<%= ctx[:vars]["agent_name"] %>"
-	location                   = "global"
-	default_language_code      = "en"
-	supported_language_codes   = ["fr", "de", "es"]
-	time_zone                  = "America/New_York"
-	description                = "Example description."
-	avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
-	enable_stackdriver_logging = true
-	enable_spell_correction    = true
-	speech_to_text_settings {
-		enable_speech_adaptation = true
-	}
+  display_name               = "<%= ctx[:vars]["agent_name"] %>"
+  location                   = "global"
+  default_language_code      = "en"
+  supported_language_codes   = ["fr", "de", "es"]
+  time_zone                  = "America/New_York"
+  description                = "Example description."
+  avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+  enable_stackdriver_logging = true
+  enable_spell_correction    = true
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
 }
 
 
 resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
-	parent       = google_dialogflow_cx_agent.agent.start_flow
-	display_name = "MyPage"
+  parent       = google_dialogflow_cx_agent.agent.start_flow
+  display_name = "MyPage"
 
-	entry_fulfillment {
-		messages {
-			text {
-				text = ["Welcome to page"]
-			}
-		}
-	}
+  entry_fulfillment {
+    messages {
+      text {
+        text = ["Welcome to page"]
+      }
+    }
+  }
 
-	form {
-		parameters {
-			display_name = "param1"
-			entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
-			fill_behavior {
-				initial_prompt_fulfillment {
-					messages {
-						text {
-							text = ["Please provide param1"]
-						}
-					}
-				}
-			}
-			required = "true"
-			redact   = "true"
-		}
-	}
+  form {
+    parameters {
+      display_name = "param1"
+      entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
+      fill_behavior {
+        initial_prompt_fulfillment {
+          messages {
+            text {
+              text = ["Please provide param1"]
+            }
+          }
+        }
+      }
+      required = "true"
+      redact   = "true"
+    }
+  }
 
-	transition_routes {
-		condition = "$page.params.status = 'FINAL'"
-		trigger_fulfillment {
-			messages {
-				text {
-					text = ["information completed, navigating to page 2"]
-				}
-			}
-		}
-		target_page = google_dialogflow_cx_page.my_page2.id
-	}
+  transition_routes {
+    condition = "$page.params.status = 'FINAL'"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["information completed, navigating to page 2"]
+        }
+      }
+    }
+    target_page = google_dialogflow_cx_page.my_page2.id
+  }
 }
 
 resource "google_dialogflow_cx_page" "my_page2" {
-	parent       = google_dialogflow_cx_agent.agent.start_flow
-	display_name = "MyPage2"
+  parent       = google_dialogflow_cx_agent.agent.start_flow
+  display_name = "MyPage2"
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_basic.tf.erb
@@ -1,0 +1,63 @@
+resource "google_dialogflow_cx_agent" "agent" {
+	display_name               = "<%= ctx[:vars]["agent_name"] %>"
+	location                   = "global"
+	default_language_code      = "en"
+	supported_language_codes   = ["fr", "de", "es"]
+	time_zone                  = "America/New_York"
+	description                = "Example description."
+	avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+	enable_stackdriver_logging = true
+	enable_spell_correction    = true
+	speech_to_text_settings {
+		enable_speech_adaptation = true
+	}
+}
+
+
+resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
+	parent       = google_dialogflow_cx_agent.agent.start_flow
+	display_name = "MyPage"
+
+	entry_fulfillment {
+		messages {
+			text {
+				text = ["Welcome to page"]
+			}
+		}
+	}
+
+	form {
+		parameters {
+			display_name = "param1"
+			entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
+			fill_behavior {
+				initial_prompt_fulfillment {
+					messages {
+						text {
+							text = ["Please provide param1"]
+						}
+					}
+				}
+			}
+			required = "true"
+			redact   = "true"
+		}
+	}
+
+	transition_routes {
+		condition = "$page.params.status = 'FINAL'"
+		trigger_fulfillment {
+			messages {
+				text {
+					text = ["information completed, navigating to page 2"]
+				}
+			}
+		}
+		target_page = google_dialogflow_cx_page.my_page2.id
+	}
+}
+
+resource "google_dialogflow_cx_page" "my_page2" {
+	parent       = google_dialogflow_cx_agent.agent.start_flow
+	display_name = "MyPage2"
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -1,13 +1,13 @@
 resource "google_dialogflow_cx_agent" "agent" {
-  display_name = "<%= ctx[:vars]["agent_name"] %>"
-  location = "global"
-  default_language_code = "en"
-  supported_language_codes = ["fr","de","es"]
-  time_zone = "America/New_York"
-  description = "Example description."
-  avatar_uri = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
-  enable_stackdriver_logging = true
-  enable_spell_correction    = true
+	display_name               = "<%= ctx[:vars]["agent_name"] %>"
+	location                   = "global"
+	default_language_code      = "en"
+	supported_language_codes   = ["fr", "de", "es"]
+	time_zone                  = "America/New_York"
+	description                = "Example description."
+	avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+	enable_stackdriver_logging = true
+	enable_spell_correction    = true
 	speech_to_text_settings {
 		enable_speech_adaptation = true
 	}
@@ -15,26 +15,50 @@ resource "google_dialogflow_cx_agent" "agent" {
 
 
 resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
-  parent       = google_dialogflow_cx_agent.agent.start_flow
-  display_name = "MyPage"
+	parent       = google_dialogflow_cx_agent.agent.start_flow
+	display_name = "MyPage"
 
-  entry_fulfillment {
+	entry_fulfillment {
 		messages {
 			text {
 				text = ["Welcome to page"]
 			}
 		}
-   }
+		messages {
+			output_audio_text {
+				text = "some output text"
+			}
+		}
+	}
 
-   form {
+	form {
 		parameters {
 			display_name = "param1"
 			entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
 			fill_behavior {
 				initial_prompt_fulfillment {
 					messages {
+						channel = "some-channel"
 						text {
 							text = ["Please provide param1"]
+						}
+					}
+					messages {
+						channel = "other-channel"
+						payload = <<EOF
+							{"some-key": "some-value", "other-key": ["other-value"]}
+						EOF
+					}
+				}
+				reprompt_event_handlers {
+					event = "sys.no-match-1"
+					trigger_fulfillment {
+						messages {
+							live_agent_handoff {
+								metadata = <<EOF
+									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+								EOF
+							}
 						}
 					}
 				}
@@ -44,7 +68,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 		}
 	}
 
-    transition_routes {
+	transition_routes {
 		condition = "$page.params.status = 'FINAL'"
 		trigger_fulfillment {
 			messages {
@@ -52,12 +76,61 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 					text = ["information completed, navigating to page 2"]
 				}
 			}
+			messages {
+				output_audio_text {
+					ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+				}
+			}
+
+			tag = "some-tag"
+
+			set_parameter_actions {
+				parameter = "some-param"
+				value     = "123.45"
+			}
+
+			conditional_cases {
+				cases = [
+					jsonencode({
+						condition = "$sys.func.RAND() < 0.5",
+						caseContent = [
+							{
+								message = { text = ["First case"] }
+							},
+							{
+								additionalCases = {
+									cases = [
+										{
+											condition = "$sys.func.RAND() < 0.2"
+											caseContent = [
+												{
+													message = { text = ["Nested case"] }
+												}
+											]
+										}
+									]
+								}
+							}
+						]
+					}),
+					jsonencode({
+						condition = "",
+						caseContent = [
+							{
+								message = { text = ["Final case"] }
+							}
+						]
+					}),
+				]
+			}
 		}
 		target_page = google_dialogflow_cx_page.my_page2.id
 	}
-} 
+}
 
 resource "google_dialogflow_cx_page" "my_page2" {
-    parent       = google_dialogflow_cx_agent.agent.start_flow
-    display_name  = "MyPage2"
+	parent       = google_dialogflow_cx_agent.agent.start_flow
+	display_name = "MyPage2"
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -20,13 +20,205 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 
 	entry_fulfillment {
 		messages {
+			channel = "some-channel"
+			response_type = "ENTRY_PROMPT"
 			text {
 				text = ["Welcome to page"]
 			}
 		}
 		messages {
+			payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+			EOF
+		}
+		messages {
+			conversation_success {
+				metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+				EOF
+			}
+		}
+		messages {
 			output_audio_text {
 				text = "some output text"
+			}
+		}
+		messages {
+			output_audio_text {
+				ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+				EOF
+			}
+		}
+		messages {
+			live_agent_handoff {
+				metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+				EOF
+			}
+		}
+		messages {
+			play_audio {
+				audio_uri = "http://example.com/some-audio-file.mp3"
+			}
+		}
+		messages {
+			telephony_transfer_call {
+				phone_number = "1-234-567-8901"
+			}
+		}
+
+		tag = "some-tag"
+
+		set_parameter_actions {
+			parameter = "some-param"
+			value     = "123.45"
+		}
+		set_parameter_actions {
+			parameter = "another-param"
+			value     = jsonencode("abc")
+		}
+		set_parameter_actions {
+			parameter = "other-param"
+			value     = jsonencode(["foo"])
+		}
+
+		conditional_cases {
+			cases = [
+				jsonencode({
+					condition = "$sys.func.RAND() < 0.5",
+					caseContent = [
+						{
+							message = { text = ["First case"] }
+						},
+						{
+							additionalCases = {
+								cases = [
+									{
+										condition = "$sys.func.RAND() < 0.2"
+										caseContent = [
+											{
+												message = { text = ["Nested case"] }
+											}
+										]
+									}
+								]
+							}
+						}
+					]
+				}),
+				jsonencode({
+					condition = "",
+					caseContent = [
+						{
+							message = { text = ["Final case"] }
+						}
+					]
+				}),
+			]
+		}
+	}
+
+	event_handlers {
+		event = "some-event"
+		trigger_fulfillment {
+			return_partial_responses = true
+			messages {
+				channel = "some-channel"
+				text {
+					text = ["Some text"]
+				}
+			}
+			messages {
+				payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+			}
+			messages {
+				conversation_success {
+					metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+				}
+			}
+			messages {
+				output_audio_text {
+					text = "some output text"
+				}
+			}
+			messages {
+				output_audio_text {
+					ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+				}
+			}
+			messages {
+				live_agent_handoff {
+					metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+				}
+			}
+			messages {
+				play_audio {
+					audio_uri = "http://example.com/some-audio-file.mp3"
+				}
+			}
+			messages {
+				telephony_transfer_call {
+					phone_number = "1-234-567-8901"
+				}
+			}
+
+			tag = "some-tag"
+
+			set_parameter_actions {
+				parameter = "some-param"
+				value     = "123.45"
+			}
+			set_parameter_actions {
+				parameter = "another-param"
+				value     = jsonencode("abc")
+			}
+			set_parameter_actions {
+				parameter = "other-param"
+				value     = jsonencode(["foo"])
+			}
+
+			conditional_cases {
+				cases = [
+					jsonencode({
+						condition = "$sys.func.RAND() < 0.5",
+						caseContent = [
+							{
+								message = { text = ["First case"] }
+							},
+							{
+								additionalCases = {
+									cases = [
+										{
+											condition = "$sys.func.RAND() < 0.2"
+											caseContent = [
+												{
+													message = { text = ["Nested case"] }
+												}
+											]
+										}
+									]
+								}
+							}
+						]
+					}),
+					jsonencode({
+						condition = "",
+						caseContent = [
+							{
+								message = { text = ["Final case"] }
+							}
+						]
+					}),
+				]
 			}
 		}
 	}
@@ -35,32 +227,220 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 		parameters {
 			display_name = "param1"
 			entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
+			default_value = "2000-01-01"
 			fill_behavior {
 				initial_prompt_fulfillment {
 					messages {
 						channel = "some-channel"
+						response_type = "PARAMETER_PROMPT"
 						text {
 							text = ["Please provide param1"]
 						}
 					}
 					messages {
-						channel = "other-channel"
 						payload = <<EOF
 							{"some-key": "some-value", "other-key": ["other-value"]}
 						EOF
+					}
+					messages {
+						conversation_success {
+							metadata = <<EOF
+								{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+							EOF
+						}
+					}
+					messages {
+						output_audio_text {
+							text = "some output text"
+						}
+					}
+					messages {
+						output_audio_text {
+							ssml = <<EOF
+								<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+							EOF
+						}
+					}
+					messages {
+						live_agent_handoff {
+							metadata = <<EOF
+								{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+							EOF
+						}
+					}
+					messages {
+						play_audio {
+							audio_uri = "http://example.com/some-audio-file.mp3"
+						}
+					}
+					messages {
+						telephony_transfer_call {
+							phone_number = "1-234-567-8901"
+						}
+					}
+
+					tag = "some-tag"
+
+					set_parameter_actions {
+						parameter = "some-param"
+						value     = "123.45"
+					}
+					set_parameter_actions {
+						parameter = "another-param"
+						value     = jsonencode("abc")
+					}
+					set_parameter_actions {
+						parameter = "other-param"
+						value     = jsonencode(["foo"])
+					}
+
+					conditional_cases {
+						cases = [
+							jsonencode({
+								condition = "$sys.func.RAND() < 0.5",
+								caseContent = [
+									{
+										message = { text = ["First case"] }
+									},
+									{
+										additionalCases = {
+											cases = [
+												{
+													condition = "$sys.func.RAND() < 0.2"
+													caseContent = [
+														{
+															message = { text = ["Nested case"] }
+														}
+													]
+												}
+											]
+										}
+									}
+								]
+							}),
+							jsonencode({
+								condition = "",
+								caseContent = [
+									{
+										message = { text = ["Final case"] }
+									}
+								]
+							}),
+						]
 					}
 				}
 				reprompt_event_handlers {
 					event = "sys.no-match-1"
 					trigger_fulfillment {
 						messages {
-							live_agent_handoff {
-								metadata = <<EOF
-									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+							messages {
+								channel = "some-channel"
+								response_type = "PARAMETER_PROMPT"
+								text {
+									text = ["Please provide param1"]
+								}
+							}
+							messages {
+								payload = <<EOF
+									{"some-key": "some-value", "other-key": ["other-value"]}
 								EOF
+							}
+							messages {
+								conversation_success {
+									metadata = <<EOF
+										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+									EOF
+								}
+							}
+							messages {
+								output_audio_text {
+									text = "some output text"
+								}
+							}
+							messages {
+								output_audio_text {
+									ssml = <<EOF
+										<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+									EOF
+								}
+							}
+							messages {
+								live_agent_handoff {
+									metadata = <<EOF
+										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+									EOF
+								}
+							}
+							messages {
+								play_audio {
+									audio_uri = "http://example.com/some-audio-file.mp3"
+								}
+							}
+							messages {
+								telephony_transfer_call {
+									phone_number = "1-234-567-8901"
+								}
+							}
+
+							tag = "some-tag"
+
+							set_parameter_actions {
+								parameter = "some-param"
+								value     = "123.45"
+							}
+							set_parameter_actions {
+								parameter = "another-param"
+								value     = jsonencode("abc")
+							}
+							set_parameter_actions {
+								parameter = "other-param"
+								value     = jsonencode(["foo"])
+							}
+
+							conditional_cases {
+								cases = [
+									jsonencode({
+										condition = "$sys.func.RAND() < 0.5",
+										caseContent = [
+											{
+												message = { text = ["First case"] }
+											},
+											{
+												additionalCases = {
+													cases = [
+														{
+															condition = "$sys.func.RAND() < 0.2"
+															caseContent = [
+																{
+																	message = { text = ["Nested case"] }
+																}
+															]
+														}
+													]
+												}
+											}
+										]
+									}),
+									jsonencode({
+										condition = "",
+										caseContent = [
+											{
+												message = { text = ["Final case"] }
+											}
+										]
+									}),
+								]
 							}
 						}
 					}
+				}
+				reprompt_event_handlers {
+					event = "sys.no-match-2"
+					target_flow = google_dialogflow_cx_agent.agent.start_flow
+				}
+				reprompt_event_handlers {
+					event = "sys.no-match-3"
+					target_page = google_dialogflow_cx_page.my_page2.id
 				}
 			}
 			required = "true"
@@ -72,8 +452,27 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 		condition = "$page.params.status = 'FINAL'"
 		trigger_fulfillment {
 			messages {
+				channel = "some-channel"
+				response_type = "HANDLER_PROMPT"
 				text {
 					text = ["information completed, navigating to page 2"]
+				}
+			}
+			messages {
+				payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+			}
+			messages {
+				conversation_success {
+					metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+				}
+			}
+			messages {
+				output_audio_text {
+					text = "some output text"
 				}
 			}
 			messages {
@@ -83,12 +482,37 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
           EOF
 				}
 			}
+			messages {
+				live_agent_handoff {
+					metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+				}
+			}
+			messages {
+				play_audio {
+					audio_uri = "http://example.com/some-audio-file.mp3"
+				}
+			}
+			messages {
+				telephony_transfer_call {
+					phone_number = "1-234-567-8901"
+				}
+			}
 
 			tag = "some-tag"
 
 			set_parameter_actions {
 				parameter = "some-param"
 				value     = "123.45"
+			}
+			set_parameter_actions {
+				parameter = "another-param"
+				value     = jsonencode("abc")
+			}
+			set_parameter_actions {
+				parameter = "other-param"
+				value     = jsonencode(["foo"])
 			}
 
 			conditional_cases {

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -21,7 +21,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
   entry_fulfillment {
     messages {
       channel = "some-channel"
-      response_type = "ENTRY_PROMPT"
       text {
         text = ["Welcome to page"]
       }
@@ -122,7 +121,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
       return_partial_responses = true
       messages {
         channel = "some-channel"
-        response_type = "HANDLER_PROMPT"
         text {
           text = ["Some text"]
         }
@@ -227,7 +225,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
         initial_prompt_fulfillment {
           messages {
             channel = "some-channel"
-            response_type = "PARAMETER_PROMPT"
             text {
               text = ["Please provide param1"]
             }
@@ -330,7 +327,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 
             messages {
               channel = "some-channel"
-              response_type = "PARAMETER_PROMPT"
               text {
                 text = ["Please provide param1"]
               }
@@ -444,7 +440,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
     trigger_fulfillment {
       messages {
         channel = "some-channel"
-        response_type = "HANDLER_PROMPT"
         text {
           text = ["information completed, navigating to page 2"]
         }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -1,569 +1,569 @@
 resource "google_dialogflow_cx_agent" "agent" {
-	display_name               = "<%= ctx[:vars]["agent_name"] %>"
-	location                   = "global"
-	default_language_code      = "en"
-	supported_language_codes   = ["fr", "de", "es"]
-	time_zone                  = "America/New_York"
-	description                = "Example description."
-	avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
-	enable_stackdriver_logging = true
-	enable_spell_correction    = true
-	speech_to_text_settings {
-		enable_speech_adaptation = true
-	}
+  display_name               = "<%= ctx[:vars]["agent_name"] %>"
+  location                   = "global"
+  default_language_code      = "en"
+  supported_language_codes   = ["fr", "de", "es"]
+  time_zone                  = "America/New_York"
+  description                = "Example description."
+  avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+  enable_stackdriver_logging = true
+  enable_spell_correction    = true
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
 }
 
 
 resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
-	parent       = google_dialogflow_cx_agent.agent.start_flow
-	display_name = "MyPage"
+  parent       = google_dialogflow_cx_agent.agent.start_flow
+  display_name = "MyPage"
 
-	entry_fulfillment {
-		messages {
-			channel = "some-channel"
-			response_type = "ENTRY_PROMPT"
-			text {
-				text = ["Welcome to page"]
-			}
-		}
-		messages {
-			payload = <<EOF
-          {"some-key": "some-value", "other-key": ["other-value"]}
-			EOF
-		}
-		messages {
-			conversation_success {
-				metadata = <<EOF
-            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
-				EOF
-			}
-		}
-		messages {
-			output_audio_text {
-				text = "some output text"
-			}
-		}
-		messages {
-			output_audio_text {
-				ssml = <<EOF
-            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-				EOF
-			}
-		}
-		messages {
-			live_agent_handoff {
-				metadata = <<EOF
-            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
-				EOF
-			}
-		}
-		messages {
-			play_audio {
-				audio_uri = "http://example.com/some-audio-file.mp3"
-			}
-		}
-		messages {
-			telephony_transfer_call {
-				phone_number = "1-234-567-8901"
-			}
-		}
+  entry_fulfillment {
+    messages {
+      channel = "some-channel"
+      response_type = "ENTRY_PROMPT"
+      text {
+        text = ["Welcome to page"]
+      }
+    }
+    messages {
+      payload = <<EOF
+        {"some-key": "some-value", "other-key": ["other-value"]}
+      EOF
+    }
+    messages {
+      conversation_success {
+        metadata = <<EOF
+          {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+        EOF
+      }
+    }
+    messages {
+      output_audio_text {
+        text = "some output text"
+      }
+    }
+    messages {
+      output_audio_text {
+        ssml = <<EOF
+          <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+        EOF
+      }
+    }
+    messages {
+      live_agent_handoff {
+        metadata = <<EOF
+          {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+        EOF
+      }
+    }
+    messages {
+      play_audio {
+        audio_uri = "http://example.com/some-audio-file.mp3"
+      }
+    }
+    messages {
+      telephony_transfer_call {
+        phone_number = "1-234-567-8901"
+      }
+    }
 
-		tag = "some-tag"
+    tag = "some-tag"
 
-		set_parameter_actions {
-			parameter = "some-param"
-			value     = "123.45"
-		}
-		set_parameter_actions {
-			parameter = "another-param"
-			value     = jsonencode("abc")
-		}
-		set_parameter_actions {
-			parameter = "other-param"
-			value     = jsonencode(["foo"])
-		}
+    set_parameter_actions {
+      parameter = "some-param"
+      value     = "123.45"
+    }
+    set_parameter_actions {
+      parameter = "another-param"
+      value     = jsonencode("abc")
+    }
+    set_parameter_actions {
+      parameter = "other-param"
+      value     = jsonencode(["foo"])
+    }
 
-		conditional_cases {
-			cases = jsonencode([
-				{
-					condition = "$sys.func.RAND() < 0.5",
-					caseContent = [
-						{
-							message = { text = { text = ["First case"] } }
-						},
-						{
-							additionalCases = {
-								cases = [
-									{
-										condition = "$sys.func.RAND() < 0.2"
-										caseContent = [
-											{
-												message = { text = { text = ["Nested case"] } }
-											}
-										]
-									}
-								]
-							}
-						}
-					]
-				},
-				{
-					condition = "",
-					caseContent = [
-						{
-							message = { text = { text = ["Final case"] } }
-						}
-					]
-				},
-			])
-		}
-	}
+    conditional_cases {
+      cases = jsonencode([
+        {
+          condition = "$sys.func.RAND() < 0.5",
+          caseContent = [
+            {
+              message = { text = { text = ["First case"] } }
+            },
+            {
+              additionalCases = {
+                cases = [
+                  {
+                    condition = "$sys.func.RAND() < 0.2"
+                    caseContent = [
+                      {
+                        message = { text = { text = ["Nested case"] } }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          condition = "",
+          caseContent = [
+            {
+              message = { text = { text = ["Final case"] } }
+            }
+          ]
+        },
+      ])
+    }
+  }
 
-	event_handlers {
-		event = "some-event"
-		trigger_fulfillment {
-			return_partial_responses = true
-			messages {
-				channel = "some-channel"
-				response_type = "HANDLER_PROMPT"
-				text {
-					text = ["Some text"]
-				}
-			}
-			messages {
-				payload = <<EOF
+  event_handlers {
+    event = "some-event"
+    trigger_fulfillment {
+      return_partial_responses = true
+      messages {
+        channel = "some-channel"
+        response_type = "HANDLER_PROMPT"
+        text {
+          text = ["Some text"]
+        }
+      }
+      messages {
+        payload = <<EOF
           {"some-key": "some-value", "other-key": ["other-value"]}
         EOF
-			}
-			messages {
-				conversation_success {
-					metadata = <<EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
             {"some-metadata-key": "some-value", "other-metadata-key": 1234}
           EOF
-				}
-			}
-			messages {
-				output_audio_text {
-					text = "some output text"
-				}
-			}
-			messages {
-				output_audio_text {
-					ssml = <<EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
             <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
           EOF
-				}
-			}
-			messages {
-				live_agent_handoff {
-					metadata = <<EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
             {"some-metadata-key": "some-value", "other-metadata-key": 1234}
           EOF
-				}
-			}
-			messages {
-				play_audio {
-					audio_uri = "http://example.com/some-audio-file.mp3"
-				}
-			}
-			messages {
-				telephony_transfer_call {
-					phone_number = "1-234-567-8901"
-				}
-			}
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8901"
+        }
+      }
 
-			tag = "some-tag"
+      tag = "some-tag"
 
-			set_parameter_actions {
-				parameter = "some-param"
-				value     = "123.45"
-			}
-			set_parameter_actions {
-				parameter = "another-param"
-				value     = jsonencode("abc")
-			}
-			set_parameter_actions {
-				parameter = "other-param"
-				value     = jsonencode(["foo"])
-			}
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      set_parameter_actions {
+        parameter = "another-param"
+        value     = jsonencode("abc")
+      }
+      set_parameter_actions {
+        parameter = "other-param"
+        value     = jsonencode(["foo"])
+      }
 
-			conditional_cases {
-				cases = jsonencode([
-					{
-						condition = "$sys.func.RAND() < 0.5",
-						caseContent = [
-							{
-								message = { text = { text = ["First case"] } }
-							},
-							{
-								additionalCases = {
-									cases = [
-										{
-											condition = "$sys.func.RAND() < 0.2"
-											caseContent = [
-												{
-													message = { text = { text = ["Nested case"] } }
-												}
-											]
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						condition = "",
-						caseContent = [
-							{
-								message = { text = { text = ["Final case"] } }
-							}
-						]
-					},
-				])
-			}
-		}
-	}
+      conditional_cases {
+        cases = jsonencode([
+          {
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = { text = ["First case"] } }
+              },
+              {
+                additionalCases = {
+                  cases = [
+                    {
+                      condition = "$sys.func.RAND() < 0.2"
+                      caseContent = [
+                        {
+                          message = { text = { text = ["Nested case"] } }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            condition = "",
+            caseContent = [
+              {
+                message = { text = { text = ["Final case"] } }
+              }
+            ]
+          },
+        ])
+      }
+    }
+  }
 
-	form {
-		parameters {
-			display_name = "param1"
-			entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
-			default_value = "2000-01-01"
-			fill_behavior {
-				initial_prompt_fulfillment {
-					messages {
-						channel = "some-channel"
-						response_type = "PARAMETER_PROMPT"
-						text {
-							text = ["Please provide param1"]
-						}
-					}
-					messages {
-						payload = <<EOF
-							{"some-key": "some-value", "other-key": ["other-value"]}
-						EOF
-					}
-					messages {
-						conversation_success {
-							metadata = <<EOF
-								{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-							EOF
-						}
-					}
-					messages {
-						output_audio_text {
-							text = "some output text"
-						}
-					}
-					messages {
-						output_audio_text {
-							ssml = <<EOF
-								<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-							EOF
-						}
-					}
-					messages {
-						live_agent_handoff {
-							metadata = <<EOF
-								{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-							EOF
-						}
-					}
-					messages {
-						play_audio {
-							audio_uri = "http://example.com/some-audio-file.mp3"
-						}
-					}
-					messages {
-						telephony_transfer_call {
-							phone_number = "1-234-567-8901"
-						}
-					}
+  form {
+    parameters {
+      display_name = "param1"
+      entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
+      default_value = "2000-01-01"
+      fill_behavior {
+        initial_prompt_fulfillment {
+          messages {
+            channel = "some-channel"
+            response_type = "PARAMETER_PROMPT"
+            text {
+              text = ["Please provide param1"]
+            }
+          }
+          messages {
+            payload = <<EOF
+              {"some-key": "some-value", "other-key": ["other-value"]}
+            EOF
+          }
+          messages {
+            conversation_success {
+              metadata = <<EOF
+                {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+              EOF
+            }
+          }
+          messages {
+            output_audio_text {
+              text = "some output text"
+            }
+          }
+          messages {
+            output_audio_text {
+              ssml = <<EOF
+                <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+              EOF
+            }
+          }
+          messages {
+            live_agent_handoff {
+              metadata = <<EOF
+                {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+              EOF
+            }
+          }
+          messages {
+            play_audio {
+              audio_uri = "http://example.com/some-audio-file.mp3"
+            }
+          }
+          messages {
+            telephony_transfer_call {
+              phone_number = "1-234-567-8901"
+            }
+          }
 
-					tag = "some-tag"
+          tag = "some-tag"
 
-					set_parameter_actions {
-						parameter = "some-param"
-						value     = "123.45"
-					}
-					set_parameter_actions {
-						parameter = "another-param"
-						value     = jsonencode("abc")
-					}
-					set_parameter_actions {
-						parameter = "other-param"
-						value     = jsonencode(["foo"])
-					}
+          set_parameter_actions {
+            parameter = "some-param"
+            value     = "123.45"
+          }
+          set_parameter_actions {
+            parameter = "another-param"
+            value     = jsonencode("abc")
+          }
+          set_parameter_actions {
+            parameter = "other-param"
+            value     = jsonencode(["foo"])
+          }
 
-					conditional_cases {
-						cases = jsonencode([
-							{
-								condition = "$sys.func.RAND() < 0.5",
-								caseContent = [
-									{
-										message = { text = { text = ["First case"] } }
-									},
-									{
-										additionalCases = {
-											cases = [
-												{
-													condition = "$sys.func.RAND() < 0.2"
-													caseContent = [
-														{
-															message = { text = { text = ["Nested case"] } }
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							},
-							{
-								condition = "",
-								caseContent = [
-									{
-										message = { text = { text = ["Final case"] } }
-									}
-								]
-							},
-						])
-					}
-				}
-				reprompt_event_handlers {
-					event = "sys.no-match-1"
-					trigger_fulfillment {
-						return_partial_responses = true
-						webhook = google_dialogflow_cx_webhook.my_webhook.id
-						messages {
-							channel = "some-channel"
-							response_type = "PARAMETER_PROMPT"
-							text {
-								text = ["Please provide param1"]
-							}
-						}
-						messages {
-							payload = <<EOF
-								{"some-key": "some-value", "other-key": ["other-value"]}
-							EOF
-						}
-						messages {
-							conversation_success {
-								metadata = <<EOF
-									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-								EOF
-							}
-						}
-						messages {
-							output_audio_text {
-								text = "some output text"
-							}
-						}
-						messages {
-							output_audio_text {
-								ssml = <<EOF
-									<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-								EOF
-							}
-						}
-						messages {
-							live_agent_handoff {
-								metadata = <<EOF
-									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-								EOF
-							}
-						}
-						messages {
-							play_audio {
-								audio_uri = "http://example.com/some-audio-file.mp3"
-							}
-						}
-						messages {
-							telephony_transfer_call {
-								phone_number = "1-234-567-8901"
-							}
-						}
+          conditional_cases {
+            cases = jsonencode([
+              {
+                condition = "$sys.func.RAND() < 0.5",
+                caseContent = [
+                  {
+                    message = { text = { text = ["First case"] } }
+                  },
+                  {
+                    additionalCases = {
+                      cases = [
+                        {
+                          condition = "$sys.func.RAND() < 0.2"
+                          caseContent = [
+                            {
+                              message = { text = { text = ["Nested case"] } }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                condition = "",
+                caseContent = [
+                  {
+                    message = { text = { text = ["Final case"] } }
+                  }
+                ]
+              },
+            ])
+          }
+        }
+        reprompt_event_handlers {
+          event = "sys.no-match-1"
+          trigger_fulfillment {
+            return_partial_responses = true
+            webhook = google_dialogflow_cx_webhook.my_webhook.id
+            messages {
+              channel = "some-channel"
+              response_type = "PARAMETER_PROMPT"
+              text {
+                text = ["Please provide param1"]
+              }
+            }
+            messages {
+              payload = <<EOF
+                {"some-key": "some-value", "other-key": ["other-value"]}
+              EOF
+            }
+            messages {
+              conversation_success {
+                metadata = <<EOF
+                  {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+                EOF
+              }
+            }
+            messages {
+              output_audio_text {
+                text = "some output text"
+              }
+            }
+            messages {
+              output_audio_text {
+                ssml = <<EOF
+                  <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+                EOF
+              }
+            }
+            messages {
+              live_agent_handoff {
+                metadata = <<EOF
+                  {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+                EOF
+              }
+            }
+            messages {
+              play_audio {
+                audio_uri = "http://example.com/some-audio-file.mp3"
+              }
+            }
+            messages {
+              telephony_transfer_call {
+                phone_number = "1-234-567-8901"
+              }
+            }
 
-						tag = "some-tag"
+            tag = "some-tag"
 
-						set_parameter_actions {
-							parameter = "some-param"
-							value     = "123.45"
-						}
-						set_parameter_actions {
-							parameter = "another-param"
-							value     = jsonencode("abc")
-						}
-						set_parameter_actions {
-							parameter = "other-param"
-							value     = jsonencode(["foo"])
-						}
+            set_parameter_actions {
+              parameter = "some-param"
+              value     = "123.45"
+            }
+            set_parameter_actions {
+              parameter = "another-param"
+              value     = jsonencode("abc")
+            }
+            set_parameter_actions {
+              parameter = "other-param"
+              value     = jsonencode(["foo"])
+            }
 
-						conditional_cases {
-							cases = jsonencode([
-								{
-									condition = "$sys.func.RAND() < 0.5",
-									caseContent = [
-										{
-											message = { text = { text = ["First case"] } }
-										},
-										{
-											additionalCases = {
-												cases = [
-													{
-														condition = "$sys.func.RAND() < 0.2"
-														caseContent = [
-															{
-																message = { text = { text = ["Nested case"] } }
-															}
-														]
-													}
-												]
-											}
-										}
-									]
-								},
-								{
-									condition = "",
-									caseContent = [
-										{
-											message = { text = { text = ["Final case"] } }
-										}
-									]
-								},
-							])
-						}
-					}
-				}
-				reprompt_event_handlers {
-					event = "sys.no-match-2"
-					target_flow = google_dialogflow_cx_agent.agent.start_flow
-				}
-				reprompt_event_handlers {
-					event = "sys.no-match-3"
-					target_page = google_dialogflow_cx_page.my_page2.id
-				}
-			}
-			required = "true"
-			redact   = "true"
-		}
-	}
+            conditional_cases {
+              cases = jsonencode([
+                {
+                  condition = "$sys.func.RAND() < 0.5",
+                  caseContent = [
+                    {
+                      message = { text = { text = ["First case"] } }
+                    },
+                    {
+                      additionalCases = {
+                        cases = [
+                          {
+                            condition = "$sys.func.RAND() < 0.2"
+                            caseContent = [
+                              {
+                                message = { text = { text = ["Nested case"] } }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  condition = "",
+                  caseContent = [
+                    {
+                      message = { text = { text = ["Final case"] } }
+                    }
+                  ]
+                },
+              ])
+            }
+          }
+        }
+        reprompt_event_handlers {
+          event = "sys.no-match-2"
+          target_flow = google_dialogflow_cx_agent.agent.start_flow
+        }
+        reprompt_event_handlers {
+          event = "sys.no-match-3"
+          target_page = google_dialogflow_cx_page.my_page2.id
+        }
+      }
+      required = "true"
+      redact   = "true"
+    }
+  }
 
-	transition_routes {
-		condition = "$page.params.status = 'FINAL'"
-		trigger_fulfillment {
-			messages {
-				channel = "some-channel"
-				response_type = "HANDLER_PROMPT"
-				text {
-					text = ["information completed, navigating to page 2"]
-				}
-			}
-			messages {
-				payload = <<EOF
+  transition_routes {
+    condition = "$page.params.status = 'FINAL'"
+    trigger_fulfillment {
+      messages {
+        channel = "some-channel"
+        response_type = "HANDLER_PROMPT"
+        text {
+          text = ["information completed, navigating to page 2"]
+        }
+      }
+      messages {
+        payload = <<EOF
           {"some-key": "some-value", "other-key": ["other-value"]}
         EOF
-			}
-			messages {
-				conversation_success {
-					metadata = <<EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
             {"some-metadata-key": "some-value", "other-metadata-key": 1234}
           EOF
-				}
-			}
-			messages {
-				output_audio_text {
-					text = "some output text"
-				}
-			}
-			messages {
-				output_audio_text {
-					ssml = <<EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
             <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
           EOF
-				}
-			}
-			messages {
-				live_agent_handoff {
-					metadata = <<EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
             {"some-metadata-key": "some-value", "other-metadata-key": 1234}
           EOF
-				}
-			}
-			messages {
-				play_audio {
-					audio_uri = "http://example.com/some-audio-file.mp3"
-				}
-			}
-			messages {
-				telephony_transfer_call {
-					phone_number = "1-234-567-8901"
-				}
-			}
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8901"
+        }
+      }
 
-			tag = "some-tag"
+      tag = "some-tag"
 
-			set_parameter_actions {
-				parameter = "some-param"
-				value     = "123.45"
-			}
-			set_parameter_actions {
-				parameter = "another-param"
-				value     = jsonencode("abc")
-			}
-			set_parameter_actions {
-				parameter = "other-param"
-				value     = jsonencode(["foo"])
-			}
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      set_parameter_actions {
+        parameter = "another-param"
+        value     = jsonencode("abc")
+      }
+      set_parameter_actions {
+        parameter = "other-param"
+        value     = jsonencode(["foo"])
+      }
 
-			conditional_cases {
-				cases = jsonencode([
-					{
-						condition = "$sys.func.RAND() < 0.5",
-						caseContent = [
-							{
-								message = { text = { text = ["First case"] } }
-							},
-							{
-								additionalCases = {
-									cases = [
-										{
-											condition = "$sys.func.RAND() < 0.2"
-											caseContent = [
-												{
-													message = { text = { text = ["Nested case"] } }
-												}
-											]
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						condition = "",
-						caseContent = [
-							{
-								message = { text = { text = ["Final case"] } }
-							}
-						]
-					},
-				])
-			}
-		}
-		target_page = google_dialogflow_cx_page.my_page2.id
-	}
+      conditional_cases {
+        cases = jsonencode([
+          {
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = { text = ["First case"] } }
+              },
+              {
+                additionalCases = {
+                  cases = [
+                    {
+                      condition = "$sys.func.RAND() < 0.2"
+                      caseContent = [
+                        {
+                          message = { text = { text = ["Nested case"] } }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            condition = "",
+            caseContent = [
+              {
+                message = { text = { text = ["Final case"] } }
+              }
+            ]
+          },
+        ])
+      }
+    }
+    target_page = google_dialogflow_cx_page.my_page2.id
+  }
 }
 
 resource "google_dialogflow_cx_page" "my_page2" {
-	parent       = google_dialogflow_cx_agent.agent.start_flow
-	display_name = "MyPage2"
+  parent       = google_dialogflow_cx_agent.agent.start_flow
+  display_name = "MyPage2"
 }
 
 resource "google_dialogflow_cx_webhook" "my_webhook" {
-	parent       = google_dialogflow_cx_agent.agent.id
-	display_name = "MyWebhook"
-	generic_web_service {
-		uri = "https://example.com"
-	}
+  parent       = google_dialogflow_cx_agent.agent.id
+  display_name = "MyWebhook"
+  generic_web_service {
+    uri = "https://example.com"
+  }
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -108,7 +108,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
           ]
         },
         {
-          condition = "",
           caseContent = [
             {
               message = { text = { text = ["Final case"] } }
@@ -212,7 +211,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
             ]
           },
           {
-            condition = "",
             caseContent = [
               {
                 message = { text = { text = ["Final case"] } }
@@ -320,7 +318,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
                 ]
               },
               {
-                condition = "",
                 caseContent = [
                   {
                     message = { text = { text = ["Final case"] } }
@@ -424,7 +421,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
                   ]
                 },
                 {
-                  condition = "",
                   caseContent = [
                     {
                       message = { text = { text = ["Final case"] } }
@@ -541,7 +537,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
             ]
           },
           {
-            condition = "",
             caseContent = [
               {
                 message = { text = { text = ["Final case"] } }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -228,7 +228,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
     parameters {
       display_name = "param1"
       entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
-      default_value = "2000-01-01"
+      default_value = jsonencode("2000-01-01")
       fill_behavior {
         initial_prompt_fulfillment {
           messages {

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -333,6 +333,8 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 				reprompt_event_handlers {
 					event = "sys.no-match-1"
 					trigger_fulfillment {
+						return_partial_responses = true
+						webhook = google_dialogflow_cx_webhook.my_webhook.id
 						messages {
 							channel = "some-channel"
 							response_type = "PARAMETER_PROMPT"
@@ -556,4 +558,12 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 resource "google_dialogflow_cx_page" "my_page2" {
 	parent       = google_dialogflow_cx_agent.agent.start_flow
 	display_name = "MyPage2"
+}
+
+resource "google_dialogflow_cx_webhook" "my_webhook" {
+	parent       = google_dialogflow_cx_agent.agent.id
+	display_name = "MyWebhook"
+	generic_web_service {
+		uri = "https://example.com"
+	}
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -125,6 +125,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 			return_partial_responses = true
 			messages {
 				channel = "some-channel"
+				response_type = "HANDLER_PROMPT"
 				text {
 					text = ["Some text"]
 				}
@@ -333,104 +334,102 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 					event = "sys.no-match-1"
 					trigger_fulfillment {
 						messages {
-							messages {
-								channel = "some-channel"
-								response_type = "PARAMETER_PROMPT"
-								text {
-									text = ["Please provide param1"]
-								}
+							channel = "some-channel"
+							response_type = "PARAMETER_PROMPT"
+							text {
+								text = ["Please provide param1"]
 							}
-							messages {
-								payload = <<EOF
-									{"some-key": "some-value", "other-key": ["other-value"]}
+						}
+						messages {
+							payload = <<EOF
+								{"some-key": "some-value", "other-key": ["other-value"]}
+							EOF
+						}
+						messages {
+							conversation_success {
+								metadata = <<EOF
+									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
 								EOF
 							}
-							messages {
-								conversation_success {
-									metadata = <<EOF
-										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-									EOF
-								}
+						}
+						messages {
+							output_audio_text {
+								text = "some output text"
 							}
-							messages {
-								output_audio_text {
-									text = "some output text"
-								}
+						}
+						messages {
+							output_audio_text {
+								ssml = <<EOF
+									<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+								EOF
 							}
-							messages {
-								output_audio_text {
-									ssml = <<EOF
-										<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-									EOF
-								}
+						}
+						messages {
+							live_agent_handoff {
+								metadata = <<EOF
+									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+								EOF
 							}
-							messages {
-								live_agent_handoff {
-									metadata = <<EOF
-										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-									EOF
-								}
+						}
+						messages {
+							play_audio {
+								audio_uri = "http://example.com/some-audio-file.mp3"
 							}
-							messages {
-								play_audio {
-									audio_uri = "http://example.com/some-audio-file.mp3"
-								}
+						}
+						messages {
+							telephony_transfer_call {
+								phone_number = "1-234-567-8901"
 							}
-							messages {
-								telephony_transfer_call {
-									phone_number = "1-234-567-8901"
-								}
-							}
+						}
 
-							tag = "some-tag"
+						tag = "some-tag"
 
-							set_parameter_actions {
-								parameter = "some-param"
-								value     = "123.45"
-							}
-							set_parameter_actions {
-								parameter = "another-param"
-								value     = jsonencode("abc")
-							}
-							set_parameter_actions {
-								parameter = "other-param"
-								value     = jsonencode(["foo"])
-							}
+						set_parameter_actions {
+							parameter = "some-param"
+							value     = "123.45"
+						}
+						set_parameter_actions {
+							parameter = "another-param"
+							value     = jsonencode("abc")
+						}
+						set_parameter_actions {
+							parameter = "other-param"
+							value     = jsonencode(["foo"])
+						}
 
-							conditional_cases {
-								cases = [
-									jsonencode({
-										condition = "$sys.func.RAND() < 0.5",
-										caseContent = [
-											{
-												message = { text = ["First case"] }
-											},
-											{
-												additionalCases = {
-													cases = [
-														{
-															condition = "$sys.func.RAND() < 0.2"
-															caseContent = [
-																{
-																	message = { text = ["Nested case"] }
-																}
-															]
-														}
-													]
-												}
+						conditional_cases {
+							cases = [
+								jsonencode({
+									condition = "$sys.func.RAND() < 0.5",
+									caseContent = [
+										{
+											message = { text = ["First case"] }
+										},
+										{
+											additionalCases = {
+												cases = [
+													{
+														condition = "$sys.func.RAND() < 0.2"
+														caseContent = [
+															{
+																message = { text = ["Nested case"] }
+															}
+														]
+													}
+												]
 											}
-										]
-									}),
-									jsonencode({
-										condition = "",
-										caseContent = [
-											{
-												message = { text = ["Final case"] }
-											}
-										]
-									}),
-								]
-							}
+										}
+									]
+								}),
+								jsonencode({
+									condition = "",
+									caseContent = [
+										{
+											message = { text = ["Final case"] }
+										}
+									]
+								}),
+							]
 						}
 					}
 				}

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -84,12 +84,12 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 		}
 
 		conditional_cases {
-			cases = [
-				jsonencode({
+			cases = jsonencode([
+				{
 					condition = "$sys.func.RAND() < 0.5",
 					caseContent = [
 						{
-							message = { text = ["First case"] }
+							message = { text = { text = ["First case"] } }
 						},
 						{
 							additionalCases = {
@@ -98,7 +98,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 										condition = "$sys.func.RAND() < 0.2"
 										caseContent = [
 											{
-												message = { text = ["Nested case"] }
+												message = { text = { text = ["Nested case"] } }
 											}
 										]
 									}
@@ -106,16 +106,16 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 							}
 						}
 					]
-				}),
-				jsonencode({
+				},
+				{
 					condition = "",
 					caseContent = [
 						{
-							message = { text = ["Final case"] }
+							message = { text = { text = ["Final case"] } }
 						}
 					]
-				}),
-			]
+				},
+			])
 		}
 	}
 
@@ -188,12 +188,12 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 			}
 
 			conditional_cases {
-				cases = [
-					jsonencode({
+				cases = jsonencode([
+					{
 						condition = "$sys.func.RAND() < 0.5",
 						caseContent = [
 							{
-								message = { text = ["First case"] }
+								message = { text = { text = ["First case"] } }
 							},
 							{
 								additionalCases = {
@@ -202,7 +202,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 											condition = "$sys.func.RAND() < 0.2"
 											caseContent = [
 												{
-													message = { text = ["Nested case"] }
+													message = { text = { text = ["Nested case"] } }
 												}
 											]
 										}
@@ -210,16 +210,16 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 								}
 							}
 						]
-					}),
-					jsonencode({
+					},
+					{
 						condition = "",
 						caseContent = [
 							{
-								message = { text = ["Final case"] }
+								message = { text = { text = ["Final case"] } }
 							}
 						]
-					}),
-				]
+					},
+				])
 			}
 		}
 	}
@@ -296,12 +296,12 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 					}
 
 					conditional_cases {
-						cases = [
-							jsonencode({
+						cases = jsonencode([
+							{
 								condition = "$sys.func.RAND() < 0.5",
 								caseContent = [
 									{
-										message = { text = ["First case"] }
+										message = { text = { text = ["First case"] } }
 									},
 									{
 										additionalCases = {
@@ -310,7 +310,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 													condition = "$sys.func.RAND() < 0.2"
 													caseContent = [
 														{
-															message = { text = ["Nested case"] }
+															message = { text = { text = ["Nested case"] } }
 														}
 													]
 												}
@@ -318,16 +318,16 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 										}
 									}
 								]
-							}),
-							jsonencode({
+							},
+							{
 								condition = "",
 								caseContent = [
 									{
-										message = { text = ["Final case"] }
+										message = { text = { text = ["Final case"] } }
 									}
 								]
-							}),
-						]
+							},
+						])
 					}
 				}
 				reprompt_event_handlers {
@@ -400,12 +400,12 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 						}
 
 						conditional_cases {
-							cases = [
-								jsonencode({
+							cases = jsonencode([
+								{
 									condition = "$sys.func.RAND() < 0.5",
 									caseContent = [
 										{
-											message = { text = ["First case"] }
+											message = { text = { text = ["First case"] } }
 										},
 										{
 											additionalCases = {
@@ -414,7 +414,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 														condition = "$sys.func.RAND() < 0.2"
 														caseContent = [
 															{
-																message = { text = ["Nested case"] }
+																message = { text = { text = ["Nested case"] } }
 															}
 														]
 													}
@@ -422,16 +422,16 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 											}
 										}
 									]
-								}),
-								jsonencode({
+								},
+								{
 									condition = "",
 									caseContent = [
 										{
-											message = { text = ["Final case"] }
+											message = { text = { text = ["Final case"] } }
 										}
 									]
-								}),
-							]
+								},
+							])
 						}
 					}
 				}
@@ -517,12 +517,12 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 			}
 
 			conditional_cases {
-				cases = [
-					jsonencode({
+				cases = jsonencode([
+					{
 						condition = "$sys.func.RAND() < 0.5",
 						caseContent = [
 							{
-								message = { text = ["First case"] }
+								message = { text = { text = ["First case"] } }
 							},
 							{
 								additionalCases = {
@@ -531,7 +531,7 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 											condition = "$sys.func.RAND() < 0.2"
 											caseContent = [
 												{
-													message = { text = ["Nested case"] }
+													message = { text = { text = ["Nested case"] } }
 												}
 											]
 										}
@@ -539,16 +539,16 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
 								}
 							}
 						]
-					}),
-					jsonencode({
+					},
+					{
 						condition = "",
 						caseContent = [
 							{
-								message = { text = ["Final case"] }
+								message = { text = { text = ["Final case"] } }
 							}
 						]
-					}),
-				]
+					},
+				])
 			}
 		}
 		target_page = google_dialogflow_cx_page.my_page2.id

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.erb
@@ -68,8 +68,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
       }
     }
 
-    tag = "some-tag"
-
     set_parameter_actions {
       parameter = "some-param"
       value     = "123.45"
@@ -170,8 +168,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
           phone_number = "1-234-567-8901"
         }
       }
-
-      tag = "some-tag"
 
       set_parameter_actions {
         parameter = "some-param"
@@ -278,8 +274,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
             }
           }
 
-          tag = "some-tag"
-
           set_parameter_actions {
             parameter = "some-param"
             value     = "123.45"
@@ -332,6 +326,8 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
           trigger_fulfillment {
             return_partial_responses = true
             webhook = google_dialogflow_cx_webhook.my_webhook.id
+            tag = "some-tag"
+
             messages {
               channel = "some-channel"
               response_type = "PARAMETER_PROMPT"
@@ -380,8 +376,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
                 phone_number = "1-234-567-8901"
               }
             }
-
-            tag = "some-tag"
 
             set_parameter_actions {
               parameter = "some-param"
@@ -496,8 +490,6 @@ resource "google_dialogflow_cx_page" "<%= ctx[:primary_resource_id] %>" {
           phone_number = "1-234-567-8901"
         }
       }
-
-      tag = "some-tag"
 
       set_parameter_actions {
         parameter = "some-param"

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -261,6 +261,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
     }
 
     transition_routes {
+      condition = "true"
       trigger_fulfillment {
         return_partial_responses = true
         messages {

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -225,12 +225,12 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 				}
 	
 				conditional_cases {
-					cases = [
-						jsonencode({
+					cases = jsonencode([
+						{
 							condition = "$sys.func.RAND() < 0.5",
 							caseContent = [
 								{
-									message = { text = ["First case"] }
+									message = { text = { text = ["First case"] } }
 								},
 								{
 									additionalCases = {
@@ -239,7 +239,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 												condition = "$sys.func.RAND() < 0.2"
 												caseContent = [
 													{
-														message = { text = ["Nested case"] }
+														message = { text = { text = ["Nested case"] } }
 													}
 												]
 											}
@@ -247,16 +247,16 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 									}
 								}
 							]
-						}),
-						jsonencode({
+						},
+						{
 							condition = "",
 							caseContent = [
 								{
-									message = { text = ["Final case"] }
+									message = { text = { text = ["Final case"] } }
 								}
 							]
-						}),
-					]
+						},
+					])
 				}
 			}
 		}
@@ -329,12 +329,12 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 				}
 
 				conditional_cases {
-					cases = [
-						jsonencode({
+					cases = jsonencode([
+						{
 							condition = "$sys.func.RAND() < 0.5",
 							caseContent = [
 								{
-									message = { text = ["First case"] }
+									message = { text = { text = ["First case"] } }
 								},
 								{
 									additionalCases = {
@@ -343,7 +343,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 												condition = "$sys.func.RAND() < 0.2"
 												caseContent = [
 													{
-														message = { text = ["Nested case"] }
+														message = { text = { text = ["Nested case"] } }
 													}
 												]
 											}
@@ -351,16 +351,16 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 									}
 								}
 							]
-						}),
-						jsonencode({
+						},
+						{
 							condition = "",
 							caseContent = [
 								{
-									message = { text = ["Final case"] }
+									message = { text = { text = ["Final case"] } }
 								}
 							]
-						}),
-					]
+						},
+					])
 				}
 			}
 			target_flow = google_dialogflow_cx_agent.agent_entity.start_flow

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -135,7 +135,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
       trigger_fulfillment {
         return_partial_responses = false
         messages {
-          response_type = "RESPONSE_TYPE_UNSPECIFIED"
           text {
             text = ["Sorry, could you say that again?"]
           }
@@ -148,7 +147,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
       trigger_fulfillment {
         return_partial_responses = false
         messages {
-          response_type = "ENTRY_PROMPT"
           text {
             text = ["One more time?"]
           }
@@ -263,7 +261,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
         return_partial_responses = true
         messages {
           channel = "some-channel"
-          response_type = "RESPONSE_TYPE_UNSPECIFIED"
           text {
             text = ["Some text"]
           }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -260,6 +260,110 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 				}
 			}
 		}
+
+		transition_routes {
+			trigger_fulfillment {
+				return_partial_responses = true
+				messages {
+					channel = "some-channel"
+					text {
+						text = ["Some text"]
+					}
+				}
+				messages {
+					payload = <<EOF
+						{"some-key": "some-value", "other-key": ["other-value"]}
+					EOF
+				}
+				messages {
+					conversation_success {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					output_audio_text {
+						text = "some output text"
+					}
+				}
+				messages {
+					output_audio_text {
+						ssml = <<EOF
+							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+						EOF
+					}
+				}
+				messages {
+					live_agent_handoff {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					play_audio {
+						audio_uri = "http://example.com/some-audio-file.mp3"
+					}
+				}
+				messages {
+					telephony_transfer_call {
+						phone_number = "1-234-567-8901"
+					}
+				}
+
+				tag = "some-tag"
+
+				set_parameter_actions {
+					parameter = "some-param"
+					value     = "123.45"
+				}
+				set_parameter_actions {
+					parameter = "another-param"
+					value     = jsonencode("abc")
+				}
+				set_parameter_actions {
+					parameter = "other-param"
+					value     = jsonencode(["foo"])
+				}
+
+				conditional_cases {
+					cases = [
+						jsonencode({
+							condition = "$sys.func.RAND() < 0.5",
+							caseContent = [
+								{
+									message = { text = ["First case"] }
+								},
+								{
+									additionalCases = {
+										cases = [
+											{
+												condition = "$sys.func.RAND() < 0.2"
+												caseContent = [
+													{
+														message = { text = ["Nested case"] }
+													}
+												]
+											}
+										]
+									}
+								}
+							]
+						}),
+						jsonencode({
+							condition = "",
+							caseContent = [
+								{
+									message = { text = ["Final case"] }
+								}
+							]
+						}),
+					]
+				}
+			}
+			target_flow = google_dialogflow_cx_agent.agent_entity.start_flow
+		}
 	}
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -266,6 +266,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 				return_partial_responses = true
 				messages {
 					channel = "some-channel"
+					response_type = "RESPONSE_TYPE_UNSPECIFIED"
 					text {
 						text = ["Some text"]
 					}

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -248,7 +248,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
               ]
             },
             {
-              condition = "",
               caseContent = [
                 {
                   message = { text = { text = ["Final case"] } }
@@ -353,7 +352,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
               ]
             },
             {
-              condition = "",
               caseContent = [
                 {
                   message = { text = { text = ["Final case"] } }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -208,8 +208,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
           }
         }
 
-        tag = "some-tag"
-
         set_parameter_actions {
           parameter = "some-param"
           value     = "123.45"
@@ -311,8 +309,6 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
             phone_number = "1-234-567-8901"
           }
         }
-
-        tag = "some-tag"
 
         set_parameter_actions {
           parameter = "some-param"

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -56,26 +56,26 @@ func testAccDialogflowCXFlow_basic(context map[string]interface{}) string {
 	}
 
 	resource "google_dialogflow_cx_agent" "agent_entity" {
-		display_name = "tf-test-%{random_suffix}"
-		location = "global"
-		default_language_code = "en"
-		supported_language_codes = ["fr","de","es"]
-		time_zone = "America/New_York"
-		description = "Description 1."
-		avatar_uri = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
-		depends_on = [google_project_iam_member.agent_create]
+		display_name             = "tf-test-%{random_suffix}"
+		location                 = "global"
+		default_language_code    = "en"
+		supported_language_codes = ["fr", "de", "es"]
+		time_zone                = "America/New_York"
+		description              = "Description 1."
+		avatar_uri               = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
+		depends_on               = [google_project_iam_member.agent_create]
 	}
-    
-	resource "google_dialogflow_cx_flow" "my_flow" {
-        parent       = google_dialogflow_cx_agent.agent_entity.id
-        display_name = "MyFlow"
 
-        nlu_settings {
-           classification_threshold = 0.3 
-           model_type               = "MODEL_TYPE_STANDARD"
-	    }
-    } 
-    `, context)
+	resource "google_dialogflow_cx_flow" "my_flow" {
+		parent       = google_dialogflow_cx_agent.agent_entity.id
+		display_name = "MyFlow"
+
+		nlu_settings {
+			classification_threshold = 0.3
+			model_type               = "MODEL_TYPE_STANDARD"
+		}
+	}
+`, context)
 }
 
 func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
@@ -93,65 +93,173 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 	}
 
 	resource "google_dialogflow_cx_agent" "agent_entity" {
-		display_name = "tf-test-%{random_suffix}update"
-		location = "global"
-		default_language_code = "en"
-		supported_language_codes = ["no"]
-		time_zone = "Europe/London"
-		description = "Description 2!"
-		avatar_uri = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo-2.png"
+		display_name               = "tf-test-dialogflowcx-agent%{random_suffix}update"
+		location                   = "global"
+		default_language_code      = "en"
+		supported_language_codes   = ["fr", "de", "es"]
+		time_zone                  = "America/New_York"
+		description                = "Example description."
+		avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
 		enable_stackdriver_logging = true
-        enable_spell_correction    = true
+		enable_spell_correction    = true
 		speech_to_text_settings {
 			enable_speech_adaptation = true
 		}
-		depends_on = [google_project_iam_member.agent_create]
+		depends_on                 = [google_project_iam_member.agent_create]
 	}
-    
+	
+	
 	resource "google_dialogflow_cx_flow" "my_flow" {
-        parent       = google_dialogflow_cx_agent.agent_entity.id
-        display_name = "MyFlow"
-
-        nlu_settings {
-           classification_threshold = 0.3 
-           model_type               = "MODEL_TYPE_STANDARD"
-	    }
-
-        event_handlers {
-		   event                    = "custom-event"
-		   trigger_fulfillment {
-			    return_partial_responses = false
+		parent       = google_dialogflow_cx_agent.agent_entity.id
+		display_name = "MyFlow"
+		description  = "Test Flow"
+	
+		nlu_settings {
+			classification_threshold = 0.3
+			model_type               = "MODEL_TYPE_STANDARD"
+		}
+	
+		event_handlers {
+			event = "custom-event"
+			trigger_fulfillment {
+				return_partial_responses = false
 				messages {
 					text {
-						text  = ["I didn't get that. Can you say it again?"]
+						text = ["I didn't get that. Can you say it again?"]
 					}
 				}
-		    }
+			}
+		}
+	
+		event_handlers {
+			event = "sys.no-match-default"
+			trigger_fulfillment {
+				return_partial_responses = false
+				messages {
+					response_type = "RESPONSE_TYPE_UNSPECIFIED"
+					text {
+						text = ["Sorry, could you say that again?"]
+					}
+				}
+			}
+		}
+	
+		event_handlers {
+			event = "sys.no-input-default"
+			trigger_fulfillment {
+				return_partial_responses = false
+				messages {
+					response_type = "ENTRY_PROMPT"
+					text {
+						text = ["One more time?"]
+					}
+				}
+			}
 		}
 
 		event_handlers {
-			event                    = "sys.no-match-default"
+			event = "another-event"
 			trigger_fulfillment {
-				 return_partial_responses = false
-				 messages {
-					 text {
-						 text  = ["Sorry, could you say that again?"]
-					 }
-				 }
-			 }
-		 }
-
-		 event_handlers {
-			event                    = "sys.no-input-default"
-			trigger_fulfillment {
-				 return_partial_responses = false
-				 messages {
-					 text {
-						 text  = ["One more time?"]
-					 }
-				 }
-			 }
-		 }
-    } 
-	  `, context)
+				return_partial_responses = true
+				messages {
+					channel = "some-channel"
+					text {
+						text = ["Some text"]
+					}
+				}
+				messages {
+					payload = <<EOF
+						{"some-key": "some-value", "other-key": ["other-value"]}
+					EOF
+				}
+				messages {
+					conversation_success {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					output_audio_text {
+						text = "some output text"
+					}
+				}
+				messages {
+					output_audio_text {
+						ssml = <<EOF
+							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+						EOF
+					}
+				}
+				messages {
+					live_agent_handoff {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					play_audio {
+						audio_uri = "http://example.com/some-audio-file.mp3"
+					}
+				}
+				messages {
+					telephony_transfer_call {
+						phone_number = "1-234-567-8901"
+					}
+				}
+	
+				tag = "some-tag"
+	
+				set_parameter_actions {
+					parameter = "some-param"
+					value     = "123.45"
+				}
+				set_parameter_actions {
+					parameter = "another-param"
+					value     = jsonencode("abc")
+				}
+				set_parameter_actions {
+					parameter = "other-param"
+					value     = jsonencode(["foo"])
+				}
+	
+				conditional_cases {
+					cases = [
+						jsonencode({
+							condition = "$sys.func.RAND() < 0.5",
+							caseContent = [
+								{
+									message = { text = ["First case"] }
+								},
+								{
+									additionalCases = {
+										cases = [
+											{
+												condition = "$sys.func.RAND() < 0.2"
+												caseContent = [
+													{
+														message = { text = ["Nested case"] }
+													}
+												]
+											}
+										]
+									}
+								}
+							]
+						}),
+						jsonencode({
+							condition = "",
+							caseContent = [
+								{
+									message = { text = ["Final case"] }
+								}
+							]
+						}),
+					]
+				}
+			}
+		}
+	}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -43,328 +43,327 @@ func TestAccDialogflowCXFlow_update(t *testing.T) {
 
 func testAccDialogflowCXFlow_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	data "google_project" "project" {}
+  data "google_project" "project" {}
 
-	resource "google_service_account" "dialogflowcx_service_account" {
-		account_id = "tf-test-dialogflow-%{random_suffix}"
-	}
+  resource "google_service_account" "dialogflowcx_service_account" {
+    account_id = "tf-test-dialogflow-%{random_suffix}"
+  }
 
-	resource "google_project_iam_member" "agent_create" {
-		project = data.google_project.project.project_id
-		role    = "roles/dialogflow.admin"
-		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
-	}
+  resource "google_project_iam_member" "agent_create" {
+    project = data.google_project.project.project_id
+    role    = "roles/dialogflow.admin"
+    member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
+  }
 
-	resource "google_dialogflow_cx_agent" "agent_entity" {
-		display_name             = "tf-test-%{random_suffix}"
-		location                 = "global"
-		default_language_code    = "en"
-		supported_language_codes = ["fr", "de", "es"]
-		time_zone                = "America/New_York"
-		description              = "Description 1."
-		avatar_uri               = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
-		depends_on               = [google_project_iam_member.agent_create]
-	}
+  resource "google_dialogflow_cx_agent" "agent_entity" {
+    display_name             = "tf-test-%{random_suffix}"
+    location                 = "global"
+    default_language_code    = "en"
+    supported_language_codes = ["fr", "de", "es"]
+    time_zone                = "America/New_York"
+    description              = "Description 1."
+    avatar_uri               = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
+    depends_on               = [google_project_iam_member.agent_create]
+  }
 
-	resource "google_dialogflow_cx_flow" "my_flow" {
-		parent       = google_dialogflow_cx_agent.agent_entity.id
-		display_name = "MyFlow"
+  resource "google_dialogflow_cx_flow" "my_flow" {
+    parent       = google_dialogflow_cx_agent.agent_entity.id
+    display_name = "MyFlow"
 
-		nlu_settings {
-			classification_threshold = 0.3
-			model_type               = "MODEL_TYPE_STANDARD"
-		}
-	}
+    nlu_settings {
+      classification_threshold = 0.3
+      model_type               = "MODEL_TYPE_STANDARD"
+    }
+  }
 `, context)
 }
 
 func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	data "google_project" "project" {}
+  data "google_project" "project" {}
 
-	resource "google_service_account" "dialogflowcx_service_account" {
-		account_id = "tf-test-dialogflow-%{random_suffix}"
-	}
+  resource "google_service_account" "dialogflowcx_service_account" {
+    account_id = "tf-test-dialogflow-%{random_suffix}"
+  }
 
-	resource "google_project_iam_member" "agent_create" {
-		project = data.google_project.project.project_id
-		role    = "roles/dialogflow.admin"
-		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
-	}
+  resource "google_project_iam_member" "agent_create" {
+    project = data.google_project.project.project_id
+    role    = "roles/dialogflow.admin"
+    member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
+  }
 
-	resource "google_dialogflow_cx_agent" "agent_entity" {
-		display_name               = "tf-test-dialogflowcx-agent%{random_suffix}update"
-		location                   = "global"
-		default_language_code      = "en"
-		supported_language_codes   = ["fr", "de", "es"]
-		time_zone                  = "America/New_York"
-		description                = "Example description."
-		avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
-		enable_stackdriver_logging = true
-		enable_spell_correction    = true
-		speech_to_text_settings {
-			enable_speech_adaptation = true
-		}
-		depends_on                 = [google_project_iam_member.agent_create]
-	}
-	
-	
-	resource "google_dialogflow_cx_flow" "my_flow" {
-		parent       = google_dialogflow_cx_agent.agent_entity.id
-		display_name = "MyFlow"
-		description  = "Test Flow"
-	
-		nlu_settings {
-			classification_threshold = 0.3
-			model_type               = "MODEL_TYPE_STANDARD"
-		}
-	
-		event_handlers {
-			event = "custom-event"
-			trigger_fulfillment {
-				return_partial_responses = false
-				messages {
-					text {
-						text = ["I didn't get that. Can you say it again?"]
-					}
-				}
-			}
-		}
-	
-		event_handlers {
-			event = "sys.no-match-default"
-			trigger_fulfillment {
-				return_partial_responses = false
-				messages {
-					response_type = "RESPONSE_TYPE_UNSPECIFIED"
-					text {
-						text = ["Sorry, could you say that again?"]
-					}
-				}
-			}
-		}
-	
-		event_handlers {
-			event = "sys.no-input-default"
-			trigger_fulfillment {
-				return_partial_responses = false
-				messages {
-					response_type = "ENTRY_PROMPT"
-					text {
-						text = ["One more time?"]
-					}
-				}
-			}
-		}
+  resource "google_dialogflow_cx_agent" "agent_entity" {
+    display_name               = "tf-test-dialogflowcx-agent%{random_suffix}update"
+    location                   = "global"
+    default_language_code      = "en"
+    supported_language_codes   = ["fr", "de", "es"]
+    time_zone                  = "America/New_York"
+    description                = "Example description."
+    avatar_uri                 = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+    enable_stackdriver_logging = true
+    enable_spell_correction    = true
+    speech_to_text_settings {
+      enable_speech_adaptation = true
+    }
+    depends_on                 = [google_project_iam_member.agent_create]
+  }
 
-		event_handlers {
-			event = "another-event"
-			trigger_fulfillment {
-				return_partial_responses = true
-				messages {
-					channel = "some-channel"
-					text {
-						text = ["Some text"]
-					}
-				}
-				messages {
-					payload = <<EOF
-						{"some-key": "some-value", "other-key": ["other-value"]}
-					EOF
-				}
-				messages {
-					conversation_success {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					output_audio_text {
-						text = "some output text"
-					}
-				}
-				messages {
-					output_audio_text {
-						ssml = <<EOF
-							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-						EOF
-					}
-				}
-				messages {
-					live_agent_handoff {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					play_audio {
-						audio_uri = "http://example.com/some-audio-file.mp3"
-					}
-				}
-				messages {
-					telephony_transfer_call {
-						phone_number = "1-234-567-8901"
-					}
-				}
-	
-				tag = "some-tag"
-	
-				set_parameter_actions {
-					parameter = "some-param"
-					value     = "123.45"
-				}
-				set_parameter_actions {
-					parameter = "another-param"
-					value     = jsonencode("abc")
-				}
-				set_parameter_actions {
-					parameter = "other-param"
-					value     = jsonencode(["foo"])
-				}
-	
-				conditional_cases {
-					cases = jsonencode([
-						{
-							condition = "$sys.func.RAND() < 0.5",
-							caseContent = [
-								{
-									message = { text = { text = ["First case"] } }
-								},
-								{
-									additionalCases = {
-										cases = [
-											{
-												condition = "$sys.func.RAND() < 0.2"
-												caseContent = [
-													{
-														message = { text = { text = ["Nested case"] } }
-													}
-												]
-											}
-										]
-									}
-								}
-							]
-						},
-						{
-							condition = "",
-							caseContent = [
-								{
-									message = { text = { text = ["Final case"] } }
-								}
-							]
-						},
-					])
-				}
-			}
-		}
+  resource "google_dialogflow_cx_flow" "my_flow" {
+    parent       = google_dialogflow_cx_agent.agent_entity.id
+    display_name = "MyFlow"
+    description  = "Test Flow"
+  
+    nlu_settings {
+      classification_threshold = 0.3
+      model_type               = "MODEL_TYPE_STANDARD"
+    }
+  
+    event_handlers {
+      event = "custom-event"
+      trigger_fulfillment {
+        return_partial_responses = false
+        messages {
+          text {
+            text = ["I didn't get that. Can you say it again?"]
+          }
+        }
+      }
+    }
 
-		transition_routes {
-			trigger_fulfillment {
-				return_partial_responses = true
-				messages {
-					channel = "some-channel"
-					response_type = "RESPONSE_TYPE_UNSPECIFIED"
-					text {
-						text = ["Some text"]
-					}
-				}
-				messages {
-					payload = <<EOF
-						{"some-key": "some-value", "other-key": ["other-value"]}
-					EOF
-				}
-				messages {
-					conversation_success {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					output_audio_text {
-						text = "some output text"
-					}
-				}
-				messages {
-					output_audio_text {
-						ssml = <<EOF
-							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-						EOF
-					}
-				}
-				messages {
-					live_agent_handoff {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					play_audio {
-						audio_uri = "http://example.com/some-audio-file.mp3"
-					}
-				}
-				messages {
-					telephony_transfer_call {
-						phone_number = "1-234-567-8901"
-					}
-				}
+    event_handlers {
+      event = "sys.no-match-default"
+      trigger_fulfillment {
+        return_partial_responses = false
+        messages {
+          response_type = "RESPONSE_TYPE_UNSPECIFIED"
+          text {
+            text = ["Sorry, could you say that again?"]
+          }
+        }
+      }
+    }
 
-				tag = "some-tag"
+    event_handlers {
+      event = "sys.no-input-default"
+      trigger_fulfillment {
+        return_partial_responses = false
+        messages {
+          response_type = "ENTRY_PROMPT"
+          text {
+            text = ["One more time?"]
+          }
+        }
+      }
+    }
 
-				set_parameter_actions {
-					parameter = "some-param"
-					value     = "123.45"
-				}
-				set_parameter_actions {
-					parameter = "another-param"
-					value     = jsonencode("abc")
-				}
-				set_parameter_actions {
-					parameter = "other-param"
-					value     = jsonencode(["foo"])
-				}
+    event_handlers {
+      event = "another-event"
+      trigger_fulfillment {
+        return_partial_responses = true
+        messages {
+          channel = "some-channel"
+          text {
+            text = ["Some text"]
+          }
+        }
+        messages {
+          payload = <<EOF
+            {"some-key": "some-value", "other-key": ["other-value"]}
+          EOF
+        }
+        messages {
+          conversation_success {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          output_audio_text {
+            text = "some output text"
+          }
+        }
+        messages {
+          output_audio_text {
+            ssml = <<EOF
+              <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+            EOF
+          }
+        }
+        messages {
+          live_agent_handoff {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          play_audio {
+            audio_uri = "http://example.com/some-audio-file.mp3"
+          }
+        }
+        messages {
+          telephony_transfer_call {
+            phone_number = "1-234-567-8901"
+          }
+        }
 
-				conditional_cases {
-					cases = jsonencode([
-						{
-							condition = "$sys.func.RAND() < 0.5",
-							caseContent = [
-								{
-									message = { text = { text = ["First case"] } }
-								},
-								{
-									additionalCases = {
-										cases = [
-											{
-												condition = "$sys.func.RAND() < 0.2"
-												caseContent = [
-													{
-														message = { text = { text = ["Nested case"] } }
-													}
-												]
-											}
-										]
-									}
-								}
-							]
-						},
-						{
-							condition = "",
-							caseContent = [
-								{
-									message = { text = { text = ["Final case"] } }
-								}
-							]
-						},
-					])
-				}
-			}
-			target_flow = google_dialogflow_cx_agent.agent_entity.start_flow
-		}
-	}
+        tag = "some-tag"
+
+        set_parameter_actions {
+          parameter = "some-param"
+          value     = "123.45"
+        }
+        set_parameter_actions {
+          parameter = "another-param"
+          value     = jsonencode("abc")
+        }
+        set_parameter_actions {
+          parameter = "other-param"
+          value     = jsonencode(["foo"])
+        }
+
+        conditional_cases {
+          cases = jsonencode([
+            {
+              condition = "$sys.func.RAND() < 0.5",
+              caseContent = [
+                {
+                  message = { text = { text = ["First case"] } }
+                },
+                {
+                  additionalCases = {
+                    cases = [
+                      {
+                        condition = "$sys.func.RAND() < 0.2"
+                        caseContent = [
+                          {
+                            message = { text = { text = ["Nested case"] } }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              condition = "",
+              caseContent = [
+                {
+                  message = { text = { text = ["Final case"] } }
+                }
+              ]
+            },
+          ])
+        }
+      }
+    }
+
+    transition_routes {
+      trigger_fulfillment {
+        return_partial_responses = true
+        messages {
+          channel = "some-channel"
+          response_type = "RESPONSE_TYPE_UNSPECIFIED"
+          text {
+            text = ["Some text"]
+          }
+        }
+        messages {
+          payload = <<EOF
+            {"some-key": "some-value", "other-key": ["other-value"]}
+          EOF
+        }
+        messages {
+          conversation_success {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          output_audio_text {
+            text = "some output text"
+          }
+        }
+        messages {
+          output_audio_text {
+            ssml = <<EOF
+              <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+            EOF
+          }
+        }
+        messages {
+          live_agent_handoff {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          play_audio {
+            audio_uri = "http://example.com/some-audio-file.mp3"
+          }
+        }
+        messages {
+          telephony_transfer_call {
+            phone_number = "1-234-567-8901"
+          }
+        }
+
+        tag = "some-tag"
+
+        set_parameter_actions {
+          parameter = "some-param"
+          value     = "123.45"
+        }
+        set_parameter_actions {
+          parameter = "another-param"
+          value     = jsonencode("abc")
+        }
+        set_parameter_actions {
+          parameter = "other-param"
+          value     = jsonencode(["foo"])
+        }
+
+        conditional_cases {
+          cases = jsonencode([
+            {
+              condition = "$sys.func.RAND() < 0.5",
+              caseContent = [
+                {
+                  message = { text = { text = ["First case"] } }
+                },
+                {
+                  additionalCases = {
+                    cases = [
+                      {
+                        condition = "$sys.func.RAND() < 0.2"
+                        caseContent = [
+                          {
+                            message = { text = { text = ["Nested case"] } }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              condition = "",
+              caseContent = [
+                {
+                  message = { text = { text = ["Final case"] } }
+                }
+              ]
+            },
+          ])
+        }
+      }
+      target_flow = google_dialogflow_cx_agent.agent_entity.start_flow
+    }
+  }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -157,8 +157,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
         }
       }
 
-      tag = "some-tag"
-
       set_parameter_actions {
         parameter = "some-param"
         value     = "123.45"
@@ -258,8 +256,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
             phone_number = "1-234-567-8901"
           }
         }
-
-        tag = "some-tag"
 
         set_parameter_actions {
           parameter = "some-param"
@@ -366,8 +362,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
               }
             }
 
-            tag = "some-tag"
-
             set_parameter_actions {
               parameter = "some-param"
               value     = "123.45"
@@ -420,6 +414,8 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
             trigger_fulfillment {
               return_partial_responses = true
               webhook = google_dialogflow_cx_webhook.my_webhook.id
+              tag = "some-tag"
+
               messages {
                 channel = "some-channel"
                 response_type = "PARAMETER_PROMPT"
@@ -468,8 +464,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
                   phone_number = "1-234-567-8901"
                 }
               }
-
-              tag = "some-tag"
 
               set_parameter_actions {
                 parameter = "some-param"
@@ -584,8 +578,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
             phone_number = "1-234-567-8901"
           }
         }
-
-        tag = "some-tag"
 
         set_parameter_actions {
           parameter = "some-param"

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -43,617 +43,617 @@ func TestAccDialogflowCXPage_update(t *testing.T) {
 
 func testAccDialogflowCXPage_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	data "google_project" "project" {}
+  data "google_project" "project" {}
 
-	resource "google_service_account" "dialogflowcx_service_account" {
-		account_id = "tf-test-dialogflow-%{random_suffix}"
-	}
+  resource "google_service_account" "dialogflowcx_service_account" {
+    account_id = "tf-test-dialogflow-%{random_suffix}"
+  }
 
-	resource "google_project_iam_member" "agent_create" {
-		project = data.google_project.project.project_id
-		role    = "roles/dialogflow.admin"
-		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
-	}
+  resource "google_project_iam_member" "agent_create" {
+    project = data.google_project.project.project_id
+    role    = "roles/dialogflow.admin"
+    member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
+  }
 
-	resource "google_dialogflow_cx_agent" "agent_page" {
-		display_name             = "tf-test-%{random_suffix}"
-		location                 = "global"
-		default_language_code    = "en"
-		supported_language_codes = ["fr", "de", "es"]
-		time_zone                = "America/New_York"
-		description              = "Description 1."
-		avatar_uri               = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
-		depends_on               = [google_project_iam_member.agent_create]
-	}
+  resource "google_dialogflow_cx_agent" "agent_page" {
+    display_name             = "tf-test-%{random_suffix}"
+    location                 = "global"
+    default_language_code    = "en"
+    supported_language_codes = ["fr", "de", "es"]
+    time_zone                = "America/New_York"
+    description              = "Description 1."
+    avatar_uri               = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
+    depends_on               = [google_project_iam_member.agent_create]
+  }
 
-	resource "google_dialogflow_cx_page" "my_page" {
-		parent       = google_dialogflow_cx_agent.agent_page.start_flow
-		display_name = "MyPage"
-	}
+  resource "google_dialogflow_cx_page" "my_page" {
+    parent       = google_dialogflow_cx_agent.agent_page.start_flow
+    display_name = "MyPage"
+  }
 `, context)
 }
 
 func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	data "google_project" "project" {}
+  data "google_project" "project" {}
 
-	resource "google_service_account" "dialogflowcx_service_account" {
-		account_id = "tf-test-dialogflow-%{random_suffix}"
-	}
+  resource "google_service_account" "dialogflowcx_service_account" {
+    account_id = "tf-test-dialogflow-%{random_suffix}"
+  }
 
-	resource "google_project_iam_member" "agent_create" {
-		project = data.google_project.project.project_id
-		role    = "roles/dialogflow.admin"
-		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
-	}
+  resource "google_project_iam_member" "agent_create" {
+    project = data.google_project.project.project_id
+    role    = "roles/dialogflow.admin"
+    member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
+  }
 
-	resource "google_dialogflow_cx_agent" "agent_page" {
-		display_name               = "tf-test-%{random_suffix}update"
-		location                   = "global"
-		default_language_code      = "en"
-		supported_language_codes   = ["no"]
-		time_zone                  = "Europe/London"
-		description                = "Description 2!"
-		avatar_uri                 = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo-2.png"
-		enable_stackdriver_logging = true
-		enable_spell_correction    = true
-		speech_to_text_settings {
-			enable_speech_adaptation = true
-		}
-		depends_on = [google_project_iam_member.agent_create]
-	}
+  resource "google_dialogflow_cx_agent" "agent_page" {
+    display_name               = "tf-test-%{random_suffix}update"
+    location                   = "global"
+    default_language_code      = "en"
+    supported_language_codes   = ["no"]
+    time_zone                  = "Europe/London"
+    description                = "Description 2!"
+    avatar_uri                 = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo-2.png"
+    enable_stackdriver_logging = true
+    enable_spell_correction    = true
+    speech_to_text_settings {
+      enable_speech_adaptation = true
+    }
+    depends_on = [google_project_iam_member.agent_create]
+  }
 
-	resource "google_dialogflow_cx_page" "my_page" {
-		parent       = google_dialogflow_cx_agent.agent_page.start_flow
-		display_name = "MyPage"
+  resource "google_dialogflow_cx_page" "my_page" {
+    parent       = google_dialogflow_cx_agent.agent_page.start_flow
+    display_name = "MyPage"
 
-		entry_fulfillment {
-			messages {
-				channel = "some-channel"
-				response_type = "ENTRY_PROMPT"
-				text {
-					text = ["Welcome to page"]
-				}
-			}
-			messages {
-				payload = <<EOF
-						{"some-key": "some-value", "other-key": ["other-value"]}
-				EOF
-			}
-			messages {
-				conversation_success {
-					metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-					EOF
-				}
-			}
-			messages {
-				output_audio_text {
-					text = "some output text"
-				}
-			}
-			messages {
-				output_audio_text {
-					ssml = <<EOF
-							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-					EOF
-				}
-			}
-			messages {
-				live_agent_handoff {
-					metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-					EOF
-				}
-			}
-			messages {
-				play_audio {
-					audio_uri = "http://example.com/some-audio-file.mp3"
-				}
-			}
-			messages {
-				telephony_transfer_call {
-					phone_number = "1-234-567-8901"
-				}
-			}
+    entry_fulfillment {
+      messages {
+        channel = "some-channel"
+        response_type = "ENTRY_PROMPT"
+        text {
+          text = ["Welcome to page"]
+        }
+      }
+      messages {
+        payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8901"
+        }
+      }
 
-			tag = "some-tag"
+      tag = "some-tag"
 
-			set_parameter_actions {
-				parameter = "some-param"
-				value     = "123.45"
-			}
-			set_parameter_actions {
-				parameter = "another-param"
-				value     = jsonencode("abc")
-			}
-			set_parameter_actions {
-				parameter = "other-param"
-				value     = jsonencode(["foo"])
-			}
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      set_parameter_actions {
+        parameter = "another-param"
+        value     = jsonencode("abc")
+      }
+      set_parameter_actions {
+        parameter = "other-param"
+        value     = jsonencode(["foo"])
+      }
 
-			conditional_cases {
-				cases = jsonencode([
-					{
-						condition = "$sys.func.RAND() < 0.5",
-						caseContent = [
-							{
-								message = { text = { text = ["First case"] } }
-							},
-							{
-								additionalCases = {
-									cases = [
-										{
-											condition = "$sys.func.RAND() < 0.2"
-											caseContent = [
-												{
-													message = { text = { text = ["Nested case"] } }
-												}
-											]
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						condition = "",
-						caseContent = [
-							{
-								message = { text = { text = ["Final case"] } }
-							}
-						]
-					},
-				])
-			}
-		}
+      conditional_cases {
+        cases = jsonencode([
+          {
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = { text = ["First case"] } }
+              },
+              {
+                additionalCases = {
+                  cases = [
+                    {
+                      condition = "$sys.func.RAND() < 0.2"
+                      caseContent = [
+                        {
+                          message = { text = { text = ["Nested case"] } }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            condition = "",
+            caseContent = [
+              {
+                message = { text = { text = ["Final case"] } }
+              }
+            ]
+          },
+        ])
+      }
+    }
 
-		event_handlers {
-			event = "some-event"
-			trigger_fulfillment {
-				return_partial_responses = true
-				messages {
-					channel = "some-channel"
-					text {
-						text = ["Some text"]
-					}
-				}
-				messages {
-					payload = <<EOF
-						{"some-key": "some-value", "other-key": ["other-value"]}
-					EOF
-				}
-				messages {
-					conversation_success {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					output_audio_text {
-						text = "some output text"
-					}
-				}
-				messages {
-					output_audio_text {
-						ssml = <<EOF
-							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-						EOF
-					}
-				}
-				messages {
-					live_agent_handoff {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					play_audio {
-						audio_uri = "http://example.com/some-audio-file.mp3"
-					}
-				}
-				messages {
-					telephony_transfer_call {
-						phone_number = "1-234-567-8901"
-					}
-				}
+    event_handlers {
+      event = "some-event"
+      trigger_fulfillment {
+        return_partial_responses = true
+        messages {
+          channel = "some-channel"
+          text {
+            text = ["Some text"]
+          }
+        }
+        messages {
+          payload = <<EOF
+            {"some-key": "some-value", "other-key": ["other-value"]}
+          EOF
+        }
+        messages {
+          conversation_success {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          output_audio_text {
+            text = "some output text"
+          }
+        }
+        messages {
+          output_audio_text {
+            ssml = <<EOF
+              <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+            EOF
+          }
+        }
+        messages {
+          live_agent_handoff {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          play_audio {
+            audio_uri = "http://example.com/some-audio-file.mp3"
+          }
+        }
+        messages {
+          telephony_transfer_call {
+            phone_number = "1-234-567-8901"
+          }
+        }
 
-				tag = "some-tag"
+        tag = "some-tag"
 
-				set_parameter_actions {
-					parameter = "some-param"
-					value     = "123.45"
-				}
-				set_parameter_actions {
-					parameter = "another-param"
-					value     = jsonencode("abc")
-				}
-				set_parameter_actions {
-					parameter = "other-param"
-					value     = jsonencode(["foo"])
-				}
+        set_parameter_actions {
+          parameter = "some-param"
+          value     = "123.45"
+        }
+        set_parameter_actions {
+          parameter = "another-param"
+          value     = jsonencode("abc")
+        }
+        set_parameter_actions {
+          parameter = "other-param"
+          value     = jsonencode(["foo"])
+        }
 
-				conditional_cases {
-					cases = jsonencode([
-						{
-							condition = "$sys.func.RAND() < 0.5",
-							caseContent = [
-								{
-									message = { text = { text = ["First case"] } }
-								},
-								{
-									additionalCases = {
-										cases = [
-											{
-												condition = "$sys.func.RAND() < 0.2"
-												caseContent = [
-													{
-														message = { text = { text = ["Nested case"] } }
-													}
-												]
-											}
-										]
-									}
-								}
-							]
-						},
-						{
-							condition = "",
-							caseContent = [
-								{
-									message = { text = { text = ["Final case"] } }
-								}
-							]
-						},
-					])
-				}
-			}
-		}
+        conditional_cases {
+          cases = jsonencode([
+            {
+              condition = "$sys.func.RAND() < 0.5",
+              caseContent = [
+                {
+                  message = { text = { text = ["First case"] } }
+                },
+                {
+                  additionalCases = {
+                    cases = [
+                      {
+                        condition = "$sys.func.RAND() < 0.2"
+                        caseContent = [
+                          {
+                            message = { text = { text = ["Nested case"] } }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              condition = "",
+              caseContent = [
+                {
+                  message = { text = { text = ["Final case"] } }
+                }
+              ]
+            },
+          ])
+        }
+      }
+    }
 
-		form {
-			parameters {
-				display_name = "param1"
-				entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
-				default_value = "2000-01-01"
-				fill_behavior {
-					initial_prompt_fulfillment {
-						messages {
-							channel = "some-channel"
-							response_type = "PARAMETER_PROMPT"
-							text {
-								text = ["Please provide param1"]
-							}
-						}
-						messages {
-							payload = <<EOF
-								{"some-key": "some-value", "other-key": ["other-value"]}
-							EOF
-						}
-						messages {
-							conversation_success {
-								metadata = <<EOF
-									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-								EOF
-							}
-						}
-						messages {
-							output_audio_text {
-								text = "some output text"
-							}
-						}
-						messages {
-							output_audio_text {
-								ssml = <<EOF
-									<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-								EOF
-							}
-						}
-						messages {
-							live_agent_handoff {
-								metadata = <<EOF
-									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-								EOF
-							}
-						}
-						messages {
-							play_audio {
-								audio_uri = "http://example.com/some-audio-file.mp3"
-							}
-						}
-						messages {
-							telephony_transfer_call {
-								phone_number = "1-234-567-8901"
-							}
-						}
+    form {
+      parameters {
+        display_name = "param1"
+        entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
+        default_value = "2000-01-01"
+        fill_behavior {
+          initial_prompt_fulfillment {
+            messages {
+              channel = "some-channel"
+              response_type = "PARAMETER_PROMPT"
+              text {
+                text = ["Please provide param1"]
+              }
+            }
+            messages {
+              payload = <<EOF
+                {"some-key": "some-value", "other-key": ["other-value"]}
+              EOF
+            }
+            messages {
+              conversation_success {
+                metadata = <<EOF
+                  {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+                EOF
+              }
+            }
+            messages {
+              output_audio_text {
+                text = "some output text"
+              }
+            }
+            messages {
+              output_audio_text {
+                ssml = <<EOF
+                  <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+                EOF
+              }
+            }
+            messages {
+              live_agent_handoff {
+                metadata = <<EOF
+                  {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+                EOF
+              }
+            }
+            messages {
+              play_audio {
+                audio_uri = "http://example.com/some-audio-file.mp3"
+              }
+            }
+            messages {
+              telephony_transfer_call {
+                phone_number = "1-234-567-8901"
+              }
+            }
 
-						tag = "some-tag"
+            tag = "some-tag"
 
-						set_parameter_actions {
-							parameter = "some-param"
-							value     = "123.45"
-						}
-						set_parameter_actions {
-							parameter = "another-param"
-							value     = jsonencode("abc")
-						}
-						set_parameter_actions {
-							parameter = "other-param"
-							value     = jsonencode(["foo"])
-						}
+            set_parameter_actions {
+              parameter = "some-param"
+              value     = "123.45"
+            }
+            set_parameter_actions {
+              parameter = "another-param"
+              value     = jsonencode("abc")
+            }
+            set_parameter_actions {
+              parameter = "other-param"
+              value     = jsonencode(["foo"])
+            }
 
-						conditional_cases {
-							cases = jsonencode([
-								{
-									condition = "$sys.func.RAND() < 0.5",
-									caseContent = [
-										{
-											message = { text = { text = ["First case"] } }
-										},
-										{
-											additionalCases = {
-												cases = [
-													{
-														condition = "$sys.func.RAND() < 0.2"
-														caseContent = [
-															{
-																message = { text = { text = ["Nested case"] } }
-															}
-														]
-													}
-												]
-											}
-										}
-									]
-								},
-								{
-									condition = "",
-									caseContent = [
-										{
-											message = { text = { text = ["Final case"] } }
-										}
-									]
-								},
-							])
-						}
-					}
-					reprompt_event_handlers {
-						event = "sys.no-match-1"
-						trigger_fulfillment {
-							return_partial_responses = true
-							webhook = google_dialogflow_cx_webhook.my_webhook.id
-							messages {
-								channel = "some-channel"
-								response_type = "PARAMETER_PROMPT"
-								text {
-									text = ["Please provide param1"]
-								}
-							}
-							messages {
-								payload = <<EOF
-									{"some-key": "some-value", "other-key": ["other-value"]}
-								EOF
-							}
-							messages {
-								conversation_success {
-									metadata = <<EOF
-										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-									EOF
-								}
-							}
-							messages {
-								output_audio_text {
-									text = "some output text"
-								}
-							}
-							messages {
-								output_audio_text {
-									ssml = <<EOF
-										<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-									EOF
-								}
-							}
-							messages {
-								live_agent_handoff {
-									metadata = <<EOF
-										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-									EOF
-								}
-							}
-							messages {
-								play_audio {
-									audio_uri = "http://example.com/some-audio-file.mp3"
-								}
-							}
-							messages {
-								telephony_transfer_call {
-									phone_number = "1-234-567-8901"
-								}
-							}
+            conditional_cases {
+              cases = jsonencode([
+                {
+                  condition = "$sys.func.RAND() < 0.5",
+                  caseContent = [
+                    {
+                      message = { text = { text = ["First case"] } }
+                    },
+                    {
+                      additionalCases = {
+                        cases = [
+                          {
+                            condition = "$sys.func.RAND() < 0.2"
+                            caseContent = [
+                              {
+                                message = { text = { text = ["Nested case"] } }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  condition = "",
+                  caseContent = [
+                    {
+                      message = { text = { text = ["Final case"] } }
+                    }
+                  ]
+                },
+              ])
+            }
+          }
+          reprompt_event_handlers {
+            event = "sys.no-match-1"
+            trigger_fulfillment {
+              return_partial_responses = true
+              webhook = google_dialogflow_cx_webhook.my_webhook.id
+              messages {
+                channel = "some-channel"
+                response_type = "PARAMETER_PROMPT"
+                text {
+                  text = ["Please provide param1"]
+                }
+              }
+              messages {
+                payload = <<EOF
+                  {"some-key": "some-value", "other-key": ["other-value"]}
+                EOF
+              }
+              messages {
+                conversation_success {
+                  metadata = <<EOF
+                    {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+                  EOF
+                }
+              }
+              messages {
+                output_audio_text {
+                  text = "some output text"
+                }
+              }
+              messages {
+                output_audio_text {
+                  ssml = <<EOF
+                    <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+                  EOF
+                }
+              }
+              messages {
+                live_agent_handoff {
+                  metadata = <<EOF
+                    {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+                  EOF
+                }
+              }
+              messages {
+                play_audio {
+                  audio_uri = "http://example.com/some-audio-file.mp3"
+                }
+              }
+              messages {
+                telephony_transfer_call {
+                  phone_number = "1-234-567-8901"
+                }
+              }
 
-							tag = "some-tag"
+              tag = "some-tag"
 
-							set_parameter_actions {
-								parameter = "some-param"
-								value     = "123.45"
-							}
-							set_parameter_actions {
-								parameter = "another-param"
-								value     = jsonencode("abc")
-							}
-							set_parameter_actions {
-								parameter = "other-param"
-								value     = jsonencode(["foo"])
-							}
+              set_parameter_actions {
+                parameter = "some-param"
+                value     = "123.45"
+              }
+              set_parameter_actions {
+                parameter = "another-param"
+                value     = jsonencode("abc")
+              }
+              set_parameter_actions {
+                parameter = "other-param"
+                value     = jsonencode(["foo"])
+              }
 
-							conditional_cases {
-								cases = jsonencode([
-									{
-										condition = "$sys.func.RAND() < 0.5",
-										caseContent = [
-											{
-												message = { text = { text = ["First case"] } }
-											},
-											{
-												additionalCases = {
-													cases = [
-														{
-															condition = "$sys.func.RAND() < 0.2"
-															caseContent = [
-																{
-																	message = { text = { text = ["Nested case"] } }
-																}
-															]
-														}
-													]
-												}
-											}
-										]
-									},
-									{
-										condition = "",
-										caseContent = [
-											{
-												message = { text = { text = ["Final case"] } }
-											}
-										]
-									},
-								])
-							}
-						}
-					}
-					reprompt_event_handlers {
-						event = "sys.no-match-2"
-						target_flow = google_dialogflow_cx_agent.agent_page.start_flow
-					}
-					reprompt_event_handlers {
-						event = "sys.no-match-3"
-						target_page = google_dialogflow_cx_page.my_page2.id
-					}
-				}
-				required = "true"
-				redact   = "true"
-			}
-		}
+              conditional_cases {
+                cases = jsonencode([
+                  {
+                    condition = "$sys.func.RAND() < 0.5",
+                    caseContent = [
+                      {
+                        message = { text = { text = ["First case"] } }
+                      },
+                      {
+                        additionalCases = {
+                          cases = [
+                            {
+                              condition = "$sys.func.RAND() < 0.2"
+                              caseContent = [
+                                {
+                                  message = { text = { text = ["Nested case"] } }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    condition = "",
+                    caseContent = [
+                      {
+                        message = { text = { text = ["Final case"] } }
+                      }
+                    ]
+                  },
+                ])
+              }
+            }
+          }
+          reprompt_event_handlers {
+            event = "sys.no-match-2"
+            target_flow = google_dialogflow_cx_agent.agent_page.start_flow
+          }
+          reprompt_event_handlers {
+            event = "sys.no-match-3"
+            target_page = google_dialogflow_cx_page.my_page2.id
+          }
+        }
+        required = "true"
+        redact   = "true"
+      }
+    }
 
-		transition_routes {
-			condition = "$page.params.status = 'FINAL'"
-			trigger_fulfillment {
-				messages {
-					channel = "some-channel"
-					response_type = "HANDLER_PROMPT"
-					text {
-						text = ["information completed, navigating to page 2"]
-					}
-				}
-				messages {
-					payload = <<EOF
-						{"some-key": "some-value", "other-key": ["other-value"]}
-					EOF
-				}
-				messages {
-					conversation_success {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					output_audio_text {
-						text = "some output text"
-					}
-				}
-				messages {
-					output_audio_text {
-						ssml = <<EOF
-							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-						EOF
-					}
-				}
-				messages {
-					live_agent_handoff {
-						metadata = <<EOF
-							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-						EOF
-					}
-				}
-				messages {
-					play_audio {
-						audio_uri = "http://example.com/some-audio-file.mp3"
-					}
-				}
-				messages {
-					telephony_transfer_call {
-						phone_number = "1-234-567-8901"
-					}
-				}
+    transition_routes {
+      condition = "$page.params.status = 'FINAL'"
+      trigger_fulfillment {
+        messages {
+          channel = "some-channel"
+          response_type = "HANDLER_PROMPT"
+          text {
+            text = ["information completed, navigating to page 2"]
+          }
+        }
+        messages {
+          payload = <<EOF
+            {"some-key": "some-value", "other-key": ["other-value"]}
+          EOF
+        }
+        messages {
+          conversation_success {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          output_audio_text {
+            text = "some output text"
+          }
+        }
+        messages {
+          output_audio_text {
+            ssml = <<EOF
+              <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+            EOF
+          }
+        }
+        messages {
+          live_agent_handoff {
+            metadata = <<EOF
+              {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+            EOF
+          }
+        }
+        messages {
+          play_audio {
+            audio_uri = "http://example.com/some-audio-file.mp3"
+          }
+        }
+        messages {
+          telephony_transfer_call {
+            phone_number = "1-234-567-8901"
+          }
+        }
 
-				tag = "some-tag"
+        tag = "some-tag"
 
-				set_parameter_actions {
-					parameter = "some-param"
-					value     = "123.45"
-				}
-				set_parameter_actions {
-					parameter = "another-param"
-					value     = jsonencode("abc")
-				}
-				set_parameter_actions {
-					parameter = "other-param"
-					value     = jsonencode(["foo"])
-				}
+        set_parameter_actions {
+          parameter = "some-param"
+          value     = "123.45"
+        }
+        set_parameter_actions {
+          parameter = "another-param"
+          value     = jsonencode("abc")
+        }
+        set_parameter_actions {
+          parameter = "other-param"
+          value     = jsonencode(["foo"])
+        }
 
-				conditional_cases {
-					cases = jsonencode([
-						{
-							condition = "$sys.func.RAND() < 0.5",
-							caseContent = [
-								{
-									message = { text = { text = ["First case"] } }
-								},
-								{
-									additionalCases = {
-										cases = [
-											{
-												condition = "$sys.func.RAND() < 0.2"
-												caseContent = [
-													{
-														message = { text = { text = ["Nested case"] } }
-													}
-												]
-											}
-										]
-									}
-								}
-							]
-						},
-						{
-							condition = "",
-							caseContent = [
-								{
-									message = { text = { text = ["Final case"] } }
-								}
-							]
-						},
-					])
-				}
-			}
-			target_page = google_dialogflow_cx_page.my_page2.id
-		}
-	}
+        conditional_cases {
+          cases = jsonencode([
+            {
+              condition = "$sys.func.RAND() < 0.5",
+              caseContent = [
+                {
+                  message = { text = { text = ["First case"] } }
+                },
+                {
+                  additionalCases = {
+                    cases = [
+                      {
+                        condition = "$sys.func.RAND() < 0.2"
+                        caseContent = [
+                          {
+                            message = { text = { text = ["Nested case"] } }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              condition = "",
+              caseContent = [
+                {
+                  message = { text = { text = ["Final case"] } }
+                }
+              ]
+            },
+          ])
+        }
+      }
+      target_page = google_dialogflow_cx_page.my_page2.id
+    }
+  }
 
-	resource "google_dialogflow_cx_page" "my_page2" {
-		parent       = google_dialogflow_cx_agent.agent_page.start_flow
-		display_name = "MyPage2"
-	}
+  resource "google_dialogflow_cx_page" "my_page2" {
+    parent       = google_dialogflow_cx_agent.agent_page.start_flow
+    display_name = "MyPage2"
+  }
 
-	resource "google_dialogflow_cx_webhook" "my_webhook" {
-		parent       = google_dialogflow_cx_agent.agent_page.id
-		display_name = "MyWebhook"
-		generic_web_service {
-			uri = "https://example.com"
-		}
-	}
+  resource "google_dialogflow_cx_webhook" "my_webhook" {
+    parent       = google_dialogflow_cx_agent.agent_page.id
+    display_name = "MyWebhook"
+    generic_web_service {
+      uri = "https://example.com"
+    }
+  }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -421,6 +421,8 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 					reprompt_event_handlers {
 						event = "sys.no-match-1"
 						trigger_fulfillment {
+							return_partial_responses = true
+							webhook = google_dialogflow_cx_webhook.my_webhook.id
 							messages {
 								channel = "some-channel"
 								response_type = "PARAMETER_PROMPT"
@@ -644,6 +646,14 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 	resource "google_dialogflow_cx_page" "my_page2" {
 		parent       = google_dialogflow_cx_agent.agent_page.start_flow
 		display_name = "MyPage2"
+	}
+
+	resource "google_dialogflow_cx_webhook" "my_webhook" {
+		parent       = google_dialogflow_cx_agent.agent_page.id
+		display_name = "MyWebhook"
+		generic_web_service {
+			uri = "https://example.com"
+		}
 	}
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -422,104 +422,102 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 						event = "sys.no-match-1"
 						trigger_fulfillment {
 							messages {
-								messages {
-									channel = "some-channel"
-									response_type = "PARAMETER_PROMPT"
-									text {
-										text = ["Please provide param1"]
-									}
+								channel = "some-channel"
+								response_type = "PARAMETER_PROMPT"
+								text {
+									text = ["Please provide param1"]
 								}
-								messages {
-									payload = <<EOF
-										{"some-key": "some-value", "other-key": ["other-value"]}
+							}
+							messages {
+								payload = <<EOF
+									{"some-key": "some-value", "other-key": ["other-value"]}
+								EOF
+							}
+							messages {
+								conversation_success {
+									metadata = <<EOF
+										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
 									EOF
 								}
-								messages {
-									conversation_success {
-										metadata = <<EOF
-											{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-										EOF
-									}
+							}
+							messages {
+								output_audio_text {
+									text = "some output text"
 								}
-								messages {
-									output_audio_text {
-										text = "some output text"
-									}
+							}
+							messages {
+								output_audio_text {
+									ssml = <<EOF
+										<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+									EOF
 								}
-								messages {
-									output_audio_text {
-										ssml = <<EOF
-											<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
-										EOF
-									}
+							}
+							messages {
+								live_agent_handoff {
+									metadata = <<EOF
+										{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+									EOF
 								}
-								messages {
-									live_agent_handoff {
-										metadata = <<EOF
-											{"some-metadata-key": "some-value", "other-metadata-key": 1234}
-										EOF
-									}
+							}
+							messages {
+								play_audio {
+									audio_uri = "http://example.com/some-audio-file.mp3"
 								}
-								messages {
-									play_audio {
-										audio_uri = "http://example.com/some-audio-file.mp3"
-									}
+							}
+							messages {
+								telephony_transfer_call {
+									phone_number = "1-234-567-8901"
 								}
-								messages {
-									telephony_transfer_call {
-										phone_number = "1-234-567-8901"
-									}
-								}
+							}
 
-								tag = "some-tag"
+							tag = "some-tag"
 
-								set_parameter_actions {
-									parameter = "some-param"
-									value     = "123.45"
-								}
-								set_parameter_actions {
-									parameter = "another-param"
-									value     = jsonencode("abc")
-								}
-								set_parameter_actions {
-									parameter = "other-param"
-									value     = jsonencode(["foo"])
-								}
+							set_parameter_actions {
+								parameter = "some-param"
+								value     = "123.45"
+							}
+							set_parameter_actions {
+								parameter = "another-param"
+								value     = jsonencode("abc")
+							}
+							set_parameter_actions {
+								parameter = "other-param"
+								value     = jsonencode(["foo"])
+							}
 
-								conditional_cases {
-									cases = [
-										jsonencode({
-											condition = "$sys.func.RAND() < 0.5",
-											caseContent = [
-												{
-													message = { text = ["First case"] }
-												},
-												{
-													additionalCases = {
-														cases = [
-															{
-																condition = "$sys.func.RAND() < 0.2"
-																caseContent = [
-																	{
-																		message = { text = ["Nested case"] }
-																	}
-																]
-															}
-														]
-													}
+							conditional_cases {
+								cases = [
+									jsonencode({
+										condition = "$sys.func.RAND() < 0.5",
+										caseContent = [
+											{
+												message = { text = ["First case"] }
+											},
+											{
+												additionalCases = {
+													cases = [
+														{
+															condition = "$sys.func.RAND() < 0.2"
+															caseContent = [
+																{
+																	message = { text = ["Nested case"] }
+																}
+															]
+														}
+													]
 												}
-											]
-										}),
-										jsonencode({
-											condition = "",
-											caseContent = [
-												{
-													message = { text = ["Final case"] }
-												}
-											]
-										}),
-									]
-								}
+											}
+										]
+									}),
+									jsonencode({
+										condition = "",
+										caseContent = [
+											{
+												message = { text = ["Final case"] }
+											}
+										]
+									}),
+								]
 							}
 						}
 					}

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -197,7 +197,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
             ]
           },
           {
-            condition = "",
             caseContent = [
               {
                 message = { text = { text = ["Final case"] } }
@@ -300,7 +299,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
               ]
             },
             {
-              condition = "",
               caseContent = [
                 {
                   message = { text = { text = ["Final case"] } }
@@ -408,7 +406,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
                   ]
                 },
                 {
-                  condition = "",
                   caseContent = [
                     {
                       message = { text = { text = ["Final case"] } }
@@ -512,7 +509,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
                     ]
                   },
                   {
-                    condition = "",
                     caseContent = [
                       {
                         message = { text = { text = ["Final case"] } }
@@ -629,7 +625,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
               ]
             },
             {
-              condition = "",
               caseContent = [
                 {
                   message = { text = { text = ["Final case"] } }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -110,7 +110,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
     entry_fulfillment {
       messages {
         channel = "some-channel"
-        response_type = "ENTRY_PROMPT"
         text {
           text = ["Welcome to page"]
         }
@@ -315,7 +314,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
           initial_prompt_fulfillment {
             messages {
               channel = "some-channel"
-              response_type = "PARAMETER_PROMPT"
               text {
                 text = ["Please provide param1"]
               }
@@ -418,7 +416,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 
               messages {
                 channel = "some-channel"
-                response_type = "PARAMETER_PROMPT"
                 text {
                   text = ["Please provide param1"]
                 }
@@ -532,7 +529,6 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
       trigger_fulfillment {
         messages {
           channel = "some-channel"
-          response_type = "HANDLER_PROMPT"
           text {
             text = ["information completed, navigating to page 2"]
           }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -56,21 +56,21 @@ func testAccDialogflowCXPage_basic(context map[string]interface{}) string {
 	}
 
 	resource "google_dialogflow_cx_agent" "agent_page" {
-		display_name = "tf-test-%{random_suffix}"
-		location = "global"
-		default_language_code = "en"
-		supported_language_codes = ["fr","de","es"]
-		time_zone = "America/New_York"
-		description = "Description 1."
-		avatar_uri = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
-		depends_on = [google_project_iam_member.agent_create]
+		display_name             = "tf-test-%{random_suffix}"
+		location                 = "global"
+		default_language_code    = "en"
+		supported_language_codes = ["fr", "de", "es"]
+		time_zone                = "America/New_York"
+		description              = "Description 1."
+		avatar_uri               = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
+		depends_on               = [google_project_iam_member.agent_create]
 	}
-    
+
 	resource "google_dialogflow_cx_page" "my_page" {
-        parent       = google_dialogflow_cx_agent.agent_page.start_flow
-        display_name  = "MyPage"
-    } 
-    `, context)
+		parent       = google_dialogflow_cx_agent.agent_page.start_flow
+		display_name = "MyPage"
+	}
+`, context)
 }
 
 func testAccDialogflowCXPage_full(context map[string]interface{}) string {
@@ -88,24 +88,24 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 	}
 
 	resource "google_dialogflow_cx_agent" "agent_page" {
-		display_name = "tf-test-%{random_suffix}update"
-		location = "global"
-		default_language_code = "en"
-		supported_language_codes = ["no"]
-		time_zone = "Europe/London"
-		description = "Description 2!"
-		avatar_uri = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo-2.png"
+		display_name               = "tf-test-%{random_suffix}update"
+		location                   = "global"
+		default_language_code      = "en"
+		supported_language_codes   = ["no"]
+		time_zone                  = "Europe/London"
+		description                = "Description 2!"
+		avatar_uri                 = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo-2.png"
 		enable_stackdriver_logging = true
-        enable_spell_correction    = true
+		enable_spell_correction    = true
 		speech_to_text_settings {
 			enable_speech_adaptation = true
 		}
 		depends_on = [google_project_iam_member.agent_create]
 	}
-    
+
 	resource "google_dialogflow_cx_page" "my_page" {
-        parent       = google_dialogflow_cx_agent.agent_page.start_flow
-        display_name  = "MyPage"
+		parent       = google_dialogflow_cx_agent.agent_page.start_flow
+		display_name = "MyPage"
 
 		entry_fulfillment {
 			messages {
@@ -141,14 +141,64 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 						text = ["information completed, navigating to page 2"]
 					}
 				}
+	
+				messages {
+					output_audio_text {
+						ssml = <<EOF
+							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+						EOF
+					}
+				}
+	
+				tag = "some-tag"
+	
+				set_parameter_actions {
+					parameter = "some-param"
+					value     = "123.45"
+				}
+	
+				conditional_cases {
+					cases = [
+						jsonencode({
+							condition = "$sys.func.RAND() < 0.5",
+							caseContent = [
+								{
+									message = { text = ["First case"] }
+								},
+								{
+									additionalCases = {
+										cases = [
+											{
+												condition = "$sys.func.RAND() < 0.2"
+												caseContent = [
+													{
+														message = { text = ["Nested case"] }
+													}
+												]
+											}
+										]
+									}
+								}
+							]
+						}),
+						jsonencode({
+							condition = "",
+							caseContent = [
+								{
+									message = { text = ["Final case"] }
+								}
+							]
+						}),
+					]
+				}
 			}
 			target_page = google_dialogflow_cx_page.my_page2.id
 		}
-    } 
-
+	}
+	
 	resource "google_dialogflow_cx_page" "my_page2" {
-        parent       = google_dialogflow_cx_agent.agent_page.start_flow
-        display_name  = "MyPage2"
-    } 
-	  `, context)
+		parent       = google_dialogflow_cx_agent.agent_page.start_flow
+		display_name = "MyPage2"
+	}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -173,12 +173,12 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 			}
 
 			conditional_cases {
-				cases = [
-					jsonencode({
+				cases = jsonencode([
+					{
 						condition = "$sys.func.RAND() < 0.5",
 						caseContent = [
 							{
-								message = { text = ["First case"] }
+								message = { text = { text = ["First case"] } }
 							},
 							{
 								additionalCases = {
@@ -187,7 +187,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 											condition = "$sys.func.RAND() < 0.2"
 											caseContent = [
 												{
-													message = { text = ["Nested case"] }
+													message = { text = { text = ["Nested case"] } }
 												}
 											]
 										}
@@ -195,16 +195,16 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 								}
 							}
 						]
-					}),
-					jsonencode({
+					},
+					{
 						condition = "",
 						caseContent = [
 							{
-								message = { text = ["Final case"] }
+								message = { text = { text = ["Final case"] } }
 							}
 						]
-					}),
-				]
+					},
+				])
 			}
 		}
 
@@ -276,12 +276,12 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 				}
 
 				conditional_cases {
-					cases = [
-						jsonencode({
+					cases = jsonencode([
+						{
 							condition = "$sys.func.RAND() < 0.5",
 							caseContent = [
 								{
-									message = { text = ["First case"] }
+									message = { text = { text = ["First case"] } }
 								},
 								{
 									additionalCases = {
@@ -290,7 +290,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 												condition = "$sys.func.RAND() < 0.2"
 												caseContent = [
 													{
-														message = { text = ["Nested case"] }
+														message = { text = { text = ["Nested case"] } }
 													}
 												]
 											}
@@ -298,16 +298,16 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 									}
 								}
 							]
-						}),
-						jsonencode({
+						},
+						{
 							condition = "",
 							caseContent = [
 								{
-									message = { text = ["Final case"] }
+									message = { text = { text = ["Final case"] } }
 								}
 							]
-						}),
-					]
+						},
+					])
 				}
 			}
 		}
@@ -384,12 +384,12 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 						}
 
 						conditional_cases {
-							cases = [
-								jsonencode({
+							cases = jsonencode([
+								{
 									condition = "$sys.func.RAND() < 0.5",
 									caseContent = [
 										{
-											message = { text = ["First case"] }
+											message = { text = { text = ["First case"] } }
 										},
 										{
 											additionalCases = {
@@ -398,7 +398,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 														condition = "$sys.func.RAND() < 0.2"
 														caseContent = [
 															{
-																message = { text = ["Nested case"] }
+																message = { text = { text = ["Nested case"] } }
 															}
 														]
 													}
@@ -406,16 +406,16 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 											}
 										}
 									]
-								}),
-								jsonencode({
+								},
+								{
 									condition = "",
 									caseContent = [
 										{
-											message = { text = ["Final case"] }
+											message = { text = { text = ["Final case"] } }
 										}
 									]
-								}),
-							]
+								},
+							])
 						}
 					}
 					reprompt_event_handlers {
@@ -488,12 +488,12 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 							}
 
 							conditional_cases {
-								cases = [
-									jsonencode({
+								cases = jsonencode([
+									{
 										condition = "$sys.func.RAND() < 0.5",
 										caseContent = [
 											{
-												message = { text = ["First case"] }
+												message = { text = { text = ["First case"] } }
 											},
 											{
 												additionalCases = {
@@ -502,7 +502,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 															condition = "$sys.func.RAND() < 0.2"
 															caseContent = [
 																{
-																	message = { text = ["Nested case"] }
+																	message = { text = { text = ["Nested case"] } }
 																}
 															]
 														}
@@ -510,16 +510,16 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 												}
 											}
 										]
-									}),
-									jsonencode({
+									},
+									{
 										condition = "",
 										caseContent = [
 											{
-												message = { text = ["Final case"] }
+												message = { text = { text = ["Final case"] } }
 											}
 										]
-									}),
-								]
+									},
+								])
 							}
 						}
 					}
@@ -605,12 +605,12 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 				}
 
 				conditional_cases {
-					cases = [
-						jsonencode({
+					cases = jsonencode([
+						{
 							condition = "$sys.func.RAND() < 0.5",
 							caseContent = [
 								{
-									message = { text = ["First case"] }
+									message = { text = { text = ["First case"] } }
 								},
 								{
 									additionalCases = {
@@ -619,7 +619,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 												condition = "$sys.func.RAND() < 0.2"
 												caseContent = [
 													{
-														message = { text = ["Nested case"] }
+														message = { text = { text = ["Nested case"] } }
 													}
 												]
 											}
@@ -627,16 +627,16 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 									}
 								}
 							]
-						}),
-						jsonencode({
+						},
+						{
 							condition = "",
 							caseContent = [
 								{
-									message = { text = ["Final case"] }
+									message = { text = { text = ["Final case"] } }
 								}
 							]
-						}),
-					]
+						},
+					])
 				}
 			}
 			target_page = google_dialogflow_cx_page.my_page2.id

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -316,7 +316,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
       parameters {
         display_name = "param1"
         entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
-        default_value = "2000-01-01"
+        default_value = jsonencode("2000-01-01")
         fill_behavior {
           initial_prompt_fulfillment {
             messages {

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -109,8 +109,205 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 
 		entry_fulfillment {
 			messages {
+				channel = "some-channel"
+				response_type = "ENTRY_PROMPT"
 				text {
 					text = ["Welcome to page"]
+				}
+			}
+			messages {
+				payload = <<EOF
+						{"some-key": "some-value", "other-key": ["other-value"]}
+				EOF
+			}
+			messages {
+				conversation_success {
+					metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+					EOF
+				}
+			}
+			messages {
+				output_audio_text {
+					text = "some output text"
+				}
+			}
+			messages {
+				output_audio_text {
+					ssml = <<EOF
+							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+					EOF
+				}
+			}
+			messages {
+				live_agent_handoff {
+					metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+					EOF
+				}
+			}
+			messages {
+				play_audio {
+					audio_uri = "http://example.com/some-audio-file.mp3"
+				}
+			}
+			messages {
+				telephony_transfer_call {
+					phone_number = "1-234-567-8901"
+				}
+			}
+
+			tag = "some-tag"
+
+			set_parameter_actions {
+				parameter = "some-param"
+				value     = "123.45"
+			}
+			set_parameter_actions {
+				parameter = "another-param"
+				value     = jsonencode("abc")
+			}
+			set_parameter_actions {
+				parameter = "other-param"
+				value     = jsonencode(["foo"])
+			}
+
+			conditional_cases {
+				cases = [
+					jsonencode({
+						condition = "$sys.func.RAND() < 0.5",
+						caseContent = [
+							{
+								message = { text = ["First case"] }
+							},
+							{
+								additionalCases = {
+									cases = [
+										{
+											condition = "$sys.func.RAND() < 0.2"
+											caseContent = [
+												{
+													message = { text = ["Nested case"] }
+												}
+											]
+										}
+									]
+								}
+							}
+						]
+					}),
+					jsonencode({
+						condition = "",
+						caseContent = [
+							{
+								message = { text = ["Final case"] }
+							}
+						]
+					}),
+				]
+			}
+		}
+
+		event_handlers {
+			event = "some-event"
+			trigger_fulfillment {
+				return_partial_responses = true
+				messages {
+					channel = "some-channel"
+					text {
+						text = ["Some text"]
+					}
+				}
+				messages {
+					payload = <<EOF
+						{"some-key": "some-value", "other-key": ["other-value"]}
+					EOF
+				}
+				messages {
+					conversation_success {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					output_audio_text {
+						text = "some output text"
+					}
+				}
+				messages {
+					output_audio_text {
+						ssml = <<EOF
+							<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+						EOF
+					}
+				}
+				messages {
+					live_agent_handoff {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					play_audio {
+						audio_uri = "http://example.com/some-audio-file.mp3"
+					}
+				}
+				messages {
+					telephony_transfer_call {
+						phone_number = "1-234-567-8901"
+					}
+				}
+
+				tag = "some-tag"
+
+				set_parameter_actions {
+					parameter = "some-param"
+					value     = "123.45"
+				}
+				set_parameter_actions {
+					parameter = "another-param"
+					value     = jsonencode("abc")
+				}
+				set_parameter_actions {
+					parameter = "other-param"
+					value     = jsonencode(["foo"])
+				}
+
+				conditional_cases {
+					cases = [
+						jsonencode({
+							condition = "$sys.func.RAND() < 0.5",
+							caseContent = [
+								{
+									message = { text = ["First case"] }
+								},
+								{
+									additionalCases = {
+										cases = [
+											{
+												condition = "$sys.func.RAND() < 0.2"
+												caseContent = [
+													{
+														message = { text = ["Nested case"] }
+													}
+												]
+											}
+										]
+									}
+								}
+							]
+						}),
+						jsonencode({
+							condition = "",
+							caseContent = [
+								{
+									message = { text = ["Final case"] }
+								}
+							]
+						}),
+					]
 				}
 			}
 		}
@@ -119,13 +316,220 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 			parameters {
 				display_name = "param1"
 				entity_type  = "projects/-/locations/-/agents/-/entityTypes/sys.date"
+				default_value = "2000-01-01"
 				fill_behavior {
 					initial_prompt_fulfillment {
 						messages {
+							channel = "some-channel"
+							response_type = "PARAMETER_PROMPT"
 							text {
 								text = ["Please provide param1"]
 							}
 						}
+						messages {
+							payload = <<EOF
+								{"some-key": "some-value", "other-key": ["other-value"]}
+							EOF
+						}
+						messages {
+							conversation_success {
+								metadata = <<EOF
+									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+								EOF
+							}
+						}
+						messages {
+							output_audio_text {
+								text = "some output text"
+							}
+						}
+						messages {
+							output_audio_text {
+								ssml = <<EOF
+									<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+								EOF
+							}
+						}
+						messages {
+							live_agent_handoff {
+								metadata = <<EOF
+									{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+								EOF
+							}
+						}
+						messages {
+							play_audio {
+								audio_uri = "http://example.com/some-audio-file.mp3"
+							}
+						}
+						messages {
+							telephony_transfer_call {
+								phone_number = "1-234-567-8901"
+							}
+						}
+
+						tag = "some-tag"
+
+						set_parameter_actions {
+							parameter = "some-param"
+							value     = "123.45"
+						}
+						set_parameter_actions {
+							parameter = "another-param"
+							value     = jsonencode("abc")
+						}
+						set_parameter_actions {
+							parameter = "other-param"
+							value     = jsonencode(["foo"])
+						}
+
+						conditional_cases {
+							cases = [
+								jsonencode({
+									condition = "$sys.func.RAND() < 0.5",
+									caseContent = [
+										{
+											message = { text = ["First case"] }
+										},
+										{
+											additionalCases = {
+												cases = [
+													{
+														condition = "$sys.func.RAND() < 0.2"
+														caseContent = [
+															{
+																message = { text = ["Nested case"] }
+															}
+														]
+													}
+												]
+											}
+										}
+									]
+								}),
+								jsonencode({
+									condition = "",
+									caseContent = [
+										{
+											message = { text = ["Final case"] }
+										}
+									]
+								}),
+							]
+						}
+					}
+					reprompt_event_handlers {
+						event = "sys.no-match-1"
+						trigger_fulfillment {
+							messages {
+								messages {
+									channel = "some-channel"
+									response_type = "PARAMETER_PROMPT"
+									text {
+										text = ["Please provide param1"]
+									}
+								}
+								messages {
+									payload = <<EOF
+										{"some-key": "some-value", "other-key": ["other-value"]}
+									EOF
+								}
+								messages {
+									conversation_success {
+										metadata = <<EOF
+											{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+										EOF
+									}
+								}
+								messages {
+									output_audio_text {
+										text = "some output text"
+									}
+								}
+								messages {
+									output_audio_text {
+										ssml = <<EOF
+											<speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+										EOF
+									}
+								}
+								messages {
+									live_agent_handoff {
+										metadata = <<EOF
+											{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+										EOF
+									}
+								}
+								messages {
+									play_audio {
+										audio_uri = "http://example.com/some-audio-file.mp3"
+									}
+								}
+								messages {
+									telephony_transfer_call {
+										phone_number = "1-234-567-8901"
+									}
+								}
+
+								tag = "some-tag"
+
+								set_parameter_actions {
+									parameter = "some-param"
+									value     = "123.45"
+								}
+								set_parameter_actions {
+									parameter = "another-param"
+									value     = jsonencode("abc")
+								}
+								set_parameter_actions {
+									parameter = "other-param"
+									value     = jsonencode(["foo"])
+								}
+
+								conditional_cases {
+									cases = [
+										jsonencode({
+											condition = "$sys.func.RAND() < 0.5",
+											caseContent = [
+												{
+													message = { text = ["First case"] }
+												},
+												{
+													additionalCases = {
+														cases = [
+															{
+																condition = "$sys.func.RAND() < 0.2"
+																caseContent = [
+																	{
+																		message = { text = ["Nested case"] }
+																	}
+																]
+															}
+														]
+													}
+												}
+											]
+										}),
+										jsonencode({
+											condition = "",
+											caseContent = [
+												{
+													message = { text = ["Final case"] }
+												}
+											]
+										}),
+									]
+								}
+							}
+						}
+					}
+					reprompt_event_handlers {
+						event = "sys.no-match-2"
+						target_flow = google_dialogflow_cx_agent.agent_page.start_flow
+					}
+					reprompt_event_handlers {
+						event = "sys.no-match-3"
+						target_page = google_dialogflow_cx_page.my_page2.id
 					}
 				}
 				required = "true"
@@ -137,11 +541,29 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 			condition = "$page.params.status = 'FINAL'"
 			trigger_fulfillment {
 				messages {
+					channel = "some-channel"
+					response_type = "HANDLER_PROMPT"
 					text {
 						text = ["information completed, navigating to page 2"]
 					}
 				}
-	
+				messages {
+					payload = <<EOF
+						{"some-key": "some-value", "other-key": ["other-value"]}
+					EOF
+				}
+				messages {
+					conversation_success {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					output_audio_text {
+						text = "some output text"
+					}
+				}
 				messages {
 					output_audio_text {
 						ssml = <<EOF
@@ -149,14 +571,39 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 						EOF
 					}
 				}
-	
+				messages {
+					live_agent_handoff {
+						metadata = <<EOF
+							{"some-metadata-key": "some-value", "other-metadata-key": 1234}
+						EOF
+					}
+				}
+				messages {
+					play_audio {
+						audio_uri = "http://example.com/some-audio-file.mp3"
+					}
+				}
+				messages {
+					telephony_transfer_call {
+						phone_number = "1-234-567-8901"
+					}
+				}
+
 				tag = "some-tag"
-	
+
 				set_parameter_actions {
 					parameter = "some-param"
 					value     = "123.45"
 				}
-	
+				set_parameter_actions {
+					parameter = "another-param"
+					value     = jsonencode("abc")
+				}
+				set_parameter_actions {
+					parameter = "other-param"
+					value     = jsonencode(["foo"])
+				}
+
 				conditional_cases {
 					cases = [
 						jsonencode({
@@ -195,7 +642,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 			target_page = google_dialogflow_cx_page.my_page2.id
 		}
 	}
-	
+
 	resource "google_dialogflow_cx_page" "my_page2" {
 		parent       = google_dialogflow_cx_agent.agent_page.start_flow
 		display_name = "MyPage2"


### PR DESCRIPTION
This fills out a bunch of stuff that was missing including:
- repromptEventHandlers (Fixes https://github.com/hashicorp/terraform-provider-google/issues/14573)
- setParameterActions (Fixes https://github.com/hashicorp/terraform-provider-google/issues/14572)
- payload, and other fulfillment messages (Fixes https://github.com/hashicorp/terraform-provider-google/issues/12946)
- conditionalCases (not requested in any open bugs that I could find)

I have deliberately skipped the following:
- [EndInteraction](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#EndInteraction) because it's "generated by Dialogflow only and not supposed to be defined by the user"
- [MixedAudio](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#MixedAudio) also because it's "generated by Dialogflow only and not supposed to be defined by the user"
- [KnowledgeInfoCard](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#knowledgeinfocard) because it contains no fields and I didn't know how to do that
- [ResponseType](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#responsetype) because, AFAICT, it's not an input.

I might have _accidentally_ missed some things too.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dialogflowcx: added `response_type`, `channel`, `payload`, `conversation_success`, `output_audio_text`, `live_agent_handoff`, `play_audo`, `telephony_transfer_call`, `set_parameter_actions`, and `conditional_cases` fields to `google_dialogflow_cx_flow` resource
```

```release-note:enhancement
dialogflowcx: added `response_type`, `channel`, `payload`, `conversation_success`, `output_audio_text`, `live_agent_handoff`, `play_audo`, `telephony_transfer_call`, `reprompt_event_handlers`, `set_parameter_actions`, and `conditional_cases` fields to `google_dialogflow_cx_page` resource
```