### PR TITLE
Apply provider default labels to handwritten resources

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -1412,10 +1412,10 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("max_staleness", res.MaxStaleness); err != nil {
 		return fmt.Errorf("Error setting max_staleness: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(res.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(res.Labels, d, "labels"); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(res.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(res.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", res.Labels); err != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -1031,7 +1031,7 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccBigQueryTable_jsonEqModeRemoved(datasetID, tableID),
@@ -1040,7 +1040,7 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -1090,7 +1090,7 @@ func TestAccBigQueryDataTable_expandArray(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccBigQueryTable_arrayExpanded(datasetID, tableID),
@@ -1099,7 +1099,7 @@ func TestAccBigQueryDataTable_expandArray(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -1123,7 +1123,7 @@ func TestAccBigQueryTable_allowDestroy(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "labels"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "labels", "terraform_labels"},
 			},
 			{
 				Config:      testAccBigQueryTable_noAllowDestroy(datasetID, tableID),
@@ -3098,7 +3098,7 @@ resource "google_bigquery_table" "test" {
 
   friendly_name = "bigquerytest"
   labels = {
-    "terrafrom_managed" = "true"
+    "terrafrom_managed" = "false"
   }
 
   schema = jsonencode(

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -37,6 +37,7 @@ func ResourceBigtableInstance() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 			resourceBigtableInstanceClusterReorderTypeList,
 			resourceBigtableInstanceUniqueClusterID,
+			tpgresource.SetLabelsDiff,
 		),
 
 		SchemaVersion: 1,
@@ -163,6 +164,13 @@ func ResourceBigtableInstance() *schema.Resource {
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
 			},
 
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"effective_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -206,8 +214,8 @@ func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) er
 	}
 	conf.DisplayName = displayName.(string)
 
-	if _, ok := d.GetOk("labels"); ok {
-		conf.Labels = tpgresource.ExpandLabels(d)
+	if _, ok := d.GetOk("effective_labels"); ok {
+		conf.Labels = tpgresource.ExpandEffectiveLabels(d)
 	}
 
 	switch d.Get("instance_type").(string) {
@@ -312,8 +320,11 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("display_name", instance.DisplayName); err != nil {
 		return fmt.Errorf("Error setting display_name: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(instance.Labels, d)); err != nil {
+	if err := d.Set("labels", tpgresource.FlattenLabels(instance.Labels, d, "labels")); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(instance.Labels, d, "terraform_labels")); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", instance.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)
@@ -353,8 +364,8 @@ func resourceBigtableInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 	conf.DisplayName = displayName.(string)
 
-	if d.HasChange("labels") {
-		conf.Labels = tpgresource.ExpandLabels(d)
+	if d.HasChange("effective_labels") {
+		conf.Labels = tpgresource.ExpandEffectiveLabels(d)
 	}
 
 	switch d.Get("instance_type").(string) {

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -320,10 +320,10 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("display_name", instance.DisplayName); err != nil {
 		return fmt.Errorf("Error setting display_name: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(instance.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(instance.Labels, d, "labels"); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(instance.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(instance.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", instance.Labels); err != nil {

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -89,7 +89,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type", "cluster", "labels"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type", "cluster", "labels", "terraform_labels"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
@@ -108,7 +108,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type", "cluster", "labels"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type", "cluster", "labels", "terraform_labels"}, // we don't read instance type back
 			},
 		},
 	})
@@ -428,7 +428,7 @@ func TestAccBigtableInstance_MultipleClustersSameID(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type", "labels"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type", "labels", "terraform_labels"}, // we don't read instance type back
 			},
 			{
 				Config:      testAccBigtableInstance_multipleClustersSameID(instanceName),
@@ -644,7 +644,7 @@ resource "google_bigtable_instance" "instance" {
   deletion_protection = false
 
   labels = {
-    env = "default"
+    env = "test"
   }
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
@@ -145,6 +145,7 @@ func ResourceCloudFunctionsFunction() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 			tpgresource.DefaultProviderRegion,
+			tpgresource.SetLabelsDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -267,6 +268,13 @@ func ResourceCloudFunctionsFunction() *schema.Resource {
 
 				**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
+			},
+
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"effective_labels": {
@@ -574,8 +582,8 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 		function.IngressSettings = v.(string)
 	}
 
-	if _, ok := d.GetOk("labels"); ok {
-		function.Labels = tpgresource.ExpandLabels(d)
+	if _, ok := d.GetOk("effective_labels"); ok {
+		function.Labels = tpgresource.ExpandEffectiveLabels(d)
 	}
 
 	if _, ok := d.GetOk("environment_variables"); ok {
@@ -686,8 +694,11 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	if err := d.Set("ingress_settings", function.IngressSettings); err != nil {
 		return fmt.Errorf("Error setting ingress_settings: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(function.Labels, d)); err != nil {
+	if err := d.Set("labels", tpgresource.FlattenLabels(function.Labels, d, "labels")); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(function.Labels, d, "terraform_labels")); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", function.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)
@@ -858,8 +869,8 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 		updateMaskArr = append(updateMaskArr, "ingressSettings")
 	}
 
-	if d.HasChange("labels") {
-		function.Labels = tpgresource.ExpandLabels(d)
+	if d.HasChange("effective_labels") {
+		function.Labels = tpgresource.ExpandEffectiveLabels(d)
 		updateMaskArr = append(updateMaskArr, "labels")
 	}
 

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
@@ -694,10 +694,10 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	if err := d.Set("ingress_settings", function.IngressSettings); err != nil {
 		return fmt.Errorf("Error setting ingress_settings: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(function.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(function.Labels, d, "labels"); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(function.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(function.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", function.Labels); err != nil {

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -80,7 +80,7 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -117,7 +117,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFileUpdatePath, random_suffix),
@@ -150,7 +150,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -425,7 +425,7 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update"),
@@ -434,7 +434,7 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 				ResourceName:            funcResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels"},
+				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -160,6 +160,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 			tpgresource.DefaultProviderRegion,
+			tpgresource.SetLabelsDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -886,6 +887,13 @@ func ResourceComposerEnvironment() *schema.Resource {
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
 			},
 
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"effective_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -916,7 +924,7 @@ func resourceComposerEnvironmentCreate(d *schema.ResourceData, meta interface{})
 
 	env := &composer.Environment{
 		Name:   envName.ResourceName(),
-		Labels: tpgresource.ExpandLabels(d),
+		Labels: tpgresource.ExpandEffectiveLabels(d),
 		Config: transformedConfig,
 	}
 
@@ -994,11 +1002,14 @@ func resourceComposerEnvironmentRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("config", flattenComposerEnvironmentConfig(res.Config)); err != nil {
 		return fmt.Errorf("Error setting Environment: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(res.Labels, d)); err != nil {
-		return fmt.Errorf("Error setting Environment: %s", err)
+	if err := d.Set("labels", tpgresource.FlattenLabels(res.Labels, d, "labels")); err != nil {
+		return fmt.Errorf("Error setting Environment labels: %s", err)
+	}
+	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(res.Labels, d, "terraform_labels")); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", res.Labels); err != nil {
-		return fmt.Errorf("Error setting Environment: %s", err)
+		return fmt.Errorf("Error setting Environment effective_labels: %s", err)
 	}
 	return nil
 }
@@ -1241,8 +1252,8 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("labels") {
-		patchEnv := &composer.Environment{Labels: tpgresource.ExpandLabels(d)}
+	if d.HasChange("effective_labels") {
+		patchEnv := &composer.Environment{Labels: tpgresource.ExpandEffectiveLabels(d)}
 		err := resourceComposerEnvironmentPatchField("labels", userAgent, patchEnv, d, tfConfig)
 		if err != nil {
 			return err

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1002,10 +1002,10 @@ func resourceComposerEnvironmentRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("config", flattenComposerEnvironmentConfig(res.Config)); err != nil {
 		return fmt.Errorf("Error setting Environment: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(res.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(res.Labels, d, "labels"); err != nil {
 		return fmt.Errorf("Error setting Environment labels: %s", err)
 	}
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(res.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(res.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", res.Labels); err != nil {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
@@ -100,7 +100,7 @@ func TestAccComposerEnvironment_update(t *testing.T) {
 				ResourceName:			"google_composer_environment.test",
 				ImportState:			 true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"labels"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			// This is a terrible clean-up step in order to get destroy to succeed,
 			// due to dangling firewall rules left by the Composer Environment blocking network deletion.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -1410,11 +1410,11 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := d.Set("labels", tpgresource.FlattenLabels(instance.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(instance.Labels, d, "labels"); err != nil {
 		return err
 	}
 
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(instance.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(instance.Labels, d, "terraform_labels"); err != nil {
 		return err
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -619,6 +619,13 @@ func ResourceComputeInstance() *schema.Resource {
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
 			},
 
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"effective_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -1069,6 +1076,7 @@ be from 0 to 999,999,999 inclusive.`,
 			),
 			desiredStatusDiff,
 			forceNewIfNetworkIPNotUpdatable,
+			tpgresource.SetLabelsDiff,
 		),
 		UseJSONNumber: true,
 	}
@@ -1202,7 +1210,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		NetworkPerformanceConfig:   networkPerformanceConfig,
 		Tags:                       resourceInstanceTags(d),
 		Params:                     params,
-		Labels:                     tpgresource.ExpandLabels(d),
+		Labels:                     tpgresource.ExpandEffectiveLabels(d),
 		ServiceAccounts:            expandServiceAccounts(d.Get("service_account").([]interface{})),
 		GuestAccelerators:          accels,
 		MinCpuPlatform:             d.Get("min_cpu_platform").(string),
@@ -1402,7 +1410,11 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := d.Set("labels", tpgresource.FlattenLabels(instance.Labels, d)); err != nil {
+	if err := d.Set("labels", tpgresource.FlattenLabels(instance.Labels, d, "labels")); err != nil {
+		return err
+	}
+
+	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(instance.Labels, d, "terraform_labels")); err != nil {
 		return err
 	}
 
@@ -1685,8 +1697,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	if d.HasChange("labels") {
-		labels := tpgresource.ExpandLabels(d)
+	if d.HasChange("effective_labels") {
+		labels := tpgresource.ExpandEffectiveLabels(d)
 		labelFingerprint := d.Get("label_fingerprint").(string)
 		req := compute.InstancesSetLabelsRequest{Labels: labels, LabelFingerprint: labelFingerprint}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -1645,7 +1645,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		}
 	}
 	if instanceTemplate.Properties.Labels != nil {
-		if err := d.Set("labels", tpgresource.FlattenLabels(instanceTemplate.Properties.Labels, d)); err != nil {
+		if err := d.Set("labels", tpgresource.FlattenLabels(instanceTemplate.Properties.Labels, d, "labels")); err != nil {
 			return fmt.Errorf("Error setting labels: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -1645,7 +1645,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		}
 	}
 	if instanceTemplate.Properties.Labels != nil {
-		if err := d.Set("labels", tpgresource.FlattenLabels(instanceTemplate.Properties.Labels, d, "labels")); err != nil {
+		if err := tpgresource.SetLabels(instanceTemplate.Properties.Labels, d, "labels"); err != nil {
 			return fmt.Errorf("Error setting labels: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -139,7 +139,7 @@ func TestAccComputeInstance_basic1(t *testing.T) {
 					testAccCheckComputeInstanceHasConfiguredDeletionProtection(&instance, false),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{"metadata.baz", "metadata.foo", "desired_status", "current_status", "labels"}),
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"metadata.baz", "metadata.foo", "desired_status", "current_status", "labels", "terraform_labels"}),
 		},
 	})
 }
@@ -1426,7 +1426,7 @@ func TestAccComputeInstance_forceChangeMachineTypeManually(t *testing.T) {
 				),
 				ExpectNonEmptyPlan: true,
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{"metadata.baz", "metadata.foo", "desired_status", "current_status", "labels"}),
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"metadata.baz", "metadata.foo", "desired_status", "current_status", "labels", "terraform_labels"}),
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
@@ -335,10 +335,10 @@ func resourceDataprocJobRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("force_delete", d.Get("force_delete")); err != nil {
 		return fmt.Errorf("Error setting force_delete: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(job.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(job.Labels, d, "labels"); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(job.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(job.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", job.Labels); err != nil {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
@@ -33,6 +33,7 @@ func ResourceDataprocJob() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
+			tpgresource.SetLabelsDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -158,9 +159,17 @@ func ResourceDataprocJob() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"effective_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
+				ForceNew:    true,
 				Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
@@ -245,8 +254,8 @@ func resourceDataprocJobCreate(d *schema.ResourceData, meta interface{}) error {
 		submitReq.Job.Scheduling = expandJobScheduling(config)
 	}
 
-	if _, ok := d.GetOk("labels"); ok {
-		submitReq.Job.Labels = tpgresource.ExpandLabels(d)
+	if _, ok := d.GetOk("effective_labels"); ok {
+		submitReq.Job.Labels = tpgresource.ExpandEffectiveLabels(d)
 	}
 
 	if v, ok := d.GetOk("pyspark_config"); ok {
@@ -326,8 +335,11 @@ func resourceDataprocJobRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("force_delete", d.Get("force_delete")); err != nil {
 		return fmt.Errorf("Error setting force_delete: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(job.Labels, d)); err != nil {
+	if err := d.Set("labels", tpgresource.FlattenLabels(job.Labels, d, "labels")); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(job.Labels, d, "terraform_labels")); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", job.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -308,10 +308,10 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("name", p.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(p.Labels, d, "labels")); err != nil {
+	if err := tpgresource.SetLabels(p.Labels, d, "labels"); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
 	}
-	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(p.Labels, d, "terraform_labels")); err != nil {
+	if err := tpgresource.SetLabels(p.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", p.Labels); err != nil {

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
@@ -39,6 +40,10 @@ func ResourceGoogleProject() *schema.Resource {
 		Read:   resourceGoogleProjectRead,
 		Update: resourceGoogleProjectUpdate,
 		Delete: resourceGoogleProjectDelete,
+
+		CustomizeDiff: customdiff.All(
+			tpgresource.SetLabelsDiff,
+		),
 
 		Importer: &schema.ResourceImporter{
 			State: resourceProjectImportState,
@@ -112,6 +117,13 @@ func ResourceGoogleProject() *schema.Resource {
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
 			},
 
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"effective_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -147,8 +159,8 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	if _, ok := d.GetOk("labels"); ok {
-		project.Labels = tpgresource.ExpandLabels(d)
+	if _, ok := d.GetOk("effective_labels"); ok {
+		project.Labels = tpgresource.ExpandEffectiveLabels(d)
 	}
 
 	var op *cloudresourcemanager.Operation
@@ -296,8 +308,11 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("name", p.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("labels", tpgresource.FlattenLabels(p.Labels, d)); err != nil {
+	if err := d.Set("labels", tpgresource.FlattenLabels(p.Labels, d, "labels")); err != nil {
 		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	if err := d.Set("terraform_labels", tpgresource.FlattenLabels(p.Labels, d, "terraform_labels")); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
 	if err := d.Set("effective_labels", p.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)
@@ -444,8 +459,8 @@ func resourceGoogleProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Project Labels have changed
-	if ok := d.HasChange("labels"); ok {
-		p.Labels = tpgresource.ExpandLabels(d)
+	if ok := d.HasChange("effective_labels"); ok {
+		p.Labels = tpgresource.ExpandEffectiveLabels(d)
 
 		// Do Update on project
 		if p, err = updateProject(config, d, project_name, userAgent, p); err != nil {

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -136,7 +136,7 @@ func TestAccProject_labels(t *testing.T) {
 				ResourceName:            "google_project.acceptance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_delete", "labels"},
+				ImportStateVerifyIgnore: []string{"skip_delete", "labels", "terraform_labels"},
 			},
 			// update project with labels
 			{

--- a/mmv1/third_party/terraform/tpgresource/labels.go
+++ b/mmv1/third_party/terraform/tpgresource/labels.go
@@ -8,10 +8,10 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-func FlattenLabels(labels map[string]string, d *schema.ResourceData, linage string) map[string]interface{} {
+func SetLabels(labels map[string]string, d *schema.ResourceData, lineage string) error {
 	transformed := make(map[string]interface{})
 
-	if v, ok := d.GetOk(linage); ok {
+	if v, ok := d.GetOk(lineage); ok {
 		if labels != nil {
 			for k, _ := range v.(map[string]interface{}) {
 				transformed[k] = labels[k]
@@ -19,7 +19,7 @@ func FlattenLabels(labels map[string]string, d *schema.ResourceData, linage stri
 		}
 	}
 
-	return transformed
+	return d.Set(lineage, transformed)
 }
 
 func SetLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {

--- a/mmv1/third_party/terraform/tpgresource/labels.go
+++ b/mmv1/third_party/terraform/tpgresource/labels.go
@@ -8,10 +8,10 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-func FlattenLabels(labels map[string]string, d *schema.ResourceData) map[string]interface{} {
+func FlattenLabels(labels map[string]string, d *schema.ResourceData, linage string) map[string]interface{} {
 	transformed := make(map[string]interface{})
 
-	if v, ok := d.GetOk("labels"); ok {
+	if v, ok := d.GetOk(linage); ok {
 		if labels != nil {
 			for k, _ := range v.(map[string]interface{}) {
 				transformed[k] = labels[k]

--- a/mmv1/third_party/terraform/tpgresource/labels.go
+++ b/mmv1/third_party/terraform/tpgresource/labels.go
@@ -8,6 +8,11 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// SetLabels is called in the READ method of the resources to set
+// the field "labels" and "terraform_labels" in the state based on the labels field in the configuration.
+// So the field "labels" and "terraform_labels" in the state will only have the user defined labels.
+// param "labels" is all of labels returned from API read reqeust.
+// param "lineage" is the terraform lineage of the field and could be "labels" or "terraform_labels".
 func SetLabels(labels map[string]string, d *schema.ResourceData, lineage string) error {
 	transformed := make(map[string]interface{})
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -204,6 +204,11 @@ func ExpandLabels(d TerraformResourceData) map[string]string {
 	return ExpandStringMap(d, "labels")
 }
 
+// ExpandEffectiveLabels pulls the value of "effective_labels" out of a TerraformResourceData as a map[string]string.
+func ExpandEffectiveLabels(d TerraformResourceData) map[string]string {
+	return ExpandStringMap(d, "effective_labels")
+}
+
 // ExpandEnvironmentVariables pulls the value of "environment_variables" out of a schema.ResourceData as a map[string]string.
 func ExpandEnvironmentVariables(d *schema.ResourceData) map[string]string {
 	return ExpandStringMap(d, "environment_variables")

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -114,6 +114,12 @@ The following arguments are supported:
 
 * `labels` - (Optional) A mapping of labels to assign to the resource.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * <a name="schema"></a>`schema` - (Optional) A JSON schema for the table.
 
     ~>**NOTE:** Because this field expects a JSON string, any changes to the

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -102,6 +102,11 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
 
 -----
 

--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -134,6 +134,12 @@ Eg. `"nodejs16"`, `"python39"`, `"dotnet3"`, `"go116"`, `"java11"`, `"ruby30"`, 
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the function. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `service_account_email` - (Optional) If provided, the self-provided service account to run the function with.
 
 * `environment_variables` - (Optional) A set of key/value environment variable pairs to assign to the function.

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -262,6 +262,12 @@ The following arguments are supported:
   No more than 64 labels can be associated with a given environment.
   Both keys and values must be <= 128 bytes in size.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `region` -
   (Optional)
   The location or Compute Engine region for the environment.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -118,6 +118,12 @@ The following arguments are supported:
 
 * `labels` - (Optional) A map of key/value label pairs to assign to the instance.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance. Ssh keys attached in the Cloud Console will be removed.
     Add them to your config in order to keep them attached to your instance. A

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -103,6 +103,12 @@ output "pyspark_status" {
 
 * `labels` - (Optional) The list of labels (key/value pairs) to add to the job.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `scheduling.max_failures_per_hour` - (Required) Maximum number of times per hour a driver may be restarted as a result of driver exiting with non-zero code before job is reported failed.
 
 * `scheduling.max_failures_total` - (Required) Maximum number of times in total a driver may be restarted as a result of driver exiting with non-zero code before job is reported failed.

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -83,6 +83,12 @@ The following arguments are supported:
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the project.
 
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `auto_create_network` - (Optional) Controls whether the 'default' network exists on the project. Defaults
     to `true`, where it is created. If set to `false`, the default network will still be created by GCP but
     will be deleted immediately by Terraform. Therefore, for quota purposes, you will still need to have 1 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
With the new model, the test for the following two resources failed. I am going to migrate these two resources later.
`google_compute_instance_template` has `forcenew: true`. 
`google_compute_region_instance_template` has `Set:  schema.HashString`


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
