### PR TITLE
upstream doc change to cloud scheduler job

### DIFF
--- a/mmv1/templates/terraform/examples/scheduler_job_paused.tf.erb
+++ b/mmv1/templates/terraform/examples/scheduler_job_paused.tf.erb
@@ -15,4 +15,7 @@ resource "google_cloud_scheduler_job" "job" {
     uri         = "https://example.com/ping"
     body        = base64encode("{\"foo\":\"bar\"}")
   }
+  headers = {
+    "Content-Type" = "application/json"
+  }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/hashicorp/terraform-provider-google/pull/15754
By default scheduler calls with data as `Content-Type: application/octet-stream`. As examples are with json data, specifying `Content-Type: application/json`.

In helped me resolved an issue when calling GCP Cloud Functions (gen2), so I think that it will be valuable addition to the docs.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
