### PR TITLE
[AlloyDB] Named IP Range Support

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -179,12 +179,37 @@ properties:
             output: true
   - !ruby/object:Api::Type::String
     name: 'network'
-    required: true
+    exactly_one_of:
+      - network
+      - network_config.0.network
+    default_from_api: true
+    deprecation_message: >-
+      `network` is deprecated and will be removed in a future major release. Instead, use `network_config` to define the network configuration.
     description: |
       The relative resource name of the VPC network on which the instance can be accessed. It is specified in the following form:
 
       "projects/{projectNumber}/global/networks/{network_id}".
     diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+  - !ruby/object:Api::Type::NestedObject
+    name: 'networkConfig'
+    description: |
+      Metadata related to network configuration.
+    default_from_api: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: network
+        exactly_one_of:
+          - network
+          - network_config.0.network
+        description: |
+          The resource link for the VPC network in which cluster resources are created and from which they are accessible via Private IP. The network must belong to the same project as the cluster.
+          It is specified in the form: "projects/{projectNumber}/global/networks/{network_id}".
+        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+      - !ruby/object:Api::Type::String
+        name: allocatedIpRange
+        description: |
+          The name of the allocated IP range for the private IP AlloyDB cluster. For example: "google-managed-services-default".
+          If set, the instance IPs for this cluster will be created in the allocated range.
   - !ruby/object:Api::Type::String
     name: 'displayName'
     description: |

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -1092,3 +1092,94 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
   }
 `, context)
 }
+
+// Ensures cluster creation works with networkConfig.
+func TestAccAlloydbCluster_withNetworkConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbCluster_withNetworkConfig(context),
+			},
+			{
+				ResourceName:      "google_alloydb_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAlloydbCluster_withNetworkConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network_config {
+	network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+  }
+}
+data "google_project" "project" {}
+resource "google_compute_network" "default" {
+  name = "tf-test-alloydb-cluster%{random_suffix}"
+}
+`, context)
+}
+
+// Ensures cluster creation works with networkConfig and a specified allocated IP range.
+func TestAccAlloydbCluster_withNetworkConfigAndAllocatedIPRange(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbCluster_withNetworkConfigAndAllocatedIPRange(context),
+			},
+			{
+				ResourceName:      "google_alloydb_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAlloydbCluster_withNetworkConfigAndAllocatedIPRange(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network_config {
+	network    = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.default.name}"
+	allocated_ip_range = google_compute_global_address.private_ip_alloc.name
+  }
+}
+data "google_project" "project" {}
+resource "google_compute_network" "default" {
+  name = "tf-test-alloydb-cluster%{random_suffix}"
+}
+resource "google_compute_global_address" "private_ip_alloc" {
+	name          =  "tf-test-alloydb-cluster%{random_suffix}"
+	address_type  = "INTERNAL"
+	purpose       = "VPC_PEERING"
+	prefix_length = 16
+	network       = google_compute_network.default.id
+  }
+  
+`, context)
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -406,3 +406,70 @@ resource "google_service_networking_connection" "vpc_connection" {
 }
 `, context)
 }
+
+// This test passes if we are able to create a primary instance by specifying network_config.network and network_config.allocated_ip_range
+func TestAccAlloydbInstance_createInstanceWithNetworkConfigAndAllocatedIPRange(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedTestNetwork(t, "alloydbinstance-network-config"),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_createInstanceWithNetworkConfigAndAllocatedIPRange(context),
+			},
+		},
+	})
+}
+
+func testAccAlloydbInstance_createInstanceWithNetworkConfigAndAllocatedIPRange(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+
+  database_flags = {
+	  "google_db_advisor.enabled" = "on"
+  }
+
+  depends_on = [google_service_networking_connection.vpc_connection]
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network_config {
+    network    = data.google_compute_network.default.id
+    allocated_ip_range = google_compute_global_address.private_ip_alloc.name
+  }
+  
+}
+
+data "google_project" "project" {}
+
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          =  "tf-test-alloydb-cluster%{random_suffix}"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 16
+  network       = data.google_compute_network.default.id
+}
+
+resource "google_service_networking_connection" "vpc_connection" {
+  network                 = data.google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -434,11 +434,6 @@ resource "google_alloydb_instance" "default" {
   cluster       = google_alloydb_cluster.default.name
   instance_id   = "tf-test-alloydb-instance%{random_suffix}"
   instance_type = "PRIMARY"
-
-  database_flags = {
-	  "google_db_advisor.enabled" = "on"
-  }
-
   depends_on = [google_service_networking_connection.vpc_connection]
 }
 


### PR DESCRIPTION
Description - 
Changes for supporting Named IP Ranges in Terraform. Going forward, the "network" field in AlloyDB cluster creation is being deprecated in favor or "network_config". While specifying the "network_config", customers can also specify an additional field "allocated_ip_range" which will then ensure that instances in this cluster are created from that range. 

Issue - https://buganizer.corp.google.com/issues/295360787

```release-note:deprecation
alloydb: deprecated `network` field in favor of `network_config`.
```

```release-note:enhancement
alloydb: added `network_config` field to support named IP ranges.
```