### PR TITLE
making allowPscGlobalAccess in ForwardingRule resource updatable

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -626,6 +626,10 @@ properties:
       This is used in PSC consumer ForwardingRule to control whether the PSC
       endpoint can be accessed from another region.
     send_empty_value: true
+    update_verb: :PATCH
+    update_url: projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}
+    update_id: 'allowPscGlobalAccess'
+    fingerprint_name: 'fingerprint'
   - !ruby/object:Api::Type::Boolean
     name: noAutomateDnsZone
     description:

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -183,10 +183,18 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
-				Config: testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context),
+			{
+				Config: testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context, true),
 			},
-			resource.TestStep{
+			{
+				ResourceName:      "google_compute_forwarding_rule.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context, false),
+			},
+			{
 				ResourceName:      "google_compute_forwarding_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -549,7 +557,15 @@ resource "google_service_directory_service" "examplesvc" {
 }
 <% end -%>
 
-func testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context map[string]interface{}) string {
+func testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context map[string]interface{}, preventDestroy bool) string {
+  context["lifecycle_block"] = ""
+	if preventDestroy {
+		context["lifecycle_block"] = `
+		lifecycle {
+			prevent_destroy = true
+		}`
+	}
+
 	return acctest.Nprintf(`
 // Forwarding rule for VPC private service connect
 resource "google_compute_forwarding_rule" "default" {
@@ -560,6 +576,7 @@ resource "google_compute_forwarding_rule" "default" {
   network                 = google_compute_network.consumer_net.name
   ip_address              = google_compute_address.consumer_address.id
   allow_psc_global_access = false
+  %{lifecycle_block}
 }
 
 // Consumer service endpoint


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15586

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: field `allowPscGlobalAccess` is now updatable in `google_compute_forwarding_rule` resource
```
