### PR TITLE
Fix TestAccFirebaseWebApp_firebaseWebAppFull

### DIFF
--- a/mmv1/third_party/terraform/services/firebase/resource_firebase_web_app_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/resource_firebase_web_app_test.go.erb
@@ -31,21 +31,9 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"google": {
-						VersionConstraint: "4.58.0",
-						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
-					},
-				},
 				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "", "key1"),
 			},
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"google": {
-						VersionConstraint: "4.58.0",
-						Source:            "hashicorp/google<%= "-" + version unless version == 'ga'  -%>",
-					},
-				},
 				Config: testAccFirebaseWebApp_firebaseWebAppFull(context, "2", "key2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.default", "api_key"),


### PR DESCRIPTION
Test was using hard-locked version of the provider


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
