### PR TITLE
Make ApiReference (apis_required) Api::Object::Named

### DIFF
--- a/mmv1/api/product/api_reference.rb
+++ b/mmv1/api/product/api_reference.rb
@@ -16,7 +16,7 @@ require 'api/object'
 module Api
   class Product < Api::Object::Named
     # Represents any APIs that are required to be enabled to use this product
-    class ApiReference < Api::Object
+    class ApiReference < Api::Object::Named
       attr_reader :name
       attr_reader :url
 


### PR DESCRIPTION
Goal is to add the [merge method](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/api/object.rb#L54) to the `apis_required` attribute on product.yaml files.

From what I can tell, ApiReference also falls in the description for https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/api/object.rb#L21. I don't think there are side effects (will confirm from the CI results), but if there is any doubt, I can just copy over the `merge` method directly.

```release-note:none

```
