### PR TITLE
New annotation being set by default

### DIFF
--- a/mmv1/templates/terraform/constants/cloud_run_service.go.erb
+++ b/mmv1/templates/terraform/constants/cloud_run_service.go.erb
@@ -28,17 +28,20 @@ func cloudrunAnnotationDiffSuppress(k, old, new string, d *schema.ResourceData) 
 	return false
 }
 
-var cloudRunGoogleProvidedTemplateAnnotations = regexp.MustCompile(`template\.0\.metadata\.0\.annotations\.run\.googleapis\.com/sandbox`)
-var cloudRunGoogleProvidedTemplateAnnotations_autoscaling_maxscale = regexp.MustCompile(`template\.0\.metadata\.0\.annotations\.autoscaling\.knative\.dev/maxScale`)
+var cloudRunGoogleProvidedTemplateAnnotations = []string{
+	"autoscaling.knative.dev/maxScale",
+	"run.googleapis.com/startup-cpu-boost",
+}
 
 func cloudrunTemplateAnnotationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// Suppress diffs for the annotations provided by API
-	if cloudRunGoogleProvidedTemplateAnnotations.MatchString(k) &&
-		old == "gvisor" && new == "" {
-		return true
+	for _, anno := range cloudRunGoogleProvidedTemplateAnnotations {
+		if strings.Contains(k, anno) && new == "" {
+			return true
+		}
 	}
-
-	if cloudRunGoogleProvidedTemplateAnnotations_autoscaling_maxscale.MatchString(k) && new == "" {
+	if strings.Contains(k, "run.googleapis.com/sandbox") &&
+		old == "gvisor" && new == "" {
 		return true
 	}
 
@@ -65,7 +68,6 @@ func cloudrunLabelDiffSuppress(k, old, new string, d *schema.ResourceData) bool 
 
 var cloudRunGoogleProvidedTemplateLabels = []string{
 	"run.googleapis.com/startupProbeType",
-	"run.googleapis.com/startup-cpu-boost",
 }
 
 func cloudrunTemplateLabelDiffSuppress(k, old, new string, d *schema.ResourceData) bool {

--- a/mmv1/templates/terraform/constants/cloud_run_service.go.erb
+++ b/mmv1/templates/terraform/constants/cloud_run_service.go.erb
@@ -65,6 +65,7 @@ func cloudrunLabelDiffSuppress(k, old, new string, d *schema.ResourceData) bool 
 
 var cloudRunGoogleProvidedTemplateLabels = []string{
 	"run.googleapis.com/startupProbeType",
+	"run.googleapis.com/startup-cpu-boost",
 }
 
 func cloudrunTemplateLabelDiffSuppress(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrun: fixed perma-diff in `cloud_run_service` when "run.googleapis.com/startup-cpu-boost" was returned in `template.metadata.annotations`
```
