### PR TITLE
Unset other credentials variables before constructing config

### DIFF
--- a/mmv1/third_party/tgc/getconfig_test.go
+++ b/mmv1/third_party/tgc/getconfig_test.go
@@ -16,9 +16,11 @@ type configAttrGetter func(cfg *transport_tpg.Config) string
 func getCredentials(cfg *transport_tpg.Config) string {
 	return cfg.Credentials
 }
+
 func getAccessToken(cfg *transport_tpg.Config) string {
 	return cfg.AccessToken
 }
+
 func getImpersonateServiceAccount(cfg *transport_tpg.Config) string {
 	return cfg.ImpersonateServiceAccount
 }
@@ -29,6 +31,7 @@ func TestNewConfigExtractsEnvVars(t *testing.T) {
 	cases := []struct {
 		name           string
 		envKey         string
+		unsetKeys      []string // environment variables that must be unset before constructing config
 		envValue       string
 		expected       string
 		getConfigValue configAttrGetter
@@ -43,6 +46,7 @@ func TestNewConfigExtractsEnvVars(t *testing.T) {
 		{
 			name:           "GOOGLE_CLOUD_KEYFILE_JSON",
 			envKey:         "GOOGLE_CLOUD_KEYFILE_JSON",
+			unsetKeys:      []string{"GOOGLE_CREDENTIALS"},
 			envValue:       "whatever",
 			expected:       "whatever",
 			getConfigValue: getCredentials,
@@ -50,6 +54,7 @@ func TestNewConfigExtractsEnvVars(t *testing.T) {
 		{
 			name:           "GCLOUD_KEYFILE_JSON",
 			envKey:         "GCLOUD_KEYFILE_JSON",
+			unsetKeys:      []string{"GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON"},
 			envValue:       "whatever",
 			expected:       "whatever",
 			getConfigValue: getCredentials,
@@ -72,7 +77,22 @@ func TestNewConfigExtractsEnvVars(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			// Store existing state of environment variables.
+			existingEnv := make(map[string]string, len(c.unsetKeys)+1)
+			for _, key := range c.unsetKeys {
+				if originalValue, isSet := os.LookupEnv(key); isSet {
+					existingEnv[key] = originalValue
+					// Unset variables that would interfere with test.
+					err := os.Unsetenv(key)
+					if err != nil {
+						t.Fatalf("error unsetting env var %s: %s", key, err)
+					}
+				}
+			}
 			originalValue, isSet := os.LookupEnv(c.envKey)
+			if isSet {
+				existingEnv[c.envKey] = originalValue
+			}
 			err := os.Setenv(c.envKey, c.envValue)
 			if err != nil {
 				t.Fatalf("error setting env var %s=%s: %s", c.envKey, c.envValue, err)
@@ -85,15 +105,18 @@ func TestNewConfigExtractsEnvVars(t *testing.T) {
 
 			assert.Equal(t, c.expected, c.getConfigValue(cfg))
 
-			if isSet {
-				err = os.Setenv(c.envKey, originalValue)
-				if err != nil {
-					t.Fatalf("error setting env var %s=%s: %s", c.envKey, originalValue, err)
-				}
-			} else {
+			// Restore previous states of environment variables.
+			if !isSet {
+				// c.envKey was previously unset.
 				err = os.Unsetenv(c.envKey)
 				if err != nil {
 					t.Fatalf("error unsetting env var %s: %s", c.envKey, err)
+				}
+			}
+			for key, value := range existingEnv {
+				err = os.Setenv(key, value)
+				if err != nil {
+					t.Fatalf("error setting env var %s=%s: %s", key, value, err)
 				}
 			}
 		})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This allows tests to pass locally when `GOOGLE_CREDENTIALS` or `GOOGLE_CLOUD_KEYFILE_JSON` are set.

Was already merged downstream in https://github.com/GoogleCloudPlatform/terraform-google-conversion/pull/1378 but reverted by modular magician.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
