### PR TITLE
Add storageinsights product and ReportConfig resource type.

### DIFF
--- a/mmv1/products/storageinsights/ReportConfig.yaml
+++ b/mmv1/products/storageinsights/ReportConfig.yaml
@@ -1,0 +1,154 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ReportConfig'
+base_url: projects/{{project}}/locations/{{location}}/reportConfigs
+create_url: projects/{{project}}/locations/{{location}}/reportConfigs
+self_link: projects/{{project}}/locations/{{location}}/reportConfigs/{{name}}
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/storage/docs/insights/using-storage-insights'
+  api: 'https://cloud.google.com/storage/docs/json_api/v1/reportConfig'
+description: |
+  Represents an inventory report configuration.
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "storage_insights_report_config"
+    primary_resource_id: "config"
+    vars:
+      bucket_name: "my-bucket"
+    config_path: "templates/terraform/examples/storage_insights_report_config.tf.erb"
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      The location of the ReportConfig. The source and destination buckets specified in the ReportConfig
+      must be in the same location.
+    immutable: true
+    required: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    output: true
+    description: |
+      The UUID of the inventory report configuration.
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
+  - !ruby/object:Api::Type::NestedObject
+    name: 'frequencyOptions'
+    description: |
+      Options for configuring how inventory reports are generated.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'frequency'
+        description: |
+          The frequency in which inventory reports are generated. Values are DAILY or WEEKLY.
+        required: true
+        values:
+          - :DAILY
+          - :WEEKLY
+      - !ruby/object:Api::Type::NestedObject
+        name: 'startDate'
+        description: |
+          The date to start generating inventory reports. For example, {"day": 15, "month": 8, "year": 2022}.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'day'
+            description: 'The day of the month to start generating inventory reports.'
+            required: true
+          - !ruby/object:Api::Type::Integer
+            name: 'month'
+            description: 'The month to start generating inventory reports.'
+            required: true
+          - !ruby/object:Api::Type::Integer
+            name: 'year'
+            description: 'The year to start generating inventory reports'
+            required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'endDate'
+        description: |
+          The date to stop generating inventory reports. For example, {"day": 15, "month": 9, "year": 2022}.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'day'
+            description: 'The day of the month to stop generating inventory reports.'
+            required: true
+          - !ruby/object:Api::Type::Integer
+            name: 'month'
+            description: 'The month to stop generating inventory reports.'
+            required: true
+          - !ruby/object:Api::Type::Integer
+            name: 'year'
+            description: 'The year to stop generating inventory reports'
+            required: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'csvOptions'
+    description: |
+      Options for configuring the format of the inventory report CSV file.
+    required: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'recordSeparator'
+        description: |
+          The character used to separate the records in the inventory report CSV file.
+      - !ruby/object:Api::Type::String
+        name: 'delimiter'
+        description: |
+          The delimiter used to separate the fields in the inventory report CSV file.
+      - !ruby/object:Api::Type::Boolean
+        name: 'headerRequired'
+        description: |
+          The boolean that indicates whether or not headers are included in the inventory report CSV file.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'objectMetadataReportOptions'
+    description: |
+      Options for including metadata in an inventory report.
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'metadataFields'
+        description: |
+          The metadata fields included in an inventory report.
+        required: true
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'storageFilters'
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'bucket'
+            description: |
+              The filter to use when specifying which bucket to generate inventory reports for.
+            required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'storageDestinationOptions'
+        description: |
+          Options for where the inventory reports are stored.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'bucket'
+            description: |
+              The destination bucket that stores the generated inventory reports.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'destinationPath'
+            description: |
+              The path within the destination bucket to store generated inventory reports.
+  - !ruby/object:Api::Type::String
+    name: 'displayName'
+    description: |
+      The editable display name of the inventory report configuration. Has a limit of 256 characters. Can be empty.
+

--- a/mmv1/products/storageinsights/ReportConfig.yaml
+++ b/mmv1/products/storageinsights/ReportConfig.yaml
@@ -151,4 +151,3 @@ properties:
     name: 'displayName'
     description: |
       The editable display name of the inventory report configuration. Has a limit of 256 characters. Can be empty.
-

--- a/mmv1/products/storageinsights/ReportConfig.yaml
+++ b/mmv1/products/storageinsights/ReportConfig.yaml
@@ -16,6 +16,8 @@ name: 'ReportConfig'
 base_url: projects/{{project}}/locations/{{location}}/reportConfigs
 create_url: projects/{{project}}/locations/{{location}}/reportConfigs
 self_link: projects/{{project}}/locations/{{location}}/reportConfigs/{{name}}
+update_verb: :PATCH
+update_mask: true
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/storage/docs/insights/using-storage-insights'
@@ -116,6 +118,10 @@ properties:
     name: 'objectMetadataReportOptions'
     description: |
       Options for including metadata in an inventory report.
+    update_mask_fields:
+      - 'objectMetadataReportOptions.metadataFields'
+      - 'objectMetadataReportOptions.storageDestinationOptions.bucket'
+      - 'objectMetadataReportOptions.storageDestinationOptions.destinationPath'
     properties:
       - !ruby/object:Api::Type::Array
         name: 'metadataFields'
@@ -125,13 +131,12 @@ properties:
         item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'storageFilters'
-        required: true
         properties:
           - !ruby/object:Api::Type::String
             name: 'bucket'
             description: |
               The filter to use when specifying which bucket to generate inventory reports for.
-            required: true
+            immutable: true
       - !ruby/object:Api::Type::NestedObject
         name: 'storageDestinationOptions'
         description: |

--- a/mmv1/products/storageinsights/product.yaml
+++ b/mmv1/products/storageinsights/product.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: StorageInsights
+display_name: Cloud Storage Insights
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://storageinsights.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/devstorage.full_control
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Google Cloud Storage
+    url: https://console.cloud.google.com/apis/library/storage-component.googleapis.com/
+  - !ruby/object:Api::Product::ApiReference
+    name: Google Cloud Storage Insights
+    url: https://console.cloud.google.com/apis/library/storageinsights.googleapis.com/

--- a/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
@@ -5,12 +5,12 @@ resource "google_storage_insights_report_config" "<%= ctx[:primary_resource_id] 
     start_date {
       day = 15
       month = 3
-      year = 2023
+      year = 2050
     }
     end_date {
       day = 15
       month = 4
-      year = 2023
+      year = 2050
     }
   }
   csv_options {

--- a/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
@@ -2,6 +2,7 @@ data "google_project" "project" {
 }
 
 resource "google_storage_insights_report_config" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "Test Report Config"
   location = "us-central1"
   frequency_options {
     frequency = "WEEKLY"
@@ -28,6 +29,7 @@ resource "google_storage_insights_report_config" "<%= ctx[:primary_resource_id] 
     }
     storage_destination_options {
       bucket = google_storage_bucket.report_bucket.name
+      destination_path = "test-insights-reports"
     }
   }
 }
@@ -44,4 +46,3 @@ resource "google_storage_bucket_iam_member" "admin" {
   role   = "roles/storage.admin"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-storageinsights.iam.gserviceaccount.com"
 }
-

--- a/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
@@ -1,0 +1,37 @@
+resource "google_storage_insights_report_config" "<%= ctx[:primary_resource_id] %>" {
+  location = "us-central1"
+  frequency_options {
+    frequency = "WEEKLY"
+    start_date {
+      day = 15
+      month = 3
+      year = 2023
+    }
+    end_date {
+      day = 15
+      month = 4
+      year = 2023
+    }
+  }
+  csv_options {
+    record_separator = "\n"
+    delimiter = ","
+    header_required = false
+  }
+  object_metadata_report_options {
+    metadata_fields = ["bucket", "name", "project"]
+    storage_filters {
+      bucket = google_storage_bucket.report_bucket.name
+    }
+    storage_destination_options {
+      bucket = google_storage_bucket.report_bucket.name
+    }
+  }
+}
+
+resource "google_storage_bucket" "report_bucket" {
+  name                        = "<%= ctx[:vars]['bucket_name'] %>"
+  location                    = "us-central1"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}

--- a/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
+++ b/mmv1/templates/terraform/examples/storage_insights_report_config.tf.erb
@@ -1,3 +1,6 @@
+data "google_project" "project" {
+}
+
 resource "google_storage_insights_report_config" "<%= ctx[:primary_resource_id] %>" {
   location = "us-central1"
   frequency_options {
@@ -35,3 +38,10 @@ resource "google_storage_bucket" "report_bucket" {
   force_destroy               = true
   uniform_bucket_level_access = true
 }
+
+resource "google_storage_bucket_iam_member" "admin" {
+  bucket = google_storage_bucket.report_bucket.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-storageinsights.iam.gserviceaccount.com"
+}
+

--- a/mmv1/third_party/terraform/services/storageinsights/resource_storage_insights_report_config_test.go
+++ b/mmv1/third_party/terraform/services/storageinsights/resource_storage_insights_report_config_test.go
@@ -1,0 +1,155 @@
+package storageinsights_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestAccStorageInsightsReportConfig_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckStorageInsightsReportConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageInsightsReportConfig_full(context),
+			},
+			{
+				ResourceName:            "google_storage_insights_report_config.config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		        {
+				Config: testAccStorageInsightsReportConfig_update(context),
+			},
+			{
+				ResourceName:            "google_storage_insights_report_config.config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+
+		},
+	})
+}
+
+func testAccStorageInsightsReportConfig_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_storage_insights_report_config" "config" {
+  display_name = "Test Report Config"
+  location = "us-central1"
+  frequency_options {
+    frequency = "WEEKLY"
+    start_date {
+      day = 15
+      month = 3
+      year = 2050
+    }
+    end_date {
+      day = 15
+      month = 4
+      year = 2050
+    }
+  }
+  csv_options {
+    record_separator = "\n"
+    delimiter = ","
+    header_required = false
+  }
+  object_metadata_report_options {
+    metadata_fields = ["bucket", "name", "project"]
+    storage_filters {
+      bucket = google_storage_bucket.report_bucket.name
+    }
+    storage_destination_options {
+      bucket = google_storage_bucket.report_bucket.name
+      destination_path = "test-insights-reports"
+    }
+  }
+}
+
+resource "google_storage_bucket" "report_bucket" {
+  name                        = "tf-test-my-bucket%{random_suffix}"
+  location                    = "us-central1"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_member" "admin" {
+  bucket = google_storage_bucket.report_bucket.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-storageinsights.iam.gserviceaccount.com"
+}
+`, context)
+}
+
+func testAccStorageInsightsReportConfig_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_storage_insights_report_config" "config" {
+  display_name = "Test Report Config Updated"
+  location = "us-central1"
+  frequency_options {
+    frequency = "MONTHLY"
+    start_date {
+      day = 14
+      month = 3
+      year = 2040
+    }
+    end_date {
+      day = 14
+      month = 4
+      year = 2040
+    }
+  }
+  csv_options {
+    record_separator = ";"
+    delimiter = "."
+    header_required = true
+  }
+  object_metadata_report_options {
+    metadata_fields = ["name", "project"]
+    storage_filters {
+	  bucket = google_storage_bucket.update_bucket.name
+	}
+    storage_destination_options {
+      bucket = google_storage_bucket.update_bucket.name
+      destination_path = "test-insights-reports-updated"
+    }
+  }
+}
+
+resource "google_storage_bucket" "update_bucket" {
+	name                        = "tf-test-update-bucket%{random_suffix}"
+	location                    = "us-central1"
+	force_destroy               = true
+	uniform_bucket_level_access = true
+  }
+
+resource "google_storage_bucket_iam_member" "admin" {
+  bucket = google_storage_bucket.report_bucket.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-storageinsights.iam.gserviceaccount.com"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/storageinsights/resource_storage_insights_report_config_test.go
+++ b/mmv1/third_party/terraform/services/storageinsights/resource_storage_insights_report_config_test.go
@@ -1,16 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package storageinsights_test
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccStorageInsightsReportConfig_update(t *testing.T) {
@@ -23,7 +20,6 @@ func TestAccStorageInsightsReportConfig_update(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckStorageInsightsReportConfigDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStorageInsightsReportConfig_full(context),
@@ -34,7 +30,7 @@ func TestAccStorageInsightsReportConfig_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location"},
 			},
-		        {
+			{
 				Config: testAccStorageInsightsReportConfig_update(context),
 			},
 			{
@@ -43,7 +39,6 @@ func TestAccStorageInsightsReportConfig_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location"},
 			},
-
 		},
 	})
 }
@@ -84,6 +79,9 @@ resource "google_storage_insights_report_config" "config" {
       destination_path = "test-insights-reports"
     }
   }
+  depends_on = [
+	google_storage_bucket_iam_member.admin,
+  ]
 }
 
 resource "google_storage_bucket" "report_bucket" {
@@ -110,7 +108,7 @@ resource "google_storage_insights_report_config" "config" {
   display_name = "Test Report Config Updated"
   location = "us-central1"
   frequency_options {
-    frequency = "MONTHLY"
+    frequency = "DAILY"
     start_date {
       day = 14
       month = 3
@@ -123,29 +121,32 @@ resource "google_storage_insights_report_config" "config" {
     }
   }
   csv_options {
-    record_separator = ";"
+    record_separator = "\r\n"
     delimiter = "."
     header_required = true
   }
   object_metadata_report_options {
-    metadata_fields = ["name", "project"]
+    metadata_fields = ["bucket", "name", "project"]
     storage_filters {
-	  bucket = google_storage_bucket.update_bucket.name
-	}
+      bucket = google_storage_bucket.report_bucket.name
+    }
     storage_destination_options {
-      bucket = google_storage_bucket.update_bucket.name
+      bucket = google_storage_bucket.report_bucket.name
       destination_path = "test-insights-reports-updated"
     }
   }
+  depends_on = [
+	google_storage_bucket_iam_member.admin,
+  ]
 }
 
-resource "google_storage_bucket" "update_bucket" {
-	name                        = "tf-test-update-bucket%{random_suffix}"
-	location                    = "us-central1"
-	force_destroy               = true
-	uniform_bucket_level_access = true
-  }
-
+resource "google_storage_bucket" "report_bucket" {
+  name                        = "tf-test-my-bucket%{random_suffix}"
+  location                    = "us-central1"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+  
 resource "google_storage_bucket_iam_member" "admin" {
   bucket = google_storage_bucket.report_bucket.name
   role   = "roles/storage.admin"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Promoting storageinsights to GA.
- fixes https://github.com/hashicorp/terraform-provider-google/issues/14735


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_storage_insights_report_config`
```
