### PR TITLE
fix(google_container_node_pool): panic interface conversion on `additional_pod_network_configs`

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -1266,10 +1266,10 @@ func expandNodeNetworkConfig(v interface{}) *container.NodeNetworkConfig {
 		for _, raw := range pod_network_configs {
 			data := raw.(map[string]interface{})
 			podnetworkConfig := &container.AdditionalPodNetworkConfig{
-				Subnetwork:        data["network"].(string),
-				SecondaryPodRange: data["subnetwork"].(string),
+				Subnetwork:        data["subnetwork"].(string),
+				SecondaryPodRange: data["secondary_pod_range"].(string),
 				MaxPodsPerNode:    &container.MaxPodsConstraint{
-					MaxPodsPerNode: data["max_pods_per_node"].(int64),
+					MaxPodsPerNode: int64(data["max_pods_per_node"].(int)),
 				},
 			}
 			podNetworkConfigs = append(podNetworkConfigs, podnetworkConfig)

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -2751,6 +2751,11 @@ resource "google_compute_subnetwork" "subnet2" {
   network                  = google_compute_network.addn_net_2.name
   ip_cidr_range            = "10.0.38.0/24"
   region                   = "us-central1"
+
+  secondary_ip_range {
+    range_name    = "pod"
+    ip_cidr_range = "10.0.64.0/19"
+  }
 }
 
 resource "google_container_cluster" "cluster" {
@@ -2784,13 +2789,18 @@ resource "google_container_node_pool" "with_multi_nic" {
     create_pod_range = false
     enable_private_nodes = true
     pod_range = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
-	additional_node_network_configs {
-	  network    = google_compute_network.addn_net_1.name
+    additional_node_network_configs {
+      network    = google_compute_network.addn_net_1.name
       subnetwork = google_compute_subnetwork.subnet1.name
     }
     additional_node_network_configs {
-	  network    = google_compute_network.addn_net_2.name
-	  subnetwork = google_compute_subnetwork.subnet2.name
+      network    = google_compute_network.addn_net_2.name
+      subnetwork = google_compute_subnetwork.subnet2.name
+    }
+    additional_pod_network_configs {
+      subnetwork          = google_compute_subnetwork.subnet2.name
+      secondary_pod_range = "pod"
+      max_pods_per_node   = 32
     }
   }
   node_config {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15694

Fix invalid interface conversion of AdditionalPodNetworkConfig:

* Fix invalid keys to extract values of `subnetwork` and `secondary_pod_range`
* Fix invalid type conversion of int64 of `max_pods_per_node`
* Add `additional_pod_network_configs` to integration test

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fix a bug where `additional_pod_network_configs` was not sent correctly in `google_container_node_pool`
```

xref: https://github.com/GoogleCloudPlatform/magic-modules/pull/8385
