### PR TITLE
Fix failed tests related to google_service_networking_connection

### DIFF
--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -64,8 +64,6 @@ examples:
       config_id: 'bbs-config'
       network_name: 'vpc-network'
       global_address_name: 'private-ip-alloc'
-    test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "peered-network")'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/cloudbuild_bitbucketserver_config.go.erb
   post_create: templates/terraform/post_create/cloudbuild_bitbucketserver_config.go.erb

--- a/mmv1/products/databasemigrationservice/connectionprofile.yaml
+++ b/mmv1/products/databasemigrationservice/connectionprofile.yaml
@@ -87,6 +87,7 @@ examples:
       profile: 'my-profileid'
       global_address_name: 'private-ip-alloc'
       network_name: 'vpc-network'
+    skip_test: true
 parameters:
   - !ruby/object:Api::Type::String
     name: 'connectionProfileId'

--- a/mmv1/products/tpu/Node.yaml
+++ b/mmv1/products/tpu/Node.yaml
@@ -36,6 +36,7 @@ examples:
     vars:
       node_name: 'test-tpu'
       global_address_name: 'my-global-address'
+      network_name: 'tpu-node-network'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: 'templates/terraform/constants/tpu_node.erb'
 custom_diff: [

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -51,8 +51,6 @@ examples:
     vars:
       address_name: "address-name"
       network_name: "network-name"
-    test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint")'
   - !ruby/object:Provider::Terraform::Examples
     name: "vertex_ai_index_endpoint_with_public_endpoint"
     primary_resource_id: "index_endpoint"

--- a/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_peered_network.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_bitbucket_server_config_peered_network.tf.erb
@@ -4,8 +4,8 @@ resource "google_project_service" "servicenetworking" {
   service = "servicenetworking.googleapis.com"
   disable_on_destroy = false
 }
- 
-data "google_compute_network" "vpc_network" {
+
+resource "google_compute_network" "vpc_network" {
     name       = "<%= ctx[:vars]['network_name'] %>"
     depends_on = [google_project_service.servicenetworking]
 }
@@ -15,11 +15,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.vpc_network.id
+  network       = google_compute_network.vpc_network.id
 }
 
 resource "google_service_networking_connection" "default" {
-  network                 = data.google_compute_network.vpc_network.id
+  network                 = google_compute_network.vpc_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
   depends_on              = [google_project_service.servicenetworking]
@@ -36,7 +36,7 @@ resource "google_cloudbuild_bitbucket_server_config" "<%= ctx[:primary_resource_
     }
     username = "test"
     api_key = "<api-key>"
-    peered_network = replace(data.google_compute_network.vpc_network.id, data.google_project.project.name, data.google_project.project.number)
+    peered_network = replace(google_compute_network.vpc_network.id, data.google_project.project.name, data.google_project.project.number)
     ssl_ca = "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
     depends_on = [google_service_networking_connection.default]
 }

--- a/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
@@ -34,7 +34,7 @@ resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
   }
 }
 
-data "google_compute_network" "network" {
+resource "google_compute_network" "network" {
   name = "default"
 }
 
@@ -43,11 +43,11 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.network.id
+  network       = google_compute_network.network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = data.google_compute_network.network.id
+  network                 = google_compute_network.network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }

--- a/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_full.tf.erb
@@ -35,7 +35,7 @@ resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_network" "network" {
-  name = "default"
+  name = "<%= ctx[:vars]['network_name'] %>"
 }
 
 resource "google_compute_global_address" "service_range" {

--- a/mmv1/templates/terraform/examples/vertex_ai_endpoint_network.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_endpoint_network.tf.erb
@@ -7,7 +7,7 @@ resource "google_vertex_ai_endpoint" "<%= ctx[:primary_resource_id] %>" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   encryption_spec {
     kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
   }
@@ -17,7 +17,7 @@ resource "google_vertex_ai_endpoint" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -27,10 +27,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
+resource "google_compute_network" "vertex_network" {
   name       = "<%= ctx[:vars]['network_name'] %>"
 }
 

--- a/mmv1/templates/terraform/examples/vertex_ai_index_endpoint.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_index_endpoint.tf.erb
@@ -5,14 +5,14 @@ resource "google_vertex_ai_index_endpoint" "<%= ctx[:primary_resource_id] %>" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -22,10 +22,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
+resource "google_compute_network" "vertex_network" {
   name       = "<%= ctx[:vars]['network_name'] %>"
 }
 

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	tpgservicenetworking "github.com/hashicorp/terraform-provider-google-beta/google-beta/services/servicenetworking"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/services/privateca"
@@ -23,6 +24,7 @@ import (
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	iam "google.golang.org/api/iam/v1"
 	"google.golang.org/api/iamcredentials/v1"
+	"google.golang.org/api/servicenetworking/v1"
 	"google.golang.org/api/serviceusage/v1"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
@@ -352,6 +354,115 @@ func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 		t.Fatalf("Error getting shared test network %q: is nil", networkName)
 	}
 	return network.Name
+}
+
+const SharedTestGlobalAddressPrefix = "tf-bootstrap-addr-"
+
+func BootstrapSharedTestGlobalAddress(t *testing.T, testId, networkId string) string {
+	project := envvar.GetTestProjectFromEnv()
+	addressName := SharedTestGlobalAddressPrefix + testId
+
+	config := BootstrapConfig(t)
+	if config == nil {
+		return ""
+	}
+
+	log.Printf("[DEBUG] Getting shared test global address %q", addressName)
+	_, err := config.NewComputeClient(config.UserAgent).GlobalAddresses.Get(project, addressName).Do()
+	if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		log.Printf("[DEBUG] Global address %q not found, bootstrapping", addressName)
+		url := fmt.Sprintf("%sprojects/%s/global/addresses", config.ComputeBasePath, project)
+		netObj := map[string]interface{}{
+			"name":          addressName,
+			"address_type":  "INTERNAL",
+			"purpose":       "VPC_PEERING",
+			"prefix_length": 16,
+			"network":       networkId,
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+			Body:      netObj,
+			Timeout:   4 * time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("Error bootstrapping shared test global address %q: %s", addressName, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for global address creation to finish")
+		err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Error bootstrapping shared test global address", config.UserAgent, 4*time.Minute)
+		if err != nil {
+			t.Fatalf("Error bootstrapping shared test global address %q: %s", addressName, err)
+		}
+	}
+
+	address, err := config.NewComputeClient(config.UserAgent).GlobalAddresses.Get(project, addressName).Do()
+	if err != nil {
+		t.Errorf("Error getting shared test global address %q: %s", addressName, err)
+	}
+	if address == nil {
+		t.Fatalf("Error getting shared test global address %q: is nil", addressName)
+	}
+	return address.Name
+}
+
+func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string) {
+	parentService := "services/servicenetworking.googleapis.com"
+	project := envvar.GetTestProjectFromEnv()
+
+	config := BootstrapConfig(t)
+	if config == nil {
+		return
+	}
+
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", project, BootstrapSharedTestNetwork(t, testId))
+	globalAddressName := BootstrapSharedTestGlobalAddress(t, testId, networkId)
+
+	readCall := config.NewServiceNetworkingClient(config.UserAgent).Services.Connections.List(parentService).Network(networkId)
+	if config.UserProjectOverride {
+		readCall.Header().Add("X-Goog-User-Project", project)
+	}
+	response, err := readCall.Do()
+	if err != nil {
+		t.Errorf("Error getting shared test service networking connection: %s", err)
+	}
+
+	var connection *servicenetworking.Connection
+	for _, c := range response.Connections {
+		if c.Network == networkId {
+			connection = c
+			break
+		}
+	}
+
+	if connection == nil {
+		log.Printf("[DEBUG] Service networking connection not found, bootstrapping")
+
+		connection := &servicenetworking.Connection{
+			Network:               networkId,
+			ReservedPeeringRanges: []string{globalAddressName},
+		}
+
+		createCall := config.NewServiceNetworkingClient(config.UserAgent).Services.Connections.Create(parentService, connection)
+		if config.UserProjectOverride {
+			createCall.Header().Add("X-Goog-User-Project", project)
+		}
+		op, err := createCall.Do()
+		if err != nil {
+			t.Fatalf("Error bootstrapping shared test service networking connection: %s", err)
+		}
+
+		log.Printf("[DEBUG] Waiting for service networking connection creation to finish")
+		if err := tpgservicenetworking.ServiceNetworkingOperationWaitTime(config, op, "Create Service Networking Connection", config.UserAgent, project, 4*time.Minute); err != nil {
+			t.Fatalf("Error bootstrapping shared test service networking connection: %s", err)
+		}
+	}
+
+	log.Printf("[DEBUG] Getting shared test service networking connection")
 }
 
 var SharedServicePerimeterProjectPrefix = "tf-bootstrap-sp-"

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -410,9 +410,26 @@ func BootstrapSharedTestGlobalAddress(t *testing.T, testId, networkId string) st
 	return address.Name
 }
 
+// BootstrapSharedServiceNetworkingConnection will create a shared network
+// if it hasn't been created in the test project, a global address
+// if it hasn't been created in the test project, and a service networking connection
+// if it hasn't been created in the test project.
+//
+// BootstrapSharedServiceNetworkingConnection returns a persistent compute network name
+// for a test or set of tests.
+//
+// To delete a service networking conneciton, all of the service instances that use that connection
+// must be deleted first. After the service instances are deleted, some service producers delay the deletion
+// utnil a waiting period has passed. For example, after four days that you delete a SQL instance,
+// the service networking connection can be deleted.
+// That is the reason to use the shared service networking connection for thest resources.
+// https://cloud.google.com/vpc/docs/configure-private-services-access#removing-connection
+//
+// testId specifies the test for which a shared network and a gobal address are used/initialized.
 func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string) string {
 	parentService := "services/servicenetworking.googleapis.com"
 	project := envvar.GetTestProjectFromEnv()
+	projectNumber := envvar.GetTestProjectNumberFromEnv()
 
 	config := BootstrapConfig(t)
 	if config == nil {
@@ -420,7 +437,7 @@ func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string) str
 	}
 
 	networkName := BootstrapSharedTestNetwork(t, testId)
-	networkId := fmt.Sprintf("projects/%v/global/networks/%v", project, networkName)
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectNumber, networkName)
 	globalAddressName := BootstrapSharedTestGlobalAddress(t, testId, networkId)
 
 	readCall := config.NewServiceNetworkingClient(config.UserAgent).Services.Connections.List(parentService).Network(networkId)

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	tpgservicenetworking "github.com/hashicorp/terraform-provider-google-beta/google-beta/services/servicenetworking"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/services/privateca"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	tpgservicenetworking "github.com/hashicorp/terraform-provider-google/google/services/servicenetworking"
 	"github.com/hashicorp/terraform-provider-google/google/services/sql"
 	"github.com/hashicorp/terraform-provider-google/google/tpgiamresource"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -410,16 +410,17 @@ func BootstrapSharedTestGlobalAddress(t *testing.T, testId, networkId string) st
 	return address.Name
 }
 
-func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string) {
+func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string) string {
 	parentService := "services/servicenetworking.googleapis.com"
 	project := envvar.GetTestProjectFromEnv()
 
 	config := BootstrapConfig(t)
 	if config == nil {
-		return
+		return ""
 	}
 
-	networkId := fmt.Sprintf("projects/%v/global/networks/%v", project, BootstrapSharedTestNetwork(t, testId))
+	networkName := BootstrapSharedTestNetwork(t, testId)
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", project, networkName)
 	globalAddressName := BootstrapSharedTestGlobalAddress(t, testId, networkId)
 
 	readCall := config.NewServiceNetworkingClient(config.UserAgent).Services.Connections.List(parentService).Network(networkId)
@@ -463,6 +464,8 @@ func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string) {
 	}
 
 	log.Printf("[DEBUG] Getting shared test service networking connection")
+
+	return networkName
 }
 
 var SharedServicePerimeterProjectPrefix = "tf-bootstrap-sp-"

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -12,7 +12,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-network"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-backup-update-1"),
 		"random_suffix": random_suffix,
 	}
 
@@ -83,7 +83,7 @@ func TestAccAlloydbBackup_createBackupWithMandatoryFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbbackup-mandatory"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-backup-mandatory-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -131,7 +131,7 @@ func TestAccAlloydbBackup_usingCMEK(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-backup-cmek"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-backup-cmek-1"),
 		"random_suffix": acctest.RandString(t, 10),
 		"key_name":      "tf-test-key-" + acctest.RandString(t, 10),
 	}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -22,7 +22,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 		CheckDestroy:             testAccCheckAlloydbBackupDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlloydbBackup_alloydbBackupFullExample(context),
+				Config: testAccAlloydbBackup_alloydbBackupBasic(context),
 			},
 			{
 				ResourceName:            "google_alloydb_backup.default",
@@ -43,7 +43,39 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 	})
 }
 
-// Updates "label" field from testAccAlloydbBackup_alloydbBackupFullExample
+func testAccAlloydbBackup_alloydbBackupBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_backup" "default" {
+  location     = "us-central1"
+  backup_id    = "tf-test-alloydb-backup%{random_suffix}"
+  cluster_name = google_alloydb_cluster.default.name
+
+  description = "example description"
+  labels = {
+    "label" = "key"
+  }
+  depends_on = [google_alloydb_instance.default]
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network    = data.google_compute_network.default.id
+}
+
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+}
+
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+`, context)
+}
+
+// Updates "label" field
 func testAccAlloydbBackup_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_alloydb_backup" "default" {

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
@@ -19,7 +19,7 @@ func TestAccAlloydbCluster_restore(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-restore"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -86,15 +86,13 @@ func testAccAlloydbClusterAndInstanceAndBackup(context map[string]interface{}) s
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -107,22 +105,8 @@ resource "google_alloydb_backup" "default" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -133,15 +117,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_OnlyOneSourceAllowed(context map[
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -155,7 +137,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored" {
   cluster_id             = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -171,22 +153,8 @@ resource "google_alloydb_cluster" "restored" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -197,15 +165,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_SourceClusterAndPointInTimeRequir
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -219,7 +185,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored" {
   cluster_id             = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
 
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
@@ -232,22 +198,8 @@ resource "google_alloydb_cluster" "restored" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -257,15 +209,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackup(context map[st
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -279,7 +229,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -291,22 +241,8 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -318,15 +254,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -340,7 +274,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -353,7 +287,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -366,22 +300,8 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -393,15 +313,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -415,7 +333,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -433,7 +351,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -451,22 +369,8 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -478,15 +382,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -508,7 +410,7 @@ resource "google_alloydb_backup" "default2" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default2.name
   }
@@ -528,7 +430,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.restored_from_backup.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -546,22 +448,8 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -573,15 +461,13 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
   cluster       = google_alloydb_cluster.source.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_backup" "default" {
@@ -595,7 +481,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -604,7 +490,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -613,22 +499,8 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
@@ -19,7 +19,7 @@ func TestAccAlloydbCluster_restore(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-restore"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-restore-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -13,7 +13,7 @@ func TestAccAlloydbInstance_update(t *testing.T) {
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix": random_suffix,
-		"network_name":  "tf-test-alloydb-network" + random_suffix,
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-update"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -57,14 +57,12 @@ resource "google_alloydb_instance" "default" {
   labels = {
 	test = "tf-test-alloydb-instance%{random_suffix}"
   }
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 
   initial_user {
     password = "tf-test-alloydb-cluster%{random_suffix}"
@@ -74,22 +72,8 @@ resource "google_alloydb_cluster" "default" {
 data "google_project" "project" {
 }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -100,7 +84,7 @@ func TestAccAlloydbInstance_createInstanceWithMandatoryFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-mandatory"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -121,34 +105,18 @@ resource "google_alloydb_instance" "default" {
   cluster       = google_alloydb_cluster.default.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -159,7 +127,7 @@ func TestAccAlloydbInstance_createInstanceWithMaximumFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-maximum"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -194,7 +162,6 @@ resource "google_alloydb_instance" "default" {
   machine_config {
 	  cpu_count = 4
   }
-  depends_on = [google_service_networking_connection.vpc_connection]
   lifecycle {
     ignore_changes = [
       gce_zone,
@@ -206,27 +173,13 @@ resource "google_alloydb_instance" "default" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -237,7 +190,7 @@ func TestAccAlloydbInstance_createPrimaryAndReadPoolInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-readpool"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -258,7 +211,6 @@ resource "google_alloydb_instance" "primary" {
   cluster       = google_alloydb_cluster.default.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_instance" "read_pool" {
@@ -268,33 +220,19 @@ resource "google_alloydb_instance" "read_pool" {
   read_pool_config {
     node_count = 4
   }
-  depends_on = [google_service_networking_connection.vpc_connection, google_alloydb_instance.primary]
+  depends_on = [google_alloydb_instance.primary]
 }
 
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -305,7 +243,7 @@ func TestAccAlloydbInstance_updateDatabaseFlagInPrimaryInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-updatedb"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -337,33 +275,18 @@ resource "google_alloydb_instance" "primary" {
   database_flags = {
 	  "alloydb.enable_auto_explain" = "true"
   }
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }
@@ -377,33 +300,18 @@ resource "google_alloydb_instance" "primary" {
   database_flags = {
 	  "alloydb.enable_auto_explain" = "false"
   }
-  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  name          =  "tf-test-alloydb-cluster%{random_suffix}"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -12,8 +12,8 @@ func TestAccAlloydbInstance_update(t *testing.T) {
 
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": random_suffix,
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-update-1"),
+		"random_suffix": random_suffix,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -22,7 +22,7 @@ func TestAccAlloydbInstance_update(t *testing.T) {
 		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlloydbInstance_alloydbInstanceBasicExample(context),
+				Config: testAccAlloydbInstance_alloydbInstanceBasic(context),
 			},
 			{
 				ResourceName:            "google_alloydb_instance.default",
@@ -41,6 +41,34 @@ func TestAccAlloydbInstance_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccAlloydbInstance_alloydbInstanceBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network    = data.google_compute_network.default.id
+
+  initial_user {
+    password = "tf-test-alloydb-cluster%{random_suffix}"
+  }
+}
+
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+`, context)
 }
 
 func testAccAlloydbInstance_update(context map[string]interface{}) string {
@@ -67,9 +95,6 @@ resource "google_alloydb_cluster" "default" {
   initial_user {
     password = "tf-test-alloydb-cluster%{random_suffix}"
   }
-}
-
-data "google_project" "project" {
 }
 
 data "google_compute_network" "default" {

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -13,7 +13,7 @@ func TestAccAlloydbInstance_update(t *testing.T) {
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix": random_suffix,
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-update"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-update-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -84,7 +84,7 @@ func TestAccAlloydbInstance_createInstanceWithMandatoryFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-mandatory"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-mandatory-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -127,7 +127,7 @@ func TestAccAlloydbInstance_createInstanceWithMaximumFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-maximum"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-maximum-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -190,7 +190,7 @@ func TestAccAlloydbInstance_createPrimaryAndReadPoolInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-readpool"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-readpool-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -243,7 +243,7 @@ func TestAccAlloydbInstance_updateDatabaseFlagInPrimaryInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-updatedb"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-updatedb-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/cloudbuild/resource_cloudbuild_worker_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudbuild/resource_cloudbuild_worker_pool_test.go.erb
@@ -104,7 +104,7 @@ func TestAccCloudbuildWorkerPool_withNetwork(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"project":       envvar.GetTestProjectFromEnv(),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "cloudbuild-workerpool"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -127,22 +127,8 @@ func TestAccCloudbuildWorkerPool_withNetwork(t *testing.T) {
 func testAccCloudbuildWorkerPool_withNetwork(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 
-resource "google_compute_network" "network" {
+data "google_compute_network" "network" {
   name = "%{network_name}"
-}
-
-resource "google_compute_global_address" "worker_range" {
-  name          = "tf-test-worker-pool-range%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.network.id
-}
-
-resource "google_service_networking_connection" "worker_pool_conn" {
-  network                 = google_compute_network.network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.worker_range.name]
 }
 
 resource "google_cloudbuild_worker_pool" "pool" {
@@ -154,10 +140,9 @@ resource "google_cloudbuild_worker_pool" "pool" {
 		no_external_ip = false
 	}
 	network_config {
-		peered_network = google_compute_network.network.id
+		peered_network = data.google_compute_network.network.id
 		peered_network_ip_range = "/29"
 	}
-	depends_on = [google_service_networking_connection.worker_pool_conn]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/cloudbuild/resource_cloudbuild_worker_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudbuild/resource_cloudbuild_worker_pool_test.go.erb
@@ -104,7 +104,7 @@ func TestAccCloudbuildWorkerPool_withNetwork(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"project":       envvar.GetTestProjectFromEnv(),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "cloudbuild-workerpool"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "cloudbuild-workerpool-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/cloudids/resource_cloudids_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/cloudids/resource_cloudids_endpoint_test.go
@@ -18,7 +18,7 @@ func TestAccCloudIdsEndpoint_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-key-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "cloud-ids-endpoint"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -48,58 +48,32 @@ func TestAccCloudIdsEndpoint_basic(t *testing.T) {
 
 func testCloudIds_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-resource "google_compute_global_address" "service_range" {
-  name          = "tf-test-address%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
   
 resource "google_cloud_ids_endpoint" "endpoint" {
   name              = "cloud-ids-test-%{random_suffix}"
   location          = "us-central1-f"
-  network           = google_compute_network.default.id
+  network           = data.google_compute_network.default.id
   severity          = "INFORMATIONAL"
   threat_exceptions = ["12", "67"]
-  depends_on        = [google_service_networking_connection.private_service_connection]
 }
 `, context)
 }
 
 func testCloudIds_basicUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
-}
-resource "google_compute_global_address" "service_range" {
-  name          = "tf-test-address%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
   
 resource "google_cloud_ids_endpoint" "endpoint" {
   name              = "cloud-ids-test-%{random_suffix}"
   location          = "us-central1-f"
-  network           = google_compute_network.default.id
+  network           = data.google_compute_network.default.id
   severity          = "INFORMATIONAL"
   threat_exceptions = ["33"]
-  depends_on        = [google_service_networking_connection.private_service_connection]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/cloudids/resource_cloudids_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/cloudids/resource_cloudids_endpoint_test.go
@@ -18,7 +18,7 @@ func TestAccCloudIdsEndpoint_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "cloud-ids-endpoint"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "cloud-ids-endpoint-1"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
@@ -77,3 +77,70 @@ resource "google_database_migration_service_connection_profile" "default" {
 }
 `, context)
 }
+
+func TestAccDatabaseMigrationServiceConnectionProfile_databaseMigrationServiceConnectionProfileAlloydb(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1"),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDatabaseMigrationServiceConnectionProfileDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseMigrationServiceConnectionProfile_databaseMigrationServiceConnectionProfileAlloydb(context),
+			},
+			{
+				ResourceName:            "google_database_migration_service_connection_profile.alloydbprofile",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "alloydb.0.settings.0.initial_user.0.password", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccDatabaseMigrationServiceConnectionProfile_databaseMigrationServiceConnectionProfileAlloydb(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+
+resource "google_database_migration_service_connection_profile" "alloydbprofile" {
+  location = "us-central1"
+  connection_profile_id = "tf-test-my-profileid%{random_suffix}"
+  display_name = "tf-test-my-profileid%{random_suffix}_display"
+  labels = { 
+    foo = "bar" 
+  }
+  alloydb {
+    cluster_id = "tf-test-dbmsalloycluster%{random_suffix}"
+    settings {
+      initial_user {
+        user = "alloyuser%{random_suffix}"
+        password = "alloypass%{random_suffix}"
+      }
+      vpc_network = data.google_compute_network.default.id
+      labels  = { 
+        alloyfoo = "alloybar" 
+      }
+      primary_instance_settings {
+        id = "priminstid"
+        machine_config {
+          cpu_count = 2
+        }
+        database_flags = { 
+        }
+        labels = { 
+          alloysinstfoo = "allowinstbar" 
+        }
+      }
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -13,7 +13,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 
 	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)
-	network := acctest.BootstrapSharedServiceNetworkingConnection(t, "memcache-instance-update")
+	network := acctest.BootstrapSharedServiceNetworkingConnection(t, "memcache-instance-update-1")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -45,7 +45,7 @@ func testAccMemcacheInstance_update(prefix, name, network string) string {
 resource "google_memcache_instance" "test" {
   name = "%s"
   region = "us-central1"
-  authorized_network = data.google_compute_network.memcache_network.self_link
+  authorized_network = data.google_compute_network.memcache_network.id
 
   node_config {
     cpu_count      = 1
@@ -72,7 +72,7 @@ func testAccMemcacheInstance_update2(prefix, name, network string) string {
 resource "google_memcache_instance" "test" {
   name = "%s"
   region = "us-central1"
-  authorized_network = data.google_compute_network.memcache_network.self_link
+  authorized_network = data.google_compute_network.memcache_network.id
 
   node_config {
     cpu_count      = 1

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -13,7 +13,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 
 	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)
-	network := "tf-test-" + acctest.RandString(t, 10)
+	network := acctest.BootstrapSharedServiceNetworkingConnection(t, "memcache-instance-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -42,24 +42,10 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 
 func testAccMemcacheInstance_update(prefix, name, network string) string {
 	return fmt.Sprintf(`
-resource "google_compute_global_address" "service_range" {
-  name          = "tf-test%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.memcache_network.id
-}
-
-resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.memcache_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.service_range.name]
-}
-
 resource "google_memcache_instance" "test" {
   name = "%s"
   region = "us-central1"
-  authorized_network = google_service_networking_connection.private_service_connection.network
+  authorized_network = data.google_compute_network.memcache_network.self_link
 
   node_config {
     cpu_count      = 1
@@ -75,32 +61,18 @@ resource "google_memcache_instance" "test" {
   }
 }
 
-resource "google_compute_network" "memcache_network" {
+data "google_compute_network" "memcache_network" {
   name = "%s"
 }
-`, prefix, name, network)
+`, name, network)
 }
 
 func testAccMemcacheInstance_update2(prefix, name, network string) string {
 	return fmt.Sprintf(`
-resource "google_compute_global_address" "service_range" {
-  name          = "tf-test%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.memcache_network.id
-}
-
-resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.memcache_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.service_range.name]
-}
-
 resource "google_memcache_instance" "test" {
   name = "%s"
   region = "us-central1"
-  authorized_network = google_service_networking_connection.private_service_connection.network
+  authorized_network = data.google_compute_network.memcache_network.self_link
 
   node_config {
     cpu_count      = 1
@@ -116,8 +88,8 @@ resource "google_memcache_instance" "test" {
   }
 }
 
-resource "google_compute_network" "memcache_network" {
+data "google_compute_network" "memcache_network" {
   name = "%s"
 }
-`, prefix, name, network)
+`, name, network)
 }

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -253,8 +253,6 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	log.Printf("[DEBUG] zhenhuatest service %s", d.Get("service"))
-	log.Printf("[DEBUG] zhenhuatest peering %s", d.Get("peering"))
 	network := d.Get("network").(string)
 	serviceNetworkingNetworkName, err := RetrieveServiceNetworkingNetworkName(d, config, network, userAgent)
 	if err != nil {
@@ -287,41 +285,42 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	}
 
 	if err := ServiceNetworkingOperationWaitTime(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
-		obj := make(map[string]interface{})
-		peering := d.Get("peering").(string)
-		obj["name"] = peering
-		url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
+		return err
+		// obj := make(map[string]interface{})
+		// peering := d.Get("peering").(string)
+		// obj["name"] = peering
+		// url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
 
-		networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
-		if err != nil {
-			return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
-		}
+		// networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
+		// if err != nil {
+		// 	return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
+		// }
 
-		project := networkFieldValue.Project
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "POST",
-			Project:   project,
-			RawURL:    url,
-			UserAgent: userAgent,
-			Body:      obj,
-			Timeout:   d.Timeout(schema.TimeoutDelete),
-		})
-		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
-		}
+		// project := networkFieldValue.Project
+		// res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		// 	Config:    config,
+		// 	Method:    "POST",
+		// 	Project:   project,
+		// 	RawURL:    url,
+		// 	UserAgent: userAgent,
+		// 	Body:      obj,
+		// 	Timeout:   d.Timeout(schema.TimeoutDelete),
+		// })
+		// if err != nil {
+		// 	return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
+		// }
 
-		op := &compute.Operation{}
-		err = tpgresource.Convert(res, op)
-		if err != nil {
-			return err
-		}
+		// op := &compute.Operation{}
+		// err = tpgresource.Convert(res, op)
+		// if err != nil {
+		// 	return err
+		// }
 
-		err = tpgcompute.ComputeOperationWaitTime(
-			config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
-		if err != nil {
-			return err
-		}
+		// err = tpgcompute.ComputeOperationWaitTime(
+		// 	config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
+		// if err != nil {
+		// 	return err
+		// }
 	}
 
 	d.SetId("")

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -8,13 +8,11 @@ import (
 	"strings"
 	"time"
 
-	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/servicenetworking/v1"
 )
 
@@ -255,16 +253,13 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
+	log.Printf("[DEBUG] zhenhuatest service %s", d.Get("service"))
+	log.Printf("[DEBUG] zhenhuatest peering %s", d.Get("peering"))
 	network := d.Get("network").(string)
 	serviceNetworkingNetworkName, err := RetrieveServiceNetworkingNetworkName(d, config, network, userAgent)
 	if err != nil {
 		return err
 	}
-
-	obj := make(map[string]interface{})
-	peering := d.Get("peering").(string)
-	obj["name"] = peering
-	url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
 
 	networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
 	if err != nil {
@@ -272,29 +267,61 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	}
 
 	project := networkFieldValue.Project
-	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "POST",
-		Project:   project,
-		RawURL:    url,
-		UserAgent: userAgent,
-		Body:      obj,
-		Timeout:   d.Timeout(schema.TimeoutDelete),
-	})
+	connectionId, err := parseConnectionId(d.Id())
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
+		return errwrap.Wrapf("Unable to parse Service Networking Connection id, err: {{err}}", err)
+	}
+	parentService := formatParentService(connectionId.Service)
+
+	deleteConnectionRequest := &servicenetworking.DeleteConnectionRequest{
+		ConsumerNetwork: serviceNetworkingNetworkName,
 	}
 
-	op := &compute.Operation{}
-	err = tpgresource.Convert(res, op)
+	deleteCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.DeleteConnection(parentService+"/connections/servicenetworking-googleapis-com", deleteConnectionRequest)
+	if config.UserProjectOverride {
+		deleteCall.Header().Add("X-Goog-User-Project", project)
+	}
+	op, err := deleteCall.Do()
 	if err != nil {
 		return err
 	}
 
-	err = tpgcompute.ComputeOperationWaitTime(
-		config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
-	if err != nil {
-		return err
+	if err := ServiceNetworkingOperationWaitTime(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
+		obj := make(map[string]interface{})
+		peering := d.Get("peering").(string)
+		obj["name"] = peering
+		url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
+
+		networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
+		if err != nil {
+			return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
+		}
+
+		project := networkFieldValue.Project
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      obj,
+			Timeout:   d.Timeout(schema.TimeoutDelete),
+		})
+		if err != nil {
+			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
+		}
+
+		op := &compute.Operation{}
+		err = tpgresource.Convert(res, op)
+		if err != nil {
+			return err
+		}
+
+		err = tpgcompute.ComputeOperationWaitTime(
+			config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId("")

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -8,11 +8,13 @@ import (
 	"strings"
 	"time"
 
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/servicenetworking/v1"
 )
 
@@ -285,42 +287,41 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	}
 
 	if err := ServiceNetworkingOperationWaitTime(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return err
-		// obj := make(map[string]interface{})
-		// peering := d.Get("peering").(string)
-		// obj["name"] = peering
-		// url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
+		obj := make(map[string]interface{})
+		peering := d.Get("peering").(string)
+		obj["name"] = peering
+		url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
 
-		// networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
-		// if err != nil {
-		// 	return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
-		// }
+		networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
+		if err != nil {
+			return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
+		}
 
-		// project := networkFieldValue.Project
-		// res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		// 	Config:    config,
-		// 	Method:    "POST",
-		// 	Project:   project,
-		// 	RawURL:    url,
-		// 	UserAgent: userAgent,
-		// 	Body:      obj,
-		// 	Timeout:   d.Timeout(schema.TimeoutDelete),
-		// })
-		// if err != nil {
-		// 	return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
-		// }
+		project := networkFieldValue.Project
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      obj,
+			Timeout:   d.Timeout(schema.TimeoutDelete),
+		})
+		if err != nil {
+			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
+		}
 
-		// op := &compute.Operation{}
-		// err = tpgresource.Convert(res, op)
-		// if err != nil {
-		// 	return err
-		// }
+		op := &compute.Operation{}
+		err = tpgresource.Convert(res, op)
+		if err != nil {
+			return err
+		}
 
-		// err = tpgcompute.ComputeOperationWaitTime(
-		// 	config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
-		// if err != nil {
-		// 	return err
-		// }
+		err = tpgcompute.ComputeOperationWaitTime(
+			config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId("")

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -8,13 +8,11 @@ import (
 	"strings"
 	"time"
 
-	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/servicenetworking/v1"
 )
 
@@ -287,41 +285,8 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	}
 
 	if err := ServiceNetworkingOperationWaitTime(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
-		obj := make(map[string]interface{})
-		peering := d.Get("peering").(string)
-		obj["name"] = peering
-		url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
-
-		networkFieldValue, err := tpgresource.ParseNetworkFieldValue(network, d, config)
-		if err != nil {
-			return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
-		}
-
-		project := networkFieldValue.Project
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "POST",
-			Project:   project,
-			RawURL:    url,
-			UserAgent: userAgent,
-			Body:      obj,
-			Timeout:   d.Timeout(schema.TimeoutDelete),
-		})
-		if err != nil {
-			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
-		}
-
-		op := &compute.Operation{}
-		err = tpgresource.Convert(res, op)
-		if err != nil {
-			return err
-		}
-
-		err = tpgcompute.ComputeOperationWaitTime(
-			config, op, project, "Updating Network", userAgent, d.Timeout(schema.TimeoutDelete))
-		if err != nil {
-			return err
-		}
+		log.Printf("[INFO] Error deleting Service Networking Connection: %s", err)
+		return nil
 	}
 
 	d.SetId("")

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -285,8 +285,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	}
 
 	if err := ServiceNetworkingOperationWaitTime(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
-		log.Printf("[INFO] Error deleting Service Networking Connection: %s", err)
-		return nil
+		return errwrap.Wrapf("Unable to remove Service Networking Connection, err: {{err}}", err)
 	}
 
 	d.SetId("")

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccServiceNetworkingConnection_create(t *testing.T) {
 	t.Parallel()
 
-	network := acctest.BootstrapSharedTestNetwork(t, "service-networking-connection-create")
+	network := fmt.Sprintf("tf-test-service-networking-connection-create-%s", acctest.RandString(t, 10))
 	addr := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	service := "servicenetworking.googleapis.com"
 
@@ -37,7 +37,7 @@ func TestAccServiceNetworkingConnection_create(t *testing.T) {
 func TestAccServiceNetworkingConnection_update(t *testing.T) {
 	t.Parallel()
 
-	network := acctest.BootstrapSharedTestNetwork(t, "service-networking-connection-update")
+	network := fmt.Sprintf("tf-test-service-networking-connection-update-%s", acctest.RandString(t, 10))
 	addr1 := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	addr2 := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	service := "servicenetworking.googleapis.com"
@@ -94,7 +94,7 @@ func testServiceNetworkingConnectionDestroy(t *testing.T, parent, network string
 
 func testAccServiceNetworkingConnection(networkName, addressRangeName, serviceName string) string {
 	return fmt.Sprintf(`
-data "google_compute_network" "servicenet" {
+resource "google_compute_network" "servicenet" {
   name = "%s"
 }
 
@@ -103,11 +103,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
+  network       = google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
+  network                 = google_compute_network.servicenet.self_link
   service                 = "%s"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -179,7 +179,7 @@ func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *tes
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-clone-2")
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-clone-2")
 
 	// 1. Create an instance.
 	// 2. Add a root@'%' user.

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -179,7 +179,7 @@ func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *tes
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-clone-2")
 
 	// 1. Create an instance.
 	// 2. Add a root@'%' user.
@@ -737,7 +737,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -970,15 +970,15 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enabled(t *testing.T) {
 	})
 }
 
-func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testing.T) {
+func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange1(t *testing.T) {
 
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-allocated")
 	addressName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
-	networkName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
+	networkName_update := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-allocated-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1013,7 +1013,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-replica")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1045,7 +1045,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(t *
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-clone")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1445,7 +1445,7 @@ func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 
 	t.Parallel()
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-test-ad")
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-test-ad")
 	addressName := "tf-test-" + acctest.RandString(t, 10)
 	rootPassword := acctest.RandString(t, 15)
 	adDomainName := acctest.BootstrapSharedTestADDomain(t, "test-domain", networkName)
@@ -2810,7 +2810,7 @@ func testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(datab
 	}
 
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2819,11 +2819,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2838,7 +2838,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
       %s
     }
   }
@@ -2877,7 +2877,7 @@ resource "google_sql_database_instance" "instance" {
     ip_configuration {
       ipv4_enabled       = "false"
       private_network    = google_compute_network.servicenet.self_link
-      allocated_ip_range = google_compute_global_address.foobar.name
+      # allocated_ip_range = google_compute_global_address.foobar.name
     }
   }
 }
@@ -2886,7 +2886,7 @@ resource "google_sql_database_instance" "instance" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2895,11 +2895,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2914,7 +2914,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true
@@ -2933,7 +2933,7 @@ resource "google_sql_database_instance" "replica1" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
       allocated_ip_range = google_compute_global_address.foobar.name
     }
   }
@@ -2954,7 +2954,7 @@ resource "google_sql_database_instance" "replica1" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2963,11 +2963,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2982,7 +2982,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true
@@ -3009,7 +3009,7 @@ resource "google_sql_database_instance" "clone1" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone_withSettings(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -3018,11 +3018,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -3037,7 +3037,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -3121,7 +3121,7 @@ resource "google_sql_database_instance" "instance" {
 `
 
 var testGoogleSqlDatabaseInstance_settings_checkServiceNetworking = `
-data "google_compute_network" "servicenet" {
+resource "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -3134,7 +3134,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled    = "false"
-      private_network = data.google_compute_network.servicenet.self_link
+      private_network = google_compute_network.servicenet.self_link
     }
   }
 }

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -178,8 +178,12 @@ func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *tes
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-clone-2")
+	testId := "sql-instance-clone-2"
+	networkName := acctest.BootstrapSharedTestNetwork(t, testId)
+	projectNumber := envvar.GetTestProjectNumberFromEnv()
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectNumber, networkName)
+	addressName := acctest.BootstrapSharedTestGlobalAddress(t, testId, networkId)
+	acctest.BootstrapSharedServiceNetworkingConnection(t, testId)
 
 	// 1. Create an instance.
 	// 2. Add a root@'%' user.
@@ -191,7 +195,7 @@ func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *tes
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressName, false, false),
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, false, false),
 			},
 			{
 				PreConfig: func() {
@@ -736,8 +740,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network")
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-1")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -745,7 +748,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressName, false, false),
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, false, false),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -754,7 +757,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressName, true, false),
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, true, false),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -763,7 +766,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressName, true, true),
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, true, true),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -772,7 +775,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressName, true, false),
+				Config: testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, true, false),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -970,15 +973,24 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enabled(t *testing.T) {
 	})
 }
 
-func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange1(t *testing.T) {
+func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testing.T) {
 
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-allocated")
-	addressName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
-	networkName_update := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-allocated-update")
+
+	projectNumber := envvar.GetTestProjectNumberFromEnv()
+	testId := "sql-instance-allocated-1"
+	networkName := acctest.BootstrapSharedTestNetwork(t, testId)
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectNumber, networkName)
+	addressName := acctest.BootstrapSharedTestGlobalAddress(t, testId, networkId)
+	acctest.BootstrapSharedServiceNetworkingConnection(t, testId)
+
+	updateTestId := "sql-instance-allocated-update-1"
+	networkName_update := acctest.BootstrapSharedTestNetwork(t, updateTestId)
+	networkId_update := fmt.Sprintf("projects/%v/global/networks/%v", projectNumber, networkName_update)
+	addressName_update := acctest.BootstrapSharedTestGlobalAddress(t, updateTestId, networkId_update)
+	acctest.BootstrapSharedServiceNetworkingConnection(t, updateTestId)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1012,8 +1024,13 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-replica")
+
+	projectNumber := envvar.GetTestProjectNumberFromEnv()
+	testId := "sql-instance-replica-1"
+	networkName := acctest.BootstrapSharedTestNetwork(t, testId)
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectNumber, networkName)
+	addressName := acctest.BootstrapSharedTestGlobalAddress(t, testId, networkId)
+	acctest.BootstrapSharedServiceNetworkingConnection(t, testId)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1044,8 +1061,12 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(t *
 	t.Parallel()
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-network-clone")
+	projectNumber := envvar.GetTestProjectNumberFromEnv()
+	testId := "sql-instance-clone-1"
+	networkName := acctest.BootstrapSharedTestNetwork(t, testId)
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectNumber, networkName)
+	addressName := acctest.BootstrapSharedTestGlobalAddress(t, testId, networkId)
+	acctest.BootstrapSharedServiceNetworkingConnection(t, testId)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1445,8 +1466,7 @@ func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 
 	t.Parallel()
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-private-test-ad")
-	addressName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedServiceNetworkingConnection(t, "sql-instance-ad-1")
 	rootPassword := acctest.RandString(t, 15)
 	adDomainName := acctest.BootstrapSharedTestADDomain(t, "test-domain", networkName)
 
@@ -1456,7 +1476,7 @@ func TestAccSqlDatabaseInstance_ActiveDirectory(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_ActiveDirectoryConfig(databaseName, networkName, addressName, rootPassword, adDomainName),
+				Config: testGoogleSqlDatabaseInstance_ActiveDirectoryConfig(databaseName, networkName, rootPassword, adDomainName),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance-with-ad",
@@ -2174,28 +2194,13 @@ resource "google_sql_database_instance" "instance" {
 }
 `
 
-func testGoogleSqlDatabaseInstance_ActiveDirectoryConfig(databaseName, networkName, addressRangeName, rootPassword, adDomainName string) string {
+func testGoogleSqlDatabaseInstance_ActiveDirectoryConfig(databaseName, networkName, rootPassword, adDomainName string) string {
 	return fmt.Sprintf(`
 data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
 resource "google_sql_database_instance" "instance-with-ad" {
-  depends_on = [google_service_networking_connection.foobar]
   name             = "%s"
   region           = "us-central1"
   database_version = "SQLSERVER_2017_STANDARD"
@@ -2212,7 +2217,7 @@ resource "google_sql_database_instance" "instance-with-ad" {
       domain = "%s"
     }
   }
-}`, networkName, addressRangeName, databaseName, rootPassword, adDomainName)
+}`, networkName, databaseName, rootPassword, adDomainName)
 }
 
 func testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig(databaseName, endDate, startDate, time string) string {
@@ -2803,7 +2808,7 @@ func verifyPscOperation(resourceName string, isPscConfigExpected bool, expectedP
 	}
 }
 
-func testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName, addressRangeName string, specifyPrivatePathOption bool, enablePrivatePath bool) string {
+func testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName string, specifyPrivatePathOption bool, enablePrivatePath bool) string {
 	privatePathOption := ""
 	if specifyPrivatePathOption {
 		privatePathOption = fmt.Sprintf("enable_private_path_for_google_cloud_services = %t", enablePrivatePath)
@@ -2814,22 +2819,7 @@ data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
 resource "google_sql_database_instance" "instance" {
-  depends_on = [google_service_networking_connection.foobar]
   name                = "%s"
   region              = "us-central1"
   database_version    = "MYSQL_5_7"
@@ -2843,31 +2833,16 @@ resource "google_sql_database_instance" "instance" {
     }
   }
 }
-`, networkName, addressRangeName, databaseName, privatePathOption)
+`, networkName, databaseName, privatePathOption)
 }
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
 resource "google_sql_database_instance" "instance" {
-  depends_on = [google_service_networking_connection.foobar]
   name                = "%s"
   region              = "us-central1"
   database_version    = "MYSQL_5_7"
@@ -2876,12 +2851,12 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
-      # allocated_ip_range = google_compute_global_address.foobar.name
+      private_network    = data.google_compute_network.servicenet.self_link
+      allocated_ip_range = "%s"
     }
   }
 }
-`, networkName, addressRangeName, databaseName)
+`, networkName, databaseName, addressRangeName)
 }
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(databaseName, networkName, addressRangeName string) string {
@@ -2890,22 +2865,7 @@ data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
 resource "google_sql_database_instance" "instance" {
-  depends_on = [google_service_networking_connection.foobar]
   name                = "%s"
   region              = "us-central1"
   database_version    = "MYSQL_5_7"
@@ -2924,7 +2884,6 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 resource "google_sql_database_instance" "replica1" {
-  depends_on = [google_service_networking_connection.foobar]
   name                = "%s-replica1"
   region              = "us-central1"
   database_version    = "MYSQL_5_7"
@@ -2934,7 +2893,7 @@ resource "google_sql_database_instance" "replica1" {
     ip_configuration {
       ipv4_enabled       = "false"
       private_network    = data.google_compute_network.servicenet.self_link
-      allocated_ip_range = google_compute_global_address.foobar.name
+      allocated_ip_range = "%s"
     }
   }
 
@@ -2949,7 +2908,7 @@ resource "google_sql_database_instance" "replica1" {
     verify_server_certificate = false
   }
 }
-`, networkName, addressRangeName, databaseName, databaseName)
+`, networkName, databaseName, databaseName, addressRangeName)
 }
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(databaseName, networkName, addressRangeName string) string {
@@ -2958,22 +2917,7 @@ data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
 resource "google_sql_database_instance" "instance" {
-  depends_on = [google_service_networking_connection.foobar]
   name                = "%s"
   region              = "us-central1"
   database_version    = "MYSQL_5_7"
@@ -3000,11 +2944,11 @@ resource "google_sql_database_instance" "clone1" {
 
   clone {
     source_instance_name = google_sql_database_instance.instance.name
-    allocated_ip_range   = google_compute_global_address.foobar.name
+    allocated_ip_range   = "%s"
   }
 
 }
-`, networkName, addressRangeName, databaseName, databaseName)
+`, networkName, databaseName, databaseName, addressRangeName)
 }
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone_withSettings(databaseName, networkName, addressRangeName string) string {
@@ -3013,22 +2957,7 @@ data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
-resource "google_compute_global_address" "foobar" {
-  name          = "%s"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.servicenet.self_link
-}
-
-resource "google_service_networking_connection" "foobar" {
-  network                 = data.google_compute_network.servicenet.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.foobar.name]
-}
-
 resource "google_sql_database_instance" "instance" {
-  depends_on = [google_service_networking_connection.foobar]
   name                = "%s"
   region              = "us-central1"
   database_version    = "MYSQL_5_7"
@@ -3055,7 +2984,7 @@ resource "google_sql_database_instance" "clone1" {
 
   clone {
     source_instance_name = google_sql_database_instance.instance.name
-    allocated_ip_range   = google_compute_global_address.foobar.name
+    allocated_ip_range   = "%s"
   }
 
   settings {
@@ -3065,7 +2994,7 @@ resource "google_sql_database_instance" "clone1" {
     }
   }
 }
-`, networkName, addressRangeName, databaseName, databaseName)
+`, networkName, databaseName, databaseName, addressRangeName)
 }
 
 var testGoogleSqlDatabaseInstance_settings = `
@@ -3192,7 +3121,7 @@ resource "google_sql_database_instance" "instance" {
 `
 
 var testGoogleSqlDatabaseInstance_settings_checkServiceNetworking = `
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -3205,7 +3134,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled    = "false"
-      private_network = google_compute_network.servicenet.self_link
+      private_network = data.google_compute_network.servicenet.self_link
     }
   }
 }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_test.go
@@ -18,7 +18,7 @@ func TestAccVertexAIEndpoint_vertexAiEndpointNetwork(t *testing.T) {
 	context := map[string]interface{}{
 		"endpoint_name": fmt.Sprint(acctest.RandInt(t) % 9999999999),
 		"kms_key_name":  acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
-		"network_name":  acctest.BootstrapSharedTestNetwork(t, "vertex-ai-endpoint-update"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-update"),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_test.go
@@ -18,7 +18,7 @@ func TestAccVertexAIEndpoint_vertexAiEndpointNetwork(t *testing.T) {
 	context := map[string]interface{}{
 		"endpoint_name": fmt.Sprint(acctest.RandInt(t) % 9999999999),
 		"kms_key_name":  acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-update"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-update-1"),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -64,23 +64,6 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   encryption_spec {
     kms_key_name = "%{kms_key_name}"
   }
-  depends_on   = [
-    google_service_networking_connection.vertex_vpc_connection
-  ]
-}
-
-resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
-}
-
-resource "google_compute_global_address" "vertex_range" {
-  name          = "tf-test-address-name%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
 }
 
 data "google_compute_network" "vertex_network" {
@@ -112,23 +95,6 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   encryption_spec {
     kms_key_name = "%{kms_key_name}"
   }
-  depends_on   = [
-    google_service_networking_connection.vertex_vpc_connection
-  ]
-}
-
-resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
-}
-
-resource "google_compute_global_address" "vertex_range" {
-  name          = "tf-test-address-name%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
 }
 
 data "google_compute_network" "vertex_network" {

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_index_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_index_endpoint_test.go
@@ -12,7 +12,7 @@ func TestAccVertexAIIndexEndpoint_updated(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  acctest.BootstrapSharedTestNetwork(t, "vertex-ai-index-endpoint-update"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-index-endpoint-update"),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_index_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_index_endpoint_test.go
@@ -12,7 +12,7 @@ func TestAccVertexAIIndexEndpoint_updated(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-index-endpoint-update"),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-index-endpoint-update-1"),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -53,15 +53,8 @@ resource "google_vertex_ai_index_endpoint" "index_endpoint" {
     label-one = "value-one"
   }
   network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
-  depends_on   = [
-    google_service_networking_connection.vertex_vpc_connection
-  ]
 }
-resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
-}
+
 resource "google_compute_global_address" "vertex_range" {
   name          = "tf-test-address-name%{random_suffix}"
   purpose       = "VPC_PEERING"
@@ -87,22 +80,8 @@ resource "google_vertex_ai_index_endpoint" "index_endpoint" {
     label-two = "value-two"
   }
   network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
-  depends_on   = [
-    google_service_networking_connection.vertex_vpc_connection
-  ]
 }
-resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
-}
-resource "google_compute_global_address" "vertex_range" {
-  name          = "tf-test-address-name%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
-}
+
 data "google_compute_network" "vertex_network" {
   name       = "%{network_name}"
 }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_index_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_index_endpoint_test.go
@@ -28,7 +28,7 @@ func TestAccVertexAIIndexEndpoint_updated(t *testing.T) {
 				ResourceName:            "google_vertex_ai_index_endpoint.index_endpoint",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "region"},
+				ImportStateVerifyIgnore: []string{"etag", "region", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccVertexAIIndexEndpoint_updated(context),
@@ -37,7 +37,7 @@ func TestAccVertexAIIndexEndpoint_updated(t *testing.T) {
 				ResourceName:            "google_vertex_ai_index_endpoint.index_endpoint",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "region"},
+				ImportStateVerifyIgnore: []string{"etag", "region", "labels", "terraform_labels"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The previous PR https://github.com/GoogleCloudPlatform/magic-modules/pull/8872 caused some nightly tests failed. 

1. To delete the `google_service_networking_connection` resource,  call the method deleteConnection. If it fails, return the error and the deletion fails. Based on the test results, only sql instance has a waiting period to delete the connection.
2. Use bootstrapped service networking connection for handwritten tests. 
3. For mm1 generated tests, create a new service networking connection, which can be deleted with deleteConnection. The reason to not use bootstrapped service networking connection is to not modify the examples in the doc. 


5.0 guide is in https://github.com/GoogleCloudPlatform/magic-modules/pull/9009
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
servicenetworking: used the `deleteConnection` method to delete the resource `google_service_networking_connection`
```
