### PR TITLE
Revert "Use Create instead of Patch to create google_service_networking_connection"

### DIFF
--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -42,6 +42,8 @@ examples:
       alloydb_cluster_name: 'alloydb-cluster'
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-basic")'
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
@@ -53,6 +55,8 @@ examples:
       alloydb_cluster_name: 'alloydb-cluster'
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-full")'
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -57,6 +57,8 @@ examples:
       alloydb_cluster_name: 'alloydb-cluster'
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "alloydb-instance-basic")'
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'

--- a/mmv1/products/databasemigrationservice/connectionprofile.yaml
+++ b/mmv1/products/databasemigrationservice/connectionprofile.yaml
@@ -87,6 +87,8 @@ examples:
       profile: 'my-profileid'
       global_address_name: 'private-ip-alloc'
       network_name: 'vpc-network'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "profile-alloydb")'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'connectionProfileId'

--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -57,6 +57,7 @@ examples:
       client_id: 'my-client-id'
       client_secret: 'my-client-secret'
     test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "looker-instance-enterprise")'
       kms_key_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -37,6 +37,8 @@ examples:
       instance_name: 'test-instance'
       network_name: 'test-network'
       address_name: 'address'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "memcache-instance-basic")'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -67,6 +67,8 @@ examples:
       instance_name: 'private-cache'
       address_name: 'address'
       network_name: 'redis-test-network'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "redis-private-service")'
   - !ruby/object:Provider::Terraform::Examples
     name: 'redis_instance_mrr'
     primary_resource_id: 'cache'

--- a/mmv1/templates/terraform/examples/alloydb_backup_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_backup_basic.tf.erb
@@ -9,7 +9,7 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
@@ -25,15 +25,15 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/mmv1/templates/terraform/examples/alloydb_backup_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_backup_full.tf.erb
@@ -13,7 +13,7 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
@@ -29,15 +29,15 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
@@ -13,7 +13,7 @@ resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 
   initial_user {
     password = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
@@ -22,7 +22,7 @@ resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }
 
@@ -31,11 +31,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_alloydb.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_alloydb.tf.erb
@@ -1,7 +1,7 @@
 data "google_project" "project" {
 }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }
 
@@ -10,11 +10,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -34,7 +34,7 @@ resource "google_database_migration_service_connection_profile" "<%= ctx[:primar
         user = "alloyuser%{random_suffix}"
         password = "alloypass%{random_suffix}"
       }
-      vpc_network = google_compute_network.default.id
+      vpc_network = data.google_compute_network.default.id
       labels  = { 
         alloyfoo = "alloybar" 
       }

--- a/mmv1/templates/terraform/examples/looker_instance_enterprise_full.tf.erb
+++ b/mmv1/templates/terraform/examples/looker_instance_enterprise_full.tf.erb
@@ -5,7 +5,7 @@ resource "google_looker_instance" "<%= ctx[:primary_resource_id] %>" {
   private_ip_enabled = true
   public_ip_enabled  = false
   reserved_range     = "${google_compute_global_address.looker_range.name}"
-  consumer_network   = google_compute_network.looker_network.id
+  consumer_network   = data.google_compute_network.looker_network.id
   admin_settings {
     allowed_email_domains = ["google.com"]
   }
@@ -49,7 +49,7 @@ resource "google_looker_instance" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_service_networking_connection" "looker_vpc_connection" {
-  network                 = google_compute_network.looker_network.id
+  network                 = data.google_compute_network.looker_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.looker_range.name]
 }
@@ -59,12 +59,12 @@ resource "google_compute_global_address" "looker_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 20
-  network       = google_compute_network.looker_network.id
+  network       = data.google_compute_network.looker_network.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "looker_network" {
+data "google_compute_network" "looker_network" {
   name = "<%= ctx[:vars]["network_name"] %>"
 }
 

--- a/mmv1/templates/terraform/examples/memcache_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/memcache_instance_basic.tf.erb
@@ -6,7 +6,7 @@
 // If this network hasn't been created and you are using this example in your
 // config, add an additional network resource or change
 // this from "data"to "resource"
-resource "google_compute_network" "memcache_network" {
+data "google_compute_network" "memcache_network" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }
 
@@ -15,11 +15,11 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.memcache_network.id
+  network       = data.google_compute_network.memcache_network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.memcache_network.id
+  network                 = data.google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }

--- a/mmv1/templates/terraform/examples/redis_instance_private_service.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_private_service.tf.erb
@@ -6,7 +6,7 @@
 // If this network hasn't been created and you are using this example in your
 // config, add an additional network resource or change
 // this from "data"to "resource"
-resource "google_compute_network" "redis-network" {
+data "google_compute_network" "redis-network" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }
 
@@ -15,11 +15,11 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.redis-network.id
+  network       = data.google_compute_network.redis-network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.redis-network.id
+  network                 = data.google_compute_network.redis-network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -32,7 +32,7 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
   location_id             = "us-central1-a"
   alternative_location_id = "us-central1-f"
 
-  authorized_network = google_compute_network.redis-network.id
+  authorized_network = data.google_compute_network.redis-network.id
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
   redis_version     = "REDIS_4_0"

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -10,10 +10,9 @@ import (
 func TestAccAlloydbBackup_update(t *testing.T) {
 	t.Parallel()
 
-	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"network_name":  "tf-test-alloydb-network" + random_suffix,
-		"random_suffix": random_suffix,
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-update"),
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -62,7 +61,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "default" {
@@ -78,16 +77,16 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 `, context)
@@ -99,7 +98,7 @@ func TestAccAlloydbBackup_createBackupWithMandatoryFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbbackup-mandatory"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -126,12 +125,12 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "default" {
   location = "us-central1"
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" { }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -148,7 +147,7 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
   lifecycle {
 	ignore_changes = [
 		address,
@@ -162,7 +161,7 @@ resource "google_compute_global_address" "private_ip_alloc" {
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -173,7 +172,7 @@ func TestAccAlloydbBackup_usingCMEK(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydb-backup-cmek"),
 		"random_suffix": acctest.RandString(t, 10),
 		"key_name":      "tf-test-key-" + acctest.RandString(t, 10),
 	}
@@ -216,7 +215,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "default" {
 	cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
 	location   = "us-central1"
-	network    = google_compute_network.default.id
+	network    = data.google_compute_network.default.id
 }
 	  
 resource "google_alloydb_instance" "default" {
@@ -232,16 +231,16 @@ resource "google_compute_global_address" "private_ip_alloc" {
 	address_type  = "INTERNAL"
 	purpose       = "VPC_PEERING"
 	prefix_length = 16
-	network       = google_compute_network.default.id
+	network       = data.google_compute_network.default.id
 }
 	  
 resource "google_service_networking_connection" "vpc_connection" {
-	network                 = google_compute_network.default.id
+	network                 = data.google_compute_network.default.id
 	service                 = "servicenetworking.googleapis.com"
 	reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 	  
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
 	name = "%{network_name}"
 }
 data "google_project" "project" {}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
@@ -19,7 +19,7 @@ func TestAccAlloydbCluster_restore(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-restore"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -86,7 +86,7 @@ func testAccAlloydbClusterAndInstanceAndBackup(context map[string]interface{}) s
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -107,7 +107,7 @@ resource "google_alloydb_backup" "default" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -116,11 +116,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -133,7 +133,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_OnlyOneSourceAllowed(context map[
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -155,7 +155,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored" {
   cluster_id             = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -171,7 +171,7 @@ resource "google_alloydb_cluster" "restored" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -180,11 +180,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -197,7 +197,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_SourceClusterAndPointInTimeRequir
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -219,7 +219,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored" {
   cluster_id             = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
 
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
@@ -232,7 +232,7 @@ resource "google_alloydb_cluster" "restored" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -241,11 +241,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -257,7 +257,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackup(context map[st
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -279,7 +279,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -291,7 +291,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -300,11 +300,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -318,7 +318,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -340,7 +340,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -353,7 +353,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -366,7 +366,7 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -375,11 +375,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -393,7 +393,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -415,7 +415,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -433,7 +433,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -451,7 +451,7 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -460,11 +460,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -478,7 +478,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -508,7 +508,7 @@ resource "google_alloydb_backup" "default2" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default2.name
   }
@@ -528,7 +528,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.restored_from_backup.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -546,7 +546,7 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -555,11 +555,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -573,7 +573,7 @@ func testAccAlloydbClusterAndInstanceAndBackup_RestoredFromBackupAndRestoredFrom
 resource "google_alloydb_cluster" "source" {
   cluster_id   = "tf-test-alloydb-cluster%{random_suffix}"
   location     = "us-central1"
-  network      = google_compute_network.default.id
+  network      = data.google_compute_network.default.id
 }
 
 resource "google_alloydb_instance" "source" {
@@ -595,7 +595,7 @@ resource "google_alloydb_backup" "default" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "tf-test-alloydb-backup-restored-cluster-%{random_suffix}"
   location              = "us-central1"
-  network               = google_compute_network.default.id
+  network               = data.google_compute_network.default.id
   restore_backup_source {
     backup_name = google_alloydb_backup.default.name
   }
@@ -604,7 +604,7 @@ resource "google_alloydb_cluster" "restored_from_backup" {
 resource "google_alloydb_cluster" "restored_from_point_in_time" {
   cluster_id             = "tf-test-alloydb-pitr-restored-cluster-%{random_suffix}"
   location               = "us-central1"
-  network                = google_compute_network.default.id
+  network                = data.google_compute_network.default.id
   restore_continuous_backup_source {
     cluster = google_alloydb_cluster.source.name
     point_in_time = google_alloydb_backup.default.update_time
@@ -613,7 +613,7 @@ resource "google_alloydb_cluster" "restored_from_point_in_time" {
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -622,11 +622,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -10,10 +10,9 @@ import (
 func TestAccAlloydbInstance_update(t *testing.T) {
 	t.Parallel()
 
-	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": random_suffix,
-		"network_name":  "tf-test-alloydb-network" + random_suffix,
+		"random_suffix": acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-update"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -64,7 +63,7 @@ resource "google_alloydb_instance" "default" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 
   initial_user {
     password = "tf-test-alloydb-cluster%{random_suffix}"
@@ -74,7 +73,7 @@ resource "google_alloydb_cluster" "default" {
 data "google_project" "project" {
 }
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -83,11 +82,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -100,7 +99,7 @@ func TestAccAlloydbInstance_createInstanceWithMandatoryFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-mandatory"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -128,12 +127,12 @@ resource "google_alloydb_instance" "default" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -142,11 +141,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -159,7 +158,7 @@ func TestAccAlloydbInstance_createInstanceWithMaximumFields(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-maximum"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -206,12 +205,12 @@ resource "google_alloydb_instance" "default" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -220,11 +219,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -237,7 +236,7 @@ func TestAccAlloydbInstance_createPrimaryAndReadPoolInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-readpool"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -274,12 +273,12 @@ resource "google_alloydb_instance" "read_pool" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -288,11 +287,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -305,7 +304,7 @@ func TestAccAlloydbInstance_updateDatabaseFlagInPrimaryInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-updatedb"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -343,12 +342,12 @@ resource "google_alloydb_instance" "primary" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -357,11 +356,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
@@ -383,12 +382,12 @@ resource "google_alloydb_instance" "primary" {
 resource "google_alloydb_cluster" "default" {
   cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network    = data.google_compute_network.default.id
 }
 
 data "google_project" "project" {}
 
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 
@@ -397,11 +396,11 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 
 resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }

--- a/mmv1/third_party/terraform/services/cloudbuild/resource_cloudbuild_worker_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudbuild/resource_cloudbuild_worker_pool_test.go.erb
@@ -104,7 +104,7 @@ func TestAccCloudbuildWorkerPool_withNetwork(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"project":       envvar.GetTestProjectFromEnv(),
-		"network_name":  "tf-test-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "cloudbuild-workerpool"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -127,7 +127,7 @@ func TestAccCloudbuildWorkerPool_withNetwork(t *testing.T) {
 func testAccCloudbuildWorkerPool_withNetwork(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 
-resource "google_compute_network" "network" {
+data "google_compute_network" "network" {
   name = "%{network_name}"
 }
 
@@ -136,11 +136,11 @@ resource "google_compute_global_address" "worker_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.network.id
+  network       = data.google_compute_network.network.id
 }
 
 resource "google_service_networking_connection" "worker_pool_conn" {
-  network                 = google_compute_network.network.id
+  network                 = data.google_compute_network.network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.worker_range.name]
 }
@@ -154,7 +154,7 @@ resource "google_cloudbuild_worker_pool" "pool" {
 		no_external_ip = false
 	}
 	network_config {
-		peered_network = google_compute_network.network.id
+		peered_network = data.google_compute_network.network.id
 		peered_network_ip_range = "/29"
 	}
 	depends_on = [google_service_networking_connection.worker_pool_conn]

--- a/mmv1/third_party/terraform/services/cloudids/resource_cloudids_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/cloudids/resource_cloudids_endpoint_test.go
@@ -18,7 +18,7 @@ func TestAccCloudIdsEndpoint_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  "tf-test-key-" + acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "cloud-ids-endpoint"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccCloudIdsEndpoint_basic(t *testing.T) {
 
 func testCloudIds_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 resource "google_compute_global_address" "service_range" {
@@ -56,10 +56,10 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -67,7 +67,7 @@ resource "google_service_networking_connection" "private_service_connection" {
 resource "google_cloud_ids_endpoint" "endpoint" {
   name              = "cloud-ids-test-%{random_suffix}"
   location          = "us-central1-f"
-  network           = google_compute_network.default.id
+  network           = data.google_compute_network.default.id
   severity          = "INFORMATIONAL"
   threat_exceptions = ["12", "67"]
   depends_on        = [google_service_networking_connection.private_service_connection]
@@ -77,7 +77,7 @@ resource "google_cloud_ids_endpoint" "endpoint" {
 
 func testCloudIds_basicUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network" "default" {
+data "google_compute_network" "default" {
   name = "%{network_name}"
 }
 resource "google_compute_global_address" "service_range" {
@@ -85,10 +85,10 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.default.id
+  network       = data.google_compute_network.default.id
 }
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.default.id
+  network                 = data.google_compute_network.default.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -96,7 +96,7 @@ resource "google_service_networking_connection" "private_service_connection" {
 resource "google_cloud_ids_endpoint" "endpoint" {
   name              = "cloud-ids-test-%{random_suffix}"
   location          = "us-central1-f"
-  network           = google_compute_network.default.id
+  network           = data.google_compute_network.default.id
   severity          = "INFORMATIONAL"
   threat_exceptions = ["33"]
   depends_on        = [google_service_networking_connection.private_service_connection]

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -13,7 +13,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 
 	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)
-	network := "tf-test-" + acctest.RandString(t, 10)
+	network := acctest.BootstrapSharedTestNetwork(t, "memcache-instance-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -47,11 +47,11 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.memcache_network.id
+  network       = data.google_compute_network.memcache_network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.memcache_network.id
+  network                 = data.google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -75,7 +75,7 @@ resource "google_memcache_instance" "test" {
   }
 }
 
-resource "google_compute_network" "memcache_network" {
+data "google_compute_network" "memcache_network" {
   name = "%s"
 }
 `, prefix, name, network)
@@ -88,11 +88,11 @@ resource "google_compute_global_address" "service_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.memcache_network.id
+  network       = data.google_compute_network.memcache_network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.memcache_network.id
+  network                 = data.google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -116,7 +116,7 @@ resource "google_memcache_instance" "test" {
   }
 }
 
-resource "google_compute_network" "memcache_network" {
+data "google_compute_network" "memcache_network" {
   name = "%s"
 }
 `, prefix, name, network)

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -94,16 +94,27 @@ func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta inte
 	project := networkFieldValue.Project
 
 	parentService := formatParentService(d.Get("service").(string))
-
-	// There is no blocker to use Create method, as the bug in CloudSQL has been fixed (https://b.corp.google.com/issues/123276199).
-	// Read more in https://stackoverflow.com/questions/55135559/unable-to-recreate-private-service-access-on-gcp
+	// We use Patch instead of Create, because we're getting
+	//  "Error waiting for Create Service Networking Connection:
+	//   Error code 9, message: Cannot modify allocated ranges in
+	//   CreateConnection. Please use UpdateConnection."
+	// if we're creating peerings to more than one VPC (like two
+	// CloudSQL instances within one project, peered with two
+	// clusters.)
+	//
+	// This is a workaround for:
+	// https://issuetracker.google.com/issues/131908322
+	//
+	// The API docs don't specify that you can do connections/-,
+	// but that's what gcloud does, and it's easier than grabbing
+	// the connection name.
 
 	// err == nil indicates that the billing_project value was found
 	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
 		project = bp
 	}
 
-	createCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Create(parentService, connection)
+	createCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true)
 	if config.UserProjectOverride {
 		createCall.Header().Add("X-Goog-User-Project", project)
 	}

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -179,7 +179,7 @@ func TestAccSqlDatabaseInstance_deleteDefaultUserBeforeSubsequentApiCalls(t *tes
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-clone-2")
 
 	// 1. Create an instance.
 	// 2. Add a root@'%' user.
@@ -737,7 +737,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(t *te
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -970,9 +970,9 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testi
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated")
 	addressName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
-	networkName_update := "tf-test-" + acctest.RandString(t, 10) + "update"
+	networkName_update := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-allocated-update")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1007,7 +1007,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(t
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-replica")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1039,7 +1039,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(t *
 
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	addressName := "tf-test-" + acctest.RandString(t, 10)
-	networkName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "sql-instance-private-network-clone")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -2798,7 +2798,7 @@ func testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(datab
 	}
 
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2807,11 +2807,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2826,7 +2826,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
       %s
     }
   }
@@ -2836,7 +2836,7 @@ resource "google_sql_database_instance" "instance" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2845,11 +2845,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2864,7 +2864,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
       allocated_ip_range = google_compute_global_address.foobar.name
     }
   }
@@ -2874,7 +2874,7 @@ resource "google_sql_database_instance" "instance" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeReplica(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2883,11 +2883,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2902,7 +2902,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true
@@ -2921,7 +2921,7 @@ resource "google_sql_database_instance" "replica1" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
       allocated_ip_range = google_compute_global_address.foobar.name
     }
   }
@@ -2942,7 +2942,7 @@ resource "google_sql_database_instance" "replica1" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -2951,11 +2951,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -2970,7 +2970,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true
@@ -2997,7 +2997,7 @@ resource "google_sql_database_instance" "clone1" {
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRangeClone_withSettings(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "servicenet" {
+data "google_compute_network" "servicenet" {
   name                    = "%s"
 }
 
@@ -3006,11 +3006,11 @@ resource "google_compute_global_address" "foobar" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.servicenet.self_link
+  network       = data.google_compute_network.servicenet.self_link
 }
 
 resource "google_service_networking_connection" "foobar" {
-  network                 = google_compute_network.servicenet.self_link
+  network                 = data.google_compute_network.servicenet.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.foobar.name]
 }
@@ -3025,7 +3025,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled       = "false"
-      private_network    = google_compute_network.servicenet.self_link
+      private_network    = data.google_compute_network.servicenet.self_link
     }
     backup_configuration {
       enabled            = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
servicenetworking: used Create instead of Patch to create `google_service_networking_connection` (revert)
```
