### PR TITLE
set vcenter field mutable

### DIFF
--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -629,33 +629,26 @@ properties:
     description: |
       VmwareVCenterConfig specifies vCenter config for the user cluster.
       Inherited from the admin cluster.
-    output: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'resourcePool'
         description: The name of the vCenter resource pool for the user cluster.
-        output: true
       - !ruby/object:Api::Type::String
         name: 'datastore'
         description: The name of the vCenter datastore for the user cluster.
-        output: true
       - !ruby/object:Api::Type::String
         name: 'datacenter'
         description: The name of the vCenter datacenter for the user cluster.
-        output: true
       - !ruby/object:Api::Type::String
         name: 'cluster'
         description: The name of the vCenter cluster for the user cluster.
-        output: true
       - !ruby/object:Api::Type::String
         name: 'folder'
         description: The name of the vCenter folder for the user cluster.
-        output: true
       - !ruby/object:Api::Type::String
         name: 'caCertData'
         description:
           Contains the vCenter CA certificate public key for SSL verification.
-        output: true
       - !ruby/object:Api::Type::String
         name: 'address'
         description: The vCenter IP address.
@@ -663,7 +656,6 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'storagePolicyName'
         description: The name of the vCenter storage policy for the user cluster.
-        output: true
   - !ruby/object:Api::Type::NestedObject
     name: status
     description: ResourceStatus representing detailed cluster state.

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.erb
@@ -58,6 +58,15 @@ resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
       konnectivity_server_node_port = 30008
     }
   }
+  vcenter {
+    resource_pool = "test-resource-pool"
+    datastore = "test-datastore"
+    datacenter = "test-datacenter"
+    cluster = "test-cluster"
+    folder = "test-folder"
+    ca_cert_data = "test-ca-cert-data"
+    storage_policy_name = "test-storage-policy-name"
+  }
   dataplane_v2 {
     dataplane_v2_enabled = true
     windows_dataplane_v2_enabled = true

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.erb
@@ -360,6 +360,15 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLbStart(context map[
         konnectivity_server_node_port = 30008
       }
     }
+    vcenter {
+      resource_pool = "test-resource-pool"
+      datastore = "test-datastore"
+      datacenter = "test-datacenter"
+      cluster = "test-cluster"
+      folder = "test-folder"
+      ca_cert_data = "test-ca-cert-data"
+      storage_policy_name = "test-storage-policy-name"
+    }
     dataplane_v2 {
       dataplane_v2_enabled = true
       windows_dataplane_v2_enabled = true
@@ -444,6 +453,15 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(context map[strin
         control_plane_node_port = 30008
         konnectivity_server_node_port = 30009
       }
+    }
+    vcenter {
+      resource_pool = "test-resource-pool-updated"
+      datastore = "test-datastore-updated"
+      datacenter = "test-datacenter-updated"
+      cluster = "test-cluster-updated"
+      folder = "test-folder-updated"
+      ca_cert_data = "test-ca-cert-data-updated"
+      storage_policy_name = "test-storage-policy-name-updated"
     }
     dataplane_v2 {
       dataplane_v2_enabled = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkeonprem: `vcenter` fields made mutable in `google_gkeonprem_vmware_cluster`
```
