### PR TITLE
Make plugin-framework provider configuration code treat empty values like the SDK

### DIFF
--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -157,31 +157,33 @@ func (p *FrameworkProviderConfig) HandleZeroValues(ctx context.Context, data *fw
 	}
 
 	// Batching implementation will change in future, but this code will be removed in 5.0.0 so may be unaffected
-	var pbConfigs []fwmodels.ProviderBatching
-	d := data.Batching.ElementsAs(ctx, &pbConfigs, true)
-	diags.Append(d...)
-	if diags.HasError() {
-		return
+	if !data.Batching.IsNull() && !data.Batching.IsUnknown() && (len(data.Batching.Elements()) > 0) {
+		var pbConfigs []fwmodels.ProviderBatching
+		d := data.Batching.ElementsAs(ctx, &pbConfigs, true)
+		diags.Append(d...)
+		if diags.HasError() {
+			return
+		}
+		if pbConfigs[0].SendAfter.Equal(types.StringValue("")) {
+			pbConfigs[0].SendAfter = types.StringNull() // Convert empty string to null
+		}
+		b, _ := types.ObjectValue(
+			map[string]attr.Type{
+				"enable_batching": types.BoolType,
+				"send_after":      types.StringType,
+			},
+			map[string]attr.Value{
+				"enable_batching": pbConfigs[0].EnableBatching,
+				"send_after":      pbConfigs[0].SendAfter,
+			},
+		)
+		newBatching, d := types.ListValue(types.ObjectType{}.WithAttributeTypes(fwmodels.ProviderBatchingAttributes), []attr.Value{b})
+		diags.Append(d...)
+		if diags.HasError() {
+			return
+		}
+		data.Batching = newBatching
 	}
-	if pbConfigs[0].SendAfter.Equal(types.StringValue("")) {
-		pbConfigs[0].SendAfter = types.StringNull() // Convert empty string to null
-	}
-	b, _ := types.ObjectValue(
-		map[string]attr.Type{
-			"enable_batching": types.BoolType,
-			"send_after":      types.StringType,
-		},
-		map[string]attr.Value{
-			"enable_batching": pbConfigs[0].EnableBatching,
-			"send_after":      pbConfigs[0].SendAfter,
-		},
-	)
-	newBatching, d := types.ListValue(types.ObjectType{}.WithAttributeTypes(fwmodels.ProviderBatchingAttributes), []attr.Value{b})
-	diags.Append(d...)
-	if diags.HasError() {
-		return
-	}
-	data.Batching = newBatching
 }
 
 // HandleDefaults will handle all the defaults necessary in the provider

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -55,6 +55,16 @@ type FrameworkProviderConfig struct {
 // LoadAndValidateFramework handles the bulk of configuring the provider
 // it is pulled out so that we can manually call this from our testing provider as well
 func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, data *fwmodels.ProviderModel, tfVersion string, diags *diag.Diagnostics, providerversion string) {
+	
+
+	// Make the plugin framwork code behave like the SDK by ignoring zero values. This means re-setting zerp values to null.
+	// This is added to fix https://github.com/hashicorp/terraform-provider-google/issues/14255 in a v4.x.x release
+	// TODO(SarahFrench) remove as part of https://github.com/hashicorp/terraform-provider-google/issues/14447 in 5.0.0
+	p.HandleZeroValues(ctx, data, diags)
+	if diags.HasError() {
+		return
+	}
+
 	// Set defaults if needed
 	p.HandleDefaults(ctx, data, diags)
 	if diags.HasError() {
@@ -104,6 +114,43 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 	p.RequestBatcherIam = transport_tpg.NewRequestBatcher("IAM", ctx, batchingConfig)
 }
 
+// HandleZeroValues will make the plugin framework act like the SDK; zero value, particularly empty strings, are converted to null.
+// This causes the plugin framework to treat the field as unset, just like how the SDK ignores empty strings.
+func (p *FrameworkProviderConfig) HandleZeroValues(ctx context.Context, data *fwmodels.ProviderModel, diags *diag.Diagnostics) {
+	if data.AccessToken.Equal(types.StringValue("")) {
+		data.AccessToken = types.StringNull()
+	}
+	if data.BillingProject.Equal(types.StringValue("")) {
+		data.BillingProject = types.StringNull()
+	}
+	if data.Credentials.Equal(types.StringValue("")) {
+		data.Credentials = types.StringNull()
+	}
+	if data.ImpersonateServiceAccount.Equal(types.StringValue("")) {
+		data.ImpersonateServiceAccount = types.StringNull()
+	}
+	if data.Project.Equal(types.StringValue("")) {
+		data.Project = types.StringNull()
+	}
+	if data.Region.Equal(types.StringValue("")) {
+		data.Region = types.StringNull()
+	}
+	if data.RequestReason.Equal(types.StringValue("")) {
+		data.RequestReason = types.StringNull()
+	}
+	if data.RequestTimeout.Equal(types.StringValue("")) {
+		data.RequestTimeout = types.StringNull()
+	}
+	if data.Zone.Equal(types.StringValue("")) {
+		data.Zone = types.StringNull()
+	}
+
+	// TODO - how to handle non-string fields? Do they need handling?
+	// - impersonate_service_account_delegates
+	// - scopes
+	// - batching , send_after, enable_batching
+}
+
 // HandleDefaults will handle all the defaults necessary in the provider
 func (p *FrameworkProviderConfig) HandleDefaults(ctx context.Context, data *fwmodels.ProviderModel, diags *diag.Diagnostics) {
 	if data.AccessToken.IsNull() && data.Credentials.IsNull() {
@@ -130,11 +177,6 @@ func (p *FrameworkProviderConfig) HandleDefaults(ctx context.Context, data *fwmo
 		data.ImpersonateServiceAccount = types.StringValue(os.Getenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"))
 	}
 
-	// TODO(SarahFrench)remove as part of https://github.com/hashicorp/terraform-provider-google/issues/14447
-	// Temporarily adding this to fix https://github.com/hashicorp/terraform-provider-google/issues/14255 in a v4.x.x release
-	if data.Project.Equal(types.StringValue("")) {
-		data.Project = types.StringNull()
-	}
 	if data.Project.IsNull() {
 		project := transport_tpg.MultiEnvDefault([]string{
 			"GOOGLE_PROJECT",

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -117,7 +118,7 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 // HandleZeroValues will make the plugin framework act like the SDK; zero value, particularly empty strings, are converted to null.
 // This causes the plugin framework to treat the field as unset, just like how the SDK ignores empty strings.
 func (p *FrameworkProviderConfig) HandleZeroValues(ctx context.Context, data *fwmodels.ProviderModel, diags *diag.Diagnostics) {
-	
+
 	// Change empty strings to null values
 	if data.AccessToken.Equal(types.StringValue("")) {
 		data.AccessToken = types.StringNull()
@@ -155,8 +156,32 @@ func (p *FrameworkProviderConfig) HandleZeroValues(ctx context.Context, data *fw
 		data.ImpersonateServiceAccountDelegates = types.ListNull(types.StringType)
 	}
 
-	// TODO - how to handle batching, send_after, enable_batching
-
+	// Batching implementation will change in future, but this code will be removed in 5.0.0 so may be unaffected
+	var pbConfigs []fwmodels.ProviderBatching
+	d := data.Batching.ElementsAs(ctx, &pbConfigs, true)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+	if pbConfigs[0].SendAfter.Equal(types.StringValue("")) {
+		pbConfigs[0].SendAfter = types.StringNull() // Convert empty string to null
+	}
+	b, _ := types.ObjectValue(
+		map[string]attr.Type{
+			"enable_batching": types.BoolType,
+			"send_after":      types.StringType,
+		},
+		map[string]attr.Value{
+			"enable_batching": pbConfigs[0].EnableBatching,
+			"send_after":      pbConfigs[0].SendAfter,
+		},
+	)
+	newBatching, d := types.ListValue(types.ObjectType{}.WithAttributeTypes(fwmodels.ProviderBatchingAttributes), []attr.Value{b})
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+	data.Batching = newBatching
 }
 
 // HandleDefaults will handle all the defaults necessary in the provider

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -57,7 +57,7 @@ type FrameworkProviderConfig struct {
 func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, data *fwmodels.ProviderModel, tfVersion string, diags *diag.Diagnostics, providerversion string) {
 	
 
-	// Make the plugin framwork code behave like the SDK by ignoring zero values. This means re-setting zerp values to null.
+	// Make the plugin framwork code behave like the SDK by ignoring zero values. This means re-setting zero values to null.
 	// This is added to fix https://github.com/hashicorp/terraform-provider-google/issues/14255 in a v4.x.x release
 	// TODO(SarahFrench) remove as part of https://github.com/hashicorp/terraform-provider-google/issues/14447 in 5.0.0
 	p.HandleZeroValues(ctx, data, diags)

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -117,6 +117,8 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 // HandleZeroValues will make the plugin framework act like the SDK; zero value, particularly empty strings, are converted to null.
 // This causes the plugin framework to treat the field as unset, just like how the SDK ignores empty strings.
 func (p *FrameworkProviderConfig) HandleZeroValues(ctx context.Context, data *fwmodels.ProviderModel, diags *diag.Diagnostics) {
+	
+	// Change empty strings to null values
 	if data.AccessToken.Equal(types.StringValue("")) {
 		data.AccessToken = types.StringNull()
 	}
@@ -145,10 +147,16 @@ func (p *FrameworkProviderConfig) HandleZeroValues(ctx context.Context, data *fw
 		data.Zone = types.StringNull()
 	}
 
-	// TODO - how to handle non-string fields? Do they need handling?
-	// - impersonate_service_account_delegates
-	// - scopes
-	// - batching , send_after, enable_batching
+	// Change lists that aren't null or unknown with length of zero to null lists
+	if !data.Scopes.IsNull() && !data.Scopes.IsUnknown() && (len(data.Scopes.Elements()) == 0) {
+		data.Scopes = types.ListNull(types.StringType)
+	}
+	if !data.ImpersonateServiceAccountDelegates.IsNull() && !data.ImpersonateServiceAccountDelegates.IsUnknown() && (len(data.ImpersonateServiceAccountDelegates.Elements()) == 0) {
+		data.ImpersonateServiceAccountDelegates = types.ListNull(types.StringType)
+	}
+
+	// TODO - how to handle batching, send_after, enable_batching
+
 }
 
 // HandleDefaults will handle all the defaults necessary in the provider

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -130,6 +130,11 @@ func (p *FrameworkProviderConfig) HandleDefaults(ctx context.Context, data *fwmo
 		data.ImpersonateServiceAccount = types.StringValue(os.Getenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"))
 	}
 
+	// TODO(SarahFrench)remove as part of https://github.com/hashicorp/terraform-provider-google/issues/14447
+	// Temporarily adding this to fix https://github.com/hashicorp/terraform-provider-google/issues/14255 in a v4.x.x release
+	if data.Project.Equal(types.StringValue("")) {
+		data.Project = types.StringNull()
+	}
 	if data.Project.IsNull() {
 		project := transport_tpg.MultiEnvDefault([]string{
 			"GOOGLE_PROJECT",

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1055,6 +1055,15 @@ func TestFrameworkProvider_LoadAndValidateFramework_impersonateServiceAccount(t 
 			},
 			ExpectedDataModelValue: types.StringNull(),
 		},
+		"when impersonate_service_account is set as an empty string in the config, an environment variable is used": {
+			ConfigValues: fwmodels.ProviderModel{
+				ImpersonateServiceAccount: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT": "value-from-env@example.com",
+			},
+			ExpectedDataModelValue: types.StringValue("value-from-env@example.com"),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when impersonate_service_account is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1142,7 +1142,7 @@ func TestFrameworkProvider_LoadAndValidateFramework_impersonateServiceAccountDel
 		// Handling empty values in config
 		"when impersonate_service_account_delegates is set as an empty array the field is treated as if it's unset, without error": {
 			ImpersonateServiceAccountDelegatesValue: []string{},
-			ExpectedDataModelValue:                  []string{},
+			ExpectedDataModelValue:                  nil,
 		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1559,13 +1559,12 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 			ExpectSendAfterValue:      types.StringValue("123s"),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when batching is configured with send_after as an empty string, send_after will be set to a default value": {
-		// 	EnableBatchingValue:       types.BoolValue(true),
-		// 	SendAfterValue:            types.StringValue(""),
-		// 	ExpectEnableBatchingValue: types.BoolValue(true),
-		// 	ExpectSendAfterValue:      types.StringValue("10s"),
-		// },
+		"when batching is configured with send_after as an empty string, send_after will be set to a default value": {
+			EnableBatchingValue:       types.BoolValue(true),
+			SendAfterValue:            types.StringValue(""),
+			ExpectEnableBatchingValue: types.BoolValue(true),
+			ExpectSendAfterValue:      types.StringValue("10s"), // When batching block is present but has missing arguments inside, default is 10s
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when batching is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -102,24 +102,23 @@ func TestFrameworkProvider_LoadAndValidateFramework_project(t *testing.T) {
 			ExpectedConfigStructValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when project is set as an empty string the field is treated as if it's unset, without error": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		Project: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringNull(),
-		// 	ExpectedConfigStructValue: types.StringNull(),
-		// },
-		// "when project is set as an empty string an environment variable will be used": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		Project: types.StringValue(""),
-		// 	},
-		// 	EnvVariables: map[string]string{
-		// 		"GOOGLE_PROJECT": "project-from-GOOGLE_PROJECT",
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringNull(),
-		// 	ExpectedConfigStructValue: types.StringValue("project-from-GOOGLE_PROJECT"),
-		// },
+		"when project is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringValue(""),
+			},
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringNull(),
+		},
+		"when project is set as an empty string an environment variable will be used": {
+			ConfigValues: fwmodels.ProviderModel{
+				Project: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_PROJECT": "project-from-GOOGLE_PROJECT",
+			},
+			ExpectedDataModelValue:    types.StringValue("project-from-GOOGLE_PROJECT"),
+			ExpectedConfigStructValue: types.StringValue("project-from-GOOGLE_PROJECT"),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when project is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1535,9 +1535,9 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 	}{
 		"batching can be configured with values for enable_batching and send_after": {
 			EnableBatchingValue:       types.BoolValue(true),
-			SendAfterValue:            types.StringValue("123s"),
+			SendAfterValue:            types.StringValue("45s"),
 			ExpectEnableBatchingValue: types.BoolValue(true),
-			ExpectSendAfterValue:      types.StringValue("123s"),
+			ExpectSendAfterValue:      types.StringValue("45s"),
 		},
 		"if batching is an empty block, it will set the default values for enable_batching and send_after": {
 			// In this test, we try to create a list containing only null values
@@ -1554,9 +1554,9 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 		},
 		"when batching is configured with only send_after, enable_batching will be set to a default value": {
 			EnableBatchingValue:       types.BoolNull(),
-			SendAfterValue:            types.StringValue("123s"),
+			SendAfterValue:            types.StringValue("45s"),
 			ExpectEnableBatchingValue: types.BoolValue(true),
-			ExpectSendAfterValue:      types.StringValue("123s"),
+			ExpectSendAfterValue:      types.StringValue("45s"),
 		},
 		// Handling empty strings in config
 		"when batching is configured with send_after as an empty string, send_after will be set to a default value": {
@@ -1580,9 +1580,9 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 		// },
 		// "when batching is configured with enable_batching as an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
 		// 	EnableBatchingValue:       types.BoolNull(),
-		// 	SendAfterValue:            types.StringValue("123s"),
+		// 	SendAfterValue:            types.StringValue("45s"),
 		// 	ExpectEnableBatchingValue: types.BoolValue(true),
-		// 	ExpectSendAfterValue:      types.StringValue("123s"),
+		// 	ExpectSendAfterValue:      types.StringValue("45s"),
 		// },
 		// Error states
 		"if batching is configured with send_after as an invalid value, there's an error": {

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -263,16 +263,15 @@ func TestFrameworkProvider_LoadAndValidateFramework_credentials(t *testing.T) {
 			ExpectedDataModelValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when credentials is set to an empty string in the config (and access_token unset), GOOGLE_APPLICATION_CREDENTIALS is used": {
-		// ConfigValues: fwmodels.ProviderModel{
-		// 	Credentials: types.StringValue(""),
-		// },
-		// 	EnvVariables: map[string]string{
-		// 		"GOOGLE_APPLICATION_CREDENTIALS": transport_tpg.TestFakeCredentialsPath, // needs to be a path to a file when used by code
-		// 	},
-		// 	ExpectedDataModelValue: types.StringNull(),
-		// },
+		"when credentials is set to an empty string in the config (and access_token unset), GOOGLE_APPLICATION_CREDENTIALS is used": {
+			ConfigValues: fwmodels.ProviderModel{
+				Credentials: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_APPLICATION_CREDENTIALS": transport_tpg.TestFakeCredentialsPath, // needs to be a path to a file when used by code
+			},
+			ExpectedDataModelValue: types.StringNull(),
+		},
 		// NOTE: these tests can't run in Cloud Build due to ADC locating credentials despite `GOOGLE_APPLICATION_CREDENTIALS` being unset
 		// See https://cloud.google.com/docs/authentication/application-default-credentials#search_order
 		// Also, when running these tests locally you need to run `gcloud auth application-default revoke` to ensure your machine isn't supplying ADCs
@@ -433,23 +432,23 @@ func TestFrameworkProvider_LoadAndValidateFramework_billingProject(t *testing.T)
 			ExpectedConfigStructValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// "when billing_project is set as an empty string the field is treated as if it's unset, without error": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		BillingProject: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringNull(),
-		// 	ExpectedConfigStructValue: types.StringNull(),
-		// },
-		// "when billing_project is set as an empty string an environment variable will be used": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		BillingProject: types.StringValue(""),
-		// 	},
-		// 	EnvVariables: map[string]string{
-		// 		"GOOGLE_BILLING_PROJECT": "billing-project-from-env",
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringValue("billing-project-from-env"),
-		// 	ExpectedConfigStructValue: types.StringValue("billing-project-from-env"),
-		// },
+		"when billing_project is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				BillingProject: types.StringValue(""),
+			},
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringNull(),
+		},
+		"when billing_project is set as an empty string an environment variable will be used": {
+			ConfigValues: fwmodels.ProviderModel{
+				BillingProject: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_BILLING_PROJECT": "billing-project-from-env",
+			},
+			ExpectedDataModelValue:    types.StringValue("billing-project-from-env"),
+			ExpectedConfigStructValue: types.StringValue("billing-project-from-env"),
+		},
 	}
 
 	for tn, tc := range cases {
@@ -548,24 +547,23 @@ func TestFrameworkProvider_LoadAndValidateFramework_region(t *testing.T) {
 			ExpectedConfigStructValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when region is set as an empty string the field is treated as if it's unset, without error": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		Region: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringNull(),
-		// 	ExpectedConfigStructValue: types.StringNull(),
-		// },
-		// "when region is set as an empty string an environment variable will be used": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		Region: types.StringValue(""),
-		// 	},
-		// 	EnvVariables: map[string]string{
-		// 		"GOOGLE_REGION": "region-from-env",
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringValue("region-from-env"),
-		// 	ExpectedConfigStructValue: types.StringValue("region-from-env"),
-		// },
+		"when region is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				Region: types.StringValue(""),
+			},
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringNull(),
+		},
+		"when region is set as an empty string an environment variable will be used": {
+			ConfigValues: fwmodels.ProviderModel{
+				Region: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_REGION": "region-from-env",
+			},
+			ExpectedDataModelValue:    types.StringValue("region-from-env"),
+			ExpectedConfigStructValue: types.StringValue("region-from-env"),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when region is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
@@ -697,24 +695,23 @@ func TestFrameworkProvider_LoadAndValidateFramework_zone(t *testing.T) {
 			ExpectedConfigStructValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when zone is set as an empty string the field is treated as if it's unset, without error": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		Zone: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringNull(),
-		// 	ExpectedConfigStructValue: types.StringNull(),
-		// },
-		// "when zone is set as an empty string an environment variable will be used": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		Zone: types.StringValue(""),
-		// 	},
-		// 	EnvVariables: map[string]string{
-		// 		"GOOGLE_ZONE": "zone-from-env",
-		// 	},
-		// 	ExpectedDataModelValue:    types.StringValue("zone-from-env"),
-		// 	ExpectedConfigStructValue: types.StringValue("zone-from-env"),
-		// },
+		"when zone is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				Zone: types.StringValue(""),
+			},
+			ExpectedDataModelValue:    types.StringNull(),
+			ExpectedConfigStructValue: types.StringNull(),
+		},
+		"when zone is set as an empty string an environment variable will be used": {
+			ConfigValues: fwmodels.ProviderModel{
+				Zone: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE": "zone-from-env",
+			},
+			ExpectedDataModelValue:    types.StringValue("zone-from-env"),
+			ExpectedConfigStructValue: types.StringValue("zone-from-env"),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when zone is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
@@ -813,23 +810,22 @@ func TestFrameworkProvider_LoadAndValidateFramework_accessToken(t *testing.T) {
 			ExpectedDataModelValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when access_token is set as an empty string the field is treated as if it's unset, without error (as long as credentials supplied in its absence)": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		AccessToken: types.StringValue(""),
-		// 		Credentials: types.StringValue(transport_tpg.TestFakeCredentialsPath),
-		// 	},
-		// 	ExpectedDataModelValue: types.StringNull(),
-		// },
-		// "when access_token is set as an empty string in the config, an environment variable is used": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		AccessToken: types.StringValue(""),
-		// 	},
-		// 	EnvVariables: map[string]string{
-		// 		"GOOGLE_OAUTH_ACCESS_TOKEN": "value-from-GOOGLE_OAUTH_ACCESS_TOKEN",
-		// 	},
-		// 	ExpectedDataModelValue: types.StringValue("value-from-GOOGLE_OAUTH_ACCESS_TOKEN"),
-		// },
+		"when access_token is set as an empty string the field is treated as if it's unset, without error (as long as credentials supplied in its absence)": {
+			ConfigValues: fwmodels.ProviderModel{
+				AccessToken: types.StringValue(""),
+				Credentials: types.StringValue(transport_tpg.TestFakeCredentialsPath),
+			},
+			ExpectedDataModelValue: types.StringNull(),
+		},
+		"when access_token is set as an empty string in the config, an environment variable is used": {
+			ConfigValues: fwmodels.ProviderModel{
+				AccessToken: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_OAUTH_ACCESS_TOKEN": "value-from-GOOGLE_OAUTH_ACCESS_TOKEN",
+			},
+			ExpectedDataModelValue: types.StringValue("value-from-GOOGLE_OAUTH_ACCESS_TOKEN"),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when access_token is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
@@ -1053,13 +1049,12 @@ func TestFrameworkProvider_LoadAndValidateFramework_impersonateServiceAccount(t 
 			ExpectedDataModelValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when impersonate_service_account is set as an empty array the field is treated as if it's unset, without error": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		ImpersonateServiceAccount: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue: types.StringNull(),
-		// },
+		"when impersonate_service_account is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				ImpersonateServiceAccount: types.StringValue(""),
+			},
+			ExpectedDataModelValue: types.StringNull(),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when impersonate_service_account is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
@@ -1346,22 +1341,21 @@ func TestFrameworkProvider_LoadAndValidateFramework_requestReason(t *testing.T) 
 			ExpectedDataModelValue: types.StringNull(),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when request_reason is set as an empty string in the config it is overridden by environment variables": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		RequestReason: types.StringValue(""),
-		// 	},
-		// 	EnvVariables: map[string]string{
-		// 		"CLOUDSDK_CORE_REQUEST_REASON": "foo",
-		// 	},
-		// 	ExpectedDataModelValue: types.StringValue("foo"),
-		// },
-		// "when request_reason is set as an empty string in the config the field is treated as if it's unset, without error": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		RequestReason: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue: types.StringNull(),
-		// },
+		"when request_reason is set as an empty string in the config it is overridden by environment variables": {
+			ConfigValues: fwmodels.ProviderModel{
+				RequestReason: types.StringValue(""),
+			},
+			EnvVariables: map[string]string{
+				"CLOUDSDK_CORE_REQUEST_REASON": "foo",
+			},
+			ExpectedDataModelValue: types.StringValue("foo"),
+		},
+		"when request_reason is set as an empty string in the config the field is treated as if it's unset, without error": {
+			ConfigValues: fwmodels.ProviderModel{
+				RequestReason: types.StringValue(""),
+			},
+			ExpectedDataModelValue: types.StringNull(),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when request_timeout is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
@@ -1450,13 +1444,12 @@ func TestFrameworkProvider_LoadAndValidateFramework_requestTimeout(t *testing.T)
 			ExpectedDataModelValue: types.StringValue("120s"),
 		},
 		// Handling empty strings in config
-		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
-		// "when request_timeout is set as an empty string, the default value is 120s.": {
-		// 	ConfigValues: fwmodels.ProviderModel{
-		// 		RequestTimeout: types.StringValue(""),
-		// 	},
-		// 	ExpectedDataModelValue: types.StringValue("120s"),
-		// },
+		"when request_timeout is set as an empty string, the default value is 120s.": {
+			ConfigValues: fwmodels.ProviderModel{
+				RequestTimeout: types.StringValue(""),
+			},
+			ExpectedDataModelValue: types.StringValue("120s"),
+		},
 		// Handling unknown values
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
 		// "when request_timeout is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -1581,12 +1581,12 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 				"batching": []interface{}{
 					map[string]interface{}{
 						"enable_batching": true,
-						"send_after":      "123s",
+						"send_after":      "45s",
 					},
 				},
 			},
 			ExpectedEnableBatchingValue: true,
-			ExpectedSendAfterValue:      "123s",
+			ExpectedSendAfterValue:      "45s",
 		},
 		"if batching is an empty block, it will set the default values for enable_batching and send_after": {
 			ConfigValues: map[string]interface{}{
@@ -1617,12 +1617,12 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 				"credentials": transport_tpg.TestFakeCredentialsPath,
 				"batching": []interface{}{
 					map[string]interface{}{
-						"send_after": "123s",
+						"send_after": "45s",
 					},
 				},
 			},
 			ExpectedEnableBatchingValue: false,
-			ExpectedSendAfterValue:      "123s",
+			ExpectedSendAfterValue:      "45s",
 		},
 		// Error states
 		"if batching is configured with send_after as an invalid value, there's an error": {

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -403,7 +403,7 @@ func TestProvider_ProviderConfigure_impersonateServiceAccount(t *testing.T) {
 			ExpectedValue:    "",
 		},
 		// Handling empty strings in config
-		"when impersonate_service_account is set as an empty array the field is treated as if it's unset, without error": {
+		"when impersonate_service_account is set as an empty string the field is treated as if it's unset, without error": {
 			ConfigValues: map[string]interface{}{
 				"impersonate_service_account": "",
 				"credentials":                 transport_tpg.TestFakeCredentialsPath,
@@ -411,6 +411,16 @@ func TestProvider_ProviderConfigure_impersonateServiceAccount(t *testing.T) {
 			ExpectError:      false,
 			ExpectFieldUnset: true,
 			ExpectedValue:    "",
+		},
+		"when impersonate_service_account is set as an empty string in the config, an environment variable is used": {
+			ConfigValues: map[string]interface{}{
+				"impersonate_service_account": "",
+				"credentials":                 transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT": "value-from-env@example.com",
+			},
+			ExpectedValue: "value-from-env@example.com",
 		},
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR fixes https://github.com/hashicorp/terraform-provider-google/issues/14255

This PR makes the plugin-framework code behave more like the SDK by ignoring empty strings, and is a bug fix to be included in a v4.x.x release. The bug it's fixing is an unintentional behaviour change introduced when the provider was muxed.

Later, I will remove this fix in 5.0.0, as an intentional breaking change as part of : https://github.com/hashicorp/terraform-provider-google/issues/14447

Also, this PR changes some arbitrary strings from "123s" to "45s" as I realised that "123s" is changed to "2m3s" during the provider configuration logic. I thought this change would help avoid confusion if tests are updated in future to inspect where that second, parsed value is used.


---


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed the provider so it resumes ignoring empty strings set in the `provider` block
```
