### PR TITLE
feat(vertexai): Make it possible to use Private Service Connect in Vertex AI Index Endpoint

### DIFF
--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -116,6 +116,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: privateServiceConnectConfig
     immutable: true
+    default_from_api: true
     description: |-
       Optional. Configuration for private service connect. `network` and `privateServiceConnectConfig` are mutually exclusive.
     conflicts:

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -48,7 +48,6 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vertex_ai_index_endpoint"
     primary_resource_id: "index_endpoint"
-    skip_docs: true
     vars:
       address_name: "address-name"
       network_name: "network-name"
@@ -62,6 +61,7 @@ examples:
     primary_resource_id: "index_endpoint"
     # It's not distinguishable if the psc is false or not set, so we need to skip the test.
     skip_import_test: true
+    skip_docs: true
   - !ruby/object:Provider::Terraform::Examples
     name: "vertex_ai_index_endpoint_with_public_endpoint"
     primary_resource_id: "index_endpoint"

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -48,6 +48,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vertex_ai_index_endpoint"
     primary_resource_id: "index_endpoint"
+    skip_docs: true
     vars:
       address_name: "address-name"
       network_name: "network-name"

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -108,7 +108,10 @@ properties:
       - !ruby/object:Api::Type::Boolean
         name: enablePrivateServiceConnect
         description: If set to true, the IndexEndpoint is created without private service access.
+        immutable: true
+        required: true
       - !ruby/object:Api::Type::Array
         name: projectAllowlist
         description: A list of Projects from which the forwarding rule will target the service attachment.
         item_type: Api::Type::String
+        immutable: true

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -99,11 +99,15 @@ properties:
       [Format](https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert): `projects/{project}/global/networks/{network}`.
       Where `{project}` is a project number, as in `12345`, and `{network}` is network name.
     immutable: true
+    conflicts:
+      - privateServiceConnectConfig
   - !ruby/object:Api::Type::NestedObject
     name: privateServiceConnectConfig
     immutable: true
     description: |-
       Optional. Configuration for private service connect. `network` and `privateServiceConnectConfig` are mutually exclusive.
+    conflicts:
+      - network
     properties:
       - !ruby/object:Api::Type::Boolean
         name: enablePrivateServiceConnect

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -114,34 +114,3 @@ properties:
         name: projectAllowlist
         description: A list of Projects from which the forwarding rule will target the service attachment.
         item_type: Api::Type::String
-  - !ruby/object:Api::Type::Array
-    name: deployedIndexes
-    description: Output only. The indexes deployed in this endpoint.
-    output: true
-    item_type: !ruby/object:Api::Type::NestedObject
-      properties:
-        - !ruby/object:Api::Type::String
-          name: id
-          output: true
-          description: The user specified ID of the DeployedIndex. The ID can be up to 128 characters long and must start with a letter and only contain letters, numbers, and underscores.
-        - !ruby/object:Api::Type::String
-          name: index
-          output: true
-          description: The name of the Index this is the deployment of. We may refer to this Index as the DeployedIndex's "original" Index.
-        - !ruby/object:Api::Type::String
-          name: displayName
-          output: true
-          description: The display name of the DeployedIndex. If not provided upon creation, the Index's displayName is used.
-        - !ruby/object:Api::Type::NestedObject
-          name: privateEndpoints
-          output: true
-          description: Provides paths for users to send requests directly to the deployed index services running on Cloud via private services access.
-          properties:
-            - !ruby/object:Api::Type::String
-              name: matchGrpcAddress
-              output: true
-              description: The ip address used to send match gRPC requests.
-            - !ruby/object:Api::Type::String
-              name: serviceAttachment
-              output: true
-              description: The name of the service attachment resource. Populated if private service connect is enabled.

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -56,8 +56,6 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vertex_ai_index_endpoint_with_psc"
     primary_resource_id: "index_endpoint"
-    test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint")'
 parameters:
   - !ruby/object:Api::Type::String
     name: region

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -68,6 +68,7 @@ parameters:
     url_param_only: true
     immutable: true
 properties:
+  # Intentionally deployedIndexes[] is not included because it's an output-only field and another terraform resource will manage a deployed index.
   - !ruby/object:Api::Type::String
     name: 'name'
     description: The resource name of the Index.

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -53,6 +53,11 @@ examples:
       network_name: "network-name"
     test_vars_overrides:
       network_name: 'acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint")'
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vertex_ai_index_endpoint_with_psc"
+    primary_resource_id: "index_endpoint"
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint")'
 parameters:
   - !ruby/object:Api::Type::String
     name: region
@@ -60,7 +65,6 @@ parameters:
     url_param_only: true
     immutable: true
 properties:
-  # Intentionally deployedIndexes[] is not included because it's an output-only field and another terraform resource will manage a deployed index.
   - !ruby/object:Api::Type::String
     name: 'name'
     description: The resource name of the Index.
@@ -97,3 +101,47 @@ properties:
       [Format](https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert): `projects/{project}/global/networks/{network}`.
       Where `{project}` is a project number, as in `12345`, and `{network}` is network name.
     immutable: true
+  - !ruby/object:Api::Type::NestedObject
+    name: privateServiceConnectConfig
+    immutable: true
+    description: |-
+      Optional. Configuration for private service connect. `network` and `privateServiceConnectConfig` are mutually exclusive.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: enablePrivateServiceConnect
+        description: If set to true, the IndexEndpoint is created without private service access.
+      - !ruby/object:Api::Type::Array
+        name: projectAllowlist
+        description: A list of Projects from which the forwarding rule will target the service attachment.
+        item_type: Api::Type::String
+  - !ruby/object:Api::Type::Array
+    name: deployedIndexes
+    description: Output only. The indexes deployed in this endpoint.
+    output: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: id
+          output: true
+          description: The user specified ID of the DeployedIndex. The ID can be up to 128 characters long and must start with a letter and only contain letters, numbers, and underscores.
+        - !ruby/object:Api::Type::String
+          name: index
+          output: true
+          description: The name of the Index this is the deployment of. We may refer to this Index as the DeployedIndex's "original" Index.
+        - !ruby/object:Api::Type::String
+          name: displayName
+          output: true
+          description: The display name of the DeployedIndex. If not provided upon creation, the Index's displayName is used.
+        - !ruby/object:Api::Type::NestedObject
+          name: privateEndpoints
+          output: true
+          description: Provides paths for users to send requests directly to the deployed index services running on Cloud via private services access.
+          properties:
+            - !ruby/object:Api::Type::String
+              name: matchGrpcAddress
+              output: true
+              description: The ip address used to send match gRPC requests.
+            - !ruby/object:Api::Type::String
+              name: serviceAttachment
+              output: true
+              description: The name of the service attachment resource. Populated if private service connect is enabled.

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -57,6 +57,11 @@ examples:
     name: "vertex_ai_index_endpoint_with_psc"
     primary_resource_id: "index_endpoint"
   - !ruby/object:Provider::Terraform::Examples
+    name: "vertex_ai_index_endpoint_with_false_psc"
+    primary_resource_id: "index_endpoint"
+    # It's not distinguishable if the psc is false or not set, so we need to skip the test.
+    skip_import_test: true
+  - !ruby/object:Provider::Terraform::Examples
     name: "vertex_ai_index_endpoint_with_public_endpoint"
     primary_resource_id: "index_endpoint"
     test_vars_overrides:
@@ -114,6 +119,7 @@ properties:
       Optional. Configuration for private service connect. `network` and `privateServiceConnectConfig` are mutually exclusive.
     conflicts:
       - network
+    custom_flatten: templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
     properties:
       - !ruby/object:Api::Type::Boolean
         name: enablePrivateServiceConnect

--- a/mmv1/templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
@@ -16,22 +16,9 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
     transformed := make(map[string]interface{})
 
     if v == nil {
-        // Even when private_service_connect is set as false, API will not return object
-        enable_psc, ok := d.GetOkExists("private_service_connect_config.0.enable_private_service_connect")
-        if ok {
-            transformed["enable_private_service_connect"] = enable_psc
-        }
-
-        project_allowlist, ok := d.GetOkExists("private_service_connect_config.0.project_allowlist")
-        if ok {
-            transformed["project_allowlist"] = project_allowlist
-        }
-
-        if len(transformed) > 0 {
-            return []interface{}{transformed}
-        }
-
-        return nil
+        // Disabled by default, but API will not return object if value is false
+        transformed["enable_private_service_connect"] = false
+        return []interface{}{transformed}
     }
 
     original := v.(map[string]interface{})

--- a/mmv1/templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
@@ -1,0 +1,46 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    transformed := make(map[string]interface{})
+
+    if v == nil {
+        // Even when private_service_connect is set as false, API will not return object
+        enable_psc, ok := d.GetOkExists("private_service_connect_config.0.enable_private_service_connect")
+        if ok {
+            transformed["enable_private_service_connect"] = enable_psc
+            return []interface{}{transformed}
+        }
+        return nil
+	}
+
+    original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+
+    transformed["enable_private_service_connect"] =
+		flattenVertexAIIndexEndpointPrivateServiceConnectConfigEnablePrivateServiceConnect(original["enablePrivateServiceConnect"], d, config)
+	transformed["project_allowlist"] =
+		flattenVertexAIIndexEndpointPrivateServiceConnectConfigProjectAllowlist(original["projectAllowlist"], d, config)
+	return []interface{}{transformed}
+}
+
+func flattenVertexAIIndexEndpointPrivateServiceConnectConfigEnablePrivateServiceConnect(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+       return v
+}
+
+func flattenVertexAIIndexEndpointPrivateServiceConnectConfigProjectAllowlist(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+       return v
+}

--- a/mmv1/templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/vertex_ai_index_endpoint_private_service_connect_config.go.erb
@@ -20,21 +20,30 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
         enable_psc, ok := d.GetOkExists("private_service_connect_config.0.enable_private_service_connect")
         if ok {
             transformed["enable_private_service_connect"] = enable_psc
+        }
+
+        project_allowlist, ok := d.GetOkExists("private_service_connect_config.0.project_allowlist")
+        if ok {
+            transformed["project_allowlist"] = project_allowlist
+        }
+
+        if len(transformed) > 0 {
             return []interface{}{transformed}
         }
+
         return nil
-	}
+    }
 
     original := v.(map[string]interface{})
-	if len(original) == 0 {
-		return nil
-	}
+    if len(original) == 0 {
+        return nil
+    }
 
     transformed["enable_private_service_connect"] =
-		flattenVertexAIIndexEndpointPrivateServiceConnectConfigEnablePrivateServiceConnect(original["enablePrivateServiceConnect"], d, config)
-	transformed["project_allowlist"] =
-		flattenVertexAIIndexEndpointPrivateServiceConnectConfigProjectAllowlist(original["projectAllowlist"], d, config)
-	return []interface{}{transformed}
+        flattenVertexAIIndexEndpointPrivateServiceConnectConfigEnablePrivateServiceConnect(original["enablePrivateServiceConnect"], d, config)
+    transformed["project_allowlist"] =
+        flattenVertexAIIndexEndpointPrivateServiceConnectConfigProjectAllowlist(original["projectAllowlist"], d, config)
+    return []interface{}{transformed}
 }
 
 func flattenVertexAIIndexEndpointPrivateServiceConnectConfigEnablePrivateServiceConnect(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {

--- a/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_false_psc.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_false_psc.tf.erb
@@ -8,10 +8,5 @@ resource "google_vertex_ai_index_endpoint" "<%= ctx[:primary_resource_id] %>" {
 
   private_service_connect_config {
     enable_private_service_connect = false
-    project_allowlist = [
-        data.google_project.project.number,
-    ]
   }
 }
-
-data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_false_psc.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_false_psc.tf.erb
@@ -1,0 +1,14 @@
+resource "google_vertex_ai_index_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "sample-endpoint"
+  description  = "A sample vertex endpoint"
+  region       = "us-central1"
+  labels       = {
+    label-one = "value-one"
+  }
+
+  private_service_connect_config {
+    enable_private_service_connect = false
+  }
+}
+
+data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_false_psc.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_false_psc.tf.erb
@@ -8,6 +8,9 @@ resource "google_vertex_ai_index_endpoint" "<%= ctx[:primary_resource_id] %>" {
 
   private_service_connect_config {
     enable_private_service_connect = false
+    project_allowlist = [
+        data.google_project.project.number,
+    ]
   }
 }
 

--- a/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_psc.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_psc.tf.erb
@@ -1,0 +1,17 @@
+resource "google_vertex_ai_index_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "sample-endpoint"
+  description  = "A sample vertex endpoint"
+  region       = "us-central1"
+  labels       = {
+    label-one = "value-one"
+  }
+
+  private_service_connect_config {
+    enable_private_service_connect = true
+    project_allowlist = [
+        data.google_project.project.number,
+    ]
+  }
+}
+
+data "google_project" "project" {}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

part of https://github.com/hashicorp/terraform-provider-google/issues/12818

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vertexai: added `private_service_connect_config` to `google_vertex_ai_index_endpoint`
```
