### PR TITLE
Disable ForceNew for project sink unique_writer_identity field

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -37,7 +37,6 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
-		ForceNew:    true,
 		Description: `Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -468,7 +468,7 @@ resource "google_logging_project_sink" "bigquery" {
   destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
 
-  unique_writer_identity = false
+  unique_writer_identity = true
 }
 
 resource "google_bigquery_dataset" "logging_sink" {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -333,7 +333,7 @@ resource "google_logging_project_sink" "described" {
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   description = "description updated"
 
-  unique_writer_identity = false
+  unique_writer_identity = true
 }
 
 resource "google_storage_bucket" "log-bucket" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Part of https://github.com/hashicorp/terraform-provider-google/issues/15266

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: supported in-place update for `unique_writer_identity` in `google_logging_project_sink`
```
