### PR TITLE
Fix broken link in the doc on how to create a PR

### DIFF
--- a/docs/content/contribute/create-pr.md
+++ b/docs/content/contribute/create-pr.md
@@ -24,7 +24,7 @@ weight: 10
 **TIP:** Speeding up review:
 1. Resolve failed [status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) quickly
    - Ask your reviewer for help if you get stuck.
-1. [Self-review your PR]({{< ref "/contribute/review-pr" >}}") or ask someone you know to review
+1. [Self-review your PR]({{< ref "/contribute/review-pr" >}}) or ask someone you know to review
 {{< /hint >}}
 
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

It's a tiny fix for the documentation.
I found the following link was broken and fixed it.

here: https://googlecloudplatform.github.io/magic-modules/contribute/create-pr/#:~:text=you%20get%20stuck.-,Self%2Dreview%20your%20PR,-or%20ask%20someone

This link url has trailing `"`.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
