### PR TITLE
Added support for `auto` and deprecated `automatic` field in `google_secret_manager_secret` resource

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -130,9 +130,10 @@ properties:
           - replication.0.automatic
           - replication.0.user_managed
           - replication.0.automatic_replication
-        deprecation_message: 'Deprecated in favor of `automatic_replication`'
+        deprecation_message: >-
+          `automatic` is deprecated and will be removed in a future major release. Use `automatic_replication` instead.
         description: |
-          **Deprecated** The Secret will automatically be replicated without any restrictions.
+          The Secret will automatically be replicated without any restrictions.
       - !ruby/object:Api::Type::NestedObject
         name: automaticReplication
         api_name: automatic

--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -38,6 +38,14 @@ examples:
     primary_resource_id: 'secret-with-annotations'
     vars:
       secret_id: 'secret'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'secret_with_automatic_cmek'
+    primary_resource_id: 'secret-with-automatic-cmek'
+    vars:
+      secret_id: 'secret'
+      kms_key_name: 'kms-key'
+    test_vars_overrides:
+      kms_key_name: 'acctest.BootstrapKMSKey(t).CryptoKey.Name'
 import_format: ['projects/{{project}}/secrets/{{secret_id}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/secret_manager_secret.go.erb
@@ -109,6 +117,8 @@ properties:
     name: replication
     required: true
     immutable: true
+    custom_expand: templates/terraform/custom_expand/secret_manager_replication.go.erb
+    custom_flatten: templates/terraform/custom_flatten/secret_manager_replication.go.erb
     description: |
       The replication policy of the secret data attached to the Secret. It cannot be changed
       after the Secret has been created.
@@ -119,16 +129,40 @@ properties:
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed
+          - replication.0.automatic_replication
+        deprecation_message: 'Deprecated in favor of `automatic_replication`'
+        description: |
+          **Deprecated** The Secret will automatically be replicated without any restrictions.
+      - !ruby/object:Api::Type::NestedObject
+        name: automaticReplication
+        api_name: automatic
+        immutable: true
+        exactly_one_of:
+          - replication.0.automatic
+          - replication.0.user_managed
+          - replication.0.automatic_replication
         description: |
           The Secret will automatically be replicated without any restrictions.
-        custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
-        custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: customerManagedEncryption
+            description: |
+              The customer-managed encryption configuration of the Secret.
+              If no configuration is provided, Google-managed default
+              encryption is used.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: kmsKeyName
+                required: true
+                description: |
+                  The resource name of the Cloud KMS CryptoKey used to encrypt secret payloads.
       - !ruby/object:Api::Type::NestedObject
         name: userManaged
         immutable: true
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed
+          - replication.0.automatic_replication
         description: |
           The Secret will be replicated to the regions specified by the user.
         properties:

--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -129,19 +129,19 @@ properties:
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed
-          - replication.0.automatic_replication
+          - replication.0.auto
         deprecation_message: >-
-          `automatic` is deprecated and will be removed in a future major release. Use `automatic_replication` instead.
+          `automatic` is deprecated and will be removed in a future major release. Use `auto` instead.
         description: |
           The Secret will automatically be replicated without any restrictions.
       - !ruby/object:Api::Type::NestedObject
-        name: automaticReplication
+        name: auto
         api_name: automatic
         immutable: true
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed
-          - replication.0.automatic_replication
+          - replication.0.auto
         description: |
           The Secret will automatically be replicated without any restrictions.
         properties:
@@ -163,7 +163,7 @@ properties:
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed
-          - replication.0.automatic_replication
+          - replication.0.auto
         description: |
           The Secret will be replicated to the regions specified by the user.
         properties:

--- a/mmv1/templates/terraform/custom_expand/secret_manager_replication.go.erb
+++ b/mmv1/templates/terraform/custom_expand/secret_manager_replication.go.erb
@@ -30,12 +30,12 @@ func expandSecretManagerSecretReplication(v interface{}, d tpgresource.Terraform
 		}
 	}
 
-	if _, ok := d.GetOk("replication.0.automatic_replication"); ok{
-		transformedAutomaticReplication, err := expandSecretManagerSecretReplicationAutomaticReplication(original["automatic_replication"], d, config)
+	if _, ok := d.GetOk("replication.0.auto"); ok{
+		transformedAuto, err := expandSecretManagerSecretReplicationAuto(original["auto"], d, config)
 		if err != nil {
 			return nil, err
         } else {
-            transformed["automatic"] = transformedAutomaticReplication
+            transformed["automatic"] = transformedAuto
 		}
 	}
 
@@ -57,7 +57,7 @@ func expandSecretManagerSecretReplicationAutomatic(v interface{}, d tpgresource.
 	return struct{}{}, nil
 }
 
-func expandSecretManagerSecretReplicationAutomaticReplication(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+func expandSecretManagerSecretReplicationAuto(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	l := v.([]interface{})
 	if len(l) == 0 {
 		return nil, nil
@@ -71,7 +71,7 @@ func expandSecretManagerSecretReplicationAutomaticReplication(v interface{}, d t
 	original := raw.(map[string]interface{})
 	transformed := make(map[string]interface{})
 
-	transformedCustomerManagedEncryption, err := expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(original["customer_managed_encryption"], d, config)
+	transformedCustomerManagedEncryption, err := expandSecretManagerSecretReplicationAutoCustomerManagedEncryption(original["customer_managed_encryption"], d, config)
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedCustomerManagedEncryption); val.IsValid() && !tpgresource.IsEmptyValue(val) {
@@ -81,7 +81,7 @@ func expandSecretManagerSecretReplicationAutomaticReplication(v interface{}, d t
 	return transformed, nil
 }
 
-func expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+func expandSecretManagerSecretReplicationAutoCustomerManagedEncryption(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	l := v.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil, nil
@@ -90,7 +90,7 @@ func expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncr
 	original := raw.(map[string]interface{})
 	transformed := make(map[string]interface{})
 
-	transformedKmsKeyName, err := expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(original["kms_key_name"], d, config)
+	transformedKmsKeyName, err := expandSecretManagerSecretReplicationAutoCustomerManagedEncryptionKmsKeyName(original["kms_key_name"], d, config)
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedKmsKeyName); val.IsValid() && !tpgresource.IsEmptyValue(val) {
@@ -100,7 +100,7 @@ func expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncr
 	return transformed, nil
 }
 
-func expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+func expandSecretManagerSecretReplicationAutoCustomerManagedEncryptionKmsKeyName(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/mmv1/templates/terraform/custom_expand/secret_manager_replication.go.erb
+++ b/mmv1/templates/terraform/custom_expand/secret_manager_replication.go.erb
@@ -1,0 +1,180 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expandSecretManagerSecretReplication(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	if _, ok := d.GetOk("replication.0.automatic"); ok{
+		transformedAutomatic, err := expandSecretManagerSecretReplicationAutomatic(original["automatic"], d, config)
+		if err != nil {
+			return nil, err
+		} else if val := reflect.ValueOf(transformedAutomatic); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+			transformed["automatic"] = transformedAutomatic
+		}
+	}
+
+	if _, ok := d.GetOk("replication.0.automatic_replication"); ok{
+		transformedAutomaticReplication, err := expandSecretManagerSecretReplicationAutomaticReplication(original["automatic_replication"], d, config)
+		if err != nil {
+			return nil, err
+        } else {
+            transformed["automatic"] = transformedAutomaticReplication
+		}
+	}
+
+	transformedUserManaged, err := expandSecretManagerSecretReplicationUserManaged(original["user_managed"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedUserManaged); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["userManaged"] = transformedUserManaged
+	}
+
+	return transformed, nil
+}
+
+func expandSecretManagerSecretReplicationAutomatic(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil || !v.(bool) {
+		return nil, nil
+	}
+
+	return struct{}{}, nil
+}
+
+func expandSecretManagerSecretReplicationAutomaticReplication(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 {
+		return nil, nil
+	}
+	
+	if l[0] == nil {
+		transformed := make(map[string]interface{})
+		return transformed, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedCustomerManagedEncryption, err := expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(original["customer_managed_encryption"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedCustomerManagedEncryption); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["customerManagedEncryption"] = transformedCustomerManagedEncryption
+	}
+
+	return transformed, nil
+}
+
+func expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedKmsKeyName, err := expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(original["kms_key_name"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedKmsKeyName); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["kmsKeyName"] = transformedKmsKeyName
+	}
+
+	return transformed, nil
+}
+
+func expandSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSecretManagerSecretReplicationUserManaged(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedReplicas, err := expandSecretManagerSecretReplicationUserManagedReplicas(original["replicas"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedReplicas); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["replicas"] = transformedReplicas
+	}
+
+	return transformed, nil
+}
+
+func expandSecretManagerSecretReplicationUserManagedReplicas(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	req := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		original := raw.(map[string]interface{})
+		transformed := make(map[string]interface{})
+
+		transformedLocation, err := expandSecretManagerSecretReplicationUserManagedReplicasLocation(original["location"], d, config)
+		if err != nil {
+			return nil, err
+		} else if val := reflect.ValueOf(transformedLocation); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+			transformed["location"] = transformedLocation
+		}
+
+		transformedCustomerManagedEncryption, err := expandSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption(original["customer_managed_encryption"], d, config)
+		if err != nil {
+			return nil, err
+		} else if val := reflect.ValueOf(transformedCustomerManagedEncryption); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+			transformed["customerManagedEncryption"] = transformedCustomerManagedEncryption
+		}
+
+		req = append(req, transformed)
+	}
+	return req, nil
+}
+
+func expandSecretManagerSecretReplicationUserManagedReplicasLocation(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedKmsKeyName, err := expandSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryptionKmsKeyName(original["kms_key_name"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedKmsKeyName); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["kmsKeyName"] = transformedKmsKeyName
+	}
+
+	return transformed, nil
+}
+
+func expandSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryptionKmsKeyName(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}

--- a/mmv1/templates/terraform/custom_expand/secret_manager_replication.go.erb
+++ b/mmv1/templates/terraform/custom_expand/secret_manager_replication.go.erb
@@ -34,8 +34,8 @@ func expandSecretManagerSecretReplication(v interface{}, d tpgresource.Terraform
 		transformedAuto, err := expandSecretManagerSecretReplicationAuto(original["auto"], d, config)
 		if err != nil {
 			return nil, err
-        } else {
-            transformed["automatic"] = transformedAuto
+		} else {
+			transformed["automatic"] = transformedAuto
 		}
 	}
 

--- a/mmv1/templates/terraform/custom_flatten/secret_manager_replication.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/secret_manager_replication.go.erb
@@ -1,0 +1,118 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flattenSecretManagerSecretReplication(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+		_, ok := d.GetOk("replication.0.automatic")
+	if ok {
+		transformed["automatic"] =
+			flattenSecretManagerSecretReplicationAutomatic(original["automatic"], d, config)
+	} else {
+		transformed["automatic_replication"] =
+			flattenSecretManagerSecretReplicationAutomaticReplication(original["automatic"], d, config)
+	}
+	transformed["user_managed"] =
+		flattenSecretManagerSecretReplicationUserManaged(original["userManaged"], d, config)
+	return []interface{}{transformed}
+}
+func flattenSecretManagerSecretReplicationAutomatic(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v != nil
+}
+
+func flattenSecretManagerSecretReplicationAutomaticReplication(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	transformed := make(map[string]interface{})
+	transformed["customer_managed_encryption"] =
+		flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(original["customerManagedEncryption"], d, config)
+	return []interface{}{transformed}
+}
+func flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["kms_key_name"] =
+		flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(original["kmsKeyName"], d, config)
+	return []interface{}{transformed}
+}
+func flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenSecretManagerSecretReplicationUserManaged(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["replicas"] =
+		flattenSecretManagerSecretReplicationUserManagedReplicas(original["replicas"], d, config)
+	return []interface{}{transformed}
+}
+func flattenSecretManagerSecretReplicationUserManagedReplicas(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"location":                    flattenSecretManagerSecretReplicationUserManagedReplicasLocation(original["location"], d, config),
+			"customer_managed_encryption": flattenSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption(original["customerManagedEncryption"], d, config),
+		})
+	}
+	return transformed
+}
+func flattenSecretManagerSecretReplicationUserManagedReplicasLocation(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["kms_key_name"] =
+		flattenSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryptionKmsKeyName(original["kmsKeyName"], d, config)
+	return []interface{}{transformed}
+}
+func flattenSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryptionKmsKeyName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}

--- a/mmv1/templates/terraform/custom_flatten/secret_manager_replication.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/secret_manager_replication.go.erb
@@ -26,8 +26,8 @@ func flattenSecretManagerSecretReplication(v interface{}, d *schema.ResourceData
 		transformed["automatic"] =
 			flattenSecretManagerSecretReplicationAutomatic(original["automatic"], d, config)
 	} else {
-		transformed["automatic_replication"] =
-			flattenSecretManagerSecretReplicationAutomaticReplication(original["automatic"], d, config)
+		transformed["auto"] =
+			flattenSecretManagerSecretReplicationAuto(original["automatic"], d, config)
 	}
 	transformed["user_managed"] =
 		flattenSecretManagerSecretReplicationUserManaged(original["userManaged"], d, config)
@@ -37,17 +37,17 @@ func flattenSecretManagerSecretReplicationAutomatic(v interface{}, d *schema.Res
 	return v != nil
 }
 
-func flattenSecretManagerSecretReplicationAutomaticReplication(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+func flattenSecretManagerSecretReplicationAuto(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
 		return nil
 	}
 	original := v.(map[string]interface{})
 	transformed := make(map[string]interface{})
 	transformed["customer_managed_encryption"] =
-		flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(original["customerManagedEncryption"], d, config)
+		flattenSecretManagerSecretReplicationAutoCustomerManagedEncryption(original["customerManagedEncryption"], d, config)
 	return []interface{}{transformed}
 }
-func flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryption(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+func flattenSecretManagerSecretReplicationAutoCustomerManagedEncryption(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
 		return nil
 	}
@@ -57,10 +57,10 @@ func flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEnc
 	}
 	transformed := make(map[string]interface{})
 	transformed["kms_key_name"] =
-		flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(original["kmsKeyName"], d, config)
+		flattenSecretManagerSecretReplicationAutoCustomerManagedEncryptionKmsKeyName(original["kmsKeyName"], d, config)
 	return []interface{}{transformed}
 }
-func flattenSecretManagerSecretReplicationAutomaticReplicationCustomerManagedEncryptionKmsKeyName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+func flattenSecretManagerSecretReplicationAutoCustomerManagedEncryptionKmsKeyName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
 

--- a/mmv1/templates/terraform/custom_flatten/secret_manager_replication.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/secret_manager_replication.go.erb
@@ -21,7 +21,7 @@ func flattenSecretManagerSecretReplication(v interface{}, d *schema.ResourceData
 		return nil
 	}
 	transformed := make(map[string]interface{})
-		_, ok := d.GetOk("replication.0.automatic")
+	_, ok := d.GetOk("replication.0.automatic")
 	if ok {
 		transformed["automatic"] =
 			flattenSecretManagerSecretReplicationAutomatic(original["automatic"], d, config)

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
@@ -4,7 +4,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_environment_variables.tf.erb
@@ -4,7 +4,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
@@ -4,7 +4,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_secret_volumes.tf.erb
@@ -4,7 +4,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
@@ -44,7 +44,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_secret.tf.erb
@@ -44,7 +44,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
@@ -48,7 +48,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.erb
@@ -48,7 +48,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
@@ -32,7 +32,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_secret.tf.erb
@@ -32,7 +32,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.erb
@@ -51,7 +51,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.erb
@@ -51,7 +51,7 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_workflow_config.tf.erb
@@ -8,7 +8,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_keyset_dual_token.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_origin_v4auth.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_edge_cache_service_dual_token.tf.erb
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/secret_version_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_version_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/secret_version_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_version_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/templates/terraform/examples/secret_with_annotations.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_annotations.tf.erb
@@ -14,6 +14,6 @@ resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
   }
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }

--- a/mmv1/templates/terraform/examples/secret_with_annotations.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_annotations.tf.erb
@@ -14,6 +14,6 @@ resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
   }
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }

--- a/mmv1/templates/terraform/examples/secret_with_automatic_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_automatic_cmek.tf.erb
@@ -1,0 +1,21 @@
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding" {
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+
+  replication {
+    automatic_replication {
+      customer_managed_encryption {
+        kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+      }
+    }
+  }
+
+  depends_on = [ google_kms_crypto_key_iam_member.kms-secret-binding ]
+}

--- a/mmv1/templates/terraform/examples/secret_with_automatic_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_automatic_cmek.tf.erb
@@ -10,7 +10,7 @@ resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
   secret_id = "<%= ctx[:vars]['secret_id'] %>"
 
   replication {
-    automatic_replication {
+    auto {
       customer_managed_encryption {
         kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
       }

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -184,14 +184,14 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret1" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
 resource "google_secret_manager_secret" "secret2" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -308,14 +308,14 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret1" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
 resource "google_secret_manager_secret" "secret2" {
   secret_id = "%s"
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -184,14 +184,14 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret1" {
   secret_id = "%s"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
 resource "google_secret_manager_secret" "secret2" {
   secret_id = "%s"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -308,14 +308,14 @@ data "google_project" "project" {
 resource "google_secret_manager_secret" "secret1" {
   secret_id = "%s"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
 resource "google_secret_manager_secret" "secret2" {
   secret_id = "%s"
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go.erb
@@ -56,7 +56,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go.erb
@@ -56,7 +56,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_secret_manager_secret" "secret" {
   secret_id = "secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_access_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_access_test.go
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -112,7 +112,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_access_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_access_test.go
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -112,7 +112,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_test.go
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -112,7 +112,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_test.go
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -112,7 +112,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -356,7 +356,7 @@ resource "google_secret_manager_secret" "secret-with-annotations" {
   }
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 `, context)
@@ -379,7 +379,7 @@ resource "google_secret_manager_secret" "secret-with-annotations" {
   }
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -235,6 +235,15 @@ func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccSecretMangerSecret_automaticBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "replication.0.automatic", "replication.0.auto"},
+			},
+			{
 				Config: testAccSecretMangerSecret_automaticCmekBasic(context),
 			},
 			{
@@ -684,6 +693,38 @@ resource "google_secret_manager_secret" "secret-basic" {
     google_kms_crypto_key_iam_member.kms-central-binding-1,
     google_kms_crypto_key_iam_member.kms-central-binding-2,
     google_kms_crypto_key_iam_member.kms-east-binding,
+  ]
+}
+`, context)
+}
+
+func testAccSecretMangerSecret_automaticBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic = true
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
   ]
 }
 `, context)

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -356,7 +356,7 @@ resource "google_secret_manager_secret" "secret-with-annotations" {
   }
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 `, context)
@@ -379,7 +379,7 @@ resource "google_secret_manager_secret" "secret-with-annotations" {
   }
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 `, context)
@@ -711,7 +711,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {}
+    auto {}
   }
   depends_on = [
     google_kms_crypto_key_iam_member.kms-secret-binding-1,
@@ -743,7 +743,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {
+    auto {
       customer_managed_encryption {
         kms_key_name = "%{kms_key_name_1}"
       }
@@ -779,7 +779,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     label = "my-label"
   }
   replication {
-    automatic_replication {
+    auto {
       customer_managed_encryption {
         kms_key_name = "%{kms_key_name_2}"
       }

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -217,6 +217,63 @@ func TestAccSecretManagerSecret_userManagedCmekUpdate(t *testing.T) {
 	})
 }
 
+func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	key1 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "global", "tf-secret-manager-automatic-key1")
+	key2 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "global", "tf-secret-manager-automatic-key2")
+	context := map[string]interface{}{
+		"pid":            envvar.GetTestProjectFromEnv(),
+		"random_suffix":  suffix,
+		"kms_key_name_1": key1.CryptoKey.Name,
+		"kms_key_name_2": key2.CryptoKey.Name,
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretMangerSecret_automaticCmekBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+			{
+				Config: testAccSecretMangerSecret_automaticCmekUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+			{
+				Config: testAccSecretMangerSecret_automaticCmekUpdate2(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+			{
+				Config: testAccSecretMangerSecret_automaticCmekBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl"},
+			},
+		},
+	})
+}
+
 func testAccSecretManagerSecret_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_secret_manager_secret" "secret-basic" {
@@ -627,6 +684,110 @@ resource "google_secret_manager_secret" "secret-basic" {
     google_kms_crypto_key_iam_member.kms-central-binding-1,
     google_kms_crypto_key_iam_member.kms-central-binding-2,
     google_kms_crypto_key_iam_member.kms-east-binding,
+  ]
+}
+`, context)
+}
+
+func testAccSecretMangerSecret_automaticCmekBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic_replication {}
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretMangerSecret_automaticCmekUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic_replication {
+      customer_managed_encryption {
+        kms_key_name = "%{kms_key_name_1}"
+      }
+    }
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretMangerSecret_automaticCmekUpdate2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  project_id = "%{pid}"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    automatic_replication {
+      customer_managed_encryption {
+        kms_key_name = "%{kms_key_name_2}"
+      }
+    }
+  }
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-secret-binding-2,
   ]
 }
 `, context)

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go.erb
@@ -61,7 +61,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -84,7 +84,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go.erb
@@ -61,7 +61,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -84,7 +84,7 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "private-key-secret" {
   secret_id = "ghe-pk-secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/ghe.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "private-key-secret" {
   secret_id = "ghe-pk-secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "github-token-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/connection/github.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "github-token-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "private-key-secret" {
   secret_id = "ghe-pk-secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/ghe.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "private-key-secret" {
   secret_id = "ghe-pk-secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "webhook-secret-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "github-token-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic = true
+    automatic_replication {}
   }
 }
 

--- a/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
+++ b/tpgtools/overrides/cloudbuildv2/samples/repository/github.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_secret_manager_secret" "github-token-secret" {
   secret_id = "github-token-secret"
 
   replication {
-    automatic_replication {}
+    auto {}
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added support for the `auto` field and deprecated `automatic` field in the `google_secret_manager_secret` resource
fixes https://github.com/hashicorp/terraform-provider-google/issues/10679
fixes https://github.com/hashicorp/terraform-provider-google/issues/9272
fixes https://github.com/hashicorp/terraform-provider-google/issues/14282

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
secretmanager: added `auto` field to `google_secret_manager_secret` resource
```
```release-note:deprecation
secretmanager: deprecated `automatic` field on `google_secret_manager_secret`. Use `auto` instead.
```