### PR TITLE
Add Apigee environment scope KVMs resource support

### DIFF
--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -1,0 +1,74 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'EnvironmentKeyvaluemaps'
+description: |
+  Collection of key/value string pairs.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Using key value maps': 'https://cloud.google.com/apigee/docs/api-platform/cache/key-value-maps'
+  api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.keyvaluemaps/create'
+
+base_url: '{{env_id}}/keyvaluemaps'
+create_url: '{{env_id}}/keyvaluemaps'
+delete_url: '{{env_id}}/keyvaluemaps/{{name}}'
+self_link: '{{env_id}}/keyvaluemaps/{{name}}/entries'
+import_format: ['{{env_id}}/keyvaluemaps/{{name}}', '{{env_id}}/{{name}}']
+skip_sweeper: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_environment_keyvaluemaps_basic'
+    primary_resource_id: 'apigee_environment_keyvaluemaps'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_test: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_environment_keyvaluemaps_test'
+    primary_resource_id: 'apigee_environment_keyvaluemaps'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_docs: true
+immutable: true
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 1
+  delete_minutes: 1
+autogen_async: true
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'envId'
+    description: |
+      The Apigee environment group associated with the Apigee environment,
+      in the format `organizations/{{org_name}}/environments/{{env_name}}`.
+    required: true
+    immutable: true
+    url_param_only: true
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/apigee_environment_keyvaluemaps.go.erb
+  custom_create: 'templates/terraform/custom_create/apigee_environment_keyvaluemaps.go'
+  decoder: templates/terraform/decoders/apigee_environment_keyvaluemaps.go.erb
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: |
+      Required. ID of the key value map.
+    required: true
+    immutable: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'encrypted'
+    description: |
+      Required. Flag that specifies whether entry values will be encrypted. This field is retained for backward compatibility and the value of encrypted will always be true. Apigee X and hybrid do not support unencrypted key value maps.
+    required: true
+    immutable: true

--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -41,6 +41,8 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
+    min_version:
+      beta
 immutable: true
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1

--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -74,9 +74,3 @@ properties:
       Required. ID of the key value map.
     required: true
     immutable: true
-  - !ruby/object:Api::Type::Boolean
-    name: 'encrypted'
-    description: |
-      Required. Flag that specifies whether entry values will be encrypted. This field is retained for backward compatibility and the value of encrypted will always be true. Apigee X and hybrid do not support unencrypted key value maps.
-    required: true
-    immutable: true

--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -54,6 +54,10 @@ timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1
   delete_minutes: 1
 autogen_async: true
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/apigee_environment_keyvaluemaps.go.erb
+  custom_create: 'templates/terraform/custom_create/apigee_environment_keyvaluemaps.go'
+  decoder: templates/terraform/decoders/apigee_environment_keyvaluemaps.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: 'envId'
@@ -63,10 +67,6 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
-custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/apigee_environment_keyvaluemaps.go.erb
-  custom_create: 'templates/terraform/custom_create/apigee_environment_keyvaluemaps.go'
-  decoder: templates/terraform/decoders/apigee_environment_keyvaluemaps.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'

--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -48,7 +48,6 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
-    skip_test: true
     min_version: beta
 immutable: true
 timeouts: !ruby/object:Api::Timeouts

--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -48,6 +48,7 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
+    skip_test: true
     min_version: beta
 immutable: true
 timeouts: !ruby/object:Api::Timeouts

--- a/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemap.yaml
@@ -41,8 +41,14 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
-    min_version:
-      beta
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_environment_keyvaluemaps_beta_test'
+    primary_resource_id: 'apigee_environment_keyvaluemaps'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_docs: true
+    min_version: beta
 immutable: true
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -1,0 +1,73 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'EnvironmentKeyvaluemapsEntries'
+description: |
+  Creates key value entries in a key value map scoped to an environment.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Using key value maps': 'https://cloud.google.com/apigee/docs/api-platform/cache/key-value-maps'
+  api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.keyvaluemaps.entries/create'
+
+base_url: '{{env_keyvaluemap_id}}/entries'
+create_url: '{{env_keyvaluemap_id}}/entries'
+delete_url: '{{env_keyvaluemap_id}}/entries/{{name}}'
+self_link: '{{env_keyvaluemap_id}}/entries/{{name}}'
+import_format:
+  ['{{env_keyvaluemap_id}}/entries/{{name}}', '{{env_keyvaluemap_id}}/{{name}}']
+skip_sweeper: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_environment_keyvaluemaps_entries_basic'
+    primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_test: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_environment_keyvaluemaps_entries_test'
+    primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_docs: true
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 1
+  delete_minutes: 1
+immutable: true
+autogen_async: true
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'env_keyvaluemap_id'
+    description: |
+      The Apigee environment keyvalumaps Id associated with the Apigee environment,
+      in the format `organizations/{{org_name}}/environments/{{env_name}}/keyvaluemaps/{{keyvaluemap_name}}`.
+    required: true
+    immutable: true
+    url_param_only: true
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/apigee_environment_keyvaluemaps_entries.go.erb
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: |
+      Required. Resource URI that can be used to identify the scope of the key value map entries.
+    required: true
+    immutable: true
+  - !ruby/object:Api::Type::String
+    name: 'value'
+    description: |
+      Required. Data or payload that is being retrieved and associated with the unique key.
+    required: true
+    immutable: true

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -42,6 +42,8 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
+    min_version:
+      beta    
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1
   delete_minutes: 1

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -42,7 +42,6 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
-    skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_environment_keyvaluemaps_entries_beta_test'
     primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
@@ -50,7 +49,6 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
-    skip_test: true
     min_version: beta
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -43,7 +43,7 @@ examples:
       billing_account: :BILLING_ACCT
     skip_docs: true
     min_version:
-      beta    
+      beta
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1
   delete_minutes: 1

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -55,6 +55,8 @@ timeouts: !ruby/object:Api::Timeouts
   delete_minutes: 1
 immutable: true
 autogen_async: true
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/apigee_environment_keyvaluemaps_entries.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: 'env_keyvaluemap_id'
@@ -64,8 +66,6 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
-custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/apigee_environment_keyvaluemaps_entries.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -42,8 +42,14 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
-    min_version:
-      beta
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_environment_keyvaluemaps_entries_beta_test'
+    primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
+    skip_docs: true
+    min_version: beta
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1
   delete_minutes: 1

--- a/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemapEntry.yaml
@@ -42,6 +42,7 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
+    skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_environment_keyvaluemaps_entries_beta_test'
     primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
@@ -49,6 +50,7 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
     skip_docs: true
+    skip_test: true
     min_version: beta
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 1

--- a/mmv1/templates/terraform/custom_create/apigee_environment_keyvaluemaps.go
+++ b/mmv1/templates/terraform/custom_create/apigee_environment_keyvaluemaps.go
@@ -1,0 +1,55 @@
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+obj := make(map[string]interface{})
+nameProp, err := expandApigeeEnvironmentKeyvaluemapsName(d.Get("name"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+	obj["name"] = nameProp
+}
+encryptedProp, err := expandApigeeEnvironmentKeyvaluemapsEncrypted(d.Get("encrypted"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("encrypted"); !tpgresource.IsEmptyValue(reflect.ValueOf(encryptedProp)) && (ok || !reflect.DeepEqual(v, encryptedProp)) {
+	obj["encrypted"] = encryptedProp
+}
+
+url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}{{env_id}}/keyvaluemaps")
+if err != nil {
+	return err
+}
+
+log.Printf("[DEBUG] Creating new EnvironmentKeyvaluemaps: %#v", obj)
+billingProject := ""
+
+// err == nil indicates that the billing_project value was found
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "POST",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: userAgent,
+	Body:      obj,
+	Timeout:   d.Timeout(schema.TimeoutCreate),
+})
+if err != nil {
+	return fmt.Errorf("Error creating EnvironmentKeyvaluemaps: %s", err)
+}
+
+// Store the ID now
+id, err := tpgresource.ReplaceVars(d, config, "{{env_id}}/keyvaluemaps/{{name}}")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+log.Printf("[DEBUG] Finished creating EnvironmentKeyvaluemaps %q: %#v", d.Id(), res)
+
+return resourceApigeeEnvironmentKeyvaluemapsRead(d, meta)

--- a/mmv1/templates/terraform/custom_create/apigee_environment_keyvaluemaps.go
+++ b/mmv1/templates/terraform/custom_create/apigee_environment_keyvaluemaps.go
@@ -10,12 +10,6 @@ if err != nil {
 } else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
 	obj["name"] = nameProp
 }
-encryptedProp, err := expandApigeeEnvironmentKeyvaluemapsEncrypted(d.Get("encrypted"), d, config)
-if err != nil {
-	return err
-} else if v, ok := d.GetOkExists("encrypted"); !tpgresource.IsEmptyValue(reflect.ValueOf(encryptedProp)) && (ok || !reflect.DeepEqual(v, encryptedProp)) {
-	obj["encrypted"] = encryptedProp
-}
 
 url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}{{env_id}}/keyvaluemaps")
 if err != nil {

--- a/mmv1/templates/terraform/custom_import/apigee_environment_keyvaluemaps.go.erb
+++ b/mmv1/templates/terraform/custom_import/apigee_environment_keyvaluemaps.go.erb
@@ -1,0 +1,18 @@
+config := meta.(*transport_tpg.Config)
+
+// current import_formats cannot import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{
+		"(?P<env_id>.+)/keyvaluemaps/(?P<name>.+)",
+		"(?P<env_id>.+)/(?P<name>.+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, "{{env_id}}/keyvaluemaps/{{name}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/apigee_environment_keyvaluemaps_entries.go.erb
+++ b/mmv1/templates/terraform/custom_import/apigee_environment_keyvaluemaps_entries.go.erb
@@ -1,0 +1,18 @@
+config := meta.(*transport_tpg.Config)
+
+// current import_formats cannot import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{
+		"(?P<env_keyvaluemap_id>.+)/entries/(?P<name>.+)",
+		"(?P<env_keyvaluemap_id>.+)/(?P<name>.+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, "{{env_keyvaluemap_id}}/entries/{{name}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/decoders/apigee_environment_keyvaluemaps.go.erb
+++ b/mmv1/templates/terraform/decoders/apigee_environment_keyvaluemaps.go.erb
@@ -1,0 +1,10 @@
+config := meta.(*transport_tpg.Config)
+name, err := tpgresource.ReplaceVars(d, config, "{{name}}")
+if err != nil {
+    return nil, err
+}
+res["name"] = name
+// "encrypted" field is retained for backward compatibility and the value of encrypted will always be true. Apigee X and hybrid do not support unencrypted key value maps.
+res["encrypted"] = true
+
+return res, nil

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
@@ -1,0 +1,68 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test-env%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "Apigee Environment"
+}
+
+resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
+  env_id    = google_apigee_environment.apigee_environment.id
+  name      = "tf-test-env-kvms%{random_suffix}"
+  encrypted = true
+}

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
@@ -1,31 +1,7 @@
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
-
-resource "google_project_service" "apigee" {
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
-}
-
-resource "google_project_service" "servicenetworking" {
-  project = google_project.project.project_id
-  service = "servicenetworking.googleapis.com"
-  depends_on = [google_project_service.apigee]
-}
-
-resource "google_project_service" "compute" {
-  project = google_project.project.project_id
-  service = "compute.googleapis.com"
-  depends_on = [google_project_service.servicenetworking]
-}
+data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
   name       = "apigee-network"
-  project    = google_project.project.project_id
-  depends_on = [google_project_service.compute]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -34,35 +10,30 @@ resource "google_compute_global_address" "apigee_range" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = google_compute_network.apigee_network.id
-  project       = google_project.project.project_id
 }
 
 resource "google_service_networking_connection" "apigee_vpc_connection" {
   network                 = google_compute_network.apigee_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
-  depends_on              = [google_project_service.servicenetworking]
 }
 
 resource "google_apigee_organization" "apigee_org" {
   analytics_region   = "us-central1"
-  project_id         = google_project.project.project_id
+  project_id         = data.google_client_config.current.project
   authorized_network = google_compute_network.apigee_network.id
-  depends_on         = [
-    google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-  ]
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
 }
 
 resource "google_apigee_environment" "apigee_environment" {
   org_id       = google_apigee_organization.apigee_org.id
-  name         = "tf-test-env%{random_suffix}"
+  name         = "tf-test-env"
   description  = "Apigee Environment"
   display_name = "Apigee Environment"
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  name     = "tf-test%{random_suffix}"
+  name     = "tf-test-instance"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
@@ -74,6 +45,6 @@ resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
 
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
   env_id    = google_apigee_environment.apigee_environment.id
-  name      = "tf-test-env-kvms%{random_suffix}"
+  name      = "tf-test-env-kvms"
   encrypted = true
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
@@ -61,6 +61,17 @@ resource "google_apigee_environment" "apigee_environment" {
   display_name = "Apigee Environment"
 }
 
+resource "google_apigee_instance" "apigee_instance" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  instance_id  = google_apigee_instance.apigee_instance.id
+  environment  = google_apigee_environment.apigee_environment.name
+}
+
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
@@ -47,4 +47,10 @@ resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id]
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms"
   encrypted = true
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment
+  ]
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_basic.tf.erb
@@ -46,7 +46,6 @@ resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms"
-  encrypted = true
   depends_on = [
     google_apigee_organization.apigee_org,
     google_apigee_environment.apigee_environment,

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
@@ -19,6 +19,7 @@ resource "google_project" "project" {
   
    project = google_project.project.project_id 
    service = "compute.googleapis.com" 
+   depends_on = [google_project_service.apigeeconnect]
  } 
   
  resource "google_project_service" "servicenetworking" { 
@@ -26,6 +27,7 @@ resource "google_project" "project" {
   
    project = google_project.project.project_id 
    service = "servicenetworking.googleapis.com" 
+   depends_on = [google_project_service.compute]
  } 
   
  resource "google_project_service" "kms" { 
@@ -33,6 +35,7 @@ resource "google_project" "project" {
   
    project = google_project.project.project_id 
    service = "cloudkms.googleapis.com" 
+   depends_on = [google_project_service.servicenetworking]
  } 
 
  resource "google_project_service" "apigeeconnect" {

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
@@ -163,4 +163,10 @@ resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id]
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment
+  ]
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
@@ -119,11 +119,11 @@ resource "google_project" "project" {
    properties { 
      property { 
        name = "features.hybrid.enabled" 
-       value = "false" 
+       value = "true" 
      } 
      property { 
        name = "features.mart.connect.enabled" 
-       value = "false" 
+       value = "true" 
      } 
    } 
   

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
@@ -165,7 +165,6 @@ resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id]
   
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
-  encrypted = true
   depends_on = [
     google_apigee_organization.apigee_org,
     google_apigee_environment.apigee_environment,

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
@@ -119,11 +119,11 @@ resource "google_project" "project" {
    properties { 
      property { 
        name = "features.hybrid.enabled" 
-       value = "true" 
+       value = "false" 
      } 
      property { 
        name = "features.mart.connect.enabled" 
-       value = "true" 
+       value = "false" 
      } 
    } 
   

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_beta_test.tf.erb
@@ -1,0 +1,166 @@
+resource "google_project" "project" { 
+   provider = google-beta 
+  
+   project_id      = "tf-test%{random_suffix}" 
+   name            = "tf-test%{random_suffix}" 
+   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>" 
+   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>" 
+ } 
+  
+ resource "google_project_service" "apigee" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "apigee.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "compute" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "compute.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "servicenetworking" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "servicenetworking.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "kms" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "cloudkms.googleapis.com" 
+ } 
+
+ resource "google_project_service" "apigeeconnect" {
+  provider = google-beta 
+
+  project = google_project.project.project_id
+  service = "apigeeconnect.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+  
+ resource "google_compute_network" "apigee_network" { 
+   provider = google-beta 
+  
+   name       = "apigee-network" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.compute] 
+ } 
+  
+ resource "google_compute_global_address" "apigee_range" { 
+   provider = google-beta 
+  
+   name          = "apigee-range" 
+   purpose       = "VPC_PEERING" 
+   address_type  = "INTERNAL" 
+   prefix_length = 16 
+   network       = google_compute_network.apigee_network.id 
+   project       = google_project.project.project_id 
+ } 
+  
+ resource "google_service_networking_connection" "apigee_vpc_connection" { 
+   provider = google-beta 
+  
+   network                 = google_compute_network.apigee_network.id 
+   service                 = "servicenetworking.googleapis.com" 
+   reserved_peering_ranges = [google_compute_global_address.apigee_range.name] 
+   depends_on              = [google_project_service.servicenetworking] 
+ } 
+  
+ resource "google_kms_key_ring" "apigee_keyring" { 
+   provider = google-beta 
+  
+   name       = "apigee-keyring" 
+   location   = "us-central1" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.kms] 
+ } 
+  
+ resource "google_kms_crypto_key" "apigee_key" { 
+   provider = google-beta 
+  
+   name            = "apigee-key" 
+   key_ring        = google_kms_key_ring.apigee_keyring.id 
+ } 
+  
+ resource "google_project_service_identity" "apigee_sa" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = google_project_service.apigee.service 
+ } 
+  
+ resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" { 
+   provider = google-beta 
+  
+   crypto_key_id = google_kms_crypto_key.apigee_key.id 
+   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter" 
+  
+   members = [ 
+     "serviceAccount:${google_project_service_identity.apigee_sa.email}", 
+   ] 
+ } 
+  
+ resource "google_apigee_organization" "apigee_org" { 
+   provider = google-beta 
+  
+   display_name                         = "apigee-org" 
+   description                          = "Terraform-managed Apigee Org" 
+   analytics_region                     = "us-central1" 
+   project_id                           = google_project.project.project_id 
+   authorized_network                   = google_compute_network.apigee_network.id 
+   billing_type                         = "EVALUATION" 
+   runtime_type                         = "CLOUD"
+   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
+   properties { 
+     property { 
+       name = "features.hybrid.enabled" 
+       value = "true" 
+     } 
+     property { 
+       name = "features.mart.connect.enabled" 
+       value = "true" 
+     } 
+   } 
+  
+   depends_on = [ 
+     google_service_networking_connection.apigee_vpc_connection, 
+     google_kms_crypto_key_iam_binding.apigee_sa_keyuser, 
+   ] 
+ } 
+
+resource "google_apigee_environment" "apigee_environment" {
+  provider = google-beta 
+
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test-env%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "Apigee Environment"
+}
+
+resource "google_apigee_instance" "apigee_instance" {
+  provider = google-beta 
+
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  provider = google-beta 
+
+  instance_id  = google_apigee_instance.apigee_instance.id
+  environment  = google_apigee_environment.apigee_environment.name
+}
+
+resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta 
+  
+  env_id    = google_apigee_environment.apigee_environment.id
+  name      = "tf-test-env-kvms%{random_suffix}"
+  encrypted = true
+}

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
@@ -1,0 +1,74 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test-env%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "Apigee Environment"
+}
+
+resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
+  env_id    = google_apigee_environment.create_apigee_environment.id
+  name      = "tf-test-env-kvms%{random_suffix}"
+  encrypted = true
+}
+
+resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
+  env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
+  name           = "testName"
+  value          = "testValue"
+}

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
@@ -1,31 +1,7 @@
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
-
-resource "google_project_service" "apigee" {
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
-}
-
-resource "google_project_service" "servicenetworking" {
-  project    = google_project.project.project_id
-  service    = "servicenetworking.googleapis.com"
-  depends_on = [google_project_service.apigee]
-}
-
-resource "google_project_service" "compute" {
-  project    = google_project.project.project_id
-  service    = "compute.googleapis.com"
-  depends_on = [google_project_service.servicenetworking]
-}
+data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
   name       = "apigee-network"
-  project    = google_project.project.project_id
-  depends_on = [google_project_service.compute]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -34,35 +10,30 @@ resource "google_compute_global_address" "apigee_range" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = google_compute_network.apigee_network.id
-  project       = google_project.project.project_id
 }
 
 resource "google_service_networking_connection" "apigee_vpc_connection" {
   network                 = google_compute_network.apigee_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
-  depends_on              = [google_project_service.servicenetworking]
 }
 
 resource "google_apigee_organization" "apigee_org" {
   analytics_region   = "us-central1"
-  project_id         = google_project.project.project_id
+  project_id         = data.google_client_config.current.project
   authorized_network = google_compute_network.apigee_network.id
-  depends_on         = [
-    google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-  ]
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
 }
 
 resource "google_apigee_environment" "apigee_environment" {
   org_id       = google_apigee_organization.apigee_org.id
-  name         = "tf-test-env%{random_suffix}"
+  name         = "tf-test-env"
   description  = "Apigee Environment"
   display_name = "Apigee Environment"
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  name     = "tf-test%{random_suffix}"
+  name     = "tf-test-instance"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
@@ -74,7 +45,7 @@ resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
 
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
   env_id    = google_apigee_environment.create_apigee_environment.id
-  name      = "tf-test-env-kvms%{random_suffix}"
+  name      = "tf-test-env-kvms"
   encrypted = true
 }
 

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
@@ -61,6 +61,17 @@ resource "google_apigee_environment" "apigee_environment" {
   display_name = "Apigee Environment"
 }
 
+resource "google_apigee_instance" "apigee_instance" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  instance_id  = google_apigee_instance.apigee_instance.id
+  environment  = google_apigee_environment.apigee_environment.name
+}
+
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
   env_id    = google_apigee_environment.create_apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
@@ -46,7 +46,6 @@ resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
   env_id    = google_apigee_environment.create_apigee_environment.id
   name      = "tf-test-env-kvms"
-  encrypted = true
   depends_on = [
     google_apigee_organization.apigee_org,
     google_apigee_environment.apigee_environment,

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_basic.tf.erb
@@ -47,10 +47,23 @@ resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluema
   env_id    = google_apigee_environment.create_apigee_environment.id
   name      = "tf-test-env-kvms"
   encrypted = true
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment
+  ]
 }
 
 resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
   env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
   name           = "testName"
   value          = "testValue"
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment,
+    google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps
+  ]
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
@@ -19,6 +19,7 @@ resource "google_project" "project" {
   
    project = google_project.project.project_id 
    service = "compute.googleapis.com" 
+   depends_on = [google_project_service.apigeeconnect]
  } 
   
  resource "google_project_service" "servicenetworking" { 
@@ -26,6 +27,7 @@ resource "google_project" "project" {
   
    project = google_project.project.project_id 
    service = "servicenetworking.googleapis.com" 
+   depends_on = [google_project_service.compute]
  } 
   
  resource "google_project_service" "kms" { 
@@ -33,6 +35,7 @@ resource "google_project" "project" {
   
    project = google_project.project.project_id 
    service = "cloudkms.googleapis.com" 
+   depends_on = [google_project_service.servicenetworking]
  } 
 
  resource "google_project_service" "apigeeconnect" {

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
@@ -163,6 +163,12 @@ resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluema
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment
+  ]
 }
 
 resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
@@ -171,4 +177,11 @@ resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_reso
   env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
   name           = "testName"
   value          = "testValue"
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment,
+    google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps
+  ]
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
@@ -119,11 +119,11 @@ resource "google_project" "project" {
    properties { 
      property { 
        name = "features.hybrid.enabled" 
-       value = "false" 
+       value = "true" 
      } 
      property { 
        name = "features.mart.connect.enabled" 
-       value = "false" 
+       value = "true" 
      } 
    } 
   

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
@@ -162,7 +162,6 @@ resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluema
 
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
-  encrypted = true
   depends_on = [
     google_apigee_organization.apigee_org,
     google_apigee_environment.apigee_environment,

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
@@ -119,11 +119,11 @@ resource "google_project" "project" {
    properties { 
      property { 
        name = "features.hybrid.enabled" 
-       value = "true" 
+       value = "false" 
      } 
      property { 
        name = "features.mart.connect.enabled" 
-       value = "true" 
+       value = "false" 
      } 
    } 
   

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_beta_test.tf.erb
@@ -1,0 +1,174 @@
+resource "google_project" "project" { 
+   provider = google-beta 
+  
+   project_id      = "tf-test%{random_suffix}" 
+   name            = "tf-test%{random_suffix}" 
+   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>" 
+   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>" 
+ } 
+  
+ resource "google_project_service" "apigee" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "apigee.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "compute" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "compute.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "servicenetworking" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "servicenetworking.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "kms" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "cloudkms.googleapis.com" 
+ } 
+
+ resource "google_project_service" "apigeeconnect" {
+  provider = google-beta 
+  
+  project = google_project.project.project_id
+  service = "apigeeconnect.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+  
+ resource "google_compute_network" "apigee_network" { 
+   provider = google-beta 
+  
+   name       = "apigee-network" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.compute] 
+ } 
+  
+ resource "google_compute_global_address" "apigee_range" { 
+   provider = google-beta 
+  
+   name          = "apigee-range" 
+   purpose       = "VPC_PEERING" 
+   address_type  = "INTERNAL" 
+   prefix_length = 16 
+   network       = google_compute_network.apigee_network.id 
+   project       = google_project.project.project_id 
+ } 
+  
+ resource "google_service_networking_connection" "apigee_vpc_connection" { 
+   provider = google-beta 
+  
+   network                 = google_compute_network.apigee_network.id 
+   service                 = "servicenetworking.googleapis.com" 
+   reserved_peering_ranges = [google_compute_global_address.apigee_range.name] 
+   depends_on              = [google_project_service.servicenetworking] 
+ } 
+  
+ resource "google_kms_key_ring" "apigee_keyring" { 
+   provider = google-beta 
+  
+   name       = "apigee-keyring" 
+   location   = "us-central1" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.kms] 
+ } 
+  
+ resource "google_kms_crypto_key" "apigee_key" { 
+   provider = google-beta 
+  
+   name            = "apigee-key" 
+   key_ring        = google_kms_key_ring.apigee_keyring.id 
+ } 
+  
+ resource "google_project_service_identity" "apigee_sa" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = google_project_service.apigee.service 
+ } 
+  
+ resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" { 
+   provider = google-beta 
+  
+   crypto_key_id = google_kms_crypto_key.apigee_key.id 
+   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter" 
+  
+   members = [ 
+     "serviceAccount:${google_project_service_identity.apigee_sa.email}", 
+   ] 
+ } 
+  
+ resource "google_apigee_organization" "apigee_org" { 
+   provider = google-beta 
+  
+   display_name                         = "apigee-org" 
+   description                          = "Terraform-managed Apigee Org" 
+   analytics_region                     = "us-central1" 
+   project_id                           = google_project.project.project_id 
+   authorized_network                   = google_compute_network.apigee_network.id 
+   billing_type                         = "EVALUATION" 
+   runtime_type                         = "CLOUD"
+   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
+   properties { 
+     property { 
+       name = "features.hybrid.enabled" 
+       value = "true" 
+     } 
+     property { 
+       name = "features.mart.connect.enabled" 
+       value = "true" 
+     } 
+   } 
+  
+   depends_on = [ 
+     google_service_networking_connection.apigee_vpc_connection, 
+     google_kms_crypto_key_iam_binding.apigee_sa_keyuser, 
+   ] 
+ } 
+
+resource "google_apigee_environment" "apigee_environment" {
+  provider = google-beta 
+
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test-env%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "Apigee Environment"
+}
+
+resource "google_apigee_instance" "apigee_instance" {
+  provider = google-beta 
+
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  provider = google-beta 
+
+  instance_id  = google_apigee_instance.apigee_instance.id
+  environment  = google_apigee_environment.apigee_environment.name
+}
+
+resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
+  provider = google-beta 
+
+  env_id    = google_apigee_environment.apigee_environment.id
+  name      = "tf-test-env-kvms%{random_suffix}"
+  encrypted = true
+}
+
+resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta 
+  
+  env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
+  name           = "testName"
+  value          = "testValue"
+}

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -1,64 +1,136 @@
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
+resource "google_project" "project" { 
+   provider = google-beta 
+  
+   project_id      = "tf-test%{random_suffix}" 
+   name            = "tf-test%{random_suffix}" 
+   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>" 
+   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>" 
+ } 
+  
+ resource "google_project_service" "apigee" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "apigee.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "compute" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "compute.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "servicenetworking" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "servicenetworking.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "kms" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "cloudkms.googleapis.com" 
+ } 
 
-resource "google_project_service" "apigee" {
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
-}
-
-resource "google_project_service" "servicenetworking" {
-  project    = google_project.project.project_id
-  service    = "servicenetworking.googleapis.com"
-  depends_on = [google_project_service.apigee]
-}
-
-resource "google_project_service" "compute" {
-  project    = google_project.project.project_id
-  service    = "compute.googleapis.com"
-  depends_on = [google_project_service.servicenetworking]
-}
-
-resource "google_project_service" "apigeeconnect" {
+ resource "google_project_service" "apigeeconnect" {
+  provider = google-beta 
+  
   project = google_project.project.project_id
   service = "apigeeconnect.googleapis.com"
   depends_on = [google_project_service.apigee]
 }
-
-resource "google_compute_network" "apigee_network" {
-  name       = "apigee-network"
-  project    = google_project.project.project_id
-  depends_on = [google_project_service.compute]
-}
-
-resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.apigee_network.id
-  project       = google_project.project.project_id
-}
-
-resource "google_service_networking_connection" "apigee_vpc_connection" {
-  network                 = google_compute_network.apigee_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
-  depends_on              = [google_project_service.servicenetworking]
-}
-
-resource "google_apigee_organization" "apigee_org" {
-  analytics_region   = "us-central1"
-  project_id         = google_project.project.project_id
-  authorized_network = google_compute_network.apigee_network.id
-  depends_on         = [
-    google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-  ]
-}
+  
+ resource "google_compute_network" "apigee_network" { 
+   provider = google-beta 
+  
+   name       = "apigee-network" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.compute] 
+ } 
+  
+ resource "google_compute_global_address" "apigee_range" { 
+   provider = google-beta 
+  
+   name          = "apigee-range" 
+   purpose       = "VPC_PEERING" 
+   address_type  = "INTERNAL" 
+   prefix_length = 16 
+   network       = google_compute_network.apigee_network.id 
+   project       = google_project.project.project_id 
+ } 
+  
+ resource "google_service_networking_connection" "apigee_vpc_connection" { 
+   provider = google-beta 
+  
+   network                 = google_compute_network.apigee_network.id 
+   service                 = "servicenetworking.googleapis.com" 
+   reserved_peering_ranges = [google_compute_global_address.apigee_range.name] 
+   depends_on              = [google_project_service.servicenetworking] 
+ } 
+  
+ resource "google_kms_key_ring" "apigee_keyring" { 
+   provider = google-beta 
+  
+   name       = "apigee-keyring" 
+   location   = "us-central1" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.kms] 
+ } 
+  
+ resource "google_kms_crypto_key" "apigee_key" { 
+   provider = google-beta 
+  
+   name            = "apigee-key" 
+   key_ring        = google_kms_key_ring.apigee_keyring.id 
+ } 
+  
+ resource "google_project_service_identity" "apigee_sa" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = google_project_service.apigee.service 
+ } 
+  
+ resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" { 
+   provider = google-beta 
+  
+   crypto_key_id = google_kms_crypto_key.apigee_key.id 
+   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter" 
+  
+   members = [ 
+     "serviceAccount:${google_project_service_identity.apigee_sa.email}", 
+   ] 
+ } 
+  
+ resource "google_apigee_organization" "apigee_org" { 
+   provider = google-beta 
+  
+   display_name                         = "apigee-org" 
+   description                          = "Terraform-managed Apigee Org" 
+   analytics_region                     = "us-central1" 
+   project_id                           = google_project.project.project_id 
+   authorized_network                   = google_compute_network.apigee_network.id 
+   billing_type                         = "EVALUATION" 
+   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
+   properties { 
+     property { 
+       name = "features.hybrid.enabled" 
+       value = "true" 
+     } 
+     property { 
+       name = "features.mart.connect.enabled" 
+       value = "true" 
+     } 
+   } 
+  
+   depends_on = [ 
+     google_service_networking_connection.apigee_vpc_connection, 
+     google_kms_crypto_key_iam_binding.apigee_sa_keyuser, 
+   ] 
+ } 
 
 resource "google_apigee_environment" "apigee_environment" {
   org_id       = google_apigee_organization.apigee_org.id

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -22,6 +22,12 @@ resource "google_project_service" "compute" {
   depends_on = [google_project_service.servicenetworking]
 }
 
+resource "google_project_service" "apigeeconnect" {
+  project = google_project.project.project_id
+  service = "apigeeconnect.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
 resource "google_compute_network" "apigee_network" {
   name       = "apigee-network"
   project    = google_project.project.project_id

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -1,0 +1,74 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test-env%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "Apigee Environment"
+}
+
+resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
+  env_id    = google_apigee_environment.apigee_environment.id
+  name      = "tf-test-env-kvms%{random_suffix}"
+  encrypted = true
+}
+
+resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
+  env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
+  name           = "testName"
+  value          = "testValue"
+}

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -61,6 +61,17 @@ resource "google_apigee_environment" "apigee_environment" {
   display_name = "Apigee Environment"
 }
 
+resource "google_apigee_instance" "apigee_instance" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  instance_id  = google_apigee_instance.apigee_instance.id
+  environment  = google_apigee_environment.apigee_environment.name
+}
+
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -114,6 +114,7 @@ resource "google_project" "project" {
    project_id                           = google_project.project.project_id 
    authorized_network                   = google_compute_network.apigee_network.id 
    billing_type                         = "EVALUATION" 
+   runtime_type                         = "CLOUD"
    runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
    properties { 
      property { 

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -88,6 +88,12 @@ resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluema
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment
+  ]
 }
 
 resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
@@ -95,4 +101,11 @@ resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_reso
   env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
   name           = "testName"
   value          = "testValue"
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment,
+    google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps
+  ]
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -87,7 +87,6 @@ resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
-  encrypted = true
   depends_on = [
     google_apigee_organization.apigee_org,
     google_apigee_environment.apigee_environment,

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -1,141 +1,72 @@
-resource "google_project" "project" { 
-   provider = google-beta 
-  
-   project_id      = "tf-test%{random_suffix}" 
-   name            = "tf-test%{random_suffix}" 
-   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>" 
-   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>" 
- } 
-  
- resource "google_project_service" "apigee" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "apigee.googleapis.com" 
- } 
-  
- resource "google_project_service" "compute" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "compute.googleapis.com" 
- } 
-  
- resource "google_project_service" "servicenetworking" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "servicenetworking.googleapis.com" 
- } 
-  
- resource "google_project_service" "kms" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "cloudkms.googleapis.com" 
- } 
-
- resource "google_project_service" "apigeeconnect" {
-  provider = google-beta 
-  
-  project = google_project.project.project_id
-  service = "apigeeconnect.googleapis.com"
-  depends_on = [google_project_service.apigee]
+resource "google_project" "project" {
+  project_id      = "tf-test-%{random_suffix}"
+  name            = "tf-test-%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
 }
-  
- resource "google_compute_network" "apigee_network" { 
-   provider = google-beta 
-  
-   name       = "apigee-network" 
-   project    = google_project.project.project_id 
-   depends_on = [google_project_service.compute] 
- } 
-  
- resource "google_compute_global_address" "apigee_range" { 
-   provider = google-beta 
-  
-   name          = "apigee-range" 
-   purpose       = "VPC_PEERING" 
-   address_type  = "INTERNAL" 
-   prefix_length = 16 
-   network       = google_compute_network.apigee_network.id 
-   project       = google_project.project.project_id 
- } 
-  
- resource "google_service_networking_connection" "apigee_vpc_connection" { 
-   provider = google-beta 
-  
-   network                 = google_compute_network.apigee_network.id 
-   service                 = "servicenetworking.googleapis.com" 
-   reserved_peering_ranges = [google_compute_global_address.apigee_range.name] 
-   depends_on              = [google_project_service.servicenetworking] 
- } 
-  
- resource "google_kms_key_ring" "apigee_keyring" { 
-   provider = google-beta 
-  
-   name       = "apigee-keyring" 
-   location   = "us-central1" 
-   project    = google_project.project.project_id 
-   depends_on = [google_project_service.kms] 
- } 
-  
- resource "google_kms_crypto_key" "apigee_key" { 
-   provider = google-beta 
-  
-   name            = "apigee-key" 
-   key_ring        = google_kms_key_ring.apigee_keyring.id 
- } 
-  
- resource "google_project_service_identity" "apigee_sa" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = google_project_service.apigee.service 
- } 
-  
- resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" { 
-   provider = google-beta 
-  
-   crypto_key_id = google_kms_crypto_key.apigee_key.id 
-   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter" 
-  
-   members = [ 
-     "serviceAccount:${google_project_service_identity.apigee_sa.email}", 
-   ] 
- } 
-  
- resource "google_apigee_organization" "apigee_org" { 
-   provider = google-beta 
-  
-   display_name                         = "apigee-org" 
-   description                          = "Terraform-managed Apigee Org" 
-   analytics_region                     = "us-central1" 
-   project_id                           = google_project.project.project_id 
-   authorized_network                   = google_compute_network.apigee_network.id 
-   billing_type                         = "EVALUATION" 
-   runtime_type                         = "CLOUD"
-   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
-   properties { 
-     property { 
-       name = "features.hybrid.enabled" 
-       value = "true" 
-     } 
-     property { 
-       name = "features.mart.connect.enabled" 
-       value = "true" 
-     } 
-   } 
-  
-   depends_on = [ 
-     google_service_networking_connection.apigee_vpc_connection, 
-     google_kms_crypto_key_iam_binding.apigee_sa_keyuser, 
-   ] 
- } 
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [ google_project_service.servicenetworking ]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [ google_project_service.apigee ]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [ google_project_service.compute ]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  billing_type       = "EVALUATION"
+  runtime_type       = "CLOUD"
+  properties { 
+    property { 
+      name = "features.hybrid.enabled" 
+      value = "false" 
+    } 
+    property { 
+      name = "features.mart.connect.enabled" 
+      value = "false" 
+    } 
+  } 
+    
+  depends_on = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee
+  ]
+}
 
 resource "google_apigee_environment" "apigee_environment" {
-  provider = google-beta 
-
   org_id       = google_apigee_organization.apigee_org.id
   name         = "tf-test-env%{random_suffix}"
   description  = "Apigee Environment"
@@ -143,30 +74,23 @@ resource "google_apigee_environment" "apigee_environment" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  provider = google-beta 
-
   name     = "tf-test%{random_suffix}"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
 
 resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
-  provider = google-beta 
-
   instance_id  = google_apigee_instance.apigee_instance.id
   environment  = google_apigee_environment.apigee_environment.name
 }
 
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
-  provider = google-beta 
-
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true
 }
 
 resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta 
   
   env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
   name           = "testName"

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -134,6 +134,8 @@ resource "google_project" "project" {
  } 
 
 resource "google_apigee_environment" "apigee_environment" {
+  provider = google-beta 
+
   org_id       = google_apigee_organization.apigee_org.id
   name         = "tf-test-env%{random_suffix}"
   description  = "Apigee Environment"
@@ -141,23 +143,31 @@ resource "google_apigee_environment" "apigee_environment" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
+  provider = google-beta 
+
   name     = "tf-test%{random_suffix}"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
 
 resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  provider = google-beta 
+
   instance_id  = google_apigee_instance.apigee_instance.id
   environment  = google_apigee_environment.apigee_environment.name
 }
 
 resource "google_apigee_environment_keyvaluemaps" "apigee_environment_keyvaluemaps" {
+  provider = google-beta 
+
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true
 }
 
 resource "google_apigee_environment_keyvaluemaps_entries" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta 
+  
   env_keyvaluemap_id = google_apigee_environment_keyvaluemaps.apigee_environment_keyvaluemaps.id
   name           = "testName"
   value          = "testValue"

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_entries_test.tf.erb
@@ -52,11 +52,11 @@ resource "google_apigee_organization" "apigee_org" {
   properties { 
     property { 
       name = "features.hybrid.enabled" 
-      value = "false" 
+      value = "true" 
     } 
     property { 
       name = "features.mart.connect.enabled" 
-      value = "false" 
+      value = "true" 
     } 
   } 
     

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -1,0 +1,68 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test-env%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "Apigee Environment"
+}
+
+resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
+  env_id    = google_apigee_environment.apigee_environment.id
+  name      = "tf-test-env-kvms%{random_suffix}"
+  encrypted = true
+}

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -61,6 +61,17 @@ resource "google_apigee_environment" "apigee_environment" {
   display_name = "Apigee Environment"
 }
 
+resource "google_apigee_instance" "apigee_instance" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  instance_id  = google_apigee_instance.apigee_instance.id
+  environment  = google_apigee_environment.apigee_environment.name
+}
+
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -22,6 +22,12 @@ resource "google_project_service" "compute" {
   depends_on = [google_project_service.servicenetworking]
 }
 
+resource "google_project_service" "apigeeconnect" {
+  project = google_project.project.project_id
+  service = "apigeeconnect.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
 resource "google_compute_network" "apigee_network" {
   name       = "apigee-network"
   project    = google_project.project.project_id

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -1,64 +1,136 @@
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
+resource "google_project" "project" { 
+   provider = google-beta 
+  
+   project_id      = "tf-test%{random_suffix}" 
+   name            = "tf-test%{random_suffix}" 
+   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>" 
+   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>" 
+ } 
+  
+ resource "google_project_service" "apigee" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "apigee.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "compute" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "compute.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "servicenetworking" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "servicenetworking.googleapis.com" 
+ } 
+  
+ resource "google_project_service" "kms" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = "cloudkms.googleapis.com" 
+ } 
 
-resource "google_project_service" "apigee" {
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
-}
+ resource "google_project_service" "apigeeconnect" {
+  provider = google-beta 
 
-resource "google_project_service" "servicenetworking" {
-  project    = google_project.project.project_id
-  service    = "servicenetworking.googleapis.com"
-  depends_on = [google_project_service.apigee]
-}
-
-resource "google_project_service" "compute" {
-  project    = google_project.project.project_id
-  service    = "compute.googleapis.com"
-  depends_on = [google_project_service.servicenetworking]
-}
-
-resource "google_project_service" "apigeeconnect" {
   project = google_project.project.project_id
   service = "apigeeconnect.googleapis.com"
   depends_on = [google_project_service.apigee]
 }
-
-resource "google_compute_network" "apigee_network" {
-  name       = "apigee-network"
-  project    = google_project.project.project_id
-  depends_on = [google_project_service.compute]
-}
-
-resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.apigee_network.id
-  project       = google_project.project.project_id
-}
-
-resource "google_service_networking_connection" "apigee_vpc_connection" {
-  network                 = google_compute_network.apigee_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
-  depends_on              = [google_project_service.servicenetworking]
-}
-
-resource "google_apigee_organization" "apigee_org" {
-  analytics_region   = "us-central1"
-  project_id         = google_project.project.project_id
-  authorized_network = google_compute_network.apigee_network.id
-  depends_on         = [
-    google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-  ]
-}
+  
+ resource "google_compute_network" "apigee_network" { 
+   provider = google-beta 
+  
+   name       = "apigee-network" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.compute] 
+ } 
+  
+ resource "google_compute_global_address" "apigee_range" { 
+   provider = google-beta 
+  
+   name          = "apigee-range" 
+   purpose       = "VPC_PEERING" 
+   address_type  = "INTERNAL" 
+   prefix_length = 16 
+   network       = google_compute_network.apigee_network.id 
+   project       = google_project.project.project_id 
+ } 
+  
+ resource "google_service_networking_connection" "apigee_vpc_connection" { 
+   provider = google-beta 
+  
+   network                 = google_compute_network.apigee_network.id 
+   service                 = "servicenetworking.googleapis.com" 
+   reserved_peering_ranges = [google_compute_global_address.apigee_range.name] 
+   depends_on              = [google_project_service.servicenetworking] 
+ } 
+  
+ resource "google_kms_key_ring" "apigee_keyring" { 
+   provider = google-beta 
+  
+   name       = "apigee-keyring" 
+   location   = "us-central1" 
+   project    = google_project.project.project_id 
+   depends_on = [google_project_service.kms] 
+ } 
+  
+ resource "google_kms_crypto_key" "apigee_key" { 
+   provider = google-beta 
+  
+   name            = "apigee-key" 
+   key_ring        = google_kms_key_ring.apigee_keyring.id 
+ } 
+  
+ resource "google_project_service_identity" "apigee_sa" { 
+   provider = google-beta 
+  
+   project = google_project.project.project_id 
+   service = google_project_service.apigee.service 
+ } 
+  
+ resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" { 
+   provider = google-beta 
+  
+   crypto_key_id = google_kms_crypto_key.apigee_key.id 
+   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter" 
+  
+   members = [ 
+     "serviceAccount:${google_project_service_identity.apigee_sa.email}", 
+   ] 
+ } 
+  
+ resource "google_apigee_organization" "apigee_org" { 
+   provider = google-beta 
+  
+   display_name                         = "apigee-org" 
+   description                          = "Terraform-managed Apigee Org" 
+   analytics_region                     = "us-central1" 
+   project_id                           = google_project.project.project_id 
+   authorized_network                   = google_compute_network.apigee_network.id 
+   billing_type                         = "EVALUATION" 
+   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
+   properties { 
+     property { 
+       name = "features.hybrid.enabled" 
+       value = "true" 
+     } 
+     property { 
+       name = "features.mart.connect.enabled" 
+       value = "true" 
+     } 
+   } 
+  
+   depends_on = [ 
+     google_service_networking_connection.apigee_vpc_connection, 
+     google_kms_crypto_key_iam_binding.apigee_sa_keyuser, 
+   ] 
+ } 
 
 resource "google_apigee_environment" "apigee_environment" {
   org_id       = google_apigee_organization.apigee_org.id

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -114,6 +114,7 @@ resource "google_project" "project" {
    project_id                           = google_project.project.project_id 
    authorized_network                   = google_compute_network.apigee_network.id 
    billing_type                         = "EVALUATION" 
+   runtime_type                         = "CLOUD"
    runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
    properties { 
      property { 

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -134,6 +134,8 @@ resource "google_project" "project" {
  } 
 
 resource "google_apigee_environment" "apigee_environment" {
+  provider = google-beta 
+
   org_id       = google_apigee_organization.apigee_org.id
   name         = "tf-test-env%{random_suffix}"
   description  = "Apigee Environment"
@@ -141,17 +143,23 @@ resource "google_apigee_environment" "apigee_environment" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
+  provider = google-beta 
+
   name     = "tf-test%{random_suffix}"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
 
 resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
+  provider = google-beta 
+
   instance_id  = google_apigee_instance.apigee_instance.id
   environment  = google_apigee_environment.apigee_environment.name
 }
 
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta 
+  
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -87,7 +87,6 @@ resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
-  encrypted = true
   depends_on = [
     google_apigee_organization.apigee_org,
     google_apigee_environment.apigee_environment,

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -88,4 +88,10 @@ resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id]
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true
+  depends_on = [
+    google_apigee_organization.apigee_org,
+    google_apigee_environment.apigee_environment,
+    google_apigee_instance.apigee_instance,
+    google_apigee_instance_attachment.apigee_instance_attachment
+  ]
 }

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -1,141 +1,72 @@
-resource "google_project" "project" { 
-   provider = google-beta 
-  
-   project_id      = "tf-test%{random_suffix}" 
-   name            = "tf-test%{random_suffix}" 
-   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>" 
-   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>" 
- } 
-  
- resource "google_project_service" "apigee" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "apigee.googleapis.com" 
- } 
-  
- resource "google_project_service" "compute" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "compute.googleapis.com" 
- } 
-  
- resource "google_project_service" "servicenetworking" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "servicenetworking.googleapis.com" 
- } 
-  
- resource "google_project_service" "kms" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = "cloudkms.googleapis.com" 
- } 
-
- resource "google_project_service" "apigeeconnect" {
-  provider = google-beta 
-
-  project = google_project.project.project_id
-  service = "apigeeconnect.googleapis.com"
-  depends_on = [google_project_service.apigee]
+resource "google_project" "project" {
+  project_id      = "tf-test-%{random_suffix}"
+  name            = "tf-test-%{random_suffix}"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
 }
-  
- resource "google_compute_network" "apigee_network" { 
-   provider = google-beta 
-  
-   name       = "apigee-network" 
-   project    = google_project.project.project_id 
-   depends_on = [google_project_service.compute] 
- } 
-  
- resource "google_compute_global_address" "apigee_range" { 
-   provider = google-beta 
-  
-   name          = "apigee-range" 
-   purpose       = "VPC_PEERING" 
-   address_type  = "INTERNAL" 
-   prefix_length = 16 
-   network       = google_compute_network.apigee_network.id 
-   project       = google_project.project.project_id 
- } 
-  
- resource "google_service_networking_connection" "apigee_vpc_connection" { 
-   provider = google-beta 
-  
-   network                 = google_compute_network.apigee_network.id 
-   service                 = "servicenetworking.googleapis.com" 
-   reserved_peering_ranges = [google_compute_global_address.apigee_range.name] 
-   depends_on              = [google_project_service.servicenetworking] 
- } 
-  
- resource "google_kms_key_ring" "apigee_keyring" { 
-   provider = google-beta 
-  
-   name       = "apigee-keyring" 
-   location   = "us-central1" 
-   project    = google_project.project.project_id 
-   depends_on = [google_project_service.kms] 
- } 
-  
- resource "google_kms_crypto_key" "apigee_key" { 
-   provider = google-beta 
-  
-   name            = "apigee-key" 
-   key_ring        = google_kms_key_ring.apigee_keyring.id 
- } 
-  
- resource "google_project_service_identity" "apigee_sa" { 
-   provider = google-beta 
-  
-   project = google_project.project.project_id 
-   service = google_project_service.apigee.service 
- } 
-  
- resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" { 
-   provider = google-beta 
-  
-   crypto_key_id = google_kms_crypto_key.apigee_key.id 
-   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter" 
-  
-   members = [ 
-     "serviceAccount:${google_project_service_identity.apigee_sa.email}", 
-   ] 
- } 
-  
- resource "google_apigee_organization" "apigee_org" { 
-   provider = google-beta 
-  
-   display_name                         = "apigee-org" 
-   description                          = "Terraform-managed Apigee Org" 
-   analytics_region                     = "us-central1" 
-   project_id                           = google_project.project.project_id 
-   authorized_network                   = google_compute_network.apigee_network.id 
-   billing_type                         = "EVALUATION" 
-   runtime_type                         = "CLOUD"
-   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id 
-   properties { 
-     property { 
-       name = "features.hybrid.enabled" 
-       value = "true" 
-     } 
-     property { 
-       name = "features.mart.connect.enabled" 
-       value = "true" 
-     } 
-   } 
-  
-   depends_on = [ 
-     google_service_networking_connection.apigee_vpc_connection, 
-     google_kms_crypto_key_iam_binding.apigee_sa_keyuser, 
-   ] 
- } 
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [ google_project_service.servicenetworking ]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [ google_project_service.apigee ]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [ google_project_service.compute ]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  billing_type       = "EVALUATION"
+  runtime_type       = "CLOUD"
+  properties { 
+    property { 
+      name = "features.hybrid.enabled" 
+      value = "false" 
+    } 
+    property { 
+      name = "features.mart.connect.enabled" 
+      value = "false" 
+    } 
+  } 
+    
+  depends_on = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee
+  ]
+}
 
 resource "google_apigee_environment" "apigee_environment" {
-  provider = google-beta 
-
   org_id       = google_apigee_organization.apigee_org.id
   name         = "tf-test-env%{random_suffix}"
   description  = "Apigee Environment"
@@ -143,23 +74,17 @@ resource "google_apigee_environment" "apigee_environment" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  provider = google-beta 
-
   name     = "tf-test%{random_suffix}"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
 
 resource "google_apigee_instance_attachment" "apigee_instance_attachment" {
-  provider = google-beta 
-
   instance_id  = google_apigee_instance.apigee_instance.id
   environment  = google_apigee_environment.apigee_environment.name
 }
 
 resource "google_apigee_environment_keyvaluemaps" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta 
-  
   env_id    = google_apigee_environment.apigee_environment.id
   name      = "tf-test-env-kvms%{random_suffix}"
   encrypted = true

--- a/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_keyvaluemaps_test.tf.erb
@@ -52,11 +52,11 @@ resource "google_apigee_organization" "apigee_org" {
   properties { 
     property { 
       name = "features.hybrid.enabled" 
-      value = "false" 
+      value = "true" 
     } 
     property { 
       name = "features.mart.connect.enabled" 
-      value = "false" 
+      value = "true" 
     } 
   } 
     


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adding Apigee KVMs support. Fixes https://github.com/hashicorp/terraform-provider-google/issues/13074

Guide: https://cloud.google.com/apigee/docs/api-platform/cache/key-value-maps#api

Environment scope kvms:

kvms api : https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.keyvaluemaps?hl=en
kvms entries api : https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.keyvaluemaps.entries?hl=en

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_apigee_environment_keyvaluemaps`
```
```release-note:new-resource
`google_apigee_environment_keyvaluemaps_entries`
```