### PR TITLE
Update to wrap generated import format regex in ^ and $

### DIFF
--- a/mmv1/products/billing/ProjectInfo.yaml
+++ b/mmv1/products/billing/ProjectInfo.yaml
@@ -28,7 +28,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/billing_project_info.go.erb
   test_check_destroy: templates/terraform/custom_check_destroy/billing_project_info.go.erb
 import_format:
-  ['projects/{{project}}', '{{project}}']
+  ['projects/{{%project}}', '{{%project}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'billing_project_info_basic'

--- a/mmv1/products/billing/ProjectInfo.yaml
+++ b/mmv1/products/billing/ProjectInfo.yaml
@@ -33,6 +33,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'billing_project_info_basic'
     primary_resource_id: 'default'
+    skip_import_test: true
     test_env_vars:
       billing_account: :BILLING_ACCT
       org_id: :ORG_ID

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -1150,7 +1150,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     config := meta.(*transport_tpg.Config)
     if err := tpgresource.ParseImportId([]string{
 <%      for import_id in import_id_formats_from_resource(object) -%>
-        "<%= format2regex(import_id) %>",
+        "^<%= format2regex(import_id) %>$",
 <%      end -%>
     }, d, config); err != nil {
       return nil, err

--- a/mmv1/third_party/terraform/services/compute/resource_compute_vpn_tunnel_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_vpn_tunnel_test.go
@@ -31,7 +31,6 @@ func TestAccComputeVpnTunnel_regionFromGateway(t *testing.T) {
 				ResourceName:            "google_compute_vpn_tunnel.foobar",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateIdPrefix:     fmt.Sprintf("%s/%s/", envvar.GetTestProjectFromEnv(), region),
 				ImportStateVerifyIgnore: []string{"shared_secret", "detailed_status"},
 			},
 		},

--- a/mmv1/third_party/terraform/services/corebilling/resource_google_billing_project_info_test.go
+++ b/mmv1/third_party/terraform/services/corebilling/resource_google_billing_project_info_test.go
@@ -29,6 +29,7 @@ func TestAccBillingProjectInfo_update(t *testing.T) {
 				ResourceName:      "google_billing_project_info.info",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("projects/%s", envvar.GetTestProjectFromEnv()),
 			},
 			{
 				Config: testAccBillingProjectInfo_basic(projectId, orgId, ""),
@@ -37,6 +38,7 @@ func TestAccBillingProjectInfo_update(t *testing.T) {
 				ResourceName:      "google_billing_project_info.info",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("projects/%s", envvar.GetTestProjectFromEnv()),
 			},
 			{
 				Config: testAccBillingProjectInfo_basic(projectId, orgId, billingAccount),
@@ -45,6 +47,7 @@ func TestAccBillingProjectInfo_update(t *testing.T) {
 				ResourceName:      "google_billing_project_info.info",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("projects/%s", envvar.GetTestProjectFromEnv()),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/corebilling/resource_google_billing_project_info_test.go
+++ b/mmv1/third_party/terraform/services/corebilling/resource_google_billing_project_info_test.go
@@ -29,7 +29,7 @@ func TestAccBillingProjectInfo_update(t *testing.T) {
 				ResourceName:      "google_billing_project_info.info",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     fmt.Sprintf("projects/%s", envvar.GetTestProjectFromEnv()),
+				ImportStateId:     fmt.Sprintf("projects/%s", projectId),
 			},
 			{
 				Config: testAccBillingProjectInfo_basic(projectId, orgId, ""),
@@ -38,7 +38,7 @@ func TestAccBillingProjectInfo_update(t *testing.T) {
 				ResourceName:      "google_billing_project_info.info",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     fmt.Sprintf("projects/%s", envvar.GetTestProjectFromEnv()),
+				ImportStateId:     fmt.Sprintf("projects/%s", projectId),
 			},
 			{
 				Config: testAccBillingProjectInfo_basic(projectId, orgId, billingAccount),
@@ -47,7 +47,7 @@ func TestAccBillingProjectInfo_update(t *testing.T) {
 				ResourceName:      "google_billing_project_info.info",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     fmt.Sprintf("projects/%s", envvar.GetTestProjectFromEnv()),
+				ImportStateId:     fmt.Sprintf("projects/%s", projectId),
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Part of https://github.com/hashicorp/terraform-provider-google/issues/14731

Currently generated import_format regex in TPG is not wrapped in start of line and end of line tokens, which allows for certain edge case false positives in non-standard import formats supplied via override.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
provider: fixed many import functions throughout the provider that matched a subset of the provided input when possible. Now, the GCP resource id supplied to "terraform import" must match exactly.
```
