### PR TITLE
Remove unnecessarry if statements for OperationWait errors

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/common_operation.go
+++ b/mmv1/third_party/terraform/tpgresource/common_operation.go
@@ -138,10 +138,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 
 func OperationWait(w Waiter, activity string, timeout time.Duration, pollInterval time.Duration) error {
 	if OperationDone(w) {
-		if w.Error() != nil {
-			return w.Error()
-		}
-		return nil
+		return w.Error()
 	}
 
 	c := &resource.StateChangeConf{
@@ -161,11 +158,8 @@ func OperationWait(w Waiter, activity string, timeout time.Duration, pollInterva
 	if err != nil {
 		return err
 	}
-	if w.Error() != nil {
-		return w.Error()
-	}
 
-	return nil
+	return w.Error()
 }
 
 // The cloud resource manager API operation is an example of one of many


### PR DESCRIPTION
Remove if statements where the return in case if statement is not entered the return would be nil anyways

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Remove unnecessary if statements for OperationWait
```
