### PR TITLE
Firestore: Add missing fields to Firestore database

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -165,5 +165,5 @@ properties:
   - !ruby/object:Api::Type::String
     name: create_time
     description: |
-      The timestamp at which this database was created.
+      Output only. The timestamp at which this database was created.
     output: true

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -172,3 +172,8 @@ properties:
     description: |
       Output only. The timestamp at which this database was most recently updated.
     output: true
+  - !ruby/object:Api::Type::String
+    name: uid
+    description: |
+      Output only. The system-generated UUID4 for this Database.
+    output: true

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -167,3 +167,8 @@ properties:
     description: |
       Output only. The timestamp at which this database was created.
     output: true
+  - !ruby/object:Api::Type::String
+    name: update_time
+    description: |
+      Output only. The timestamp at which this database was most recently updated.
+    output: true

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -158,7 +158,7 @@ properties:
   - !ruby/object:Api::Type::Fingerprint
     name: etag
     description: |
-      This checksum is computed by the server based on the value of other fields,
+      Output only. This checksum is computed by the server based on the value of other fields,
       and may be sent on update and delete requests to ensure the client has an
       up-to-date value before proceeding.
     output: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds a few missing fields from the Firestore database.
https://cloud.google.com/firestore/docs/reference/rest/v1/projects.databases

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `update_time` and `uid` fields to `google_firestore_database` resource
```
