### PR TITLE
Add tests around how plugin framework provider configuration code handles `batching` block

### DIFF
--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1218,28 +1218,53 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 	// - ImpersonateServiceAccountDelegates: If we don't set this, we get a nil pointer exception ¯\_(ツ)_/¯
 
 	cases := map[string]struct {
-		// It's not easy to define basetypes.ListValue values directly in test case, so instead
-		// pass values into test function to control construction of basetypes.ListValue there.
-		SetAsNull              bool
-		SetAsUnknown           bool
-		BatchingValue          []interface{}
-		EnvVariables           map[string]string
-		ExpectedDataModelValue []string
-		// ExpectedConfigStructValue not used here, as impersonate_service_account_delegates info isn't stored in the config struct
-		ExpectError bool
-	}{
-		"batching value set in the provider schema ok": {
-			BatchingValue: []interface{}{
-				// fwmodels.ProviderBatching{
-				// 	EnableBatching: types.BoolValue(true),
-				// 	SendAfter:      types.StringValue("10s"),
-				// },
+		// It's not easy to create the value of Batching in the test case, so these inputs are used in the test function
+		SetBatchingAsNull    bool
+		SetBatchingAsUnknown bool
+		EnableBatchingValue  basetypes.BoolValue
+		SendAfterValue       basetypes.StringValue
 
-				map[string]interface{}{
-					"enable_batching": true,
-					"send_after":      "10s",
-				},
-			},
+		EnvVariables map[string]string
+
+		ExpectBatchingNull        bool
+		ExpectBatchingUnknown     bool
+		ExpectEnableBatchingValue basetypes.BoolValue
+		ExpectSendAfterValue      basetypes.StringValue
+		ExpectError               bool
+	}{
+		"batching can be configured with values for enable_batching and send_after": {
+			EnableBatchingValue:       types.BoolValue(true),
+			SendAfterValue:            types.StringValue("123s"),
+			ExpectEnableBatchingValue: types.BoolValue(true),
+			ExpectSendAfterValue:      types.StringValue("123s"),
+		},
+		"if batching is an empty block, it will set the default values for enable_batching and send_after": {
+			// In this test, we try to create a list containing only null values
+			EnableBatchingValue:       types.BoolNull(),
+			SendAfterValue:            types.StringNull(),
+			ExpectEnableBatchingValue: types.BoolValue(true),
+			ExpectSendAfterValue:      types.StringValue("10s"),
+		},
+		"when batching is configured with only enable_batching, send_after will be set to a default value": {
+			EnableBatchingValue:       types.BoolValue(true),
+			SendAfterValue:            types.StringNull(),
+			ExpectEnableBatchingValue: types.BoolValue(true),
+			ExpectSendAfterValue:      types.StringValue("10s"),
+		},
+		"when batching is configured with only send_after, enable_batching will be set to a default value": {
+			EnableBatchingValue:       types.BoolNull(),
+			SendAfterValue:            types.StringValue("123s"),
+			ExpectEnableBatchingValue: types.BoolValue(true),
+			ExpectSendAfterValue:      types.StringValue("123s"),
+		},
+		// Error states
+		"if batching is configured with send_after as an invalid value, there's an error": {
+			SendAfterValue: types.StringValue("invalid value"),
+			ExpectError:    true,
+		},
+		"if batching is configured with send_after as number value without seconds (s), there's an error": {
+			SendAfterValue: types.StringValue("123"),
+			ExpectError:    true,
 		},
 	}
 
@@ -1260,15 +1285,27 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 			impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{}) // empty list
 			data.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
 
-			if !tc.SetAsNull && !tc.SetAsUnknown {
-				b, _ := types.ListValueFrom(ctx, types.StringType, tc.BatchingValue)
-				data.Batching = b
+			// TODO(SarahFrench) - this code will change when batching is reworked
+			// See https://github.com/GoogleCloudPlatform/magic-modules/pull/7668
+			if !tc.SetBatchingAsNull && !tc.SetBatchingAsUnknown {
+				b, _ := types.ObjectValue(
+					map[string]attr.Type{
+						"enable_batching": types.BoolType,
+						"send_after":      types.StringType,
+					},
+					map[string]attr.Value{
+						"enable_batching": tc.EnableBatchingValue,
+						"send_after":      tc.SendAfterValue,
+					},
+				)
+				batching, _ := types.ListValue(types.ObjectType{}.WithAttributeTypes(fwmodels.ProviderBatchingAttributes), []attr.Value{b})
+				data.Batching = batching
 			}
-			if tc.SetAsNull {
-				data.Batching = types.ListNull(types.StringType)
+			if tc.SetBatchingAsNull {
+				data.Batching = types.ListNull(types.ObjectType{}.WithAttributeTypes(fwmodels.ProviderBatchingAttributes))
 			}
-			if tc.SetAsUnknown {
-				data.Batching = types.ListUnknown(types.StringType)
+			if tc.SetBatchingAsUnknown {
+				data.Batching = types.ListUnknown(types.ObjectType{}.WithAttributeTypes(fwmodels.ProviderBatchingAttributes))
 			}
 
 			p := fwtransport.FrameworkProviderConfig{}
@@ -1288,9 +1325,19 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 				t.Fatalf("did not expect error, but [%d] error(s) occurred", diags.ErrorsCount())
 			}
 			// Checking mutation of the data model
-			expected, _ := types.ListValueFrom(ctx, types.StringType, tc.ExpectedDataModelValue)
-			if !data.Batching.Equal(expected) {
-				t.Fatalf("want batching in the `fwmodels.ProviderModel` struct to be `%s`, but got the value `%s`", tc.ExpectedDataModelValue, data.Batching.String())
+			if !data.Batching.IsNull() && tc.ExpectBatchingNull {
+				t.Fatalf("want batching in the `fwmodels.ProviderModel` struct to be null, but got the value `%s`", data.Batching.String())
+			}
+			if !data.Batching.IsUnknown() && tc.ExpectBatchingUnknown {
+				t.Fatalf("want batching in the `fwmodels.ProviderModel` struct to be unknown, but got the value `%s`", data.Batching.String())
+			}
+			var pbConfigs []fwmodels.ProviderBatching
+			_ = data.Batching.ElementsAs(ctx, &pbConfigs, true)
+			if !pbConfigs[0].EnableBatching.Equal(tc.ExpectEnableBatchingValue) {
+				t.Fatalf("want batching.enable_batching in the `fwmodels.ProviderModel` struct to be `%s`, but got the value `%s`", tc.ExpectEnableBatchingValue.String(), data.Batching.String())
+			}
+			if !pbConfigs[0].SendAfter.Equal(tc.ExpectSendAfterValue) {
+				t.Fatalf("want batching.send_after in the `fwmodels.ProviderModel` struct to be `%s`, but got the value `%s`", tc.ExpectSendAfterValue.String(), data.Batching.String())
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1565,6 +1565,25 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 		// 	ExpectEnableBatchingValue: types.BoolValue(true),
 		// 	ExpectSendAfterValue:      types.StringValue("10s"),
 		// },
+		// Handling unknown values
+		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14444
+		// "when batching is an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
+		// 	SetBatchingAsUnknown:      true,
+		// 	ExpectEnableBatchingValue: types.BoolValue(true),
+		// 	ExpectSendAfterValue:      types.StringValue("10s"),
+		// },
+		// "when batching is configured with send_after as an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
+		// 	EnableBatchingValue:       types.BoolValue(true),
+		// 	SendAfterValue:            types.StringUnknown(),
+		// 	ExpectEnableBatchingValue: types.BoolValue(true),
+		// 	ExpectSendAfterValue:      types.StringValue("10s"),
+		// },
+		// "when batching is configured with enable_batching as an unknown value, the provider treats it as if it's unset (align to SDK behaviour)": {
+		// 	EnableBatchingValue:       types.BoolNull(),
+		// 	SendAfterValue:            types.StringValue("123s"),
+		// 	ExpectEnableBatchingValue: types.BoolValue(true),
+		// 	ExpectSendAfterValue:      types.StringValue("123s"),
+		// },
 		// Error states
 		"if batching is configured with send_after as an invalid value, there's an error": {
 			SendAfterValue: types.StringValue("invalid value"),

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1557,6 +1557,14 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 			ExpectEnableBatchingValue: types.BoolValue(true),
 			ExpectSendAfterValue:      types.StringValue("123s"),
 		},
+		// Handling empty strings in config
+		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
+		// "when batching is configured with send_after as an empty string, send_after will be set to a default value": {
+		// 	EnableBatchingValue:       types.BoolNull(),
+		// 	SendAfterValue:            types.StringValue(""),
+		// 	ExpectEnableBatchingValue: types.BoolValue(true),
+		// 	ExpectSendAfterValue:      types.StringValue("10s"),
+		// },
 		// Error states
 		"if batching is configured with send_after as an invalid value, there's an error": {
 			SendAfterValue: types.StringValue("invalid value"),

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1209,3 +1209,89 @@ func TestFrameworkProvider_LoadAndValidateFramework_impersonateServiceAccountDel
 		})
 	}
 }
+
+func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
+
+	// Note: In the test function we need to set the below fields in test case's fwmodels.ProviderModel value
+	// this is to stop the code under tests experiencing errors, and could be addressed in future refactoring.
+	// - Credentials: If we don't set this then the test looks for application default credentials and can fail depending on the machine running the test
+	// - ImpersonateServiceAccountDelegates: If we don't set this, we get a nil pointer exception ¯\_(ツ)_/¯
+
+	cases := map[string]struct {
+		// It's not easy to define basetypes.ListValue values directly in test case, so instead
+		// pass values into test function to control construction of basetypes.ListValue there.
+		SetAsNull              bool
+		SetAsUnknown           bool
+		BatchingValue          []interface{}
+		EnvVariables           map[string]string
+		ExpectedDataModelValue []string
+		// ExpectedConfigStructValue not used here, as impersonate_service_account_delegates info isn't stored in the config struct
+		ExpectError bool
+	}{
+		"batching value set in the provider schema ok": {
+			BatchingValue: []interface{}{
+				// fwmodels.ProviderBatching{
+				// 	EnableBatching: types.BoolValue(true),
+				// 	SendAfter:      types.StringValue("10s"),
+				// },
+
+				map[string]interface{}{
+					"enable_batching": true,
+					"send_after":      "10s",
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
+
+			ctx := context.Background()
+			tfVersion := "foobar"
+			providerversion := "999"
+			diags := diag.Diagnostics{}
+
+			data := fwmodels.ProviderModel{}
+			data.Credentials = types.StringValue(transport_tpg.TestFakeCredentialsPath)
+			impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{}) // empty list
+			data.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
+
+			if !tc.SetAsNull && !tc.SetAsUnknown {
+				b, _ := types.ListValueFrom(ctx, types.StringType, tc.BatchingValue)
+				data.Batching = b
+			}
+			if tc.SetAsNull {
+				data.Batching = types.ListNull(types.StringType)
+			}
+			if tc.SetAsUnknown {
+				data.Batching = types.ListUnknown(types.StringType)
+			}
+
+			p := fwtransport.FrameworkProviderConfig{}
+
+			// Act
+			p.LoadAndValidateFramework(ctx, &data, tfVersion, &diags, providerversion)
+
+			// Assert
+			if diags.HasError() && tc.ExpectError {
+				return
+			}
+			if diags.HasError() && !tc.ExpectError {
+				for i, err := range diags.Errors() {
+					num := i + 1
+					t.Logf("unexpected error #%d : %s", num, err.Summary())
+				}
+				t.Fatalf("did not expect error, but [%d] error(s) occurred", diags.ErrorsCount())
+			}
+			// Checking mutation of the data model
+			expected, _ := types.ListValueFrom(ctx, types.StringType, tc.ExpectedDataModelValue)
+			if !data.Batching.Equal(expected) {
+				t.Fatalf("want batching in the `fwmodels.ProviderModel` struct to be `%s`, but got the value `%s`", tc.ExpectedDataModelValue, data.Batching.String())
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -1560,7 +1560,7 @@ func TestFrameworkProvider_LoadAndValidateFramework_batching(t *testing.T) {
 		// Handling empty strings in config
 		// TODO(SarahFrench) make these tests pass to address: https://github.com/hashicorp/terraform-provider-google/issues/14255
 		// "when batching is configured with send_after as an empty string, send_after will be set to a default value": {
-		// 	EnableBatchingValue:       types.BoolNull(),
+		// 	EnableBatchingValue:       types.BoolValue(true),
 		// 	SendAfterValue:            types.StringValue(""),
 		// 	ExpectEnableBatchingValue: types.BoolValue(true),
 		// 	ExpectSendAfterValue:      types.StringValue("10s"),

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -1556,9 +1556,23 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 		ExpectedEnableBatchingValue bool
 		ExpectedSendAfterValue      string
 	}{
-		"if batch is an empty block, it will set the default values": {
+		"batching can be configured with values for enable_batching and send_after": {
 			ConfigValues: map[string]interface{}{
 				"credentials": transport_tpg.TestFakeCredentialsPath,
+				"batching": []interface{}{
+					map[string]interface{}{
+						"enable_batching": true,
+						"send_after":      "123s",
+					},
+				},
+			},
+			ExpectedEnableBatchingValue: true,
+			ExpectedSendAfterValue:      "123s",
+		},
+		"if batching is an empty block, it will set the default values for enable_batching and send_after": {
+			ConfigValues: map[string]interface{}{
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+				// batching not set
 			},
 			// Although at the schema level it's shown that by default it's set to false, the actual default value
 			// is true and can be seen in the `ExpanderProviderBatchingConfig` struct
@@ -1567,20 +1581,7 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 			ExpectedSendAfterValue:      "", // uses "" value to be able to set the default value of 30s
 			ExpectFieldUnset:            true,
 		},
-		"if batch is configured with both enable_batching and send_after": {
-			ConfigValues: map[string]interface{}{
-				"credentials": transport_tpg.TestFakeCredentialsPath,
-				"batching": []interface{}{
-					map[string]interface{}{
-						"enable_batching": true,
-						"send_after":      "10s",
-					},
-				},
-			},
-			ExpectedEnableBatchingValue: true,
-			ExpectedSendAfterValue:      "10s",
-		},
-		"if batch is configured with only enable_batching": {
+		"when batching is configured with only enable_batching, send_after will be set to a default value": {
 			ConfigValues: map[string]interface{}{
 				"credentials": transport_tpg.TestFakeCredentialsPath,
 				"batching": []interface{}{
@@ -1592,19 +1593,20 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 			ExpectedEnableBatchingValue: true,
 			ExpectedSendAfterValue:      "",
 		},
-		"if batch is configured with only send_after": {
+		"when batching is configured with only send_after, enable_batching will be set to a default value": {
 			ConfigValues: map[string]interface{}{
 				"credentials": transport_tpg.TestFakeCredentialsPath,
 				"batching": []interface{}{
 					map[string]interface{}{
-						"send_after": "10s",
+						"send_after": "123s",
 					},
 				},
 			},
 			ExpectedEnableBatchingValue: false,
-			ExpectedSendAfterValue:      "10s",
+			ExpectedSendAfterValue:      "123s",
 		},
-		"if batch is configured with invalid value for send_after": {
+		// Error states
+		"if batching is configured with send_after as an invalid value, there's an error": {
 			ConfigValues: map[string]interface{}{
 				"credentials": transport_tpg.TestFakeCredentialsPath,
 				"batching": []interface{}{
@@ -1613,10 +1615,9 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSendAfterValue: "invalid value",
-			ExpectError:            true,
+			ExpectError: true,
 		},
-		"if batch is configured with value without seconds (s) for send_after": {
+		"if batching is configured with send_after as number value without seconds (s), there's an error": {
 			ConfigValues: map[string]interface{}{
 				"credentials": transport_tpg.TestFakeCredentialsPath,
 				"batching": []interface{}{
@@ -1625,8 +1626,7 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSendAfterValue: "10",
-			ExpectError:            true,
+			ExpectError: true,
 		},
 	}
 

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -1615,7 +1615,8 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 					},
 				},
 			},
-			ExpectError: true,
+			ExpectedSendAfterValue: "invalid value",
+			ExpectError:            true,
 		},
 		"if batching is configured with send_after as number value without seconds (s), there's an error": {
 			ConfigValues: map[string]interface{}{
@@ -1626,7 +1627,8 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 					},
 				},
 			},
-			ExpectError: true,
+			ExpectedSendAfterValue: "10",
+			ExpectError:            true,
 		},
 	}
 
@@ -1665,10 +1667,10 @@ func TestProvider_ProviderConfigure_batching(t *testing.T) {
 				if ok {
 					val := v.(string)
 					if val != tc.ExpectedSendAfterValue {
-						t.Fatalf("expected request_timeout value set in provider data to be %v, got %v", tc.ExpectedSendAfterValue, val)
+						t.Fatalf("expected send_after value set in provider data to be %v, got %v", tc.ExpectedSendAfterValue, val)
 					}
 					if tc.ExpectFieldUnset {
-						t.Fatalf("expected request_timeout value to not be set in provider data, got %s", val)
+						t.Fatalf("expected send_after value to not be set in provider data, got %s", val)
 					}
 				}
 				// Return early in tests where errors expected


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is adding tests to assert that the plugin framework version of the provider config code matches the behaviour of the original SDK version of that logic. This comment shares context about why we are adding these tests: https://github.com/GoogleCloudPlatform/magic-modules/pull/8818#issuecomment-1710592425

There are SDK tests for how `batching` is handled, see here: https://github.com/GoogleCloudPlatform/magic-modules/blob/9d00d08f5aa04dae82c7e760a8d06efbb2659745/mmv1/third_party/terraform/provider/provider_internal_test.go#L1549

That SDK test is updated in this PR.

This PR also adds plugin framework versions of those tests, and tests should show that the same test cases pass in both contexts (SDK vs PF).

---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
