### PR TITLE
existing Data Sources now return errors on 404s

### DIFF
--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_folder_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_folder_service_account.go
@@ -56,7 +56,7 @@ func dataSourceAccessApprovalFolderServiceAccountRead(d *schema.ResourceData, me
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleDataSourceNotFoundError(url, fmt.Sprintf("AccessApprovalFolderServiceAccount %q"), err, d)
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AccessApprovalFolderServiceAccount %q", d.Id()), url)
 	}
 
 	if err := d.Set("name", res["name"]); err != nil {

--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_folder_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_folder_service_account.go
@@ -56,7 +56,7 @@ func dataSourceAccessApprovalFolderServiceAccountRead(d *schema.ResourceData, me
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("AccessApprovalFolderServiceAccount %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(url, fmt.Sprintf("AccessApprovalFolderServiceAccount %q"), err, d)
 	}
 
 	if err := d.Set("name", res["name"]); err != nil {

--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_organization_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_organization_service_account.go
@@ -56,7 +56,7 @@ func dataSourceAccessApprovalOrganizationServiceAccountRead(d *schema.ResourceDa
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("AccessApprovalOrganizationServiceAccount %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AccessApprovalOrganizationServiceAccount %q", d.Id()), url)
 	}
 
 	if err := d.Set("name", res["name"]); err != nil {

--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_project_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_project_service_account.go
@@ -56,7 +56,7 @@ func dataSourceAccessApprovalProjectServiceAccountRead(d *schema.ResourceData, m
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("AccessApprovalProjectServiceAccount %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AccessApprovalProjectServiceAccount %q", d.Id()), url)
 	}
 
 	if err := d.Set("name", res["name"]); err != nil {

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_locations.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_locations.go
@@ -94,7 +94,7 @@ func dataSourceAlloydbLocationsRead(d *schema.ResourceData, meta interface{}) er
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Locations %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Locations %q", d.Id()), url)
 	}
 	var locations []map[string]interface{}
 	for {
@@ -142,7 +142,7 @@ func dataSourceAlloydbLocationsRead(d *schema.ResourceData, meta interface{}) er
 			UserAgent: userAgent,
 		})
 		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Locations %q", d.Id()))
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Locations %q", d.Id()), url)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_supported_database_flags.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_supported_database_flags.go
@@ -147,7 +147,7 @@ func dataSourceAlloydbSupportedDatabaseFlagsRead(d *schema.ResourceData, meta in
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("SupportedDatabaseFlags %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("SupportedDatabaseFlags %q", d.Id()), url)
 	}
 	var supportedDatabaseFlags []map[string]interface{}
 	for {
@@ -221,7 +221,7 @@ func dataSourceAlloydbSupportedDatabaseFlagsRead(d *schema.ResourceData, meta in
 			UserAgent: userAgent,
 		})
 		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("SupportedDatabaseFlags %q", d.Id()))
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("SupportedDatabaseFlags %q", d.Id()), url)
 		}
 	}
 	if err := d.Set("supported_database_flags", supportedDatabaseFlags); err != nil {

--- a/mmv1/third_party/terraform/services/appengine/data_source_google_app_engine_default_service_account.go
+++ b/mmv1/third_party/terraform/services/appengine/data_source_google_app_engine_default_service_account.go
@@ -62,7 +62,7 @@ func dataSourceGoogleAppEngineDefaultServiceAccountRead(d *schema.ResourceData, 
 
 	sa, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Get(serviceAccountName).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Account %q", serviceAccountName))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Service Account %q", serviceAccountName), serviceAccountName)
 	}
 
 	d.SetId(sa.Name)

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_repository.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_repository.go
@@ -38,11 +38,16 @@ func dataSourceArtifactRegistryRepositoryRead(d *schema.ResourceData, meta inter
 	}
 
 	repository_id := d.Get("repository_id").(string)
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s/repositories/%s", project, location, repository_id))
+	id := fmt.Sprintf("projects/%s/locations/%s/repositories/%s", project, location, repository_id)
+	d.SetId(id)
 
 	err = resourceArtifactRegistryRepositoryRead(d, meta)
 	if err != nil {
 		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connection.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connection.go
@@ -38,7 +38,17 @@ func dataSourceGoogleBeyondcorpAppConnectionRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s/appConnections/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/locations/%s/appConnections/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceBeyondcorpAppConnectionRead(d, meta)
+	err = resourceBeyondcorpAppConnectionRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connector.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connector.go
@@ -38,7 +38,17 @@ func dataSourceGoogleBeyondcorpAppConnectorRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s/appConnectors/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/locations/%s/appConnectors/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceBeyondcorpAppConnectorRead(d, meta)
+	err = resourceBeyondcorpAppConnectorRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_gateway.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_gateway.go
@@ -38,7 +38,17 @@ func dataSourceGoogleBeyondcorpAppGatewayRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s/appGateways/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/locations/%s/appGateways/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceBeyondcorpAppGatewayRead(d, meta)
+	err = resourceBeyondcorpAppGatewayRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_default_service_account.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_default_service_account.go
@@ -43,7 +43,7 @@ func dataSourceGoogleBigqueryDefaultServiceAccountRead(d *schema.ResourceData, m
 
 	projectResource, err := config.NewBigQueryClient(userAgent).Projects.GetServiceAccount(project).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, "BigQuery service account not found")
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Project %q BigQuery service account", project), fmt.Sprintf("Project %q BigQuery service account", project))
 	}
 
 	d.SetId(projectResource.Email)

--- a/mmv1/third_party/terraform/services/billing/data_source_google_billing_account.go
+++ b/mmv1/third_party/terraform/services/billing/data_source_google_billing_account.go
@@ -64,7 +64,7 @@ func dataSourceBillingAccountRead(d *schema.ResourceData, meta interface{}) erro
 	if v, ok := d.GetOk("billing_account"); ok {
 		resp, err := config.NewBillingClient(userAgent).BillingAccounts.Get(CanonicalBillingAccountName(v.(string))).Do()
 		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Billing Account Not Found : %s", v))
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Billing Account Not Found : %s", v), CanonicalBillingAccountName(v.(string)))
 		}
 
 		if openOk && resp.Open != open.(bool) {

--- a/mmv1/third_party/terraform/services/cloudbuild/data_source_google_cloudbuild_trigger.go
+++ b/mmv1/third_party/terraform/services/cloudbuild/data_source_google_cloudbuild_trigger.go
@@ -32,7 +32,16 @@ func dataSourceGoogleCloudBuildTriggerRead(d *schema.ResourceData, meta interfac
 	}
 
 	id = strings.ReplaceAll(id, "/locations/global/", "/")
-
 	d.SetId(id)
-	return resourceCloudBuildTriggerRead(d, meta)
+
+	err = resourceCloudBuildTriggerRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/cloudfunctions/data_source_google_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions/data_source_google_cloudfunctions_function.go
@@ -1,6 +1,8 @@
 package cloudfunctions
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -46,6 +48,10 @@ func dataSourceGoogleCloudFunctionsFunctionRead(d *schema.ResourceData, meta int
 	err = resourceCloudFunctionsRead(d, meta)
 	if err != nil {
 		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", cloudFuncId.CloudFunctionId())
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function.go
@@ -32,11 +32,16 @@ func dataSourceGoogleCloudFunctions2FunctionRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s/functions/%s", project, d.Get("location").(string), d.Get("name").(string)))
+	id := fmt.Sprintf("projects/%s/locations/%s/functions/%s", project, d.Get("location").(string), d.Get("name").(string))
+	d.SetId(id)
 
 	err = resourceCloudfunctions2functionRead(d, meta)
 	if err != nil {
 		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_memberships.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_memberships.go.erb
@@ -85,7 +85,7 @@ func dataSourceGoogleCloudIdentityGroupMembershipsRead(d *schema.ResourceData, m
 		return nil
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroupMemberships %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroupMemberships %q", d.Id()), "")
 	}
 
 	if err := d.Set("memberships", result); err != nil {

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_groups.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_groups.go.erb
@@ -84,7 +84,7 @@ func dataSourceGoogleCloudIdentityGroupsRead(d *schema.ResourceData, meta interf
 		return nil
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroups %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroups %q", d.Id()), "")
 	}
 
 	if err := d.Set("groups", result); err != nil {

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_groups.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_groups.go.erb
@@ -84,7 +84,7 @@ func dataSourceGoogleCloudIdentityGroupsRead(d *schema.ResourceData, meta interf
 		return nil
 	})
 	if err != nil {
-		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroups %q", d.Id()), "")
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroups %q", d.Id()), "Groups")
 	}
 
 	if err := d.Set("groups", result); err != nil {

--- a/mmv1/third_party/terraform/services/cloudrun/data_source_cloud_run_service.go
+++ b/mmv1/third_party/terraform/services/cloudrun/data_source_cloud_run_service.go
@@ -28,5 +28,14 @@ func dataSourceGoogleCloudRunServiceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceCloudRunServiceRead(d, meta)
+	err = resourceCloudRunServiceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_environment.go
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_environment.go
@@ -35,7 +35,16 @@ func dataSourceGoogleComposerEnvironmentRead(d *schema.ResourceData, meta interf
 	}
 	envName := d.Get("name").(string)
 
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s/environments/%s", project, region, envName))
+	id := fmt.Sprintf("projects/%s/locations/%s/environments/%s", project, region, envName)
+	d.SetId(id)
+	err = resourceComposerEnvironmentRead(d, meta)
+	if err != nil {
+		return err
+	}
 
-	return resourceComposerEnvironmentRead(d, meta)
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_health_check.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_health_check.go
@@ -1,6 +1,8 @@
 package compute
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -29,5 +31,14 @@ func dataSourceGoogleComputeHealthCheckRead(d *schema.ResourceData, meta interfa
 	}
 	d.SetId(id)
 
-	return resourceComputeHealthCheckRead(d, meta)
+	err = resourceComputeHealthCheckRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group.go
@@ -27,6 +27,7 @@ func DataSourceGoogleComputeNetworkEndpointGroup() *schema.Resource {
 
 func dataSourceComputeNetworkEndpointGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
+	id := ""
 	if name, ok := d.GetOk("name"); ok {
 		project, err := tpgresource.GetProject(d, config)
 		if err != nil {
@@ -36,7 +37,8 @@ func dataSourceComputeNetworkEndpointGroupRead(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
-		d.SetId(fmt.Sprintf("projects/%s/zones/%s/networkEndpointGroups/%s", project, zone, name.(string)))
+		id = fmt.Sprintf("projects/%s/zones/%s/networkEndpointGroups/%s", project, zone, name.(string))
+		d.SetId(id)
 	} else if selfLink, ok := d.GetOk("self_link"); ok {
 		parsed, err := tpgresource.ParseNetworkEndpointGroupFieldValue(selfLink.(string), d, config)
 		if err != nil {
@@ -51,10 +53,20 @@ func dataSourceComputeNetworkEndpointGroupRead(d *schema.ResourceData, meta inte
 		if err := d.Set("project", parsed.Project); err != nil {
 			return fmt.Errorf("Error setting project: %s", err)
 		}
-		d.SetId(fmt.Sprintf("projects/%s/zones/%s/networkEndpointGroups/%s", parsed.Project, parsed.Zone, parsed.Name))
+		id = fmt.Sprintf("projects/%s/zones/%s/networkEndpointGroups/%s", parsed.Project, parsed.Zone, parsed.Name)
+		d.SetId(id)
 	} else {
 		return errors.New("Must provide either `self_link` or `zone/name`")
 	}
 
-	return resourceComputeNetworkEndpointGroupRead(d, meta)
+	err := resourceComputeNetworkEndpointGroupRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_peering.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_peering.go
@@ -35,7 +35,17 @@ func dataSourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return err
 	}
-	d.SetId(fmt.Sprintf("%s/%s", networkFieldValue.Name, d.Get("name").(string)))
+	id := fmt.Sprintf("%s/%s", networkFieldValue.Name, d.Get("name").(string))
+	d.SetId(id)
 
-	return resourceComputeNetworkPeeringRead(d, meta)
+	err = resourceComputeNetworkPeeringRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_address.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_address.go
@@ -108,9 +108,11 @@ func dataSourceGoogleComputeAddressRead(d *schema.ResourceData, meta interface{}
 	}
 	name := d.Get("name").(string)
 
+	id := fmt.Sprintf("projects/%s/regions/%s/addresses/%s", project, region, name)
+
 	address, err := config.NewComputeClient(userAgent).Addresses.Get(project, region, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Address Not Found : %s", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Address Not Found : %s", name), id)
 	}
 
 	if err := d.Set("address", address.Address); err != nil {
@@ -147,7 +149,7 @@ func dataSourceGoogleComputeAddressRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error setting region: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/addresses/%s", project, region, name))
+	d.SetId(id)
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_backend_bucket.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_backend_bucket.go
@@ -33,7 +33,17 @@ func dataSourceComputeBackendBucketRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/global/backendBuckets/%s", project, backendBucketName))
+	id := fmt.Sprintf("projects/%s/global/backendBuckets/%s", project, backendBucketName)
+	d.SetId(id)
 
-	return resourceComputeBackendBucketRead(d, meta)
+	err = resourceComputeBackendBucketRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_backend_service.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_backend_service.go
@@ -33,7 +33,17 @@ func dataSourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/global/backendServices/%s", project, serviceName))
+	id := fmt.Sprintf("projects/%s/global/backendServices/%s", project, serviceName)
+	d.SetId(id)
 
-	return resourceComputeBackendServiceRead(d, meta)
+	err = resourceComputeBackendServiceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_default_service_account.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_default_service_account.go
@@ -51,7 +51,7 @@ func dataSourceGoogleComputeDefaultServiceAccountRead(d *schema.ResourceData, me
 
 	projectCompResource, err := config.NewComputeClient(userAgent).Projects.Get(project).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, "GCE default service account")
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, "GCE default service account", fmt.Sprintf("%q GCE default service account", project))
 	}
 
 	serviceAccountName, err := tpgresource.ServiceAccountFQN(projectCompResource.DefaultServiceAccount, d, config)
@@ -61,7 +61,7 @@ func dataSourceGoogleComputeDefaultServiceAccountRead(d *schema.ResourceData, me
 
 	sa, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Get(serviceAccountName).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Account %q", serviceAccountName))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Service Account %q", serviceAccountName), serviceAccountName)
 	}
 
 	d.SetId(sa.Name)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_disk.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_disk.go
@@ -29,5 +29,14 @@ func dataSourceGoogleComputeDiskRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceComputeDiskRead(d, meta)
+	err = resourceComputeDiskRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_forwarding_rule.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_forwarding_rule.go
@@ -39,7 +39,17 @@ func dataSourceGoogleComputeForwardingRuleRead(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/forwardingRules/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/regions/%s/forwardingRules/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceComputeForwardingRuleRead(d, meta)
+	err = resourceComputeForwardingRuleRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_global_address.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_global_address.go
@@ -89,9 +89,11 @@ func dataSourceGoogleComputeGlobalAddressRead(d *schema.ResourceData, meta inter
 		return err
 	}
 	name := d.Get("name").(string)
+	id := fmt.Sprintf("projects/%s/global/addresses/%s", project, name)
+
 	address, err := config.NewComputeClient(userAgent).GlobalAddresses.Get(project, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Global Address Not Found : %s", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Global Address Not Found : %s", name), id)
 	}
 
 	if err := d.Set("address", address.Address); err != nil {
@@ -124,6 +126,6 @@ func dataSourceGoogleComputeGlobalAddressRead(d *schema.ResourceData, meta inter
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	d.SetId(fmt.Sprintf("projects/%s/global/addresses/%s", project, name))
+	d.SetId(id)
 	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway.go
@@ -39,7 +39,17 @@ func dataSourceGoogleComputeHaVpnGatewayRead(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/vpnGateways/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/regions/%s/vpnGateways/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceComputeHaVpnGatewayRead(d, meta)
+	err = resourceComputeHaVpnGatewayRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go.erb
@@ -34,9 +34,11 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	id := fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, name)
+
 	instance, err := config.NewComputeClient(userAgent).Instances.Get(project, zone, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Instance %s", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Instance %s", name), id)
 	}
 
 	md := flattenMetadataBeta(instance.Metadata)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_group.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_group.go
@@ -84,6 +84,7 @@ func DataSourceGoogleComputeInstanceGroup() *schema.Resource {
 
 func dataSourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
+	id := ""
 	if name, ok := d.GetOk("name"); ok {
 		zone, err := tpgresource.GetZone(d, config)
 		if err != nil {
@@ -93,7 +94,7 @@ func dataSourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}
 		if err != nil {
 			return err
 		}
-		d.SetId(fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", project, zone, name.(string)))
+		id = fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", project, zone, name.(string))
 	} else if selfLink, ok := d.GetOk("self_link"); ok {
 		parsed, err := tpgresource.ParseInstanceGroupFieldValue(selfLink.(string), d, config)
 		if err != nil {
@@ -108,10 +109,20 @@ func dataSourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}
 		if err := d.Set("project", parsed.Project); err != nil {
 			return fmt.Errorf("Error setting project: %s", err)
 		}
-		d.SetId(fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", parsed.Project, parsed.Zone, parsed.Name))
+		id = fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", parsed.Project, parsed.Zone, parsed.Name)
 	} else {
 		return errors.New("Must provide either `self_link` or `zone/name`")
 	}
+	d.SetId(id)
 
-	return resourceComputeInstanceGroupRead(d, meta)
+	err := resourceComputeInstanceGroupRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
@@ -59,9 +59,12 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	name := d.Get("name").(string)
+
+	id := fmt.Sprintf("projects/%s/global/networks/%s", project, name)
+
 	network, err := config.NewComputeClient(userAgent).Networks.Get(project, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", name), id)
 	}
 	if err := d.Set("gateway_ipv4", network.GatewayIPv4); err != nil {
 		return fmt.Errorf("Error setting gateway_ipv4: %s", err)
@@ -75,6 +78,6 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 	if err := d.Set("subnetworks_self_links", network.Subnetworks); err != nil {
 		return fmt.Errorf("Error setting subnetworks_self_links: %s", err)
 	}
-	d.SetId(fmt.Sprintf("projects/%s/global/networks/%s", project, network.Name))
+	d.SetId(id)
 	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group.go.erb
@@ -104,11 +104,11 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-
+	id := fmt.Sprintf("projects/%s/regions/%s/instanceGroups/%s", project, region, name)
 	instanceGroup, err := config.NewComputeClient(userAgent).RegionInstanceGroups.Get(
 		project, region, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Region Instance Group %q", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Region Instance Group %q", name), id)
 	}
 
 	members, err := config.NewComputeClient(userAgent).RegionInstanceGroups.ListInstances(
@@ -129,7 +129,7 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 			return fmt.Errorf("Error setting instances: %s", err)
 		}
 	}
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroups/%s", project, region, name))
+	d.SetId(id)
 	if err := d.Set("self_link", instanceGroup.SelfLink); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_network_endpoint_group.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_network_endpoint_group.go
@@ -26,6 +26,7 @@ func DataSourceGoogleComputeRegionNetworkEndpointGroup() *schema.Resource {
 
 func dataSourceComputeRegionNetworkEndpointGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
+	id := ""
 	if name, ok := d.GetOk("name"); ok {
 		project, err := tpgresource.GetProject(d, config)
 		if err != nil {
@@ -36,7 +37,7 @@ func dataSourceComputeRegionNetworkEndpointGroupRead(d *schema.ResourceData, met
 			return err
 		}
 
-		d.SetId(fmt.Sprintf("projects/%s/regions/%s/networkEndpointGroups/%s", project, region, name.(string)))
+		id = fmt.Sprintf("projects/%s/regions/%s/networkEndpointGroups/%s", project, region, name.(string))
 	} else if selfLink, ok := d.GetOk("self_link"); ok {
 		parsed, err := tpgresource.ParseNetworkEndpointGroupRegionalFieldValue(selfLink.(string), d, config)
 		if err != nil {
@@ -52,10 +53,19 @@ func dataSourceComputeRegionNetworkEndpointGroupRead(d *schema.ResourceData, met
 			return fmt.Errorf("Error setting region: %s", err)
 		}
 
-		d.SetId(fmt.Sprintf("projects/%s/regions/%s/networkEndpointGroups/%s", parsed.Project, parsed.Region, parsed.Name))
+		id = fmt.Sprintf("projects/%s/regions/%s/networkEndpointGroups/%s", parsed.Project, parsed.Region, parsed.Name)
 	} else {
 		return errors.New("Must provide either `self_link` or `region/name`")
 	}
+	d.SetId(id)
+	err := resourceComputeRegionNetworkEndpointGroupRead(d, meta)
+	if err != nil {
+		return err
+	}
 
-	return resourceComputeRegionNetworkEndpointGroupRead(d, meta)
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_certificate.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_certificate.go
@@ -33,7 +33,16 @@ func dataSourceComputeRegionSslCertificateRead(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/sslCertificates/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/regions/%s/sslCertificates/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceComputeRegionSslCertificateRead(d, meta)
+	err = resourceComputeRegionSslCertificateRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_resource_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_resource_policy.go.erb
@@ -36,7 +36,17 @@ func dataSourceGoogleComputeResourcePolicyRead(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, region, name))
+	id := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, region, name)
+	d.SetId(id)
 
-	return resourceComputeResourcePolicyRead(d, meta)
+	err = resourceComputeResourcePolicyRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_router.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_router.go
@@ -1,6 +1,8 @@
 package compute
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
@@ -22,5 +24,13 @@ func dataSourceComputeRouterRead(d *schema.ResourceData, meta interface{}) error
 	routerName := d.Get("name").(string)
 
 	d.SetId(routerName)
-	return resourceComputeRouterRead(d, meta)
+	err := resourceComputeRouterRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", routerName)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_router_nat.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_router_nat.go
@@ -31,5 +31,14 @@ func dataSourceGoogleComputeRouterNatRead(d *schema.ResourceData, meta interface
 	}
 	d.SetId(id)
 
-	return resourceComputeRouterNatRead(d, meta)
+	err = resourceComputeRouterNatRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ssl_certificate.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ssl_certificate.go
@@ -33,7 +33,17 @@ func dataSourceComputeSslCertificateRead(d *schema.ResourceData, meta interface{
 	}
 	certificateName := d.Get("name").(string)
 
-	d.SetId(fmt.Sprintf("projects/%s/global/sslCertificates/%s", project, certificateName))
+	id := fmt.Sprintf("projects/%s/global/sslCertificates/%s", project, certificateName)
+	d.SetId(id)
 
-	return resourceComputeSslCertificateRead(d, meta)
+	err = resourceComputeSslCertificateRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ssl_policy.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ssl_policy.go
@@ -33,7 +33,17 @@ func datasourceComputeSslPolicyRead(d *schema.ResourceData, meta interface{}) er
 	}
 	policyName := d.Get("name").(string)
 
-	d.SetId(fmt.Sprintf("projects/%s/global/sslPolicies/%s", project, policyName))
+	id := fmt.Sprintf("projects/%s/global/sslPolicies/%s", project, policyName)
+	d.SetId(id)
 
-	return resourceComputeSslPolicyRead(d, meta)
+	err = resourceComputeSslPolicyRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.erb
@@ -90,10 +90,11 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
+	id := fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", project, region, name)
 
 	subnetwork, err := config.NewComputeClient(userAgent).Subnetworks.Get(project, region, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Subnetwork Not Found : %s", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Subnetwork Not Found : %s", name), id)
 	}
 
 	if err := d.Set("ip_cidr_range", subnetwork.IpCidrRange); err != nil {
@@ -127,7 +128,7 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error setting secondary_ip_range: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", project, region, name))
+	d.SetId(id)
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_vpn_gateway.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_vpn_gateway.go.erb
@@ -72,12 +72,13 @@ func dataSourceGoogleComputeVpnGatewayRead(d *schema.ResourceData, meta interfac
 	}
 
 	name := d.Get("name").(string)
+	id := fmt.Sprintf("projects/%s/regions/%s/targetVpnGateways/%s", project, region, name)
 
 	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.NewComputeClient(userAgent))
 
 	gateway, err := vpnGatewaysService.Get(project, region, name).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("VPN Gateway Not Found : %s", name))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("VPN Gateway Not Found : %s", name), id)
 	}
 	if err := d.Set("network", tpgresource.ConvertSelfLinkToV1(gateway.Network)); err != nil {
 		return fmt.Errorf("Error setting network: %s", err)
@@ -94,6 +95,6 @@ func dataSourceGoogleComputeVpnGatewayRead(d *schema.ResourceData, meta interfac
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/targetVpnGateways/%s", project, region, name))
+	d.SetId(id)
 	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_global_compute_forwarding_rule.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_global_compute_forwarding_rule.go
@@ -33,7 +33,17 @@ func dataSourceGoogleComputeGlobalForwardingRuleRead(d *schema.ResourceData, met
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/global/forwardingRules/%s", project, name))
+	id := fmt.Sprintf("projects/%s/global/forwardingRules/%s", project, name)
+	d.SetId(id)
 
-	return resourceComputeGlobalForwardingRuleRead(d, meta)
+	err = resourceComputeGlobalForwardingRuleRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }

--- a/mmv1/third_party/terraform/services/dataprocmetastore/data_source_dataproc_metastore_service.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/data_source_dataproc_metastore_service.go.erb
@@ -28,5 +28,13 @@ func dataSourceDataprocMetastoreServiceRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceDataprocMetastoreServiceRead(d, meta)
+	err = resourceDataprocMetastoreServiceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/dns/data_source_dns_keys.go
+++ b/mmv1/third_party/terraform/services/dns/data_source_dns_keys.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Ensure the implementation satisfies the expected interfaces
@@ -179,9 +178,7 @@ func (d *GoogleDnsKeysDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	clientResp, err := d.client.DnsKeys.List(data.Project.ValueString(), data.ManagedZone.ValueString()).Do()
 	if err != nil {
-		if !transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
-			resp.Diagnostics.AddError(fmt.Sprintf("Error when reading or editing dataSourceDnsKeys"), err.Error())
-		}
+		resp.Diagnostics.AddError(fmt.Sprintf("Error when reading or editing dataSourceDnsKeys"), err.Error())
 		// Save data into Terraform state
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app.go.erb
@@ -37,6 +37,14 @@ func dataSourceGoogleFirebaseAndroidAppRead(d *schema.ResourceData, meta interfa
 	if err := d.Set("name", name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	return resourceFirebaseAndroidAppRead(d, meta)
+	err = resourceFirebaseAndroidAppRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", name)
+	}
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app.go.erb
@@ -37,6 +37,14 @@ func dataSourceGoogleFirebaseAppleAppRead(d *schema.ResourceData, meta interface
         if err := d.Set("name", name); err != nil {
                 return fmt.Errorf("Error setting name: %s", err)
         }
-        return resourceFirebaseAppleAppRead(d, meta)
+        err = resourceFirebaseAppleAppRead(d, meta)
+        if err != nil {
+                return err
+        }
+
+        if d.Id() == "" {
+                return fmt.Errorf("%s not found", name)
+        }
+        return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app.go.erb
@@ -37,6 +37,14 @@ func dataSourceGoogleFirebaseWebAppRead(d *schema.ResourceData, meta interface{}
 	if err := d.Set("name", name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	return resourceFirebaseWebAppRead(d, meta)
+	err = resourceFirebaseWebAppRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", name)
+	}
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/firebasehosting/data_source_google_firebase_hosting_channel.go.erb
+++ b/mmv1/third_party/terraform/services/firebasehosting/data_source_google_firebase_hosting_channel.go.erb
@@ -31,6 +31,14 @@ func dataSourceGoogleFirebaseHostingChannelRead(d *schema.ResourceData, meta int
 	}
 	d.SetId(id)
 
-	return resourceFirebaseHostingChannelRead(d, meta)
+	err = resourceFirebaseHostingChannelRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_beta_workload_identity_pool.go.erb
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_beta_workload_identity_pool.go.erb
@@ -31,7 +31,15 @@ func dataSourceIAMBetaWorkloadIdentityPoolRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceIAMBetaWorkloadIdentityPoolRead(d, meta)
+	err = resourceIAMBetaWorkloadIdentityPoolRead(d, meta)
+	if err != nil {
+		return err
+	}
 
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_beta_workload_identity_pool_provider.go.erb
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_beta_workload_identity_pool_provider.go.erb
@@ -32,7 +32,15 @@ func dataSourceIAMBetaWorkloadIdentityPoolProviderRead(d *schema.ResourceData, m
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceIAMBetaWorkloadIdentityPoolProviderRead(d, meta)
+	err = resourceIAMBetaWorkloadIdentityPoolProviderRead(d, meta)
+	if err != nil {
+		return err
+	}
 
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/iap/data_source_iap_client.go
+++ b/mmv1/third_party/terraform/services/iap/data_source_iap_client.go
@@ -27,5 +27,13 @@ func dataSourceGoogleIapClientRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceIapClientRead(d, meta)
+	err = resourceIapClientRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key.go
@@ -1,6 +1,8 @@
 package kms
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -31,7 +33,16 @@ func dataSourceGoogleKmsCryptoKeyRead(d *schema.ResourceData, meta interface{}) 
 		Name:      d.Get("name").(string),
 	}
 
-	d.SetId(cryptoKeyId.CryptoKeyId())
+	id := cryptoKeyId.CryptoKeyId()
+	d.SetId(id)
 
-	return resourceKMSCryptoKeyRead(d, meta)
+	err = resourceKMSCryptoKeyRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version.go
@@ -87,7 +87,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("KmsCryptoKeyVersion %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("KmsCryptoKeyVersion %q", d.Id()), url)
 	}
 
 	if err := d.Set("version", flattenKmsCryptoKeyVersionVersion(res["name"], d)); err != nil {
@@ -120,7 +120,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("KmsCryptoKey %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("KmsCryptoKey %q", d.Id()), url)
 	}
 
 	if res["purpose"] == "ASYMMETRIC_SIGN" || res["purpose"] == "ASYMMETRIC_DECRYPT" {

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_ring.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_ring.go
@@ -1,6 +1,8 @@
 package kms
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -31,7 +33,16 @@ func dataSourceGoogleKmsKeyRingRead(d *schema.ResourceData, meta interface{}) er
 		Location: d.Get("location").(string),
 		Project:  project,
 	}
-	d.SetId(keyRingId.KeyRingId())
+	id := keyRingId.KeyRingId()
+	d.SetId(id)
 
-	return resourceKMSKeyRingRead(d, meta)
+	err = resourceKMSKeyRingRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/logging/data_source_google_logging_project_cmek_settings.go
+++ b/mmv1/third_party/terraform/services/logging/data_source_google_logging_project_cmek_settings.go
@@ -85,7 +85,7 @@ func dataSourceGoogleLoggingProjectCmekSettingsRead(d *schema.ResourceData, meta
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("LoggingProjectCmekSettings %q", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("LoggingProjectCmekSettings %q", d.Id()), url)
 	}
 
 	d.SetId(fmt.Sprintf("projects/%s/cmekSettings", project))

--- a/mmv1/third_party/terraform/services/logging/data_source_google_logging_sink.go
+++ b/mmv1/third_party/terraform/services/logging/data_source_google_logging_sink.go
@@ -33,7 +33,7 @@ func dataSourceGoogleLoggingSinkRead(d *schema.ResourceData, meta interface{}) e
 
 	sink, err := config.NewLoggingClient(userAgent).Sinks.Get(sinkId).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Logging Sink %s", d.Id()))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Logging Sink %s", d.Id()), sinkId)
 	}
 
 	if err := flattenResourceLoggingSink(d, sink); err != nil {

--- a/mmv1/third_party/terraform/services/privateca/data_source_certificate_authority.go
+++ b/mmv1/third_party/terraform/services/privateca/data_source_certificate_authority.go
@@ -73,7 +73,7 @@ func dataSourcePrivatecaCertificateAuthorityRead(d *schema.ResourceData, meta in
 			UserAgent: userAgent,
 		})
 		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("PrivatecaCertificateAuthority %q", d.Id()))
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("PrivatecaCertificateAuthority %q", d.Id()), url)
 		}
 		if err := d.Set("pem_csr", res["pemCsr"]); err != nil {
 			return fmt.Errorf("Error fetching CertificateAuthority: %s", err)

--- a/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_subscription.go
@@ -28,5 +28,13 @@ func dataSourceGooglePubsubSubscriptionRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourcePubsubSubscriptionRead(d, meta)
+	err = resourcePubsubSubscriptionRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_topic.go
+++ b/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_topic.go
@@ -28,5 +28,13 @@ func dataSourceGooglePubsubTopicRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourcePubsubTopicRead(d, meta)
+	err = resourcePubsubTopicRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_instance.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_instance.go
@@ -1,6 +1,8 @@
 package redis
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -29,5 +31,13 @@ func dataSourceGoogleRedisInstanceRead(d *schema.ResourceData, meta interface{})
 	}
 	d.SetId(id)
 
-	return resourceRedisInstanceRead(d, meta)
+	err = resourceRedisInstanceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_folder.go
@@ -61,13 +61,14 @@ func dataSourceFolderRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(canonicalFolderName(d.Get("folder").(string)))
+	id := canonicalFolderName(d.Get("folder").(string))
+	d.SetId(id)
 	if err := resourceGoogleFolderRead(d, meta); err != nil {
 		return err
 	}
 	// If resource doesn't exist, read will not set ID and we should return error.
 	if d.Id() == "" {
-		return nil
+		return fmt.Errorf("%s not found", id)
 	}
 
 	if v, ok := d.GetOk("lookup_organization"); ok && v.(bool) {

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_folder_organization_policy.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_folder_organization_policy.go
@@ -22,7 +22,16 @@ func DataSourceGoogleFolderOrganizationPolicy() *schema.Resource {
 
 func datasourceGoogleFolderOrganizationPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
-	d.SetId(fmt.Sprintf("%s/%s", d.Get("folder"), d.Get("constraint")))
+	id := fmt.Sprintf("%s/%s", d.Get("folder"), d.Get("constraint"))
+	d.SetId(id)
 
-	return resourceGoogleFolderOrganizationPolicyRead(d, meta)
+	err := resourceGoogleFolderOrganizationPolicyRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_iam_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_iam_role.go
@@ -43,7 +43,7 @@ func dataSourceGoogleIamRoleRead(d *schema.ResourceData, meta interface{}) error
 	roleName := d.Get("name").(string)
 	role, err := config.NewIamClient(userAgent).Roles.Get(roleName).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Error reading IAM Role %s: %s", roleName, err))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Error reading IAM Role %s: %s", roleName, err), roleName)
 	}
 
 	d.SetId(role.Name)

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_organization.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_organization.go
@@ -103,7 +103,7 @@ func dataSourceOrganizationRead(d *schema.ResourceData, meta interface{}) error 
 			Timeout: d.Timeout(schema.TimeoutRead),
 		})
 		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Organization Not Found : %s", v))
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Organization Not Found : %s", v), canonicalOrganizationName(v.(string)))
 		}
 
 		organization = resp

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_organization_policy.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_organization_policy.go
@@ -22,7 +22,16 @@ func DataSourceGoogleProjectOrganizationPolicy() *schema.Resource {
 
 func datasourceGoogleProjectOrganizationPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
-	d.SetId(fmt.Sprintf("%s:%s", d.Get("project"), d.Get("constraint")))
+	id := fmt.Sprintf("%s:%s", d.Get("project"), d.Get("constraint"))
+	d.SetId(id)
 
-	return resourceGoogleProjectOrganizationPolicyRead(d, meta)
+	err := resourceGoogleProjectOrganizationPolicyRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_service.go
@@ -28,5 +28,13 @@ func dataSourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceGoogleProjectServiceRead(d, meta)
+	err = resourceGoogleProjectServiceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account.go
@@ -59,7 +59,7 @@ func dataSourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}
 
 	sa, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Get(serviceAccountName).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Account %q", serviceAccountName))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Service Account %q", serviceAccountName), serviceAccountName)
 	}
 
 	d.SetId(sa.Name)

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_key.go
@@ -66,7 +66,7 @@ func dataSourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interfac
 	// Confirm the service account key exists
 	sak, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Keys.Get(keyName).PublicKeyType(publicKeyType).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Account Key %q", keyName))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Service Account Key %q", keyName), keyName)
 	}
 
 	d.SetId(sak.Name)

--- a/mmv1/third_party/terraform/services/runtimeconfig/data_source_runtimeconfig_config.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/data_source_runtimeconfig_config.go.erb
@@ -31,6 +31,14 @@ func dataSourceGoogleRuntimeconfigConfigRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceRuntimeconfigConfigRead(d, meta)
+	err = resourceRuntimeconfigConfigRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }
 <% end %>

--- a/mmv1/third_party/terraform/services/runtimeconfig/data_source_runtimeconfig_variable.go.erb
+++ b/mmv1/third_party/terraform/services/runtimeconfig/data_source_runtimeconfig_variable.go.erb
@@ -33,7 +33,15 @@ func dataSourceGoogleRuntimeconfigVariableRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceRuntimeconfigVariableRead(d, meta)
+	err = resourceRuntimeconfigVariableRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret.go
@@ -26,5 +26,13 @@ func dataSourceSecretManagerSecretRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceSecretManagerSecretRead(d, meta)
+	err = resourceSecretManagerSecretRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/sourcerepo/data_source_sourcerepo_repository.go
+++ b/mmv1/third_party/terraform/services/sourcerepo/data_source_sourcerepo_repository.go
@@ -31,5 +31,13 @@ func dataSourceGoogleSourceRepoRepositoryRead(d *schema.ResourceData, meta inter
 	}
 	d.SetId(id)
 
-	return resourceSourceRepoRepositoryRead(d, meta)
+	err = resourceSourceRepoRepositoryRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/spanner/data_source_spanner_instance.go
+++ b/mmv1/third_party/terraform/services/spanner/data_source_spanner_instance.go
@@ -32,5 +32,13 @@ func dataSourceSpannerInstanceRead(d *schema.ResourceData, meta interface{}) err
 	}
 	d.SetId(id)
 
-	return resourceSpannerInstanceRead(d, meta)
+	err = resourceSpannerInstanceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/sql/data_source_sql_database.go
+++ b/mmv1/third_party/terraform/services/sql/data_source_sql_database.go
@@ -27,10 +27,14 @@ func dataSourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error fetching project for Database: %s", err)
 	}
-	d.SetId(fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, d.Get("instance").(string), d.Get("name").(string)))
+	id := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, d.Get("instance").(string), d.Get("name").(string))
+	d.SetId(id)
 	err = resourceSQLDatabaseRead(d, meta)
 	if err != nil {
 		return err
+	}
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
 	}
 	if err := d.Set("deletion_policy", nil); err != nil {
 		return fmt.Errorf("Error setting deletion_policy: %s", err)

--- a/mmv1/third_party/terraform/services/sql/data_source_sql_database_instance.go
+++ b/mmv1/third_party/terraform/services/sql/data_source_sql_database_instance.go
@@ -1,6 +1,8 @@
 package sql
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
@@ -18,7 +20,15 @@ func DataSourceSqlDatabaseInstance() *schema.Resource {
 }
 
 func dataSourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	id := d.Get("name").(string)
+	err := resourceSqlDatabaseInstanceRead(d, meta)
+	if err != nil {
+		return err
+	}
 
-	return resourceSqlDatabaseInstanceRead(d, meta)
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
 
+	return nil
 }

--- a/mmv1/third_party/terraform/services/sql/data_source_sql_databases.go
+++ b/mmv1/third_party/terraform/services/sql/data_source_sql_databases.go
@@ -60,7 +60,7 @@ func dataSourceSqlDatabasesRead(d *schema.ResourceData, meta interface{}) error 
 	})
 
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Databases in %q instance", d.Get("instance").(string)))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Databases in %q instance", d.Get("instance").(string)), fmt.Sprintf("Databases in %q instance", d.Get("instance").(string)))
 	}
 	flattenedDatabases := flattenDatabases(databases.Items)
 

--- a/mmv1/third_party/terraform/services/storage/data_source_google_storage_project_service_account.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_google_storage_project_service_account.go
@@ -55,7 +55,7 @@ func dataSourceGoogleStorageProjectServiceAccountRead(d *schema.ResourceData, me
 
 	serviceAccount, err := serviceAccountGetRequest.Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, "GCS service account not found")
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, "GCS service account not found", fmt.Sprintf("Project %q GCS service account", project))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/mmv1/third_party/terraform/services/storagetransfer/data_source_google_storage_transfer_project_service_account.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/data_source_google_storage_transfer_project_service_account.go
@@ -47,7 +47,7 @@ func dataSourceGoogleStorageTransferProjectServiceAccountRead(d *schema.Resource
 
 	serviceAccount, err := config.NewStorageTransferClient(userAgent).GoogleServiceAccounts.Get(project).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, "Google Cloud Storage Transfer service account not found")
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, "Google Cloud Storage Transfer service account not found", fmt.Sprintf("Project %q Google Cloud Storage Transfer account", project))
 	}
 
 	d.SetId(serviceAccount.AccountEmail)

--- a/mmv1/third_party/terraform/services/vertexai/data_source_vertex_ai_index.go
+++ b/mmv1/third_party/terraform/services/vertexai/data_source_vertex_ai_index.go
@@ -29,5 +29,13 @@ func dataSourceVertexAIIndexRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceVertexAIIndexRead(d, meta)
+	err = resourceVertexAIIndexRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_cluster.go.erb
@@ -28,6 +28,14 @@ func dataSourceVmwareengineClusterRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceVmwareengineClusterRead(d, meta)
+	err = resourceVmwareengineClusterRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network.go.erb
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network.go.erb
@@ -30,6 +30,14 @@ func dataSourceVmwareengineNetworkRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceVmwareengineNetworkRead(d, meta)
+	err = resourceVmwareengineNetworkRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_private_cloud.go.erb
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_private_cloud.go.erb
@@ -30,6 +30,14 @@ func dataSourceVmwareenginePrivateCloudRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	return resourceVmwareenginePrivateCloudRead(d, meta)
+	err = resourceVmwareenginePrivateCloudRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/vpcaccess/data_source_vpc_access_connector.go
+++ b/mmv1/third_party/terraform/services/vpcaccess/data_source_vpc_access_connector.go
@@ -30,5 +30,13 @@ func dataSourceVPCAccessConnectorRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(id)
 
-	return resourceVPCAccessConnectorRead(d, meta)
+	err = resourceVPCAccessConnectorRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -136,9 +136,9 @@ func HandleNotFoundError(err error, d *schema.ResourceData, resource string) err
 		fmt.Sprintf("Error when reading or editing %s: {{err}}", resource), err)
 }
 
-func HandleDataSourceNotFoundError(url, resource string, err error, d *schema.ResourceData) error {
+func HandleDataSourceNotFoundError(err error, d *schema.ResourceData, resource, url string) error {
 	if IsGoogleApiErrorWithCode(err, 404) {
-		return fmt.Errorf("Error 404: %s not found", url)
+		return fmt.Errorf("%s not found", url)
 	}
 
 	return errwrap.Wrapf(

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -136,6 +136,15 @@ func HandleNotFoundError(err error, d *schema.ResourceData, resource string) err
 		fmt.Sprintf("Error when reading or editing %s: {{err}}", resource), err)
 }
 
+func HandleDataSourceNotFoundError(url, resource string, err error, d *schema.ResourceData) error {
+	if IsGoogleApiErrorWithCode(err, 404) {
+		return fmt.Errorf("Error 404: %s not found", url)
+	}
+
+	return errwrap.Wrapf(
+		fmt.Sprintf("Error when reading or editing %s: {{err}}", resource), err)
+}
+
 func IsGoogleApiErrorWithCode(err error, errCode int) bool {
 	gerr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error)
 	return ok && gerr != nil && gerr.Code == errCode


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/12873

This does not guarantee all data sources will return errors if empty -- there are some for which this is intended functionality such as data sources filtering for what data they would have displayed, or if an endpoint is successfully reached due to actually existing but simply containing no information for the data source to display, as their lack of data is intentional.

Local testing entailed doing trial runs of data sources that had more unusual configurations (e.g. [1](https://github.com/GoogleCloudPlatform/magic-modules/pull/8858/files#diff-4458a6d2843b8486cac42668ecdd9ac877f84be06c6955879405b34a9c5a353c)), and verifying functionality for a few different resources that the more universal configurations (e.g. [1](https://github.com/GoogleCloudPlatform/magic-modules/pull/8858/files#diff-546c506f2a50de8fe02dba28abe8768e286ccc7b4a24aea48e4c7ecf4a468609) and [2](https://github.com/GoogleCloudPlatform/magic-modules/pull/8858/files#diff-c7307db044ba174c9167c3ae449ef79b9b23fd33f15b4aaa8638bfce65e2cbea)) that involved either replacing references to `transport_tpg.HandleNotFoundError` with `transport_tpg.HandleDataSourceNotFoundError` or wrapping standard resource read functions with a check for an empty ID, as this would be returned by these resource reads using `transport_tpg.HandleNotFoundError`.

Should not result in false-positives as the two main functionality changes due the following:

If using the `transport_tpg.HandleDataSourceNotFoundError` return an error on 404 directly, maintains logic for returning non 404 errors

If using the `d.Id == ""` check, the d.SetId("") would be passed up via the `transport_tpg.HandleNotFoundError` function, in which case this is the Error we directly are intending to add (the example functionality previously added via Container Cluster per parent issue)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change

```
