### PR TITLE
add event_stream block to google_storage_transfer_job schema

### DIFF
--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -80,6 +80,35 @@ func ResourceStorageTransferJob() *schema.Resource {
 				ForceNew:    true,
 				Description: `The project in which the resource belongs. If it is not provided, the provider project is used.`,
 			},
+			"event_stream": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "Specifies a unique name of the resource such as AWS SQS ARN in the form 'arn:aws:sqs:region:account_id:queue_name', or Pub/Sub subscription resource name in the form 'projects/{project}/subscriptions/{sub}'",
+						},
+						"event_stream_start_time": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							Description:  "Specifies the date and time that Storage Transfer Service starts listening for events from this stream. If no start time is specified or start time is in the past, Storage Transfer Service starts listening immediately",
+							ValidateFunc: validation.IsRFC3339Time,
+						},
+						"event_stream_expiration_time": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							Description:  "Specifies the data and time at which Storage Transfer Service stops listening for events from this stream. After this time, any transfers in progress will complete, but no new transfers are initiated",
+							ValidateFunc: validation.IsRFC3339Time,
+						},
+					},
+				},
+			},
 			"transfer_spec": {
 				Type:     schema.TypeList,
 				Required: true,

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -903,6 +903,30 @@ func expandTransferSchedules(transferSchedules []interface{}) *storagetransfer.S
 	}
 }
 
+func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string]interface{} {
+	if transferSchedule == nil || reflect.DeepEqual(transferSchedule, &storagetransfer.Schedule{}) {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"schedule_start_date": flattenDate(transferSchedule.ScheduleStartDate),
+	}
+
+	if transferSchedule.ScheduleEndDate != nil {
+		data["schedule_end_date"] = flattenDate(transferSchedule.ScheduleEndDate)
+	}
+
+	if transferSchedule.StartTimeOfDay != nil {
+		data["start_time_of_day"] = flattenTimeOfDay(transferSchedule.StartTimeOfDay)
+	}
+
+	if transferSchedule.RepeatInterval != "" {
+		data["repeat_interval"] = transferSchedule.RepeatInterval
+	}
+
+	return []map[string]interface{}{data}
+}
+
 func expandEventStream(e []interface{}) *storagetransfer.EventStream {
 	if len(e) == 0 || e[0] == nil {
 		return nil
@@ -925,60 +949,12 @@ func flattenEventStream(eventStream *storagetransfer.EventStream) []map[string]i
 		"name": eventStream.Name,
 	}
 
-	if eventStream.EventStreamStartTime != nil {
+	if eventStream.EventStreamStartTime != "" {
 		data["event_stream_start_time"] = eventStream.EventStreamStartTime
 	}
 
-	if eventStream.EventStreamExpirationTime != nil {
+	if eventStream.EventStreamExpirationTime != "" {
 		data["event_stream_expiration_time"] = eventStream.EventStreamExpirationTime
-	}
-
-	return []map[string]interface{}{data}
-}
-
-func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string]interface{} {
-	if transferSchedule == nil || reflect.DeepEqual(transferSchedule, &storagetransfer.Schedule{}) {
-		return nil
-	}
-
-	data := map[string]interface{}{
-		"schedule_start_date": flattenDate(transferSchedule.ScheduleStartDate),
-	}
-
-	if transferSchedule.ScheduleEndDate != nil {
-		data["schedule_end_date"] = flattenDate(transferSchedule.ScheduleEndDate)
-	}
-
-	if transferSchedule.StartTimeOfDay != nil {
-		data["start_time_of_day"] = flattenTimeOfDay(transferSchedule.StartTimeOfDay)
-	}
-
-	if transferSchedule.RepeatInterval != "" {
-		data["repeat_interval"] = transferSchedule.RepeatInterval
-	}
-
-	return []map[string]interface{}{data}
-}
-
-func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string]interface{} {
-	if transferSchedule == nil || reflect.DeepEqual(transferSchedule, &storagetransfer.Schedule{}) {
-		return nil
-	}
-
-	data := map[string]interface{}{
-		"schedule_start_date": flattenDate(transferSchedule.ScheduleStartDate),
-	}
-
-	if transferSchedule.ScheduleEndDate != nil {
-		data["schedule_end_date"] = flattenDate(transferSchedule.ScheduleEndDate)
-	}
-
-	if transferSchedule.StartTimeOfDay != nil {
-		data["start_time_of_day"] = flattenTimeOfDay(transferSchedule.StartTimeOfDay)
-	}
-
-	if transferSchedule.RepeatInterval != "" {
-		data["repeat_interval"] = transferSchedule.RepeatInterval
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -82,7 +82,7 @@ func ResourceStorageTransferJob() *schema.Resource {
 			},
 			"event_stream": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -94,14 +94,14 @@ func ResourceStorageTransferJob() *schema.Resource {
 						},
 						"event_stream_start_time": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
 							Description:  "Specifies the date and time that Storage Transfer Service starts listening for events from this stream. If no start time is specified or start time is in the past, Storage Transfer Service starts listening immediately",
 							ValidateFunc: validation.IsRFC3339Time,
 						},
 						"event_stream_expiration_time": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
 							Description:  "Specifies the data and time at which Storage Transfer Service stops listening for events from this stream. After this time, any transfers in progress will complete, but no new transfers are initiated",
 							ValidateFunc: validation.IsRFC3339Time,

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -695,6 +695,13 @@ func resourceStorageTransferJobUpdate(d *schema.ResourceData, meta interface{}) 
 	transferJob := &storagetransfer.TransferJob{}
 	fieldMask := []string{}
 
+	if d.HasChange("event_stream") {
+		fieldMask = append(fieldMask, "event_stream")
+		if v, ok := d.GetOk("event_stream"); ok {
+			transferJob.Description = expandEventStream(v.([]interface{}))
+		}
+	}
+
 	if d.HasChange("description") {
 		fieldMask = append(fieldMask, "description")
 		if v, ok := d.GetOk("description"); ok {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -81,10 +81,10 @@ func ResourceStorageTransferJob() *schema.Resource {
 				Description: `The project in which the resource belongs. If it is not provided, the provider project is used.`,
 			},
 			"event_stream": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"schedule"},
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				ExactlyOneOf: []string{"schedule"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -220,10 +220,10 @@ func ResourceStorageTransferJob() *schema.Resource {
 				Description: `Notification configuration.`,
 			},
 			"schedule": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"event_stream"},
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				ExactlyOneOf: []string{"event_stream"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"schedule_start_date": {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -81,9 +81,10 @@ func ResourceStorageTransferJob() *schema.Resource {
 				Description: `The project in which the resource belongs. If it is not provided, the provider project is used.`,
 			},
 			"event_stream": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"schedule"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -219,9 +220,10 @@ func ResourceStorageTransferJob() *schema.Resource {
 				Description: `Notification configuration.`,
 			},
 			"schedule": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"event_stream"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"schedule_start_date": {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -594,6 +594,7 @@ func resourceStorageTransferJobCreate(d *schema.ResourceData, meta interface{}) 
 		ProjectId:          project,
 		Status:             d.Get("status").(string),
 		Schedule:           expandTransferSchedules(d.Get("schedule").([]interface{})),
+		EventStream:        expandEventStream(d.Get("event_stream").([]interface{})),
 		TransferSpec:       expandTransferSpecs(d.Get("transfer_spec").([]interface{})),
 		NotificationConfig: expandTransferJobNotificationConfig(d.Get("notification_config").([]interface{})),
 	}
@@ -900,6 +901,63 @@ func expandTransferSchedules(transferSchedules []interface{}) *storagetransfer.S
 		StartTimeOfDay:    expandTimeOfDays(schedule["start_time_of_day"].([]interface{})),
 		RepeatInterval:    schedule["repeat_interval"].(string),
 	}
+}
+
+func expandEventStream(e []interface{}) *storagetransfer.EventStream {
+	if len(e) == 0 || e[0] == nil {
+		return nil
+	}
+
+	eventStream := e[0].(map[string]interface{})
+	return &storagetransfer.EventStream{
+		Name:                      eventStream["name"].(string),
+		EventStreamStartTime:      eventStream["event_stream_start_time"].(string),
+		EventStreamExpirationTime: eventStream["event_stream_expiration_time"].(string),
+	}
+}
+
+func flattenEventStream(eventStream *storagetransfer.EventStream) []map[string]interface{} {
+	if eventStream == nil || reflect.DeepEqual(eventStream, &storagetransfer.EventStream{}) {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"name": eventStream.Name,
+	}
+
+	if eventStream.EventStreamStartTime != nil {
+		data["event_stream_start_time"] = eventStream.EventStreamStartTime
+	}
+
+	if eventStream.EventStreamExpirationTime != nil {
+		data["event_stream_expiration_time"] = eventStream.EventStreamExpirationTime
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string]interface{} {
+	if transferSchedule == nil || reflect.DeepEqual(transferSchedule, &storagetransfer.Schedule{}) {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"schedule_start_date": flattenDate(transferSchedule.ScheduleStartDate),
+	}
+
+	if transferSchedule.ScheduleEndDate != nil {
+		data["schedule_end_date"] = flattenDate(transferSchedule.ScheduleEndDate)
+	}
+
+	if transferSchedule.StartTimeOfDay != nil {
+		data["start_time_of_day"] = flattenTimeOfDay(transferSchedule.StartTimeOfDay)
+	}
+
+	if transferSchedule.RepeatInterval != "" {
+		data["repeat_interval"] = transferSchedule.RepeatInterval
+	}
+
+	return []map[string]interface{}{data}
 }
 
 func flattenTransferSchedule(transferSchedule *storagetransfer.Schedule) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -89,20 +89,17 @@ func ResourceStorageTransferJob() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							ForceNew:    true,
 							Description: "Specifies a unique name of the resource such as AWS SQS ARN in the form 'arn:aws:sqs:region:account_id:queue_name', or Pub/Sub subscription resource name in the form 'projects/{project}/subscriptions/{sub}'",
 						},
 						"event_stream_start_time": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							Description:  "Specifies the date and time that Storage Transfer Service starts listening for events from this stream. If no start time is specified or start time is in the past, Storage Transfer Service starts listening immediately",
 							ValidateFunc: validation.IsRFC3339Time,
 						},
 						"event_stream_expiration_time": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							Description:  "Specifies the data and time at which Storage Transfer Service stops listening for events from this stream. After this time, any transfers in progress will complete, but no new transfers are initiated",
 							ValidateFunc: validation.IsRFC3339Time,
 						},

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
@@ -444,26 +444,6 @@ resource "google_storage_transfer_job" "transfer_job" {
     }
   }
 
-  schedule {
-    schedule_start_date {
-      year  = 2018
-      month = 10
-      day   = 1
-    }
-    schedule_end_date {
-      year  = 2019
-      month = 10
-      day   = 1
-    }
-    start_time_of_day {
-      hours   = 0
-      minutes = 30
-      seconds = 0
-      nanos   = 0
-    }
-	  repeat_interval = "604800s"
-  }
-
   depends_on = [
     google_storage_bucket_iam_member.data_source,
     google_storage_bucket_iam_member.data_sink,

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package storagetransfer_test
 
 import (

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
@@ -439,7 +439,7 @@ data "google_storage_transfer_project_service_account" "default" {
 }
 
 resource "google_storage_bucket" "data_source" {
-  name          = "%s"
+  name          = "tf-test-%s"
   project       = "%s"
   location      = "US"
   force_destroy = true

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -120,6 +120,8 @@ The following arguments are supported:
 
 - - -
 
+* `event_stream` - (Optional) Specifies the Event-driven transfer options. Event-driven transfers listen to an event stream to transfer updated files. Structure [documented below](#nested_event_stream)
+
 * `project` - (Optional) The project in which the resource belongs. If it
 	is not provided, the provider project is used.
 
@@ -160,6 +162,14 @@ The following arguments are supported:
 * `start_time_of_day` - (Optional) The time in UTC at which the transfer will be scheduled to start in a day. Transfers may start later than this time. If not specified, recurring and one-time transfers that are scheduled to run today will run immediately; recurring transfers that are scheduled to run on a future date will start at approximately midnight UTC on that date. Note that when configuring a transfer with the Cloud Platform Console, the transfer's start time in a day is specified in your local timezone. Structure [documented below](#nested_start_time_of_day).
 
 * `repeat_interval` - (Optional) Interval between the start of each scheduled transfer. If unspecified, the default value is 24 hours. This value may not be less than 1 hour. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+
+<a name="nested_event_stream"></a>The `event_stream` block supports:
+
+* `name` - (Required) Specifies a unique name of the resource such as AWS SQS ARN in the form 'arn:aws:sqs:region:account_id:queue_name', or Pub/Sub subscription resource name in the form 'projects/{project}/subscriptions/{sub}'.
+
+* `event_stream_start_time` - (Optional) Specifies the date and time that Storage Transfer Service starts listening for events from this stream. If no start time is specified or start time is in the past, Storage Transfer Service starts listening immediately. A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+* `event_stream_expiration_time` - (Optional) Specifies the data and time at which Storage Transfer Service stops listening for events from this stream. After this time, any transfers in progress will complete, but no new transfers are initiated.A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
 
 <a name="nested_object_conditions"></a>The `object_conditions` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -116,11 +116,11 @@ The following arguments are supported:
 
 * `transfer_spec` - (Required) Transfer specification. Structure [documented below](#nested_transfer_spec).
 
-* `schedule` - (Required) Schedule specification defining when the Transfer Job should be scheduled to start, end and what time to run. Structure [documented below](#nested_schedule).
-
 - - -
 
-* `event_stream` - (Optional) Specifies the Event-driven transfer options. Event-driven transfers listen to an event stream to transfer updated files. Structure [documented below](#nested_event_stream)
+* `schedule` - (Optional) Schedule specification defining when the Transfer Job should be scheduled to start, end and what time to run. Structure [documented below](#nested_schedule). Either `schedule` or `event_stream` must be set.
+
+* `event_stream` - (Optional) Specifies the Event-driven transfer options. Event-driven transfers listen to an event stream to transfer updated files. Structure [documented below](#nested_event_stream) Either `event_stream` or `schedule` must be set.
 
 * `project` - (Optional) The project in which the resource belongs. If it
 	is not provided, the provider project is used.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds the `event_stream` field to the `google_storage_transfer_job` resource. This can be found in the docs [here](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs#TransferJob.FIELDS.event_stream)

It's also referenced as part of a feature request here: https://github.com/hashicorp/terraform-provider-google/issues/13293

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storagetransfer: added `event_stream` field to `google_storage_transfer_job` resource
```
