### PR TITLE
feat(vertexai): Make it possible to create a public Vertex AI Index Endpoint

### DIFF
--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -53,6 +53,11 @@ examples:
       network_name: "network-name"
     test_vars_overrides:
       network_name: 'acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint")'
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vertex_ai_index_endpoint_with_public_endpoint"
+    primary_resource_id: "index_endpoint"
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint")'
 parameters:
   - !ruby/object:Api::Type::String
     name: region
@@ -97,3 +102,12 @@ properties:
       [Format](https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert): `projects/{project}/global/networks/{network}`.
       Where `{project}` is a project number, as in `12345`, and `{network}` is network name.
     immutable: true
+  - !ruby/object:Api::Type::Boolean
+    name: publicEndpointEnabled
+    immutable: true
+    ignore_read: true
+    description: If true, the deployed index will be accessible through public endpoint.
+  - !ruby/object:Api::Type::String
+    name: publicEndpointDomainName
+    output: true
+    description: If publicEndpointEnabled is true, this field will be populated with the domain name to use for this index endpoint.

--- a/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_public_endpoint.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_endpoint_with_public_endpoint.tf.erb
@@ -1,0 +1,11 @@
+resource "google_vertex_ai_index_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "sample-endpoint"
+  description  = "A sample vertex endpoint with an public endpoint"
+  region       = "us-central1"
+  labels       = {
+    label-one = "value-one"
+  }
+
+  public_endpoint_enabled = true
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
part of https://github.com/hashicorp/terraform-provider-google/issues/12818

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vertexai: added `public_endpoint_enabled` to `google_vertex_ai_index_endpoint`
```
