### PR TITLE
feat: (firestore_database) Add point_in_time_recovery_enablement

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -147,6 +147,18 @@ properties:
       - :ENABLED
       - :DISABLED
     default_from_api: true
+  - !ruby/object:Api::Type::Enum
+    name: pointInTimeRecoveryEnablement
+    description: |
+      Whether to enable the PITR feature on this database.
+      If `POINT_IN_TIME_RECOVERY_ENABLED` is selected, reads are supported on selected versions of the data from within the past 7 days.
+      versionRetentionPeriod and earliestVersionTime can be used to determine the supported versions. These include reads against any timestamp within the past hour
+      and reads against 1-minute snapshots beyond 1 hour and within 7 days.
+      If `POINT_IN_TIME_RECOVERY_DISABLED` is selected, reads are supported on any version of the data from within the past 1 hour.
+    values:
+      - :POINT_IN_TIME_RECOVERY_ENABLED
+      - :POINT_IN_TIME_RECOVERY_DISABLED
+    default_value: :POINT_IN_TIME_RECOVERY_DISABLED
   - !ruby/object:Api::Type::String
     name: key_prefix
     description: |
@@ -166,4 +178,19 @@ properties:
     name: create_time
     description: |
       The timestamp at which this database was created.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: versionRetentionPeriod
+    description: |
+      Output only. The period during which past versions of data are retained in the database.
+      Any read or query can specify a readTime within this window, and will read the state of the database at that time.
+      If the PITR feature is enabled, the retention period is 7 days. Otherwise, the retention period is 1 hour.
+      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+    output: true
+  - !ruby/object:Api::Type::String
+    name: earliestVersionTime
+    description: |
+      Output only. The earliest timestamp at which older versions of the data can be read from the database. See versionRetentionPeriod above; this field is populated with now - versionRetentionPeriod.
+      This value is continuously updated, and becomes stale the moment it is queried. If you are using this value to recover data, make sure to account for the time from the moment when the value is queried to the moment when you initiate the recovery.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -20,12 +20,13 @@ resource "google_project_service" "firestore" {
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                     = google_project.project.project_id
-  name                        = "my-database"
-  location_id                 = "nam5"
-  type                        = "FIRESTORE_NATIVE"
-  concurrency_mode            = "OPTIMISTIC"
-  app_engine_integration_mode = "DISABLED"
+  project                           = google_project.project.project_id
+  name                              = "my-database"
+  location_id                       = "nam5"
+  type                              = "FIRESTORE_NATIVE"
+  concurrency_mode                  = "OPTIMISTIC"
+  app_engine_integration_mode       = "DISABLED"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
 
   depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
@@ -19,13 +19,13 @@ resource "google_project_service" "firestore" {
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                     = google_project.project.project_id
-  name                        = "datastore-mode-database"
-  location_id                 = "nam5"
-  type                        = "DATASTORE_MODE"
-  concurrency_mode            = "OPTIMISTIC"
-  app_engine_integration_mode = "DISABLED"
+  project                           = google_project.project.project_id
+  name                              = "datastore-mode-database"
+  location_id                       = "nam5"
+  type                              = "DATASTORE_MODE"
+  concurrency_mode                  = "OPTIMISTIC"
+  app_engine_integration_mode       = "DISABLED"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
 
   depends_on = [google_project_service.firestore]
 }
-

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
@@ -10,10 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccFirestoreDatabase_update(t *testing.T) {
+func TestAccFirestoreDatabase_updateConcurrencyMode(t *testing.T) {
 	t.Parallel()
 
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 	randomSuffix := acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -24,7 +25,7 @@ func TestAccFirestoreDatabase_update(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirestoreDatabase_concurrencyMode(orgId, randomSuffix, "OPTIMISTIC"),
+				Config: testAccFirestoreDatabase_concurrencyMode(orgId, billingAccount, randomSuffix, "OPTIMISTIC"),
 			},
 			{
 				ResourceName:      "google_firestore_database.default",
@@ -33,7 +34,7 @@ func TestAccFirestoreDatabase_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"etag", "project"},
 			},
 			{
-				Config: testAccFirestoreDatabase_concurrencyMode(orgId, randomSuffix, "PESSIMISTIC"),
+				Config: testAccFirestoreDatabase_concurrencyMode(orgId, billingAccount, randomSuffix, "PESSIMISTIC"),
 			},
 			{
 				ResourceName:      "google_firestore_database.default",
@@ -45,12 +46,49 @@ func TestAccFirestoreDatabase_update(t *testing.T) {
 	})
 }
 
-func testAccFirestoreDatabase_concurrencyMode(orgId string, randomSuffix string, concurrencyMode string) string {
+func TestAccFirestoreDatabase_updatePitrEnablement(t *testing.T) {
+	t.Parallel()
+
+	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	randomSuffix := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirestoreDatabase_pitrEnablement(orgId, billingAccount, randomSuffix, "POINT_IN_TIME_RECOVERY_ENABLED"),
+			},
+			{
+				ResourceName:      "google_firestore_database.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"etag", "project"},
+			},
+			{
+				Config: testAccFirestoreDatabase_pitrEnablement(orgId, billingAccount, randomSuffix, "POINT_IN_TIME_RECOVERY_DISABLED"),
+			},
+			{
+				ResourceName:      "google_firestore_database.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"etag", "project"},
+			},
+		},
+	})
+}
+
+func testAccFirestoreDatabase_basicDependencies(orgId, billingAccount string, randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_project" "default" {
-  project_id = "tf-test%s"
-  name       = "tf-test%s"
-  org_id     = "%s"
+  project_id      = "tf-test%s"
+  name            = "tf-test%s"
+  org_id          = "%s"
+  billing_account = "%s"
 }
 
 resource "time_sleep" "wait_60_seconds" {
@@ -66,6 +104,11 @@ resource "google_project_service" "firestore" {
   # Needed for CI tests for permissions to propagate, should not be needed for actual usage
   depends_on = [time_sleep.wait_60_seconds]
 }
+`, randomSuffix, randomSuffix, orgId, billingAccount)
+}
+
+func testAccFirestoreDatabase_concurrencyMode(orgId, billingAccount string, randomSuffix string, concurrencyMode string) string {
+	return testAccFirestoreDatabase_basicDependencies(orgId, billingAccount, randomSuffix) + fmt.Sprintf(`
 
 resource "google_firestore_database" "default" {
   name             = "(default)"
@@ -77,5 +120,21 @@ resource "google_firestore_database" "default" {
 
   depends_on = [google_project_service.firestore]
 }
-`, randomSuffix, randomSuffix, orgId, concurrencyMode)
+`, concurrencyMode)
+}
+
+func testAccFirestoreDatabase_pitrEnablement(orgId, billingAccount string, randomSuffix string, pointInTimeRecoveryEnablement string) string {
+	return testAccFirestoreDatabase_basicDependencies(orgId, billingAccount, randomSuffix) + fmt.Sprintf(`
+
+resource "google_firestore_database" "default" {
+  name                              = "(default)"
+  type                              = "DATASTORE_MODE"
+  location_id                       = "nam5"
+  point_in_time_recovery_enablement = "%s"
+
+  project = google_project.default.project_id
+
+  depends_on = [google_project_service.firestore]
+}
+`, pointInTimeRecoveryEnablement)
 }


### PR DESCRIPTION
Fixes b/292570801

Adds the new field `point_in_time_recovery_enablement` and some corresponding output-only fields to `google_firestore_database`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `point_in_time_recovery_enablement` field to `google_firestore_database` resource
```
