### PR TITLE
Change the default value of unique_writer_identity in resource logging_project_sink to true.

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -36,9 +36,9 @@ func ResourceLoggingProjectSink() *schema.Resource {
 	schm.Schema["unique_writer_identity"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Default:     false,
+		Default:     true,
 		ForceNew:    true,
-		Description: `Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
+		Description: `Whether or not to create a unique identity associated with this sink. If true (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm
 }
@@ -160,3 +160,4 @@ func resourceLoggingProjectSinkDelete(d *schema.ResourceData, meta interface{}) 
 	d.SetId("")
 	return nil
 }
+

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package logging
 
 import (
@@ -160,4 +162,3 @@ func resourceLoggingProjectSinkDelete(d *schema.ResourceData, meta interface{}) 
 	d.SetId("")
 	return nil
 }
-

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -38,7 +38,7 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Optional:    true,
 		Default:     true,
 		ForceNew:    true,
-		Description: `Whether or not to create a unique identity associated with this sink. If true (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
+		Description: `Whether or not to create a unique identity associated with this sink. If false (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -292,13 +292,11 @@ func testAccLoggingProjectSink_basic(name, project, bucketName string) string {
 resource "google_logging_project_sink" "basic" {
   name        = "%s"
   project     = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
-
-  unique_writer_identity = false
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -310,14 +308,12 @@ func testAccLoggingProjectSink_described(name, project, bucketName string) strin
 resource "google_logging_project_sink" "described" {
   name        = "%s"
   project     = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   description = "this is a description for a project level logging sink"
-
-  unique_writer_identity = false
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -329,14 +325,12 @@ func testAccLoggingProjectSink_described_update(name, project, bucketName string
 resource "google_logging_project_sink" "described" {
   name        = "%s"
   project     = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   description = "description updated"
-
-  unique_writer_identity = false
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -348,14 +342,14 @@ func testAccLoggingProjectSink_disabled(name, project, bucketName string) string
 resource "google_logging_project_sink" "disabled" {
   name        = "%s"
   project     = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   disabled    = true
 
   unique_writer_identity = false
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -367,14 +361,14 @@ func testAccLoggingProjectSink_disabled_update(name, project, bucketName, disabl
 resource "google_logging_project_sink" "disabled" {
   name        = "%s"
   project     = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   disabled    = "%s"
 
   unique_writer_identity = true
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -385,13 +379,13 @@ func testAccLoggingProjectSink_uniqueWriter(name, bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_logging_project_sink" "unique_writer" {
   name        = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
 
   unique_writer_identity = true
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -402,13 +396,13 @@ func testAccLoggingProjectSink_uniqueWriterUpdated(name, bucketName string) stri
 	return fmt.Sprintf(`
 resource "google_logging_project_sink" "unique_writer" {
   name        = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
 
   unique_writer_identity = true
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -420,7 +414,7 @@ func testAccLoggingProjectSink_heredoc(name, project, bucketName string) string 
 resource "google_logging_project_sink" "heredoc" {
   name        = "%s"
   project     = "%s"
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.gcs-bucket.name}"
 
   filter = <<EOS
 
@@ -433,7 +427,7 @@ EOS
   unique_writer_identity = false
 }
 
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "gcs-bucket" {
   name     = "%s"
   location = "US"
 }
@@ -444,7 +438,7 @@ func testAccLoggingProjectSink_bigquery_before(sinkName, bqDatasetID string) str
 	return fmt.Sprintf(`
 resource "google_logging_project_sink" "bigquery" {
   name        = "%s"
-  destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.bq_dataset.dataset_id}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
 
   unique_writer_identity = true
@@ -454,7 +448,7 @@ resource "google_logging_project_sink" "bigquery" {
   }
 }
 
-resource "google_bigquery_dataset" "logging_sink" {
+resource "google_bigquery_dataset" "bq_dataset" {
   dataset_id  = "%s"
   description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
 }
@@ -465,13 +459,11 @@ func testAccLoggingProjectSink_bigquery_after(sinkName, bqDatasetID string) stri
 	return fmt.Sprintf(`
 resource "google_logging_project_sink" "bigquery" {
   name        = "%s"
-  destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.bq_dataset.dataset_id}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
-
-  unique_writer_identity = false
 }
 
-resource "google_bigquery_dataset" "logging_sink" {
+resource "google_bigquery_dataset" "bq_dataset" {
   dataset_id  = "%s"
   description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
 }
@@ -495,8 +487,6 @@ resource "google_logging_project_sink" "loggingbucket" {
     description = "test-2"
     filter = "resource.type = k8s_container"
   }
-
-  unique_writer_identity = true
 }
 
 `, name, project, project)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Change the default value of unique_writer_identity in resource logging_project_sink to true. unique_writer_identity = false is legacy behavior. New sinks should always set this field to be true.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
logging: changed the default value of `unique_writer_identity` from `false` to `true` in `google_logging_project_sink`.
```
