### PR TITLE
Removed MembershipRBACRoleBinding from ga provider

### DIFF
--- a/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
@@ -17,6 +17,7 @@ base_url: 'projects/{{project}}/locations/{{location}}/memberships/{{membership_
 create_url: 'projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/rbacrolebindings/?rbacrolebinding_id={{membership_rbac_role_binding_id}}'
 self_link: 'projects/{{project}}/locations/{{location}}/memberships/{{membership_id}}/rbacrolebindings/{{membership_rbac_role_binding_id}}'
 immutable: true
+min_version: beta
 description: |
   RBACRoleBinding represents a rbacrolebinding across the Fleet.
 references: !ruby/object:Api::Resource::ReferenceLinks
@@ -47,6 +48,7 @@ examples:
     name: 'gkehub_membership_rbac_role_binding_basic'
     primary_resource_name: 'fmt.Sprintf(\"tf-test-membership%s\", context[\"random_suffix\"]), fmt.Sprintf(\"tf-test-rbac-role-binding%s\", context[\"random_suffix\"])'
     primary_resource_id: 'membershiprbacrolebinding'
+    min_version: beta
     vars:
       cluster_name: "basiccluster"
     test_env_vars:

--- a/mmv1/templates/terraform/examples/gkehub_membership_rbac_role_binding_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_rbac_role_binding_basic.tf.erb
@@ -1,21 +1,24 @@
 resource "google_container_cluster" "primary" {
+  provider = google-beta
   name               = "<%= ctx[:vars]['cluster_name'] %>"
   location           = "us-central1-a"
   initial_node_count = 1
 }
 
 resource "google_gke_hub_membership" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   membership_id = "tf-test-membership%{random_suffix}"
   endpoint {
     gke_cluster {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-  
+
   depends_on = [google_container_cluster.primary]
 }
 
 resource "google_gke_hub_membership_rbac_role_binding" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   membership_rbac_role_binding_id = "tf-test-membership-rbac-role-binding%{random_suffix}"
   membership_id = "tf-test-membership%{random_suffix}"
   user = "service-${data.google_project.project.number}@gcp-sa-anthossupport.iam.gserviceaccount.com"
@@ -26,4 +29,6 @@ resource "google_gke_hub_membership_rbac_role_binding" "<%= ctx[:primary_resourc
   depends_on = [google_gke_hub_membership.<%= ctx[:primary_resource_id] %>]
 }
 
-data "google_project" "project" {}
+data "google_project" "project" {
+  provider = google-beta
+}


### PR DESCRIPTION
Fix forward for https://github.com/GoogleCloudPlatform/magic-modules/pull/8440

https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_NightlyTests_GOOGLE_PACKAGE_GKEHUB2/16141?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildTestsSection=true&expandBuildChangesSection=true

The change to add this resource to the GA provider is breaking as the API doesn't appear to support it at the GA level. As it has not been released yet I will remove this resource from the GA provider and cherry pick it into our 4.80.0 release branches.

```
=== RUN   TestAccGKEHub2MembershipRBACRoleBinding_gkehubMembershipRbacRoleBindingBasicExample
=== PAUSE TestAccGKEHub2MembershipRBACRoleBinding_gkehubMembershipRbacRoleBindingBasicExample
=== CONT  TestAccGKEHub2MembershipRBACRoleBinding_gkehubMembershipRbacRoleBindingBasicExample
    vcr_utils.go:152: Step 1/2 error: Error running apply: exit status 1
        Error: Error creating MembershipRBACRoleBinding: googleapi: got HTTP response code 404 with body: <!DOCTYPE html>
```
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
