### PR TITLE
Fix import of bigquery transfer config location

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -74,8 +74,9 @@ properties:
     output: true
     description: |
       The resource name of the transfer config. Transfer config names have the
-      form projects/{projectId}/locations/{location}/transferConfigs/{configId}.
-      Where configId is usually a uuid, but this is not required.
+      form projects/{projectId}/locations/{location}/transferConfigs/{configId}
+      or projects/{projectId}/transferConfigs/{configId},
+      where configId is usually a uuid, but this is not required.
       The name is ignored when creating a transfer config.
   - !ruby/object:Api::Type::String
     name: 'destinationDatasetId'

--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -31,7 +31,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/bigquery_data_transfer.go.erb
   decoder: templates/terraform/decoders/bigquery_data_transfer.go.erb
   encoder: templates/terraform/encoders/bigquery_data_transfer.go.erb
-  custom_import: templates/terraform/custom_import/self_link_as_name.erb
+  custom_import: templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb
 custom_diff: [
   'sensitiveParamCustomizeDiff',

--- a/mmv1/templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
+++ b/mmv1/templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
@@ -3,7 +3,7 @@ config := meta.(*transport_tpg.Config)
 	
 // current import_formats can't import fields with forward slashes in their value
 if err := tpgresource.ParseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)", "(?P<name>[^ ]+)"}, d, config); err != nil {
-    return nil, err
+	return nil, err
 }
 
 // import location if the name format follows: projects/{{project}}/locations/{{location}}/transferConfigs/{{config_id}}

--- a/mmv1/templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
+++ b/mmv1/templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
@@ -1,0 +1,21 @@
+
+config := meta.(*transport_tpg.Config)
+	
+// current import_formats can't import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)", "(?P<name>[^ ]+)"}, d, config); err != nil {
+    return nil, err
+}
+
+stringParts := strings.Split(d.Get("name").(string), "/")
+if len(stringParts) != 6 {
+	return nil, fmt.Errorf(
+			"Saw %s when the name is expected to have shape %s",
+			d.Get("name"),
+			"projects/{{project}}/locations/{{location}}/transferConfigs/{{config_id}}",
+		)
+}
+
+if err := d.Set("location", stringParts[3]); err != nil {
+	return nil, fmt.Errorf("Error setting location: %s", err)
+}
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
+++ b/mmv1/templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
@@ -6,16 +6,16 @@ if err := tpgresource.ParseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)
     return nil, err
 }
 
-stringParts := strings.Split(d.Get("name").(string), "/")
-if len(stringParts) != 6 {
-	return nil, fmt.Errorf(
-			"Saw %s when the name is expected to have shape %s",
-			d.Get("name"),
-			"projects/{{project}}/locations/{{location}}/transferConfigs/{{config_id}}",
-		)
+// import location if the name format follows: projects/{{project}}/locations/{{location}}/transferConfigs/{{config_id}}
+name := d.Get("name").(string)
+stringParts := strings.Split(name, "/")
+if len(stringParts) == 6 {
+	if err := d.Set("location", stringParts[3]); err != nil {
+		return nil, fmt.Errorf("Error setting location: %s", err)
+	}
+} else {
+	log.Printf("[INFO] Transfer config location not imported as it is not included in the name: %s", name)
 }
 
-if err := d.Set("location", stringParts[3]); err != nil {
-	return nil, fmt.Errorf("Error setting location: %s", err)
-}
+
 return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix the custom import code for bigquery transfer config, and make it import the location properly.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12011

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquerydatatransfer: fixed a bug when importing 'location' of 'google_bigquery_data_transfer_config'
```
