### PR TITLE
Fix id validation for custom service and SLO to match what's actually usable

### DIFF
--- a/mmv1/products/monitoring/Service.yaml
+++ b/mmv1/products/monitoring/Service.yaml
@@ -54,7 +54,7 @@ parameters:
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     default_from_api: true
     validation: !ruby/object:Provider::Terraform::Validation
-      regex: '^[a-z0-9\-]+$'
+      regex: '^[a-zA-Z0-9\-_:.]+$'
 properties:
   - !ruby/object:Api::Type::String
     name: name

--- a/mmv1/products/monitoring/Slo.yaml
+++ b/mmv1/products/monitoring/Slo.yaml
@@ -95,7 +95,7 @@ parameters:
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     default_from_api: true
     validation: !ruby/object:Provider::Terraform::Validation
-      regex: '^[a-z0-9\-]+$'
+      regex: '^[a-zA-Z0-9\-_:.]+$'
 properties:
   - !ruby/object:Api::Type::String
     name: name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes hashicorp/terraform-provider-google#15825

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

The validation for the following id fields were too strict, so they have been adjusted to match the actual formats. Please refer to the issue for specific examples.

- `service_id` on `google_monitoring_custom_service`
- `slo_id` on `google_monitoring_slo`

I checked this documentation. [Types of breaking changes | Magic Modules](https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/)
This change relaxes the validation to contain the current pattern, so I think this is not a breaking change.

Do I need to add tests for the validation defined in regex? If so, I'll add it.
It would be helpful if you could advise on existing test cases for such a change.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed validation of `service_id` on `google_monitoring_custom_service` and `slo_id` on `google_monitoring_slo` 
```
