### PR TITLE
Apply new labels model to more resources (part 1)

### DIFF
--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -527,7 +527,7 @@ module Api
       )
     end
 
-    def igore_read_labels_fields(props)
+    def ignore_read_labels_fields(props)
       fields = []
       props.each do |p|
         if (p.is_a? Api::Type::KeyValueLabels) ||
@@ -535,7 +535,7 @@ module Api
            (p.is_a? Api::Type::KeyValueAnnotations)
           fields << p.terraform_lineage
         elsif (p.is_a? Api::Type::NestedObject) && !p.all_properties.nil?
-          fields.concat(igore_read_labels_fields(p.all_properties))
+          fields.concat(ignore_read_labels_fields(p.all_properties))
         end
       end
       fields

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -527,6 +527,7 @@ module Api
       )
     end
 
+    # Return labels fields that should be added to ImportStateVerifyIgnore
     def ignore_read_labels_fields(props)
       fields = []
       props.each do |p|

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -478,9 +478,7 @@ module Api
       end
 
       props << build_terraform_labels_field('labels', labels.field_min_version)
-      props << build_effective_labels_field(
-        'labels', labels.field_min_version, labels.update_verb, labels.update_url
-      )
+      props << build_effective_labels_field('labels', labels)
     end
 
     def add_annotations_fields(props, parent, annotations)
@@ -495,13 +493,10 @@ module Api
         @custom_diff.append('tpgresource.SetMetadataAnnotationsDiff')
       end
 
-      props << build_effective_labels_field(
-        'annotations', annotations.field_min_version,
-        annotations.update_verb, annotations.update_url
-      )
+      props << build_effective_labels_field('annotations', annotations)
     end
 
-    def build_effective_labels_field(name, min_version, update_verb, update_url)
+    def build_effective_labels_field(name, labels)
       description = "All of #{name} (key/value pairs)\
  present on the resource in GCP, including the #{name} configured through Terraform,\
  other clients and services."
@@ -511,9 +506,10 @@ module Api
         output: true,
         api_name: name,
         description:,
-        min_version:,
-        update_verb:,
-        update_url:
+        min_version: labels.field_min_version,
+        update_verb: labels.update_verb,
+        update_url: labels.update_url,
+        immutable: labels.immutable
       )
     end
 

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -769,7 +769,7 @@ module Api
       attr_accessor :ignore_write
 
       def initialize(name: nil, output: nil, api_name: nil, description: nil, min_version: nil,
-                     ignore_write: nil, update_verb: nil, update_url: nil)
+                     ignore_write: nil, update_verb: nil, update_url: nil, immutable: nil)
         super()
 
         @name = name
@@ -780,6 +780,7 @@ module Api
         @ignore_write = ignore_write
         @update_verb = update_verb
         @update_url = update_url
+        @immutable = immutable
       end
 
       def validate

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -269,7 +269,7 @@ module Api
     # Prints the access path of the field in the configration eg: metadata.0.labels
     # The only intended purpose is to get the value of the labes field by calling d.Get().
     def terraform_lineage
-      return name&.underscore if __parent.nil?
+      return name&.underscore if __parent.nil? || __parent.flatten_object
 
       "#{__parent.terraform_lineage}.0.#{name&.underscore}"
     end

--- a/mmv1/products/activedirectory/Domain.yaml
+++ b/mmv1/products/activedirectory/Domain.yaml
@@ -85,7 +85,7 @@ properties:
     description:
       'The unique name of the domain using the format:
       `projects/{project}/locations/global/domains/{domainName}`.'
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'Resource labels that can contain user-provided metadata'
   - !ruby/object:Api::Type::Array

--- a/mmv1/products/activedirectory/Peering.yaml
+++ b/mmv1/products/activedirectory/Peering.yaml
@@ -73,7 +73,7 @@ properties:
     output: true
     description: |
       Unique name of the peering in this scope including projects and location using the form: projects/{projectId}/locations/global/peerings/{peeringId}.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'Resource labels that can contain user-provided metadata'
   - !ruby/object:Api::Type::String

--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -92,7 +92,7 @@ properties:
     required: true
     immutable: true
     diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'User-defined labels for the alloydb backup.'
   - !ruby/object:Api::Type::Time

--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -106,7 +106,7 @@ properties:
     output: true
     description: |
       The system-generated UID of the resource.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'User-defined labels for the alloydb cluster.'
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/apigateway/ApiConfig.yaml
+++ b/mmv1/products/apigateway/ApiConfig.yaml
@@ -120,7 +120,7 @@ properties:
     output: true
     description: |
       The ID of the associated Service Config (https://cloud.google.com/service-infrastructure/docs/glossary#config).
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Resource labels to represent user-provided metadata.

--- a/mmv1/products/apigateway/ApiResource.yaml
+++ b/mmv1/products/apigateway/ApiResource.yaml
@@ -87,7 +87,7 @@ properties:
     name: 'createTime'
     description: Creation timestamp in RFC3339 text format.
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Resource labels to represent user-provided metadata.

--- a/mmv1/products/apigateway/Gateway.yaml
+++ b/mmv1/products/apigateway/Gateway.yaml
@@ -102,7 +102,7 @@ properties:
     description:
       The default API Gateway host name of the form
       {gatewayId}-{hash}.{region_code}.gateway.dev.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Resource labels to represent user-provided metadata.

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -131,7 +131,7 @@ properties:
     name: description
     description: |-
       The user-provided description of the repository.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Labels with user-defined metadata.

--- a/mmv1/products/beyondcorp/AppConnection.yaml
+++ b/mmv1/products/beyondcorp/AppConnection.yaml
@@ -88,7 +88,7 @@ properties:
     name: 'displayName'
     description: |
       An arbitrary user-provided name for the AppConnection.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Resource labels to represent user provided metadata.

--- a/mmv1/products/beyondcorp/AppConnector.yaml
+++ b/mmv1/products/beyondcorp/AppConnector.yaml
@@ -82,7 +82,7 @@ properties:
     name: 'displayName'
     description: |
       An arbitrary user-provided name for the AppConnector.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Resource labels to represent user provided metadata.

--- a/mmv1/products/beyondcorp/AppGateway.yaml
+++ b/mmv1/products/beyondcorp/AppGateway.yaml
@@ -98,7 +98,7 @@ properties:
     name: 'displayName'
     description: |
       An arbitrary user-provided name for the AppGateway.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Resource labels to represent user provided metadata.

--- a/mmv1/products/bigquery/Job.yaml
+++ b/mmv1/products/bigquery/Job.yaml
@@ -168,7 +168,7 @@ properties:
         name: 'jobTimeoutMs'
         description: |
           Job timeout in milliseconds. If this time limit is exceeded, BigQuery may attempt to terminate the job.
-      - !ruby/object:Api::Type::KeyValuePairs
+      - !ruby/object:Api::Type::KeyValueLabels
         name: 'labels'
         description: |
           The labels associated with this job. You can use these to organize and group your jobs.

--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -88,7 +88,7 @@ properties:
     name: 'id'
     description: 'An opaque ID uniquely identifying the table.'
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       The labels associated with this dataset. You can use these to

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -95,7 +95,7 @@ properties:
     name: 'description'
     description: |
       A human-readable description of the resource.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'Set of label tags associated with the Certificate resource.'
   - !ruby/object:Api::Type::String

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -109,7 +109,7 @@ properties:
       accurate to nanoseconds with up to nine fractional digits.
       Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       'Set of label tags associated with the CertificateIssuanceConfig resource.

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -76,11 +76,10 @@ properties:
       accurate to nanoseconds with up to nine fractional digits.
       Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Set of labels associated with a Certificate Map resource.
-    default_from_api: true
   - !ruby/object:Api::Type::Array
     name: 'gclbTargets'
     description: |

--- a/mmv1/products/certificatemanager/CertificateMapEntry.yaml
+++ b/mmv1/products/certificatemanager/CertificateMapEntry.yaml
@@ -92,13 +92,12 @@ properties:
       with nanosecond resolution and up to nine fractional digits.
       Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       Set of labels associated with a Certificate Map Entry.
       An object containing a list of "key": value pairs.
       Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
-    default_from_api: true
   - !ruby/object:Api::Type::Array
     name: 'certificates'
     required: true

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -63,7 +63,7 @@ properties:
     name: 'description'
     description: |
       A human-readable description of the resource.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description:
       'Set of label tags associated with the DNS Authorization resource.'

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -84,7 +84,7 @@ properties:
       A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
       Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'Set of label tags associated with the trust config.'
     immutable: true

--- a/mmv1/products/cloudfunctions/CloudFunction.yaml
+++ b/mmv1/products/cloudfunctions/CloudFunction.yaml
@@ -129,7 +129,7 @@ properties:
     description: |
       The version identifier of the Cloud Function. Each deployment attempt
       results in a new version of a function being created.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       A set of key/value label pairs associated with this Cloud Function.

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -630,7 +630,7 @@ properties:
     name: 'updateTime'
     output: true
     description: 'The last update timestamp of a Cloud Function.'
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       A set of key/value label pairs associated with this Cloud Function.

--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -138,7 +138,7 @@ properties:
     output: true
     description: |
       The time when the Group was last updated.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     required: true
     description: |

--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -138,7 +138,7 @@ properties:
     output: true
     description: |
       The time when the Group was last updated.
-  - !ruby/object:Api::Type::KeyValueLabels
+  - !ruby/object:Api::Type::KeyValuePairs
     name: 'labels'
     required: true
     description: |

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -129,7 +129,7 @@ properties:
     output: true
     description: |
       A number that monotonically increases every time the user modifies the desired state.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |-
       Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component,

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -144,7 +144,7 @@ properties:
     output: true
     description: |
       A number that monotonically increases every time the user modifies the desired state. Please note that unlike v1, this is an int64 value. As with most Google APIs, its JSON representation will be a string instead of an integer.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |-
       Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component,

--- a/mmv1/products/databasemigrationservice/connectionprofile.yaml
+++ b/mmv1/products/databasemigrationservice/connectionprofile.yaml
@@ -116,7 +116,7 @@ properties:
     output: true
     description: |
       Output only. The timestamp when the resource was created. A timestamp in RFC3339 UTC 'Zulu' format, accurate to nanoseconds. Example: '2014-10-02T15:01:23.045123456Z'.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       The resource labels for connection profile to use to annotate any related underlying resources such as Compute Engine VMs.

--- a/mmv1/products/datafusion/Instance.yaml
+++ b/mmv1/products/datafusion/Instance.yaml
@@ -141,7 +141,7 @@ properties:
     name: 'enableRbac'
     description: |
       Option to enable granular role-based access control.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       The resource labels for instance to use to annotate any related underlying resources,

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -126,7 +126,7 @@ properties:
     name: 'displayName'
     description: |
       User friendly display name.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       User-defined labels for the scan. A list of key->value pairs.

--- a/mmv1/products/dataplex/Task.yaml
+++ b/mmv1/products/dataplex/Task.yaml
@@ -116,7 +116,7 @@ properties:
       - :CREATING
       - :DELETING
       - :ACTION_REQUIRED
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |
       User-defined labels for the task.

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -81,7 +81,7 @@ properties:
     name: 'name'
     output: true
     description: The resource's name.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: Labels.
   - !ruby/object:Api::Type::String

--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -59,7 +59,7 @@ properties:
     name: 'name'
     output: true
     description: The resource's name.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: Labels.
   - !ruby/object:Api::Type::String

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -157,7 +157,7 @@ properties:
     name: 'name'
     output: true
     description: The stream's name.
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: Labels.
   - !ruby/object:Api::Type::String

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -105,7 +105,7 @@ module Provider
     end
 
     def force_new?(property, resource)
-      !property.output &&
+      (!property.output || property.is_a?(Api::Type::KeyValueEffectiveLabels)) &&
         (property.immutable || (resource.immutable && property.update_url.nil? &&
                               property.immutable.nil? &&
                             (property.parent.nil? ||

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -47,7 +47,7 @@ object.examples
       .select{|p| p.url_param_only || p.ignore_read || p.is_a?(Api::Type::ResourceRef)}
       .map { |p| p.name.underscore }
       .concat(example.ignore_read_extra)
-      .concat(object.igore_read_labels_fields(object.properties_with_excluded))
+      .concat(object.ignore_read_labels_fields(object.properties_with_excluded))
 
     # Use explicit version for the example if given.
     # Otherwise, use object version.

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -44,9 +44,10 @@ object.examples
     test_slug = "#{resource_name}_#{example.name.camelize(:lower)}Example"
 
     ignore_read = object.all_user_properties
-      .select{|p| p.url_param_only || p.ignore_read || p.is_a?(Api::Type::ResourceRef) || p.is_a?(Api::Type::KeyValueLabels) || p.is_a?(Api::Type::KeyValueAnnotations) || p.is_a?(Api::Type::KeyValueTerraformLabels)}
+      .select{|p| p.url_param_only || p.ignore_read || p.is_a?(Api::Type::ResourceRef)}
       .map { |p| p.name.underscore }
       .concat(example.ignore_read_extra)
+      .concat(object.igore_read_labels_fields(object.properties_with_excluded))
 
     # Use explicit version for the example if given.
     # Otherwise, use object version.

--- a/mmv1/templates/terraform/examples/certificate_manager_google_managed_certificate_dns.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_google_managed_certificate_dns.tf.erb
@@ -2,6 +2,9 @@ resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id]
   name        = "<%= ctx[:vars]['cert_name'] %>"
   description = "The default cert"
   scope       = "EDGE_CACHE"
+  labels = {
+    env = "test"
+  }
   managed {
     domains = [
       google_certificate_manager_dns_authorization.instance.domain,

--- a/mmv1/templates/terraform/expand_property_method.erb
+++ b/mmv1/templates/terraform/expand_property_method.erb
@@ -75,6 +75,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d t
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
   transformed := make(map[string]interface{})
 <%     property.nested_properties.each do |prop| -%>
+<%           next if prop.is_a?(Api::Type::KeyValuePairs) && prop.ignore_write -%>
   <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
   transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
   if err != nil {

--- a/mmv1/third_party/terraform/acctest/test_utils.go.erb
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.erb
@@ -50,6 +50,12 @@ func CheckDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourc
 			if _, ok := ignoreFields[k]; ok {
 				continue
 			}
+			if _, ok := ignoreFields["labels.%"]; ok && strings.HasPrefix(k, "labels.") {
+				continue
+			}
+			if _, ok := ignoreFields["terraform_labels.%"]; ok && strings.HasPrefix(k, "terraform_labels.") {
+				continue
+			}
 			if k == "%" {
 				continue
 			}

--- a/mmv1/third_party/terraform/services/activedirectory/resource_active_directory_domain_update_test.go
+++ b/mmv1/third_party/terraform/services/activedirectory/resource_active_directory_domain_update_test.go
@@ -39,7 +39,7 @@ func TestAccActiveDirectoryDomain_update(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"domain_name"},
+				ImportStateVerifyIgnore: []string{"domain_name", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccADDomainUpdate(context),
@@ -48,7 +48,7 @@ func TestAccActiveDirectoryDomain_update(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"domain_name"},
+				ImportStateVerifyIgnore: []string{"domain_name", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccADDomainBasic(context),
@@ -57,7 +57,7 @@ func TestAccActiveDirectoryDomain_update(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"domain_name"},
+				ImportStateVerifyIgnore: []string{"domain_name", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -28,7 +28,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 				ResourceName:            "google_alloydb_backup.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time"},
+				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccAlloydbBackup_update(context),
@@ -37,7 +37,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 				ResourceName:            "google_alloydb_backup.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time"},
+				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -190,7 +190,7 @@ func TestAccAlloydbBackup_usingCMEK(t *testing.T) {
 				ResourceName:            "google_alloydb_backup.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time"},
+				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -26,7 +26,7 @@ func TestAccAlloydbCluster_update(t *testing.T) {
 				ResourceName:            "google_alloydb_cluster.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location"},
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccAlloydbCluster_update(context),
@@ -35,7 +35,7 @@ func TestAccAlloydbCluster_update(t *testing.T) {
 				ResourceName:            "google_alloydb_cluster.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location"},
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccAlloydbCluster_alloydbClusterBasicExample(context),

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_repository_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_repository_test.go
@@ -38,6 +38,10 @@ resource "google_artifact_registry_repository" "my-repo" {
   repository_id = "tf-test-my-repository%{random_suffix}"
   description   = "example docker repository%{random_suffix}"
   format        = "DOCKER"
+  labels = {
+    my_key    = "my_val"
+    other_key = "other_val"
+  }
 }
 
 data "google_artifact_registry_repository" "my-repo" {

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_repository_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_repository_test.go
@@ -23,8 +23,8 @@ func TestAccDataSourceGoogleArtifactRegistryRepositoryConfig(t *testing.T) {
 			{
 				Config: testAccDataSourceGoogleArtifactRegistryRepositoryConfig(context),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.CheckDataSourceStateMatchesResourceState(funcDataName,
-						"google_artifact_registry_repository.my-repo"),
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(funcDataName,
+						"google_artifact_registry_repository.my-repo", map[string]struct{}{"labels.%": {}, "terraform_labels.%": {}}),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.erb
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.erb
@@ -26,6 +26,7 @@ func TestAccArtifactRegistryRepository_update(t *testing.T) {
 				ResourceName:      "google_artifact_registry_repository.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccArtifactRegistryRepository_update2(repositoryID),
@@ -34,6 +35,7 @@ func TestAccArtifactRegistryRepository_update(t *testing.T) {
 				ResourceName:      "google_artifact_registry_repository.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_job_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_job_test.go
@@ -32,7 +32,7 @@ func TestAccBigQueryJob_withLocation(t *testing.T) {
 				ImportStateId:           importID,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "status.0.state"},
+				ImportStateVerifyIgnore: []string{"etag", "status.0.state", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -1031,7 +1031,7 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccBigQueryTable_jsonEqModeRemoved(datasetID, tableID),
@@ -1040,7 +1040,7 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -1090,7 +1090,7 @@ func TestAccBigQueryDataTable_expandArray(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccBigQueryTable_arrayExpanded(datasetID, tableID),
@@ -1099,7 +1099,7 @@ func TestAccBigQueryDataTable_expandArray(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -1123,7 +1123,7 @@ func TestAccBigQueryTable_allowDestroy(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "labels", "terraform_labels"},
 			},
 			{
 				Config:      testAccBigQueryTable_noAllowDestroy(datasetID, tableID),

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
@@ -26,7 +26,7 @@ func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
 				ResourceName:            "google_certificate_manager_dns_authorization.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name"},
+				ImportStateVerifyIgnore: []string{"name", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCertificateManagerDnsAuthorization_update1(context),
@@ -35,7 +35,7 @@ func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
 				ResourceName:            "google_certificate_manager_dns_authorization.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name"},
+				ImportStateVerifyIgnore: []string{"name", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
@@ -23,17 +23,19 @@ func TestAccCertificateManagerTrustConfig_update(t *testing.T) {
 				Config: testAccCertificateManagerTrustConfig_update0(context),
 			},
 			{
-				ResourceName:      "google_certificate_manager_trust_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_certificate_manager_trust_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCertificateManagerTrustConfig_update1(context),
 			},
 			{
-				ResourceName:      "google_certificate_manager_trust_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_certificate_manager_trust_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -80,7 +80,7 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -117,7 +117,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFileUpdatePath, random_suffix),
@@ -150,7 +150,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -425,7 +425,7 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update"),
@@ -434,7 +434,7 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceGoogleCloudFunctions2Function_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceGoogleCloudFunctions2FunctionConfig(functionName,
 					bucketName, zipFilePath),
-				// As the value of "labels" and "terraform_lables" in the state is dpendent on the configuration,
+				// As the value of "labels" and "terraform_labels" in the state is dependent on the configuration,
 				// and these fields are not set in the configuration of the data source, so these fields are empty in the state of the data source.
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(funcDataNameHttp,
@@ -59,7 +59,7 @@ resource "google_cloudfunctions2_function" "function_http_v2" {
   location = "us-central1"
   description = "a new function"
   labels = {
-	  env = "test"
+    env = "test"
   }
   build_config {
     runtime = "nodejs12"

--- a/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
@@ -35,6 +35,12 @@ func TestAccDataSourceGoogleCloudFunctions2Function_basic(t *testing.T) {
 
 func testAccDataSourceGoogleCloudFunctions2FunctionConfig(functionName, bucketName, zipFilePath string) string {
 	return fmt.Sprintf(`
+provider "google" {
+  default_labels = {
+    default_key1 = "default_value1"
+  }
+}
+
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
@@ -50,7 +56,9 @@ resource "google_cloudfunctions2_function" "function_http_v2" {
   name = "%s"
   location = "us-central1"
   description = "a new function"
-
+  labels = {
+	  env = "test"
+  }
   build_config {
     runtime = "nodejs12"
     entry_point = "helloHttp"

--- a/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
@@ -24,9 +24,11 @@ func TestAccDataSourceGoogleCloudFunctions2Function_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceGoogleCloudFunctions2FunctionConfig(functionName,
 					bucketName, zipFilePath),
+				// As the value of "labels" and "terraform_lables" in the state is dpendent on the configuration,
+				// and these fields are not set in the configuration of the data source, so these fields are empty in the state of the data source.
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(funcDataNameHttp,
-						"google_cloudfunctions2_function.function_http_v2", map[string]struct{}{"build_config.0.source.0.storage_source.0.bucket": {}, "build_config.0.source.0.storage_source.0.object": {}}),
+						"google_cloudfunctions2_function.function_http_v2", map[string]struct{}{"build_config.0.source.0.storage_source.0.bucket": {}, "build_config.0.source.0.storage_source.0.object": {}, "labels.%": {}, "terraform_labels.%": {}}),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/cloudfunctions2/resource_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/resource_cloudfunctions2_function_test.go
@@ -28,7 +28,7 @@ func TestAccCloudFunctions2Function_update(t *testing.T) {
 				ResourceName:            "google_cloudfunctions2_function.terraform-test2",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket"},
+				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudFunctions2Function_test_update(context),
@@ -37,7 +37,7 @@ func TestAccCloudFunctions2Function_update(t *testing.T) {
 				ResourceName:            "google_cloudfunctions2_function.terraform-test2",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket"},
+				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudFunctions2Function_test_redeploy(context),
@@ -46,7 +46,7 @@ func TestAccCloudFunctions2Function_update(t *testing.T) {
 				ResourceName:            "google_cloudfunctions2_function.terraform-test2",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket"},
+				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -70,6 +70,9 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   name = "tf-test-test-function%{random_suffix}"
   location = "us-central1"
   description = "a new function"
+  labels = {
+    env = "test"
+  }
 
   build_config {
     runtime = "nodejs12"
@@ -109,7 +112,10 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   name = "tf-test-test-function%{random_suffix}"
   location = "us-central1"
   description = "an updated function"
-
+  labels = {
+    env = "test-update"
+  }
+  
   build_config {
     runtime = "nodejs12"
     entry_point = "helloHttp"

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go
@@ -26,7 +26,7 @@ func TestAccCloudRunV2Job_cloudrunv2JobFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_job.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "launch_stage", "annotations"},
+				ImportStateVerifyIgnore: []string{"location", "launch_stage", "labels", "terraform_labels", "annotations"},
 			},
 			{
 				Config: testAccCloudRunV2Job_cloudrunv2JobFullUpdate(context),
@@ -35,7 +35,7 @@ func TestAccCloudRunV2Job_cloudrunv2JobFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_job.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "launch_stage", "annotations"},
+				ImportStateVerifyIgnore: []string{"location", "launch_stage", "labels", "terraform_labels", "annotations"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go
@@ -30,7 +30,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_service.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location", "annotations"},
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudRunV2Service_cloudrunv2ServiceFullUpdate(context),
@@ -39,7 +39,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_service.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location", "annotations"},
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
@@ -25,7 +25,7 @@ func TestAccDatabaseMigrationServiceConnectionProfile_update(t *testing.T) {
 				ResourceName:            "google_database_migration_service_connection_profile.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql.0.password"},
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql.0.password", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDatabaseMigrationServiceConnectionProfile_update(suffix),
@@ -34,7 +34,7 @@ func TestAccDatabaseMigrationServiceConnectionProfile_update(t *testing.T) {
 				ResourceName:            "google_database_migration_service_connection_profile.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql.0.password"},
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql.0.password", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/datafusion/resource_data_fusion_instance_test.go
+++ b/mmv1/third_party/terraform/services/datafusion/resource_data_fusion_instance_test.go
@@ -21,17 +21,19 @@ func TestAccDataFusionInstance_update(t *testing.T) {
 				Config: testAccDataFusionInstance_basic(instanceName),
 			},
 			{
-				ResourceName:      "google_data_fusion_instance.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_data_fusion_instance.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDataFusionInstance_updated(instanceName),
 			},
 			{
-				ResourceName:      "google_data_fusion_instance.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_data_fusion_instance.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})
@@ -97,17 +99,19 @@ func TestAccDataFusionInstanceEnterprise_update(t *testing.T) {
 				Config: testAccDataFusionInstanceEnterprise_basic(instanceName),
 			},
 			{
-				ResourceName:      "google_data_fusion_instance.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_data_fusion_instance.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDataFusionInstanceEnterprise_updated(instanceName),
 			},
 			{
-				ResourceName:      "google_data_fusion_instance.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_data_fusion_instance.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_stream_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_stream_test.go
@@ -33,7 +33,7 @@ func TestAccDatastreamStream_update(t *testing.T) {
 				ResourceName:            "google_datastream_stream.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state"},
+				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDatastreamStream_datastreamStreamBasicUpdate(context, "RUNNING", true),
@@ -43,7 +43,7 @@ func TestAccDatastreamStream_update(t *testing.T) {
 				ResourceName:            "google_datastream_stream.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state"},
+				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDatastreamStream_datastreamStreamBasicUpdate(context, "PAUSED", true),
@@ -53,7 +53,7 @@ func TestAccDatastreamStream_update(t *testing.T) {
 				ResourceName:            "google_datastream_stream.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state"},
+				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDatastreamStream_datastreamStreamBasicUpdate(context, "RUNNING", true),
@@ -63,7 +63,7 @@ func TestAccDatastreamStream_update(t *testing.T) {
 				ResourceName:            "google_datastream_stream.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state"},
+				ImportStateVerifyIgnore: []string{"stream_id", "location", "desired_state", "labels", "terraform_labels"},
 			},
 			{
 				// Disable prevent_destroy


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
1. Handle the case that the labels field is inside a flatten object (`google_bigquery_job`)
2. Make `effective_labels` immutable if `labels` filed is immutable
3. Apply the labels model to more MMV1 resources

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
