### PR TITLE
Add json content-type header to google_cloud_scheduler_job json examples

### DIFF
--- a/mmv1/templates/terraform/examples/scheduler_job_http.tf.erb
+++ b/mmv1/templates/terraform/examples/scheduler_job_http.tf.erb
@@ -13,5 +13,8 @@ resource "google_cloud_scheduler_job" "job" {
     http_method = "POST"
     uri         = "https://example.com/"
     body        = base64encode("{\"foo\":\"bar\"}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
   }
 }

--- a/mmv1/templates/terraform/examples/scheduler_job_paused.tf.erb
+++ b/mmv1/templates/terraform/examples/scheduler_job_paused.tf.erb
@@ -14,5 +14,8 @@ resource "google_cloud_scheduler_job" "job" {
     http_method = "POST"
     uri         = "https://example.com/ping"
     body        = base64encode("{\"foo\":\"bar\"}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Originally posted to the Terraform `hashicorp/terraform-provider-google` repo: https://github.com/hashicorp/terraform-provider-google/pull/15754

Replaces https://github.com/GoogleCloudPlatform/magic-modules/pull/8890 which was an attempt to move it to this repo but code changes were applied incorrectly (and only to 1 out of 2 files).

## Context:

To add more context:
I did further verification using new Terraform resources on a simple project, to simulate this change:

```
# before (as-is without content-type header)
resource "google_cloud_scheduler_job" "scheduler_test_default_content_type" {
  name             = "scheduler-test-default-content-type"
  description      = "test http job - variant 1 - without content-type header"
  region           = local.region
  schedule         = "0 1 * * *"
  time_zone        = "America/New_York"
  attempt_deadline = "15s"

  http_target {
    http_method = "POST"
    uri         = local.test_function_url
    body        = base64encode("{\"foo\":\"bar\"}")

    oidc_token {
      service_account_email = local.default_compute_sa
    }
  }
}

# after (with content-type header)
resource "google_cloud_scheduler_job" "scheduler_test_default_content_type_2" {
  name             = "scheduler-test-default-content-type-2"
  description      = "test http job - variant 2 - with content-type header"
  region           = local.region
  schedule         = "0 2 * * *"
  time_zone        = "America/New_York"
  attempt_deadline = "15s"

  http_target {
    http_method = "POST"
    uri         = local.test_function_url
    body        = base64encode("{\"foo\":\"bar\"}")
    headers = {
      "Content-Type" = "application/json"
    }

    oidc_token {
      service_account_email = local.default_compute_sa
    }
  }
}
```

With the following Cloud Function (gen2) code:

```py
import functions_framework

@functions_framework.http
def hello_http(request):
    content_type = request.headers.get('Content-Type')
    print(f'Content-Type: {content_type}')

    body = request.get_data(as_text=True)
    print(f'Request Body: {body}')

    request_json = request.get_json(silent=True)
    print(f"request_json:   {request_json}")
    
    # raises 415 status code (Unsupported Media Type) when called from "before", with application/octet-stream content type
    # request_json_2 = request.get_json(silent=False)

    if request_json and 'foo' in request_json:
        foo = request_json['foo']
    else:
        foo = 'Unknown'

    resp = 'foo: {}!'.format(foo)
    print(f"Returning {resp}")

    return resp
```

The results:
- log for `gcloud scheduler jobs run scheduler-test-default-content-type --project=[...] --location=[...]`
```
Content-Type: application/octet-stream
Request Body: {"foo":"bar"}
request_json: None
Returning foo: Unknown!
```
- log for `gcloud scheduler jobs run scheduler-test-default-content-type-2 --project=[...] --location=[...]`
```
Content-Type: application/json
Request Body: {"foo":"bar"}
request_json: {'foo': 'bar'}
Returning foo: bar!
```

---

Besides this example above, google docs for scheduler HttpMethod ([docs](https://cloud.google.com/scheduler/docs/reference/rpc/google.cloud.scheduler.v1#httptarget)) explicitly state for `headers`:
> Content-Type: This will be set to "application/octet-stream". You can override this default by explicitly setting Content-Type to a particular media type when creating the job. For example, you can set Content-Type to "application/json"
 
So in case of example in the terraform docs that uses JSON body, the `Content-Type` should be adjusted accordingly.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
