### PR TITLE
docs(firestore_database): Fix typo in google_firestore_database locationId

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -117,7 +117,7 @@ properties:
     name: locationId
     required: true
     description: |
-      The location of the database. Available databases are listed at
+      The location of the database. Available locations are listed at
       https://cloud.google.com/firestore/docs/locations.
     immutable: true
   - !ruby/object:Api::Type::Enum


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
