### PR TITLE
Node pool operations should retry if there is a quota issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.4.19

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -581,9 +581,11 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		operation, err = clusterNodePoolsCreateCall.Do()
 
 		if err != nil {
-			if tpgresource.IsFailedPreconditionError(err) {
+			if tpgresource.IsFailedPreconditionError(err) || tpgresource.IsQuotaError(err) {
 				// We get failed precondition errors if the cluster is updating
 				// while we try to add the node pool.
+				// We get quota errors if there the number of running concurrent
+                                // operations reaches the quota.
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -786,9 +788,11 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		operation, err = clusterNodePoolsDeleteCall.Do()
 
 		if err != nil {
-			if tpgresource.IsFailedPreconditionError(err) {
+			if tpgresource.IsFailedPreconditionError(err) || tpgresource.IsQuotaError(err) {
 				// We get failed precondition errors if the cluster is updating
 				// while we try to delete the node pool.
+				// We get quota errors if there the number of running concurrent
+				// operations reaches the quota.
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -515,10 +515,12 @@ func CheckGoogleIamPolicy(value string) error {
 	return nil
 }
 
-// Retries an operation while the canonical error code is FAILED_PRECONDTION or RESOURCE_EXHAUSTED
-// which indicates there is an incompatible operation already running on the
-// cluster or there are the number of allowed concurrent operations running on the cluster. These errors can be safely retried until the incompatible operation
-// completes, and the newly requested operation can begin.
+// Retries an operation while the canonical error code is FAILED_PRECONDTION
+// or RESOURCE_EXHAUSTED which indicates there is an incompatible operation
+// already running on the cluster or there are the number of allowed concurrent
+// operations running on the cluster. These errors can be safely retried until
+// the incompatible operation completes, and the newly requested operation can
+// begin.
 func RetryWhileIncompatibleOperation(timeout time.Duration, lockKey string, f func() error) error {
 	return resource.Retry(timeout, func() *resource.RetryError {
 		if err := transport_tpg.LockedCall(lockKey, f); err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Node pool update, create and delete operation should be retriable if they got a quota error from the api call. Quota error
means that the number of running concurrent operations on the cluster reaches the quota. It should be retriable.

Reviewers note:

- There is one failure from `make test`. It's a build failure unrelated this change.
```
# github.com/hashicorp/terraform-provider-google/google/services/biglake_test [github.com/hashicorp/terraform-provider-google/google/services/biglake.test]
google/services/biglake/resource_biglake_database_test.go:26:13: undefined: testAccBiglakeDatabase_biglakeDatabaseExample
...
FAIL	github.com/hashicorp/terraform-provider-google/google/services/biglake [build failed]
```
- When I generate the provider (ga version) and there are a bunch of unrelated diff in the generated code. Could you please check if I'm making the right change,  Did I missed anything, etc.
- I ran related acceptance test `make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'` but got massive failure with the same error
```
Error: Error waiting for creating GKE cluster: The network "default" does not have available private IP space in 10.0.0.0/8 to reserve a /14 block for containers for cluster {Zone=us-central1-a, ProjectNum=572772069087, ProjectName=cindyzhengjw-gke-dev, ClusterName=tf-test-cluster-ghgg3wicmo, ClusterHash=77b8405669a34c92a105a3dbc18466947fd140938b354ff5b9ea8cc5fd8fe0d3}.
        
          with google_container_cluster.cluster,
          on terraform_plugin_test.tf line 2, in resource "google_container_cluster" "cluster":
           2: resource "google_container_cluster" "cluster" {
```



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
