### PR TITLE
Add Firestore deletion protection

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -176,6 +176,7 @@ properties:
       - :DELETE_PROTECTION_ENABLED
       - :DELETE_PROTECTION_DISABLED
     default_from_api: true
+    skip_test: true
   - !ruby/object:Api::Type::Fingerprint
     name: etag
     description: |

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -155,6 +155,15 @@ properties:
       that is returned from the Cloud Datastore APIs in Google App Engine first generation runtimes.
       This value may be empty in which case the appid to use for URL-encoded keys is the project_id (eg: foo instead of v~foo).
     output: true
+  - !ruby/object:Api::Type::Enum
+    name: deleteProtectionState
+    description: |
+      State of delete protection for the database.
+    values:
+      - :DELETE_PROTECTION_STATE_UNSPECIFIED
+      - :DELETE_PROTECTION_ENABLED
+      - :DELETE_PROTECTION_DISABLED
+    default_from_api: true
   - !ruby/object:Api::Type::Fingerprint
     name: etag
     description: |

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -99,6 +99,10 @@ examples:
       - etag
     vars:
       project_id: 'my-project'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firestore_database_with_delete_protection'
+    primary_resource_id: 'database'
+    skip_test: true
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -176,7 +180,6 @@ properties:
       - :DELETE_PROTECTION_ENABLED
       - :DELETE_PROTECTION_DISABLED
     default_from_api: true
-    skip_test: true
   - !ruby/object:Api::Type::Fingerprint
     name: etag
     description: |

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -27,7 +27,7 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   concurrency_mode                  = "OPTIMISTIC"
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
-  delete_protection_state     = "DELETE_PROTECTION_ENABLED"
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
 
   depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -27,7 +27,6 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   concurrency_mode                  = "OPTIMISTIC"
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
-  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
 
   depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -26,6 +26,7 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   type                        = "FIRESTORE_NATIVE"
   concurrency_mode            = "OPTIMISTIC"
   app_engine_integration_mode = "DISABLED"
+  delete_protection_state     = "DELETE_PROTECTION_ENABLED"
 
   depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_database_with_delete_protection.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_with_delete_protection.tf.erb
@@ -1,0 +1,13 @@
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+  project                           = google_project.project.project_id
+  name                              = "my-database"
+  location_id                       = "nam5"
+  type                              = "FIRESTORE_NATIVE"
+
+  # Prevents accidental deletion of the database.
+  # To delete the database, first set this field to `DELETE_PROTECTION_DISABLED`, apply the changes.
+  # Then delete the database resource and apply the changes again.
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
+
+  depends_on = [google_project_service.firestore]
+}

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
@@ -82,6 +82,42 @@ func TestAccFirestoreDatabase_updatePitrEnablement(t *testing.T) {
 	})
 }
 
+func TestAccFirestoreDatabase_updateDeleteProtectionState(t *testing.T) {
+	t.Parallel()
+
+	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	randomSuffix := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirestoreDatabase_deleteProtectionState(orgId, billingAccount, randomSuffix, "DELETE_PROTECTION_ENABLED"),
+			},
+			{
+				ResourceName:      "google_firestore_database.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"etag", "project"},
+			},
+			{
+				Config: testAccFirestoreDatabase_deleteProtectionState(orgId, billingAccount, randomSuffix, "DELETE_PROTECTION_DISABLED"),
+			},
+			{
+				ResourceName:      "google_firestore_database.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"etag", "project"},
+			},
+		},
+	})
+}
+
 func testAccFirestoreDatabase_basicDependencies(orgId, billingAccount string, randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_project" "default" {
@@ -137,4 +173,20 @@ resource "google_firestore_database" "default" {
   depends_on = [google_project_service.firestore]
 }
 `, pointInTimeRecoveryEnablement)
+}
+
+func testAccFirestoreDatabase_deleteProtectionState(orgId, billingAccount string, randomSuffix string, deleteProtectionState string) string {
+	return testAccFirestoreDatabase_basicDependencies(orgId, billingAccount, randomSuffix) + fmt.Sprintf(`
+
+resource "google_firestore_database" "default" {
+  name                    = "(default)"
+  type                    = "DATASTORE_MODE"
+  location_id             = "nam5"
+  delete_protection_state = "%s"
+
+  project = google_project.default.project_id
+
+  depends_on = [google_project_service.firestore]
+}
+`, deleteProtectionState)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds Firestore deletion protection support to prevent accidental deletion of Firestore databases.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15789

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `delete_protection_state` field to `google_firestore_database` resource.
```
