### PR TITLE
Revert "Fixes to provider config code unit tests"

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -1413,7 +1413,7 @@ func TestProvider_ProviderConfigure_requestTimeout(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			acctest.UnsetTestProviderConfigEnvs(t)
+			unsetTestProviderConfigEnvs(t)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -1502,8 +1502,8 @@ func TestProvider_ProviderConfigure_requestReason(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			acctest.UnsetTestProviderConfigEnvs(t)
-			acctest.SetupTestEnvs(t, tc.EnvVariables)
+			unsetTestProviderConfigEnvs(t)
+			setupTestEnvs(t, tc.EnvVariables)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 
@@ -1635,7 +1635,7 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 
 			// Arrange
 			ctx := context.Background()
-			acctest.UnsetTestProviderConfigEnvs(t)
+			unsetTestProviderConfigEnvs(t)
 			p := provider.Provider()
 			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
 


### PR DESCRIPTION
Reverting this PR to flex unit tests. 

Won't actually check this change in 