### PR TITLE
Removed guard around operation WithResponse method & improved error handling

### DIFF
--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -83,7 +83,6 @@ func create<%= product_name %>Waiter(config *transport_tpg.Config, op map[string
   return w, nil
 }
 
-<% if async.result.resource_inside_response -%>
 <%# Not all APIs will need a WithResponse operation, but it's hard to check whether
     they will or not since it involves iterating over all resources.
     Might as well just nolint it so we can pass the linter checks.
@@ -99,7 +98,6 @@ func <%= product_name.camelize() -%>OperationWaitTimeWithResponse(config *transp
   }
   return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
 }
-<% end -%>
 
 func <%= product_name.camelize() -%>OperationWaitTime(config *transport_tpg.Config, op map[string]interface{}, <% if has_project -%> project,<% end -%> activity, userAgent string, timeout time.Duration) error {
   if val, ok := op["name"]; !ok || val == "" {

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -12,9 +12,8 @@
 package <%= product_ns.downcase -%>
 
 import (
-<% if async.result.resource_inside_response -%>
   "encoding/json"
-<% end -%>
+  "errors"
   "fmt"
   "time"
 
@@ -96,7 +95,11 @@ func <%= product_name.camelize() -%>OperationWaitTimeWithResponse(config *transp
   if err := tpgresource.OperationWait(w, activity, timeout, config.PollInterval); err != nil {
       return err
   }
-  return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
+  rawResponse := []byte(w.CommonOperationWaiter.Op.Response)
+  if len(rawResponse) == 0 {
+    return errors.New("`resource` not set in operation response")
+  }
+  return json.Unmarshal(rawResponse, response)
 }
 
 func <%= product_name.camelize() -%>OperationWaitTime(config *transport_tpg.Config, op map[string]interface{}, <% if has_project -%> project,<% end -%> activity, userAgent string, timeout time.Duration) error {


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/15618 
Resolved https://github.com/hashicorp/terraform-provider-google/issues/15620

Reference: https://yaqs.corp.google.com/eng/q/4428772363542200320#a1n8

```release-note:bug
provider: Improved error message when resource creation fails to to invalid API response
```
