### PR TITLE
Marks `template.volumes.secret.items.mode` field not required in Cloud Run V2 resources

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -568,7 +568,6 @@ properties:
                               The Cloud Secret Manager secret version. Can be 'latest' for the latest value or an integer for a specific version
                           - !ruby/object:Api::Type::Integer
                             name: 'mode'
-                            required: true
                             description: |-
                               Integer octal mode bits to use on this file, must be a value between 01 and 0777 (octal). If 0 or not set, the Volume's default mode will be used.
                 - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -687,7 +687,6 @@ properties:
                           The Cloud Secret Manager secret version. Can be 'latest' for the latest value or an integer for a specific version
                       - !ruby/object:Api::Type::Integer
                         name: 'mode'
-                        required: true
                         description: |-
                           Integer octal mode bits to use on this file, must be a value between 01 and 0777 (octal). If 0 or not set, the Volume's default mode will be used.
             - !ruby/object:Api::Type::NestedObject

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
@@ -12,7 +12,6 @@ resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
         items {
           version = "1"
           path = "my-secret"
-          mode = 256 # 0400
         }
       }
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I think this field was marked as required initially by mistake. Our API doesn't require this field and doesn't set a service side default value.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: Changed `template.volumes.secret.items.mode` field in `google_cloud_run_v2_job` resource to a non-required field.
```

```release-note:enhancement
cloudrunv2: Changed `template.volumes.secret.items.mode` field in `google_cloud_run_v2_service` resource to a non-required field.
```
