### PR TITLE
Make `google_monitoring_metric_descriptor.labels` ForceNew

### DIFF
--- a/mmv1/products/monitoring/MetricDescriptor.yaml
+++ b/mmv1/products/monitoring/MetricDescriptor.yaml
@@ -74,6 +74,7 @@ properties:
       The set of labels that can be used to describe a specific instance of this
       metric type. In order to delete a label, the entire resource must be
       deleted, then created with the desired labels.
+    immutable: true
     is_set: true
     item_type: !ruby/object:Api::Type::NestedObject
       properties:

--- a/mmv1/products/monitoring/MetricDescriptor.yaml
+++ b/mmv1/products/monitoring/MetricDescriptor.yaml
@@ -162,7 +162,6 @@ properties:
       Use sentence case without an ending period, for example "Request count".
   - !ruby/object:Api::Type::NestedObject
     name: metadata
-    immutable: true
     description: Metadata which can be used to guide usage of the metric.
     ignore_read: true
     properties:

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_metric_descriptor_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_metric_descriptor_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestAccMonitoringMetricDescriptor_update(t *testing.T) {
-	// TODO: Fix requires a breaking change https://github.com/hashicorp/terraform-provider-google/issues/12139
-	t.Skip()
 
 	t.Parallel()
 	acctest.VcrTest(t, resource.TestCase{
@@ -19,8 +17,7 @@ func TestAccMonitoringMetricDescriptor_update(t *testing.T) {
 		CheckDestroy:             testAccCheckMonitoringMetricDescriptorDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMonitoringMetricDescriptor_update("key1", "STRING",
-					"description1", "30s", "30s"),
+				Config: testAccMonitoringMetricDescriptor_update("30s", "30s"),
 			},
 			{
 				ResourceName:            "google_monitoring_metric_descriptor.basic",
@@ -29,8 +26,7 @@ func TestAccMonitoringMetricDescriptor_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"metadata", "launch_stage"},
 			},
 			{
-				Config: testAccMonitoringMetricDescriptor_update("key2", "INT64",
-					"description2", "60s", "60s"),
+				Config: testAccMonitoringMetricDescriptor_update("60s", "60s"),
 			},
 			{
 				ResourceName:            "google_monitoring_metric_descriptor.basic",
@@ -42,8 +38,7 @@ func TestAccMonitoringMetricDescriptor_update(t *testing.T) {
 	})
 }
 
-func testAccMonitoringMetricDescriptor_update(key, valueType, description,
-	samplePeriod, ingestDelay string) string {
+func testAccMonitoringMetricDescriptor_update(samplePeriod, ingestDelay string) string {
 	return fmt.Sprintf(`
 resource "google_monitoring_metric_descriptor" "basic" {
 	description = "Daily sales records from all branch stores."
@@ -53,9 +48,9 @@ resource "google_monitoring_metric_descriptor" "basic" {
 	value_type = "DOUBLE"
 	unit = "{USD}"
 	labels {
-		key = "%s"
-		value_type = "%s"
-		description = "%s"
+		key = "key"
+		value_type = "STRING"
+		description = "description"
 	}
 	launch_stage = "BETA"
 	metadata {
@@ -63,6 +58,6 @@ resource "google_monitoring_metric_descriptor" "basic" {
 		ingest_delay = "%s"
 	}
 }
-`, key, valueType, description, samplePeriod, ingestDelay,
+`, samplePeriod, ingestDelay,
 	)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
`labels` are not updatable,`metadata` is. The child `metadata` fields were already updatable, just setting the parent appropriately.

fixes https://github.com/hashicorp/terraform-provider-google/issues/12139
upgrade guide: https://github.com/GoogleCloudPlatform/magic-modules/pull/8970

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
monitoring: made `labels` immutable in `google_monitoring_metric_descriptor`
```
```release-note:bug
monitoring: fixed an issue where `metadata` was not able to be updated in `google_monitoring_metric_descriptor`
```
