### PR TITLE
Mark `num_finite_buckets` required for cloud logging metric bucket_options

### DIFF
--- a/mmv1/products/logging/Metric.yaml
+++ b/mmv1/products/logging/Metric.yaml
@@ -211,20 +211,14 @@ properties:
             required: true
           - !ruby/object:Api::Type::Double
             name: width
-            at_least_one_of:
-              - bucket_options.0.linear_buckets.0.num_finite_buckets
-              - bucket_options.0.linear_buckets.0.width
-              - bucket_options.0.linear_buckets.0.offset
             description: |
               Must be greater than 0.
+            required: true
           - !ruby/object:Api::Type::Double
             name: offset
-            at_least_one_of:
-              - bucket_options.0.linear_buckets.0.num_finite_buckets
-              - bucket_options.0.linear_buckets.0.width
-              - bucket_options.0.linear_buckets.0.offset
             description: |
               Lower bound of the first bucket.
+            required: true
       - !ruby/object:Api::Type::NestedObject
         name: exponentialBuckets
         at_least_one_of:
@@ -242,20 +236,14 @@ properties:
             required: true
           - !ruby/object:Api::Type::Double
             name: growthFactor
-            at_least_one_of:
-              - bucket_options.0.exponential_buckets.0.num_finite_buckets
-              - bucket_options.0.exponential_buckets.0.growth_factor
-              - bucket_options.0.exponential_buckets.0.scale
             description: |
               Must be greater than 1.
+            required: true
           - !ruby/object:Api::Type::Double
             name: scale
-            at_least_one_of:
-              - bucket_options.0.exponential_buckets.0.num_finite_buckets
-              - bucket_options.0.exponential_buckets.0.growth_factor
-              - bucket_options.0.exponential_buckets.0.scale
             description: |
               Must be greater than 0.
+            required: true
       - !ruby/object:Api::Type::NestedObject
         name: explicitBuckets
         at_least_one_of:

--- a/mmv1/products/logging/Metric.yaml
+++ b/mmv1/products/logging/Metric.yaml
@@ -212,6 +212,7 @@ properties:
               - bucket_options.0.linear_buckets.0.offset
             description: |
               Must be greater than 0.
+            required: true
           - !ruby/object:Api::Type::Double
             name: width
             at_least_one_of:
@@ -246,6 +247,7 @@ properties:
               - bucket_options.0.exponential_buckets.0.scale
             description: |
               Must be greater than 0.
+            required: true
           - !ruby/object:Api::Type::Double
             name: growthFactor
             at_least_one_of:

--- a/mmv1/products/logging/Metric.yaml
+++ b/mmv1/products/logging/Metric.yaml
@@ -206,10 +206,6 @@ properties:
         properties:
           - !ruby/object:Api::Type::Integer
             name: numFiniteBuckets
-            at_least_one_of:
-              - bucket_options.0.linear_buckets.0.num_finite_buckets
-              - bucket_options.0.linear_buckets.0.width
-              - bucket_options.0.linear_buckets.0.offset
             description: |
               Must be greater than 0.
             required: true
@@ -241,10 +237,6 @@ properties:
         properties:
           - !ruby/object:Api::Type::Integer
             name: numFiniteBuckets
-            at_least_one_of:
-              - bucket_options.0.exponential_buckets.0.num_finite_buckets
-              - bucket_options.0.exponential_buckets.0.growth_factor
-              - bucket_options.0.exponential_buckets.0.scale
             description: |
               Must be greater than 0.
             required: true

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -37,7 +37,6 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
-		ForceNew:    true,
 		Description: `Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package logging
 
 import (
@@ -37,7 +39,7 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
-                ForceNew:    true,
+		ForceNew:    true,
 		Description: `Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package logging
 
 import (

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -37,6 +37,7 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
+                ForceNew:    true,
 		Description: `Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

 Fixes https://github.com/hashicorp/terraform-provider-google/issues/12964


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
logging: made `growth_factor`, `num_finite_buckets`, and `scale` required for `google_logging_metric`
```
