### PR TITLE
Add new TPUv2 product and VM resource in beta

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -25,6 +25,24 @@ create_url: projects/{{project}}/locations/{{zone}}/nodes?nodeId={{name}}
 update_url: projects/{{project}}/locations/{{zone}}/nodes/{{name}}
 update_verb: :PATCH
 update_mask: true
+autogen_async: true
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+    resource_inside_response: true
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'tpu_v2_vm_basic'

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -1,0 +1,66 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'Vm'
+description: |
+  A Cloud TPU VM instance.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/tpu/docs/'
+  api: 'https://cloud.google.com/tpu/docs/reference/rest/v2/projects.locations.nodes'
+base_url: projects/{{project}}/locations/{{zone}}/nodes
+self_link: projects/{{project}}/locations/{{zone}}/nodes/{{name}}
+create_url: projects/{{project}}/locations/{{zone}}/nodes?nodeId={{name}}
+update_url: projects/{{project}}/locations/{{zone}}/nodes/{{name}}
+update_verb: :PATCH
+update_mask: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'tpu_v2_vm_basic'
+    min_version: 'beta'
+    primary_resource_id: 'tpu'
+    vars:
+      vm_name: 'test-tpu'
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'zone'
+    description: |
+      The GCP location for the TPU. If it is not provided, the provider zone is used.
+    immutable: true
+    url_param_only: true
+    default_from_api: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    required: true
+    immutable: true
+    description: |
+      The immutable name of the TPU.
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+  - !ruby/object:Api::Type::String
+    name: 'runtimeVersion'
+    required: true
+    immutable: true
+    description: |
+      Runtime version for the TPU.
+  - !ruby/object:Api::Type::String
+    name: 'acceleratorType'
+    immutable: true
+    default_value: 'v2-8'
+    description: |
+      TPU accelerator type for the TPU. If not specified, this defaults to 'v2-8'.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      Text description of the TPU.

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -32,6 +32,12 @@ examples:
     primary_resource_id: 'tpu'
     vars:
       vm_name: 'test-tpu'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'tpu_v2_vm_full'
+    min_version: 'beta'
+    primary_resource_id: 'tpu'
+    vars:
+      vm_name: 'test-tpu'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'zone'

--- a/mmv1/products/tpuv2/product.yaml
+++ b/mmv1/products/tpuv2/product.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: TpuV2
+display_name: Cloud TPU v2
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://tpu.googleapis.com/v2/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Cloud TPU API
+    url: https://console.cloud.google.com/apis/library/tpu.googleapis.com/

--- a/mmv1/products/tpuv2/product.yaml
+++ b/mmv1/products/tpuv2/product.yaml
@@ -17,7 +17,7 @@ display_name: Cloud TPU v2
 versions:
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://tpu.googleapis.com/v2/
+    base_url: https://tpu.googleapis.com/v2alpha1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:

--- a/mmv1/products/tpuv2/product.yaml
+++ b/mmv1/products/tpuv2/product.yaml
@@ -17,7 +17,7 @@ display_name: Cloud TPU v2
 versions:
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://tpu.googleapis.com/v2alpha1/
+    base_url: https://tpu.googleapis.com/v2/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
@@ -6,8 +6,7 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
 
   name = "<%= ctx[:vars]["vm_name"] %>"
-  zone = "us-central1-b"
+  zone = "us-central1-c"
 
   runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
-  accelerator_type = "v3-8"
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
@@ -9,4 +9,5 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   zone = "us-central1-b"
 
   runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
+  accelerator_type = "v3-8"
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
@@ -8,5 +8,5 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]["vm_name"] %>"
   zone = "us-central1-c"
 
-  runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
+  runtime_version = "tpu-vm-tf-2.13.0"
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_basic.tf.erb
@@ -1,0 +1,13 @@
+data "google_tpu_v2_runtime_versions" "available" {
+  provider = google-beta
+}
+
+resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  name = "<%= ctx[:vars]["vm_name"] %>"
+  zone = "us-central1-b"
+
+  accelerator_type = "v3-8"
+  runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
+}

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -13,6 +13,6 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   zone = "us-central1-c"
   description = "Text description of the TPU."
 
-  runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
-  accelerator_type = data.google_tpu_v2_accelerator_types.available.types[0]
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -10,9 +10,9 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
 
   name = "<%= ctx[:vars]["vm_name"] %>"
-  zone = "us-central1-b"
+  zone = "us-central1-c"
   description = "Text description of the TPU."
 
   runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
-  accelerator_type = "v3-8"
+  accelerator_type = data.google_tpu_v2_accelerator_types.available.types[0]
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -2,11 +2,17 @@ data "google_tpu_v2_runtime_versions" "available" {
   provider = google-beta
 }
 
+data "google_tpu_v2_accelerator_types" "available" {
+  provider = google-beta
+}
+
 resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
 
   name = "<%= ctx[:vars]["vm_name"] %>"
   zone = "us-central1-b"
+  description = "Text description of the TPU."
 
   runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
+  accelerator_type = data.google_tpu_v2_accelerator_types.available.types[0]
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -14,5 +14,5 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   description = "Text description of the TPU."
 
   runtime_version  = data.google_tpu_v2_runtime_versions.available.versions[0]
-  accelerator_type = data.google_tpu_v2_accelerator_types.available.types[0]
+  accelerator_type = "v3-8"
 }

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -345,6 +345,10 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_tags_tag_key":                              tags.DataSourceGoogleTagsTagKey(),
 		"google_tags_tag_value":                            tags.DataSourceGoogleTagsTagValue(),
 		"google_tpu_tensorflow_versions":                   tpu.DataSourceTpuTensorflowVersions(),
+		<% unless version == 'ga' -%>
+		"google_tpu_v2_runtime_versions":                   tpuv2.DataSourceTpuV2RuntimeVersions(),
+		"google_tpu_v2_accelerator_types":                  tpuv2.DataSourceTpuV2AcceleratorTypes(),
+		<% end -%>
 		"google_vpc_access_connector":                      vpcaccess.DataSourceVPCAccessConnector(),
 		"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
 		"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types.go
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types.go
@@ -1,0 +1,93 @@
+package tpuv2
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceTpuV2AcceleratorTypes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTpuV2AcceleratorTypesRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceTpuV2AcceleratorTypesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	zone, err := tpgresource.GetZone(d, config)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{TpuV2BasePath}}projects/{{project}}/locations/{{zone}}/acceleratorTypes")
+	if err != nil {
+		return err
+	}
+
+	typesRaw, err := tpgresource.PaginatedListRequest(project, url, userAgent, config, flattenTpuV2AcceleratorTypes)
+	if err != nil {
+		return fmt.Errorf("error listing TPU v2 accelerator types: %s", err)
+	}
+
+	types := make([]string, len(typesRaw))
+	for i, typeRaw := range typesRaw {
+		types[i] = typeRaw.(string)
+	}
+	sort.Strings(types)
+
+	log.Printf("[DEBUG] Received Google TPU v2 accelerator types: %q", types)
+
+	if err := d.Set("types", types); err != nil {
+		return fmt.Errorf("error setting types: %s", err)
+	}
+	if err := d.Set("zone", zone); err != nil {
+		return fmt.Errorf("error setting zone: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s", project, zone))
+
+	return nil
+}
+
+func flattenTpuV2AcceleratorTypes(resp map[string]interface{}) []interface{} {
+	typeObjList := resp["acceleratorTypes"].([]interface{})
+	types := make([]interface{}, len(typeObjList))
+	for i, typ := range typeObjList {
+		typeObj := typ.(map[string]interface{})
+		types[i] = typeObj["type"]
+	}
+	return types
+}

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go
@@ -1,0 +1,68 @@
+package tpuv2_test
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccTpuV2AcceleratorTypes_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTpuV2AcceleratorTypesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTpuV2AcceleratorTypes("data.google_tpu_v2_accelerator_types.available"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTpuV2AcceleratorTypes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find TPU v2 accelerator types data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("data source id not set")
+		}
+
+		count, ok := rs.Primary.Attributes["types.#"]
+		if !ok {
+			return errors.New("can't find 'types' attribute")
+		}
+
+		cnt, err := strconv.Atoi(count)
+		if err != nil {
+			return errors.New("failed to read number of types")
+		}
+		if cnt < 2 {
+			return fmt.Errorf("expected at least 2 types, received %d, this is most likely a bug", cnt)
+		}
+
+		for i := 0; i < cnt; i++ {
+			idx := fmt.Sprintf("types.%d", i)
+			_, ok := rs.Primary.Attributes[idx]
+			if !ok {
+				return fmt.Errorf("expected %q, type not found", idx)
+			}
+		}
+		return nil
+	}
+}
+
+const testAccTpuV2AcceleratorTypesConfig = `
+data "google_tpu_v2_accelerator_types" "available" {}
+`

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions.go
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions.go
@@ -1,0 +1,93 @@
+package tpuv2
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceTpuV2RuntimeVersions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTpuV2RuntimeVersionsRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceTpuV2RuntimeVersionsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	zone, err := tpgresource.GetZone(d, config)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{TpuV2BasePath}}projects/{{project}}/locations/{{zone}}/runtimeVersions")
+	if err != nil {
+		return err
+	}
+
+	versionsRaw, err := tpgresource.PaginatedListRequest(project, url, userAgent, config, flattenTpuV2RuntimeVersions)
+	if err != nil {
+		return fmt.Errorf("error listing TPU v2 runtime versions: %s", err)
+	}
+
+	versions := make([]string, len(versionsRaw))
+	for i, ver := range versionsRaw {
+		versions[i] = ver.(string)
+	}
+	sort.Strings(versions)
+
+	log.Printf("[DEBUG] Received Google TPU v2 runtime versions: %q", versions)
+
+	if err := d.Set("versions", versions); err != nil {
+		return fmt.Errorf("error setting versions: %s", err)
+	}
+	if err := d.Set("zone", zone); err != nil {
+		return fmt.Errorf("error setting zone: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s", project, zone))
+
+	return nil
+}
+
+func flattenTpuV2RuntimeVersions(resp map[string]interface{}) []interface{} {
+	verObjList := resp["runtimeVersions"].([]interface{})
+	versions := make([]interface{}, len(verObjList))
+	for i, v := range verObjList {
+		verObj := v.(map[string]interface{})
+		versions[i] = verObj["version"]
+	}
+	return versions
+}

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go
@@ -1,0 +1,68 @@
+package tpuv2_test
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccTpuV2RuntimeVersions_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTpuV2RuntimeVersionsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTpuV2RuntimeVersions("data.google_tpu_v2_runtime_versions.available"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTpuV2RuntimeVersions(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find TPU v2 runtime versions data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("data source id not set")
+		}
+
+		count, ok := rs.Primary.Attributes["versions.#"]
+		if !ok {
+			return errors.New("can't find 'versions' attribute")
+		}
+
+		cnt, err := strconv.Atoi(count)
+		if err != nil {
+			return errors.New("failed to read number of versions")
+		}
+		if cnt < 2 {
+			return fmt.Errorf("expected at least 2 versions, received %d, this is most likely a bug", cnt)
+		}
+
+		for i := 0; i < cnt; i++ {
+			idx := fmt.Sprintf("versions.%d", i)
+			_, ok := rs.Primary.Attributes[idx]
+			if !ok {
+				return fmt.Errorf("expected %q, version not found", idx)
+			}
+		}
+		return nil
+	}
+}
+
+const testAccTpuV2RuntimeVersionsConfig = `
+data "google_tpu_v2_runtime_versions" "available" {}
+`

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -1,0 +1,98 @@
+<% autogen_exception -%>
+package tpuv2_test
+
+<% unless version == 'ga' -%>
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
+)
+
+func TestAccTpuV2Vm_update(t *testing.T) {
+	t.Parallel()
+
+        randomSuffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+                "random_suffix": randomSuffix,
+                "description": "Old description original context",
+	}
+	updatedContext := map[string]interface{}{
+                "random_suffix": randomSuffix,
+                "description": "New description updated context",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckTpuV2VmDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTpuV2Vm_full(context),
+			},
+			{
+				ResourceName:            "google_tpu_v2_vm.tpu",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+			{
+				Config: testAccTpuV2Vm_update(updatedContext),
+			},
+			{
+				ResourceName:            "google_tpu_v2_vm.tpu",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+		},
+	})
+}
+
+func testAccTpuV2Vm_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_tpu_v2_runtime_versions" "available" {
+  provider = google-beta
+}
+
+data "google_tpu_v2_accelerator_types" "available" {
+  provider = google-beta
+}
+
+resource "google_tpu_v2_vm" "tpu" {
+  provider = google-beta
+
+  name = "tf-test-test-tpu%{random_suffix}"
+  zone = "us-central1-c"
+  description = "%{description}"
+
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+}
+`, context)
+}
+
+func testAccTpuV2Vm_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_tpu_v2_runtime_versions" "available" {
+  provider = google-beta
+}
+
+data "google_tpu_v2_accelerator_types" "available" {
+  provider = google-beta
+}
+
+resource "google_tpu_v2_vm" "tpu" {
+  provider = google-beta
+
+  name = "tf-test-test-tpu%{random_suffix}"
+  zone = "us-central1-c"
+  description = "%{description}"
+
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/website/docs/d/tpu_v2_accelerator_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_v2_accelerator_types.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Cloud TPU v2"
+description: |-
+  Get available accelerator types.
+---
+
+# google\_tpu\_v2\_accelerator\_types
+
+Get accelerator types available for a project. For more information see the [official documentation](https://cloud.google.com/tpu/docs/) and [API](https://cloud.google.com/tpu/docs/reference/rest/v2/projects.locations.acceleratorTypes).
+
+## Example Usage
+
+```hcl
+data "google_tpu_v2_accelerator_types" "available" {
+}
+```
+
+## Example Usage: Configure Basic TPU VM with available type
+
+```hcl
+data "google_tpu_v2_accelerator_types" "available" {
+}
+
+data "google_tpu_v2_runtime_versions" "available" {
+}
+
+resource "google_tpu_v2_vm" "tpu" {
+  name = "test-tpu"
+  zone = "us-central1-b"
+  runtime_version = data.google_tpu_v2_runtime_versions.available.versions[0]
+  accelerator_type = data.google_tpu_v2_accelerator_types.available.types[0]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Optional) The project to list types for. If it
+    is not provided, the provider project is used.
+
+* `zone` - (Optional) The zone to list types for. If it
+    is not provided, the provider zone is used.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `types` - The list of accelerator types available for the given project and zone.

--- a/mmv1/third_party/terraform/website/docs/d/tpu_v2_runtime_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_v2_runtime_versions.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud TPU v2"
+description: |-
+  Get available runtime versions.
+---
+
+# google\_tpu\_v2\_runtime\_versions
+
+Get runtime versions available for a project. For more information see the [official documentation](https://cloud.google.com/tpu/docs/) and [API](https://cloud.google.com/tpu/docs/reference/rest/v2/projects.locations.runtimeVersions).
+
+## Example Usage
+
+```hcl
+data "google_tpu_v2_runtime_versions" "available" {
+}
+```
+
+## Example Usage: Configure Basic TPU VM with available version
+
+```hcl
+data "google_tpu_v2_runtime_versions" "available" {
+}
+
+resource "google_tpu_v2_vm" "tpu" {
+  name = "test-tpu"
+  zone = "us-central1-b"
+  runtime_version = data.google_tpu_v2_runtime_versions.available.versions[0]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Optional) The project to list versions for. If it
+    is not provided, the provider project is used.
+
+* `zone` - (Optional) The zone to list versions for. If it
+    is not provided, the provider zone is used.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `versions` - The list of runtime versions available for the given project and zone.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add new TPUv2 product and required VM (TPU VM) resource with minimum required fields and description to the google-beta provider. Also add data sources for the required fields in beta.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_tpu_v2_vm` (beta)
```
