### PR TITLE
Update generate-providers.md

### DIFF
--- a/docs/content/get-started/generate-providers.md
+++ b/docs/content/get-started/generate-providers.md
@@ -162,9 +162,9 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
 
    ```bash
    cd $GOPATH/src/github.com/hashicorp/terraform-provider-google
-   make testacc TEST=./google TESTARGS='-run=TestAccPubsubTopic_'
+   make testacc TEST=./google/services/pubsub TESTARGS='-run=TestAccPubsubTopic_'
    cd $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
-   make testacc TEST=./google-beta TESTARGS='-run=TestAccPubsubTopic_'
+   make testacc TEST=./google-beta/services/pubsub TESTARGS='-run=TestAccPubsubTopic_'
    ```
 
 ## Troubleshoot


### PR DESCRIPTION
Update the test command so that tests would be searched recursively. Without this change `make testacc` always fails with "no tests" founds:

Before:
```
 [08/30 16:16]  ~/…/github.com/hashicorp/terraform-provider-google  make testacc TEST=./google TESTARGS='-run=TestAccComputeRegionInstanceTemplate'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeRegionInstanceTemplate -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
?   	github.com/hashicorp/terraform-provider-google/google	[no test files]
````

After:
```
 [08/30 16:14]  ~/…/github.com/hashicorp/terraform-provider-google  make testacc TEST=./google/... TESTARGS='-run=TestAccComputeRegionInstanceTemplate'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/... -v -run=TestAccComputeRegionInstanceTemplate -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
...
=== RUN   TestAccComputeRegionInstanceTemplate_basic
=== PAUSE TestAccComputeRegionInstanceTemplate_basic
=== RUN   TestAccComputeRegionInstanceTemplate_imageShorthand
=== PAUSE TestAccComputeRegionInstanceTemplate_imageShorthand
=== RUN   TestAccComputeRegionInstanceTemplate_preemptible
=== PAUSE TestAccComputeRegionInstanceTemplate_preemptible
=== RUN   TestAccComputeRegionInstanceTemplate_IP
=== PAUSE TestAccComputeRegionInstanceTemplate_IP
=== RUN   TestAccComputeRegionInstanceTemplate_IPv6
=== PAUSE TestAccComputeRegionInstanceTemplate_IPv6
=== RUN   TestAccComputeRegionInstanceTemplate_networkTier
...
```

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
