### PR TITLE
feat(workstations): add env block in google_workstations_workstation

### DIFF
--- a/mmv1/products/workstations/Workstation.yaml
+++ b/mmv1/products/workstations/Workstation.yaml
@@ -125,6 +125,10 @@ properties:
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'annotations'
     description: 'Client-specified annotations. This is distinct from labels.'
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'env'
+    description: |
+      'Client-specified environment variables passed to the workstation container's entrypoint.'
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: |

--- a/mmv1/templates/terraform/examples/workstation_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_basic.tf.erb
@@ -54,6 +54,10 @@ resource "google_workstations_workstation" "<%= ctx[:primary_resource_id] %>" {
     "label" = "key"
   }
 
+  env = {
+    name = "foo"
+  }
+
   annotations = {
     label-one = "value-one"
   }

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_test.go.erb
@@ -88,6 +88,10 @@ resource "google_workstations_workstation" "default" {
   labels = {
 	  foo = "bar"
   }
+
+  env = {
+    name = "bar"
+  }
 }
 `, context)
 }
@@ -136,6 +140,10 @@ resource "google_workstations_workstation" "default" {
 
   labels = {
 	  foo = "bar"
+  }
+
+  env = {
+    name = "test"
   }
 }
 `, context)


### PR DESCRIPTION
# Description

Support `env` block on the `google_workstations_workstation` resource.

Fixes [#15660](https://github.com/hashicorp/terraform-provider-google/issues/15660)


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added `env` field to `google_workstations_workstation` resource (beta)
```