### PR TITLE
Add deprecation messages for cloudiot resources

### DIFF
--- a/mmv1/products/cloudiot/Device.yaml
+++ b/mmv1/products/cloudiot/Device.yaml
@@ -24,6 +24,8 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Official Documentation': 'https://cloud.google.com/iot/docs/'
   api: 'https://cloud.google.com/iot/docs/reference/cloudiot/rest/'
 import_format: ['{{%registry}}/devices/{{name}}']
+deprecation_message: >-
+  `google_cloudiot_device` is deprecated in the API. This resource will be removed in the next major release of the provider.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudiot_device_basic'

--- a/mmv1/products/cloudiot/DeviceRegistry.yaml
+++ b/mmv1/products/cloudiot/DeviceRegistry.yaml
@@ -41,6 +41,8 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/cloudiot_device_registry.go.erb
   extra_schema_entry: templates/terraform/extra_schema_entry/cloudiot_device_registry.go.erb
   pre_update: templates/terraform/pre_update/cloudiot_device_registry.go.erb
+deprecation_message: >-
+  `google_cloudiot_registry` is deprecated in the API. This resource will be removed in the next major release of the provider.
 docs: !ruby/object:Provider::Terraform::Docs
   optional_properties: |
     * `state_notification_config` - A PubSub topic to publish device state updates.

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -370,3 +370,12 @@ resource "google_project_iam_binding" "gcs-bucket-writer" {
   ]
 }
 ```
+## Product: `cloudiot`
+
+### resource `google_cloudiot_device` is now removed
+
+### resource `google_cloudiot_registry` is now removed
+
+### resource `google_cloudiot_registry_iam_*` is now removed
+
+### datasource `google_cloudiot_registry_iam_policy` is now removed


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
docs: added deprecation message for resource `google_cloudiot_device` and `google_cloudiot_registry` and updated the 5.0.0 guide
```
