### PR TITLE
Add initial version of a plugin-framework provider config test, move code between packages to allow tests

### DIFF
--- a/mmv1/third_party/terraform/acctest/framework_test_utils.go.erb
+++ b/mmv1/third_party/terraform/acctest/framework_test_utils.go.erb
@@ -5,18 +5,12 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"reflect"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
 
 func GetFwTestProvider(t *testing.T) *frameworkTestProvider {
@@ -79,49 +73,4 @@ func testStringValue(sPtr *string) string {
 	}
 
 	return *sPtr
-}
-
-// This function isn't a test of transport.go; instead, it is used as an alternative
-// to ReplaceVars inside tests.
-func ReplaceVarsForFrameworkTest(prov *fwtransport.FrameworkProviderConfig, rs *terraform.ResourceState, linkTmpl string) (string, error) {
-	re := regexp.MustCompile("{{([[:word:]]+)}}")
-	var project, region, zone string
-
-	if strings.Contains(linkTmpl, "{{project}}") {
-		project = rs.Primary.Attributes["project"]
-	}
-
-	if strings.Contains(linkTmpl, "{{region}}") {
-		region = tpgresource.GetResourceNameFromSelfLink(rs.Primary.Attributes["region"])
-	}
-
-	if strings.Contains(linkTmpl, "{{zone}}") {
-		zone = tpgresource.GetResourceNameFromSelfLink(rs.Primary.Attributes["zone"])
-	}
-
-	replaceFunc := func(s string) string {
-		m := re.FindStringSubmatch(s)[1]
-		if m == "project" {
-			return project
-		}
-		if m == "region" {
-			return region
-		}
-		if m == "zone" {
-			return zone
-		}
-
-		if v, ok := rs.Primary.Attributes[m]; ok {
-			return v
-		}
-
-		// Attempt to draw values from the provider
-		if f := reflect.Indirect(reflect.ValueOf(prov)).FieldByName(m); f.IsValid() {
-			return f.String()
-		}
-
-		return ""
-	}
-
-	return re.ReplaceAllStringFunc(linkTmpl, replaceFunc), nil
 }

--- a/mmv1/third_party/terraform/acctest/test_utils.go.erb
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.erb
@@ -205,3 +205,50 @@ func CreateZIPArchiveForCloudFunctionSource(t *testing.T, sourcePath string) str
 	}
 	return tmpfile.Name()
 }
+
+// providerConfigEnvNames returns a list of all the environment variables that could be set by a user to configure the provider
+func providerConfigEnvNames() []string {
+
+	envs := []string{}
+
+	// Use existing collections of ENV names
+	envVarsSets := [][]string{
+		envvar.CredsEnvVars,   // credentials field
+		envvar.ProjectEnvVars, // project field
+		envvar.RegionEnvVars,  //region field
+		envvar.ZoneEnvVars,    // zone field
+	}
+	for _, set := range envVarsSets {
+		envs = append(envs, set...)
+	}
+
+	// Add remaining ENVs
+	envs = append(envs, "GOOGLE_OAUTH_ACCESS_TOKEN")          // access_token field
+	envs = append(envs, "GOOGLE_BILLING_PROJECT")             // billing_project field
+	envs = append(envs, "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT") // impersonate_service_account field
+	envs = append(envs, "USER_PROJECT_OVERRIDE")              // user_project_override field
+	envs = append(envs, "CLOUDSDK_CORE_REQUEST_REASON")       // request_reason field
+
+	return envs
+}
+
+// UnsetProviderConfigEnvs unsets any ENVs in the test environment that
+// configure the provider.
+// The testing package will restore the original values after the test
+func UnsetTestProviderConfigEnvs(t *testing.T) {
+	envs := providerConfigEnvNames()
+	if len(envs) > 0 {
+		for _, k := range envs {
+			t.Setenv(k, "")
+		}
+	}
+}
+
+func SetupTestEnvs(t *testing.T, envValues map[string]string) {
+	// Set ENVs
+	if len(envValues) > 0 {
+		for k, v := range envValues {
+			t.Setenv(k, v)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/acctest/test_utils.go.erb
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.erb
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func CheckDataSourceStateMatchesResourceState(dataSourceName, resourceName string) func(*terraform.State) error {
@@ -251,4 +252,10 @@ func SetupTestEnvs(t *testing.T, envValues map[string]string) {
 			t.Setenv(k, v)
 		}
 	}
+}
+
+// Returns a fake credentials JSON string with the client_email set to a test-specific value
+func GenerateFakeCredentialsJson(testId string) string {
+	json := fmt.Sprintf(`{"private_key_id": "foo","private_key": "bar","client_email": "%s@example.com","client_id": "id@foo.com","type": "service_account"}`, testId)
+	return json
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_test.go.erb
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -223,7 +224,7 @@ func testAccCheckDNSManagedZoneDestroyProducerFramework(t *testing.T) func(s *te
 
 			p := acctest.GetFwTestProvider(t)
 
-			url, err := acctest.ReplaceVarsForFrameworkTest(&p.FrameworkProvider.FrameworkProviderConfig, rs, "{{DNSBasePath}}projects/{{project}}/managedZones/{{name}}")
+			url, err := fwresource.ReplaceVarsForFrameworkTest(&p.FrameworkProvider.FrameworkProviderConfig, rs, "{{DNSBasePath}}projects/{{project}}/managedZones/{{name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/fwresource/field_helpers.go
+++ b/mmv1/third_party/terraform/fwresource/field_helpers.go
@@ -2,10 +2,14 @@ package fwresource
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
 
@@ -61,4 +65,49 @@ func ParseProjectFieldValueFramework(resourceType, fieldValue, projectSchemaFiel
 
 		ResourceType: resourceType,
 	}
+}
+
+// This function isn't a test of transport.go; instead, it is used as an alternative
+// to ReplaceVars inside tests.
+func ReplaceVarsForFrameworkTest(prov *fwtransport.FrameworkProviderConfig, rs *terraform.ResourceState, linkTmpl string) (string, error) {
+	re := regexp.MustCompile("{{([[:word:]]+)}}")
+	var project, region, zone string
+
+	if strings.Contains(linkTmpl, "{{project}}") {
+		project = rs.Primary.Attributes["project"]
+	}
+
+	if strings.Contains(linkTmpl, "{{region}}") {
+		region = tpgresource.GetResourceNameFromSelfLink(rs.Primary.Attributes["region"])
+	}
+
+	if strings.Contains(linkTmpl, "{{zone}}") {
+		zone = tpgresource.GetResourceNameFromSelfLink(rs.Primary.Attributes["zone"])
+	}
+
+	replaceFunc := func(s string) string {
+		m := re.FindStringSubmatch(s)[1]
+		if m == "project" {
+			return project
+		}
+		if m == "region" {
+			return region
+		}
+		if m == "zone" {
+			return zone
+		}
+
+		if v, ok := rs.Primary.Attributes[m]; ok {
+			return v
+		}
+
+		// Attempt to draw values from the provider
+		if f := reflect.Indirect(reflect.ValueOf(prov)).FieldByName(m); f.IsValid() {
+			return f.String()
+		}
+
+		return ""
+	}
+
+	return re.ReplaceAllStringFunc(linkTmpl, replaceFunc), nil
 }

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
@@ -40,6 +40,77 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 			},
 			ExpectedValue: types.StringValue("my-project-from-config"),
 		},
+		"project value can be set by environment variable: GOOGLE_PROJECT is used first": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringNull(), // unset
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_PROJECT":        "project-from-GOOGLE_PROJECT",
+				"GOOGLE_CLOUD_PROJECT":  "project-from-GOOGLE_CLOUD_PROJECT",
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: types.StringValue("project-from-GOOGLE_PROJECT"),
+		},
+		"project value can be set by environment variable: GOOGLE_CLOUD_PROJECT is used second": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringNull(), // unset
+			},
+			EnvVariables: map[string]string{
+				// GOOGLE_PROJECT unset
+				"GOOGLE_CLOUD_PROJECT":  "project-from-GOOGLE_CLOUD_PROJECT",
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: types.StringValue("project-from-GOOGLE_CLOUD_PROJECT"),
+		},
+		"project value can be set by environment variable: GCLOUD_PROJECT is used third": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringNull(), // unset
+			},
+			EnvVariables: map[string]string{
+				// GOOGLE_PROJECT unset
+				// GOOGLE_CLOUD_PROJECT unset
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: types.StringValue("project-from-GCLOUD_PROJECT"),
+		},
+		"project value can be set by environment variable: CLOUDSDK_CORE_PROJECT is used fourth": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringNull(), // unset
+			},
+			EnvVariables: map[string]string{
+				// GOOGLE_PROJECT unset
+				// GOOGLE_CLOUD_PROJECT unset
+				// GCLOUD_PROJECT unset
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: types.StringValue("project-from-CLOUDSDK_CORE_PROJECT"),
+		},
+		"when no project values are provided via config or environment variables, the field remains unset without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringNull(), // unset
+			},
+			ExpectedValue: types.StringNull(),
+		},
+		// Handling empty strings in config
+		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
+		// "when project is set as an empty string the field is treated as if it's unset, without error": {
+		// 	ConfigValues: fwmodels.ProviderModel{
+		// 		Project: types.StringValue(""),
+		// 	},
+		// 	ExpectedValue: types.StringNull(),
+		// },
+		// "when project is set as an empty string an environment variable will be used": {
+		// 	ConfigValues: fwmodels.ProviderModel{
+		// 		Project: types.StringValue(""),
+		// 	},
+		// 	EnvVariables: map[string]string{
+		// 		"GOOGLE_PROJECT": "project-from-GOOGLE_PROJECT",
+		// 	},
+		// 	ExpectedValue: types.StringValue("project-from-GOOGLE_PROJECT"),
+		// },
 	}
 
 	for tn, tc := range cases {

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
@@ -1,0 +1,82 @@
+package fwtransport_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
+	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValues  map[string]interface{}
+		EnvVariables  map[string]string
+		ExpectedValue string
+		ExpectError   bool
+	}{
+		"project value set in the provider schema is not overridden by environment variables": {
+			ConfigValues: map[string]interface{}{
+				"project": "my-project-from-config",
+				// See hardcoded values in test function
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_PROJECT":        "project-from-GOOGLE_PROJECT",
+				"GOOGLE_CLOUD_PROJECT":  "project-from-GOOGLE_CLOUD_PROJECT",
+				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
+			},
+			ExpectedValue: "my-project-from-config",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			ctx := context.Background()
+			unsetTestProviderConfigEnvs(t) // inaccessible due to being in the provider_test package
+			setupTestEnvs(t, tc.EnvVariables)
+
+			tfVersion := "foobar"
+			providerversion := "999"
+			diags := diag.Diagnostics{}
+
+			impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{})
+
+			data := fwmodels.ProviderModel{
+				Project: types.StringValue(tc.ExpectedValue),
+
+				// We need to set the below fields to stop the code under tests experiencing errors
+				// Credentials: If we don't set this then the test looks for application default credentials and can fail depending on the machine running the test
+				// ImpersonateServiceAccountDelegates: If we don't set this, we get a nil pointer exception ¯\_(ツ)_/¯
+				Credentials:                        types.StringValue(transport_tpg.TestFakeCredentialsPath),
+				ImpersonateServiceAccountDelegates: impersonateServiceAccountDelegates,
+			}
+
+			p := fwtransport.FrameworkProviderConfig{}
+			p.LoadAndValidateFramework(ctx, data, tfVersion, &diags, providerversion)
+
+			if diags.HasError() && tc.ExpectError {
+				return
+			}
+			if diags.HasError() && !tc.ExpectError {
+				for i, err := range diags.Errors() {
+					num := i + 1
+					t.Logf("unexpected error #%d : %s", num, err.Summary())
+				}
+				t.Fatalf("did not expect error, but [%d] error(s) occurred", diags.ErrorsCount())
+			}
+			if p.Project.IsNull() {
+				t.Fatalf("want project to be `%s`, but the value is null [null=%v]", tc.ExpectedValue, p.Project.IsNull())
+			}
+			if !p.Project.Equal(types.StringValue(tc.ExpectedValue)) {
+				t.Fatalf("want project to be `%s`, but got the value `%s`", tc.ExpectedValue, p.Project.String())
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package fwtransport_test
 
 import (
@@ -7,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
@@ -14,16 +16,21 @@ import (
 )
 
 func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
+
+	// Note: In the test function we need to set the below fields in test case's fwmodels.ProviderModel value
+	// this is to stop the code under tests experiencing errors, and could be addressed in future refactoring.
+	// - Credentials: If we don't set this then the test looks for application default credentials and can fail depending on the machine running the test
+	// - ImpersonateServiceAccountDelegates: If we don't set this, we get a nil pointer exception ¯\_(ツ)_/¯
+
 	cases := map[string]struct {
-		ConfigValues  map[string]interface{}
+		ConfigValues  fwmodels.ProviderModel
 		EnvVariables  map[string]string
-		ExpectedValue string
+		ExpectedValue basetypes.StringValue
 		ExpectError   bool
 	}{
 		"project value set in the provider schema is not overridden by environment variables": {
-			ConfigValues: map[string]interface{}{
-				"project": "my-project-from-config",
-				// See hardcoded values in test function
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringValue("my-project-from-config"),
 			},
 			EnvVariables: map[string]string{
 				"GOOGLE_PROJECT":        "project-from-GOOGLE_PROJECT",
@@ -31,7 +38,7 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
 				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
 			},
-			ExpectedValue: "my-project-from-config",
+			ExpectedValue: types.StringValue("my-project-from-config"),
 		},
 	}
 
@@ -39,29 +46,25 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 
 			// Arrange
-			ctx := context.Background()
 			acctest.UnsetTestProviderConfigEnvs(t)
 			acctest.SetupTestEnvs(t, tc.EnvVariables)
 
+			ctx := context.Background()
 			tfVersion := "foobar"
 			providerversion := "999"
 			diags := diag.Diagnostics{}
-
-			impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{})
-
-			data := fwmodels.ProviderModel{
-				Project: types.StringValue(tc.ExpectedValue),
-
-				// We need to set the below fields to stop the code under tests experiencing errors
-				// Credentials: If we don't set this then the test looks for application default credentials and can fail depending on the machine running the test
-				// ImpersonateServiceAccountDelegates: If we don't set this, we get a nil pointer exception ¯\_(ツ)_/¯
-				Credentials:                        types.StringValue(transport_tpg.TestFakeCredentialsPath),
-				ImpersonateServiceAccountDelegates: impersonateServiceAccountDelegates,
-			}
+			
+			data := tc.ConfigValues
+			data.Credentials = types.StringValue(transport_tpg.TestFakeCredentialsPath)
+			impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{}) // empty list
+			data.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
 
 			p := fwtransport.FrameworkProviderConfig{}
+
+			// Act
 			p.LoadAndValidateFramework(ctx, data, tfVersion, &diags, providerversion)
 
+			// Assert
 			if diags.HasError() && tc.ExpectError {
 				return
 			}
@@ -72,10 +75,7 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				}
 				t.Fatalf("did not expect error, but [%d] error(s) occurred", diags.ErrorsCount())
 			}
-			if p.Project.IsNull() {
-				t.Fatalf("want project to be `%s`, but the value is null [null=%v]", tc.ExpectedValue, p.Project.IsNull())
-			}
-			if !p.Project.Equal(types.StringValue(tc.ExpectedValue)) {
+			if !p.Project.Equal(tc.ExpectedValue) {
 				t.Fatalf("want project to be `%s`, but got the value `%s`", tc.ExpectedValue, p.Project.String())
 			}
 		})

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -39,8 +40,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t) // inaccessible due to being in the provider_test package
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 
 			tfVersion := "foobar"
 			providerversion := "999"

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
@@ -23,10 +23,11 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 	// - ImpersonateServiceAccountDelegates: If we don't set this, we get a nil pointer exception ¯\_(ツ)_/¯
 
 	cases := map[string]struct {
-		ConfigValues  fwmodels.ProviderModel
-		EnvVariables  map[string]string
-		ExpectedValue basetypes.StringValue
-		ExpectError   bool
+		ConfigValues              fwmodels.ProviderModel
+		EnvVariables              map[string]string
+		ExpectedDataModelValue    basetypes.StringValue // Sometimes the value is mutated, and no longer matches the original value we supply
+		ExpectedConfigStructValue basetypes.StringValue // Sometimes the value in config struct differs from what is in the data model
+		ExpectError               bool
 	}{
 		"project value set in the provider schema is not overridden by environment variables": {
 			ConfigValues: fwmodels.ProviderModel{
@@ -38,7 +39,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
 				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
 			},
-			ExpectedValue: types.StringValue("my-project-from-config"),
+			ExpectedDataModelValue:    types.StringValue("my-project-from-config"),
+			ExpectedConfigStructValue: types.StringValue("my-project-from-config"),
 		},
 		"project value can be set by environment variable: GOOGLE_PROJECT is used first": {
 			ConfigValues: fwmodels.ProviderModel{
@@ -50,7 +52,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
 				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
 			},
-			ExpectedValue: types.StringValue("project-from-GOOGLE_PROJECT"),
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringValue("project-from-GOOGLE_PROJECT"),
 		},
 		"project value can be set by environment variable: GOOGLE_CLOUD_PROJECT is used second": {
 			ConfigValues: fwmodels.ProviderModel{
@@ -62,7 +65,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
 				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
 			},
-			ExpectedValue: types.StringValue("project-from-GOOGLE_CLOUD_PROJECT"),
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringValue("project-from-GOOGLE_CLOUD_PROJECT"),
 		},
 		"project value can be set by environment variable: GCLOUD_PROJECT is used third": {
 			ConfigValues: fwmodels.ProviderModel{
@@ -74,7 +78,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				"GCLOUD_PROJECT":        "project-from-GCLOUD_PROJECT",
 				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
 			},
-			ExpectedValue: types.StringValue("project-from-GCLOUD_PROJECT"),
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringValue("project-from-GCLOUD_PROJECT"),
 		},
 		"project value can be set by environment variable: CLOUDSDK_CORE_PROJECT is used fourth": {
 			ConfigValues: fwmodels.ProviderModel{
@@ -86,13 +91,15 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				// GCLOUD_PROJECT unset
 				"CLOUDSDK_CORE_PROJECT": "project-from-CLOUDSDK_CORE_PROJECT",
 			},
-			ExpectedValue: types.StringValue("project-from-CLOUDSDK_CORE_PROJECT"),
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringValue("project-from-CLOUDSDK_CORE_PROJECT"),
 		},
 		"when no project values are provided via config or environment variables, the field remains unset without error": {
 			ConfigValues: fwmodels.ProviderModel{
 				Project: types.StringNull(), // unset
 			},
-			ExpectedValue: types.StringNull(),
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringNull(),
 		},
 		// Handling empty strings in config
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
@@ -100,7 +107,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 		// 	ConfigValues: fwmodels.ProviderModel{
 		// 		Project: types.StringValue(""),
 		// 	},
-		// 	ExpectedValue: types.StringNull(),
+		// 	ExpectedDataModelValue:    types.StringNull(),
+		// 	ExpectedConfigStructValue: types.StringNull(),
 		// },
 		// "when project is set as an empty string an environment variable will be used": {
 		// 	ConfigValues: fwmodels.ProviderModel{
@@ -109,7 +117,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 		// 	EnvVariables: map[string]string{
 		// 		"GOOGLE_PROJECT": "project-from-GOOGLE_PROJECT",
 		// 	},
-		// 	ExpectedValue: types.StringValue("project-from-GOOGLE_PROJECT"),
+		// 	ExpectedDataModelValue:    types.StringNull(),
+		// 	ExpectedConfigStructValue: types.StringValue("project-from-GOOGLE_PROJECT"),
 		// },
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
@@ -117,7 +126,8 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 		// 	ConfigValues: fwmodels.ProviderModel{
 		// 		Project: types.StringUnknown(),
 		// 	},
-		// 	ExpectedValue: types.StringNull(),
+		// 	ExpectedDataModelValue:    types.StringNull(),
+		// 	ExpectedConfigStructValue: types.StringNull(),
 		// },
 	}
 
@@ -154,8 +164,13 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 				}
 				t.Fatalf("did not expect error, but [%d] error(s) occurred", diags.ErrorsCount())
 			}
-			if !p.Project.Equal(tc.ExpectedValue) {
-				t.Fatalf("want project to be `%s`, but got the value `%s`", tc.ExpectedValue, p.Project.String())
+			// Checking mutation of the data model
+			if !data.Project.Equal(tc.ExpectedDataModelValue) {
+				t.Fatalf("want project in the `fwmodels.ProviderModel` struct to be `%s`, but got the value `%s`", tc.ExpectedDataModelValue, data.Project.String())
+			}
+			// Checking the value passed to the config structs
+			if !p.Project.Equal(tc.ExpectedConfigStructValue) {
+				t.Fatalf("want project in the `FrameworkProviderConfig` struct to be `%s`, but got the value `%s`", tc.ExpectedConfigStructValue, p.Project.String())
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.erb
@@ -111,6 +111,14 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 		// 	},
 		// 	ExpectedValue: types.StringValue("project-from-GOOGLE_PROJECT"),
 		// },
+		// Handling unknown values
+		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
+		// "when project is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
+		// 	ConfigValues: fwmodels.ProviderModel{
+		// 		Project: types.StringUnknown(),
+		// 	},
+		// 	ExpectedValue: types.StringNull(),
+		// },
 	}
 
 	for tn, tc := range cases {

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 
@@ -83,12 +82,6 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 	}
 }
 
-// Returns a fake credentials JSON string with the client_email set to a test-specific value
-func generateFakeCredentialsJson(testId string) string {
-	json := fmt.Sprintf(`{"private_key_id": "foo","private_key": "bar","client_email": "%s@example.com","client_id": "id@foo.com","type": "service_account"}`, testId)
-	return json
-}
-
 func TestProvider_ProviderConfigure_credentials(t *testing.T) {
 
 	const pathToMissingFile string = "./this/path/doesnt/exist.json" // Doesn't exist
@@ -119,46 +112,46 @@ func TestProvider_ProviderConfigure_credentials(t *testing.T) {
 		},
 		"credentials set in the config are not overridden by environment variables": {
 			ConfigValues: map[string]interface{}{
-				"credentials": generateFakeCredentialsJson("test"),
+				"credentials": acctest.GenerateFakeCredentialsJson("test"),
 			},
 			EnvVariables: map[string]string{
-				"GOOGLE_CREDENTIALS":             generateFakeCredentialsJson("GOOGLE_CREDENTIALS"),
-				"GOOGLE_CLOUD_KEYFILE_JSON":      generateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
-				"GCLOUD_KEYFILE_JSON":            generateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
-				"GOOGLE_APPLICATION_CREDENTIALS": generateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
+				"GOOGLE_CREDENTIALS":             acctest.GenerateFakeCredentialsJson("GOOGLE_CREDENTIALS"),
+				"GOOGLE_CLOUD_KEYFILE_JSON":      acctest.GenerateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
+				"GCLOUD_KEYFILE_JSON":            acctest.GenerateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
+				"GOOGLE_APPLICATION_CREDENTIALS": acctest.GenerateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
 			},
-			ExpectedSchemaValue: generateFakeCredentialsJson("test"),
-			ExpectedConfigValue: generateFakeCredentialsJson("test"),
+			ExpectedSchemaValue: acctest.GenerateFakeCredentialsJson("test"),
+			ExpectedConfigValue: acctest.GenerateFakeCredentialsJson("test"),
 		},
 		"when credentials is unset in the config, environment variables are used: GOOGLE_CREDENTIALS used first": {
 			EnvVariables: map[string]string{
-				"GOOGLE_CREDENTIALS":             generateFakeCredentialsJson("GOOGLE_CREDENTIALS"),
-				"GOOGLE_CLOUD_KEYFILE_JSON":      generateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
-				"GCLOUD_KEYFILE_JSON":            generateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
-				"GOOGLE_APPLICATION_CREDENTIALS": generateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
+				"GOOGLE_CREDENTIALS":             acctest.GenerateFakeCredentialsJson("GOOGLE_CREDENTIALS"),
+				"GOOGLE_CLOUD_KEYFILE_JSON":      acctest.GenerateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
+				"GCLOUD_KEYFILE_JSON":            acctest.GenerateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
+				"GOOGLE_APPLICATION_CREDENTIALS": acctest.GenerateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
 			},
 			ExpectedSchemaValue: "",
-			ExpectedConfigValue: generateFakeCredentialsJson("GOOGLE_CREDENTIALS"),
+			ExpectedConfigValue: acctest.GenerateFakeCredentialsJson("GOOGLE_CREDENTIALS"),
 		},
 		"when credentials is unset in the config, environment variables are used: GOOGLE_CLOUD_KEYFILE_JSON used second": {
 			EnvVariables: map[string]string{
 				// GOOGLE_CREDENTIALS not set
-				"GOOGLE_CLOUD_KEYFILE_JSON":      generateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
-				"GCLOUD_KEYFILE_JSON":            generateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
-				"GOOGLE_APPLICATION_CREDENTIALS": generateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
+				"GOOGLE_CLOUD_KEYFILE_JSON":      acctest.GenerateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
+				"GCLOUD_KEYFILE_JSON":            acctest.GenerateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
+				"GOOGLE_APPLICATION_CREDENTIALS": acctest.GenerateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
 			},
 			ExpectedSchemaValue: "",
-			ExpectedConfigValue: generateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
+			ExpectedConfigValue: acctest.GenerateFakeCredentialsJson("GOOGLE_CLOUD_KEYFILE_JSON"),
 		},
 		"when credentials is unset in the config, environment variables are used: GCLOUD_KEYFILE_JSON used third": {
 			EnvVariables: map[string]string{
 				// GOOGLE_CREDENTIALS not set
 				// GOOGLE_CLOUD_KEYFILE_JSON not set
-				"GCLOUD_KEYFILE_JSON":            generateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
-				"GOOGLE_APPLICATION_CREDENTIALS": generateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
+				"GCLOUD_KEYFILE_JSON":            acctest.GenerateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
+				"GOOGLE_APPLICATION_CREDENTIALS": acctest.GenerateFakeCredentialsJson("GOOGLE_APPLICATION_CREDENTIALS"),
 			},
 			ExpectedSchemaValue: "",
-			ExpectedConfigValue: generateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
+			ExpectedConfigValue: acctest.GenerateFakeCredentialsJson("GCLOUD_KEYFILE_JSON"),
 		},
 		"when credentials is unset in the config (and access_token unset), GOOGLE_APPLICATION_CREDENTIALS is used for auth but not to set values in the config": {
 			EnvVariables: map[string]string{

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/provider"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -80,53 +80,6 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// ProviderConfigEnvNames returns a list of all the environment variables that could be set by a user to configure the provider
-func ProviderConfigEnvNames() []string {
-
-	envs := []string{}
-
-	// Use existing collections of ENV names
-	envVarsSets := [][]string{
-		envvar.CredsEnvVars,   // credentials field
-		envvar.ProjectEnvVars, // project field
-		envvar.RegionEnvVars,  //region field
-		envvar.ZoneEnvVars,    // zone field
-	}
-	for _, set := range envVarsSets {
-		envs = append(envs, set...)
-	}
-
-	// Add remaining ENVs
-	envs = append(envs, "GOOGLE_OAUTH_ACCESS_TOKEN")          // access_token field
-	envs = append(envs, "GOOGLE_BILLING_PROJECT")             // billing_project field
-	envs = append(envs, "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT") // impersonate_service_account field
-	envs = append(envs, "USER_PROJECT_OVERRIDE")              // user_project_override field
-	envs = append(envs, "CLOUDSDK_CORE_REQUEST_REASON")       // request_reason field
-
-	return envs
-}
-
-// unsetProviderConfigEnvs unsets any ENVs in the test environment that
-// configure the provider.
-// The testing package will restore the original values after the test
-func unsetTestProviderConfigEnvs(t *testing.T) {
-	envs := ProviderConfigEnvNames()
-	if len(envs) > 0 {
-		for _, k := range envs {
-			t.Setenv(k, "")
-		}
-	}
-}
-
-func setupTestEnvs(t *testing.T, envValues map[string]string) {
-	// Set ENVs
-	if len(envValues) > 0 {
-		for k, v := range envValues {
-			t.Setenv(k, v)
-		}
 	}
 }
 
@@ -251,8 +204,8 @@ func TestProvider_ProviderConfigure_credentials(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -371,8 +324,8 @@ func TestProvider_ProviderConfigure_accessToken(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -473,8 +426,8 @@ func TestProvider_ProviderConfigure_impersonateServiceAccount(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -569,8 +522,8 @@ func TestProvider_ProviderConfigure_impersonateServiceAccountDelegates(t *testin
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -733,8 +686,8 @@ func TestProvider_ProviderConfigure_project(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -844,8 +797,8 @@ func TestProvider_ProviderConfigure_billingProject(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -969,8 +922,8 @@ func TestProvider_ProviderConfigure_region(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -1122,8 +1075,8 @@ func TestProvider_ProviderConfigure_zone(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -1250,8 +1203,8 @@ func TestProvider_ProviderConfigure_userProjectOverride(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -1352,8 +1305,8 @@ func TestProvider_ProviderConfigure_scopes(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			unsetTestProviderConfigEnvs(t)
-			setupTestEnvs(t, tc.EnvVariables)
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 

--- a/mmv1/third_party/terraform/services/dns/data_source_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/data_source_dns_managed_zone_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -104,7 +105,7 @@ func testAccCheckDNSManagedZoneDestroyProducerFramework(t *testing.T) func(s *te
 
 			p := acctest.GetFwTestProvider(t)
 
-			url, err := acctest.ReplaceVarsForFrameworkTest(&p.FrameworkProvider.FrameworkProviderConfig, rs, "{{DNSBasePath}}projects/{{project}}/managedZones/{{name}}")
+			url, err := fwresource.ReplaceVarsForFrameworkTest(&p.FrameworkProvider.FrameworkProviderConfig, rs, "{{DNSBasePath}}projects/{{project}}/managedZones/{{name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/dns/data_source_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/data_source_dns_record_set_test.go.erb
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -90,7 +91,7 @@ func testAccCheckDnsRecordSetDestroyProducerFramework(t *testing.T) func(s *terr
 
 			p := acctest.GetFwTestProvider(t)
 
-			url, err := acctest.ReplaceVarsForFrameworkTest(&p.FrameworkProvider.FrameworkProviderConfig, rs, "{{DNSBasePath}}projects/{{project}}/managedZones/{{managed_zone}}/rrsets/{{name}}/{{type}}")
+			url, err := fwresource.ReplaceVarsForFrameworkTest(&p.FrameworkProvider.FrameworkProviderConfig, rs, "{{DNSBasePath}}projects/{{project}}/managedZones/{{managed_zone}}/rrsets/{{name}}/{{type}}")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR begins to add tests that match [equivalent tests created for the SDK version of the provider config code](https://github.com/hashicorp/terraform-provider-google/blob/1661ce35494d1b2db15e9f57ac8e4ca23898027b/google/provider/provider_internal_test.go#L630). The motivation of adding these tests is to ensure parity between the SDK and plugin framework versions of the provider config code, as muxing the provider resulted in bugs like: https://github.com/hashicorp/terraform-provider-google/issues/14255

Currently there isn't parity in how the two bits of code handle empty strings (see commented out test cases) and I will address that in a separate PR to this one.

To allow the tests to be created I needed to move code between packages to allow reuse of test-related functions and to avoid circular dependencies.

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
