### PR TITLE
Fix TestAccDataformRepositoryReleaseConfig_dataformRepositoryReleaseC

### DIFF
--- a/mmv1/products/dataform/ReleaseConfig.yaml
+++ b/mmv1/products/dataform/ReleaseConfig.yaml
@@ -37,6 +37,7 @@ examples:
       git_repository_name: 'my/repository'
       dataform_repository_name: 'dataform_repository'
       data: secret-data
+      secret_name: my_secret
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/products/dataform/WorkflowConfig.yaml
+++ b/mmv1/products/dataform/WorkflowConfig.yaml
@@ -38,6 +38,7 @@ examples:
       git_repository_name: 'my/repository'
       dataform_repository_name: 'dataform_repository'
       data: secret-data
+      secret_name: my_secret
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
@@ -5,7 +5,7 @@ resource "google_sourcerepo_repository" "git_repository" {
 
 resource "google_secret_manager_secret" "secret" {
   provider  = google-beta
-  secret_id = "secret"
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
     automatic = true

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -5,7 +5,7 @@ resource "google_sourcerepo_repository" "git_repository" {
 
 resource "google_secret_manager_secret" "secret" {
   provider  = google-beta
-  secret_id = "<%= ctx[:vars]['my_secret'] %>"
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
     automatic = true

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -5,7 +5,7 @@ resource "google_sourcerepo_repository" "git_repository" {
 
 resource "google_secret_manager_secret" "secret" {
   provider  = google-beta
-  secret_id = "secret"
+  secret_id = "<%= ctx[:vars]['my_secret'] %>"
 
   replication {
     automatic = true


### PR DESCRIPTION
fixes two tests TestAccDataformRepositoryReleaseConfig_dataformRepositoryReleaseConfigExample

test error

```
        Error: Error creating Secret: googleapi: Error 409: Secret [projects/****/secrets/secret] already exists.
          with google_secret_manager_secret.secret,
          on terraform_plugin_test.tf line 7, in resource "google_secret_manager_secret" "secret":
           7: resource "google_secret_manager_secret" "secret" {

```
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
