### PR TITLE
Move empty_dir volumes and the container depends_on field to GA

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -588,7 +588,6 @@ properties:
                   name: 'emptyDir'
                   description: |-
                     Ephemeral storage used as a shared volume.
-                  min_version: beta
                   # exactly_one_of:
                   #   - template.0.template.0.volumes.0.secret
                   #   - template.0.template.0.volumes.0.cloudSqlInstance

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -95,7 +95,6 @@ examples:
       secret_id: 'secret'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_job_emptydir'
-    min_version: 'beta'
     primary_resource_id: 'default'
     primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-job%s\", context[\"random_suffix\"\
       ])"

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -106,7 +106,6 @@ examples:
       secret_id: 'secret-1'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_service_multicontainer'
-    min_version: 'beta'
     primary_resource_id: 'default'
     primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-service%s\", context[\"\
       random_suffix\"])"

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -639,7 +639,6 @@ properties:
               name: 'dependsOn'
               description: |-
                 Containers which should be started before this container. If specified the container will wait to start until all containers with the listed names are healthy.
-              min_version: beta
               item_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'volumes'
@@ -707,7 +706,6 @@ properties:
               name: 'emptyDir'
               description: |-
                 Ephemeral storage used as a shared volume.
-              min_version: beta
               # exactly_one_of:
               #   - template.0.volumes.0.secret
               #   - template.0.volumes.0.cloudSqlInstance

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir.tf.erb
@@ -1,5 +1,4 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
   launch_stage = "BETA"

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_multicontainer.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_multicontainer.tf.erb
@@ -1,5 +1,4 @@
 resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
   location = "us-central1"
   launch_stage = "BETA"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Promote empty_dir volumes and the container depends_on fields to the GA provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
cloudrunv2: Added the field `template.containers.depends_on` to `google_cloud_run_v2_service` (ga).
```
```release-note:enhancement
cloudrunv2: Added the field `template.volumes.empty_dir` to `google_cloud_run_v2_service` (ga).
```
```release-note:enhancement
cloudrunv2: Added the field `template.template.volumes.empty_dir` to `google_cloud_run_v2_job` (ga).
```

