### PR TITLE
Artifact Registry: implement VPC SC Config

### DIFF
--- a/mmv1/products/artifactregistry/VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/VPCSCConfig.yaml
@@ -32,6 +32,8 @@ update_verb: :PATCH
 skip_delete: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
+    # Requires VPC SC Policy configured on organization
+    skip_test: true
     name: 'artifact_registry_vpcsc_config'
     primary_resource_id: 'my-config'
 autogen_async: false

--- a/mmv1/products/artifactregistry/VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/VPCSCConfig.yaml
@@ -23,13 +23,13 @@ docs: !ruby/object:Provider::Terraform::Docs
     VPC SC configs are automatically created for a given location. Creating a
     resource of this type will acquire and update the resource that already
     exists at the location. Deleting this resource will remove the config from
-    your Terraform state and reset the config.
+    your Terraform state but leave the resource as is.
 base_url: 'projects/{{project}}/locations/{{location}}/vpcscConfig'
 self_link: 'projects/{{project}}/locations/{{location}}/vpcscConfig'
 create_url: 'projects/{{project}}/locations/{{location}}/vpcscConfig'
 create_verb: :PATCH
 update_verb: :PATCH
-delete_verb: :PATCH
+skip_delete: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     # Requires VPC SC Policy configured on organization

--- a/mmv1/products/artifactregistry/VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/VPCSCConfig.yaml
@@ -32,8 +32,6 @@ update_verb: :PATCH
 skip_delete: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    # Requires VPC SC Policy configured on organization
-    skip_test: true
     name: 'artifact_registry_vpcsc_config'
     primary_resource_id: 'my-config'
 autogen_async: false

--- a/mmv1/products/artifactregistry/VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/VPCSCConfig.yaml
@@ -1,0 +1,70 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'VPCSCConfig'
+description: |-
+  The Artifact Registry VPC SC config that applies to a Project.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/artifact-registry/docs/reference/rest/v1/VPCSCConfig'
+min_version: beta
+docs: !ruby/object:Provider::Terraform::Docs
+  note: |-
+    VPC SC configs are automatically created for a given location. Creating a
+    resource of this type will acquire and update the resource that already
+    exists at the location. Deleting this resource will remove the config from
+    your Terraform state and reset the config.
+base_url: 'projects/{{project}}/locations/{{location}}/vpcscConfig'
+self_link: 'projects/{{project}}/locations/{{location}}/vpcscConfig'
+create_url: 'projects/{{project}}/locations/{{location}}/vpcscConfig'
+create_verb: :PATCH
+update_verb: :PATCH
+delete_verb: :PATCH
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    # Requires VPC SC Policy configured on organization
+    skip_test: true
+    name: 'artifact_registry_vpcsc_config'
+    primary_resource_id: 'my-config'
+autogen_async: false
+async: !ruby/object:Api::OpAsync
+  actions: []
+  # necessary to compile
+  operation: !ruby/object:Api::OpAsync::Operation
+    base_url: '{{op_id}}'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  encoder: templates/terraform/encoders/location_from_region.go.erb
+parameters:
+  - !ruby/object:Api::Type::String
+    name: location
+    required: false
+    immutable: true
+    url_param_only: true
+    default_from_api: true
+    description: |
+      The name of the location this config is located in.
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |-
+      The name of the project's VPC SC Config.
+      Always of the form: projects/{project}/location/{location}/vpcscConfig
+properties:
+  - !ruby/object:Api::Type::Enum
+    name: vpcscPolicy
+    min_version: beta
+    description: |-
+      The VPC SC policy for project and location.
+    values:
+      - :DENY
+      - :ALLOW

--- a/mmv1/templates/terraform/examples/artifact_registry_vpcsc_config.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_vpcsc_config.tf.erb
@@ -1,0 +1,6 @@
+resource "google_artifact_registry_vpcsc_config" "<%= ctx[:primary_resource_id] %>" {
+  provider      = google-beta
+  location      = "us-central1"
+  vpcsc_policy   = "ALLOW"
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Implements VPC SC Config resource in beta provider.
Fixes hashicorp/terraform-provider-google#15622

The example cannot run as a test because the resource requires enabling VPC SC on the organization.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_artifact_registry_vpcsc_config`
```
